### PR TITLE
json-message utf8_encode()

### DIFF
--- a/core/json_api.php
+++ b/core/json_api.php
@@ -36,7 +36,7 @@ require_api( 'url_api.php' );
  */
 function json_url( $p_url, $p_member = null ) {
 	$t_data = url_get( $p_url );
-	$t_json = json_decode( $t_data );
+	$t_json = json_decode( utf8_encode($t_data) );
 
 	if( is_null( $p_member ) ) {
 		return $t_json;


### PR DESCRIPTION
Using the source-integration by jreese
jreese/source-integration
I discovered a problem with german umlauts (äöüÄÖÜ) in json reply-messages.
First I wanted to fix the problem in the source-integration but jreese thought an integration in mantisbt would be better:
https://github.com/jreese/source-integration/pull/1#issuecomment-675011
