### PR TITLE
Background color with CSS instead of bgcolor

### DIFF
--- a/account_sponsor_page.php
+++ b/account_sponsor_page.php
@@ -174,9 +174,9 @@ if ( 0 == $t_sponsors ) {
 		}
 
 		# choose color based on status
-		$status_label = MantisEnum::getLabel( config_get('status_enum_string' ), $t_bug->status );
+		$status_label = get_status_css_class( $t_bug->status );
 
-		echo '<tr class="' . $status_label .  '-color">';
+		echo '<tr class="' . $status_label .  '">';
 		echo '<td><a href="' . string_get_bug_view_url( $row['bug'] ) . '">' . bug_format_id( $row['bug'] ) . '</a></td>';
 		echo '<td>' . project_get_field( $t_bug->project_id, 'name' ) . '&#160;</td>';
 		echo '<td class="right">' . $t_released_label . '&#160;</td>';
@@ -287,9 +287,9 @@ if ( 0 == $t_sponsors ) {
 		}
 
 		# choose color based on status
-		$status_label = MantisEnum::getLabel( config_get('status_enum_string' ), $t_bug->status );
+		$status_label = get_status_css_class( $t_bug->status );
 
-		echo '<tr class="' . $status_label .  '-color">';
+		echo '<tr class="' . $status_label .  '">';
 		echo '<td><a href="' . string_get_bug_view_url( $row['bug'] ) . '">' . bug_format_id( $row['bug'] ) . '</a></td>';
 		echo '<td>' . project_get_field( $t_bug->project_id, 'name' ) . '&#160;</td>';
 		echo '<td class="right">' . $t_released_label . '&#160;</td>';

--- a/bug_update_advanced_page.php
+++ b/bug_update_advanced_page.php
@@ -397,9 +397,9 @@ if ( $tpl_show_status || $tpl_show_resolution ) {
 		echo '<th class="category"><label for="status">' . lang_get( 'status' ) . '</label></th>';
 		
 		# choose color based on status
-		$status_label = MantisEnum::getLabel( config_get('status_enum_string' ), $tpl_bug->status );
+		$status_label = get_status_css_class( $tpl_bug->status );
 		
-		echo '<td class="' . $status_label .  '-color">';
+		echo '<td class="' . $status_label .  '">';
 		print_status_option_list( 'status', $tpl_bug->status,
 							( $tpl_bug->reporter_id == auth_get_current_user_id() &&
 									( ON == config_get( 'allow_reporter_close' ) ) ), $tpl_bug->project_id );

--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -477,9 +477,9 @@ if ( $tpl_show_status || $tpl_show_resolution ) {
 		echo '<th class="bug-status category">', lang_get( 'status' ), '</th>';
 		
 		# choose color based on status
-		$status_label = MantisEnum::getLabel( config_get('status_enum_string' ), $tpl_bug->status );
+		$status_label = get_status_css_class( $tpl_bug->status );
 		
-		echo '<td class="bug-status ', $status_label, '-color">', $tpl_status, '</td>';
+		echo '<td class="bug-status ', $status_label, '">', $tpl_status, '</td>';
 	} else {
 		$t_spacer += 2;
 	}

--- a/core/bug_group_action_api.php
+++ b/core/bug_group_action_api.php
@@ -84,9 +84,9 @@ function bug_group_action_print_bug_list( $p_bug_ids_array ) {
 		$t_class = sprintf( "row-%d", ( $t_i++ % 2 ) + 1 );
 		
 		# choose color based on status
-		$status_label = MantisEnum::getLabel( config_get('status_enum_string' ), bug_get_field( $t_bug_id, 'status' ) );
+		$status_label = get_status_css_class( bug_get_field( $t_bug_id, 'status' ) );
 		
-		echo sprintf( "<tr class=\"%s-color\"> <td>%s</td> <td>%s</td> </tr>\n", $status_label, string_get_bug_view_link( $t_bug_id ), string_attribute( bug_get_field( $t_bug_id, 'summary' ) ) );
+		echo sprintf( "<tr class=\"%s\"> <td>%s</td> <td>%s</td> </tr>\n", $status_label, string_get_bug_view_link( $t_bug_id ), string_attribute( bug_get_field( $t_bug_id, 'summary' ) ) );
 	}
 
 	echo '</table>';

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1718,3 +1718,12 @@ function html_buttons_view_bug_page( $p_bug_id ) {
 
 	echo '</tr></table>';
 }
+
+/**
+ * get the css class name for the given status
+ * @param int $p_status
+ * @return string
+ */
+function get_status_css_class( $p_status ) {
+	return string_attribute( MantisEnum::getLabel( config_get('status_enum_string' ), $p_status ) . '-color' );
+}

--- a/core/relationship_api.php
+++ b/core/relationship_api.php
@@ -707,9 +707,9 @@ function relationship_get_details( $p_bug_id, $p_relationship, $p_html = false, 
 
 	if( $p_html_preview == false ) {
 		# choose color based on status
-		$status_label = MantisEnum::getLabel( config_get('status_enum_string' ), $t_bug->status );
+		$status_label = get_status_css_class( $t_bug->status );
 	
-		$t_relationship_info_html = '<tr class="' . $status_label . '-color">' . $t_relationship_info_html . '</tr>' . "\n";
+		$t_relationship_info_html = '<tr class="' . $status_label . '">' . $t_relationship_info_html . '</tr>' . "\n";
 	} else {
 		$t_relationship_info_html = '<tr>' . $t_relationship_info_html . '</tr>';
 	}

--- a/my_view_inc.php
+++ b/my_view_inc.php
@@ -449,7 +449,7 @@ for( $i = 0;$i < $t_count; $i++ ) {
 	$t_last_updated = date( config_get( 'normal_date_format' ), $t_bug->last_updated );
 
 	# choose color based on status
-	$status_label = MantisEnum::getLabel( config_get('status_enum_string' ), $t_bug->status );
+	$status_label = get_status_css_class( $t_bug->status );
 
 	# Check for attachments
 	$t_attachment_count = 0;
@@ -469,7 +469,7 @@ for( $i = 0;$i < $t_count; $i++ ) {
     }
 	?>
 
-<tr class="my-buglist-bug <?php echo $t_bug_class?> <?php echo $status_label . '-color'; ?>">
+<tr class="my-buglist-bug <?php echo $t_bug_class?> <?php echo $status_label; ?>">
 	<?php
 	# -- Bug ID and details link + Pencil shortcut --?>
 	<td class="center nowrap my-buglist-id">

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -195,9 +195,9 @@ function write_bug_rows ( $p_rows )
 		}
 
 		# choose color based on status
-		$status_label = MantisEnum::getLabel( config_get('status_enum_string' ), $t_row->status );
+		$status_label = get_status_css_class( $t_row->status );
 		
-		echo '<tr class="' . $status_label . '-color">';
+		echo '<tr class="' . $status_label . '">';
 
 		foreach( $t_columns as $t_column ) {
 			$t_column_value_function = 'print_column_value';


### PR DESCRIPTION
Made use of the already existing CSS produced by css/status_config.php to apply on bug status to set background color, instead of the bgcolor attribute that prevent further customizations using CSS.
