### PR TITLE
Json api

### DIFF
--- a/api/json/action_bug_report.php
+++ b/api/json/action_bug_report.php
@@ -1,0 +1,167 @@
+<?php
+
+global $g_json_file_tmp_name;
+$g_json_file_tmp_name = '';
+
+access_ensure_project_level( config_get('report_bug_threshold' ) , $project_id, $user_id);
+
+$t_bug_data = new BugData;
+$t_bug_data->build				= json_get_string( 'build', '' );
+$t_bug_data->platform				= json_get_string( 'platform', '' );
+$t_bug_data->os					= json_get_string( 'os', '' );
+$t_bug_data->os_build				= json_get_string( 'os_build', '' );
+$t_bug_data->version			= json_get_string( 'product_version', '' );
+$t_bug_data->profile_id			= json_get_int( 'profile_id', 0 );
+$t_bug_data->handler_id			= json_get_int( 'handler_id', 0 );
+$t_bug_data->view_state			= json_get_int( 'view_state', config_get( 'default_bug_view_status' ) );
+
+$t_bug_data->category_id			= json_get_int( 'category_id', 0 );
+$t_bug_data->reproducibility		= json_get_int( 'reproducibility', config_get( 'default_bug_reproducibility' ) );
+$t_bug_data->severity				= json_get_int( 'severity', config_get( 'default_bug_severity' ) );
+$t_bug_data->priority				= json_get_int( 'priority', config_get( 'default_bug_priority' ) );
+$t_bug_data->projection				= json_get_int( 'projection', config_get( 'default_bug_projection' ) );
+$t_bug_data->eta					= json_get_int( 'eta', config_get( 'default_bug_eta' ) );
+$t_bug_data->resolution				= config_get( 'default_bug_resolution' );
+$t_bug_data->status					= config_get( 'bug_submit_status' );
+$t_bug_data->summary				= json_get_string( 'summary' );
+$t_bug_data->description			= json_get_string( 'description' );
+$t_bug_data->steps_to_reproduce	= json_get_string( 'steps_to_reproduce', config_get( 'default_bug_steps_to_reproduce' ) );
+$t_bug_data->additional_information	= json_get_string( 'additional_info', config_get ( 'default_bug_additional_info' ) );
+$t_bug_data->due_date 				= json_get_string( 'due_date', '');
+
+if ( is_blank ( $t_bug_data->due_date ) ) {
+	$t_bug_data->due_date = date_get_null();
+} else {
+	$t_bug_data->due_date = $t_bug_data->due_date;
+}
+
+$f_file					= json_get_file( 'file', null ); /** @todo (thraxisp) Note that this always returns a structure */
+
+$f_report_stay			= json_get_bool( 'report_stay', false );
+$t_bug_data->project_id			= json_get_int( 'project_id' );
+
+$t_bug_data->reporter_id		= auth_get_current_user_id();
+
+$t_bug_data->summary			= trim( $t_bug_data->summary );
+
+if ( access_has_project_level( config_get( 'roadmap_update_threshold' ), $t_bug_data->project_id ) ) {
+	$t_bug_data->target_version = json_get_string( 'target_version', '' );
+}
+
+# if a profile was selected then let's use that information
+if ( 0 != $t_bug_data->profile_id ) {
+	if ( profile_is_global( $t_bug_data->profile_id ) ) {
+		$row = user_get_profile_row( ALL_USERS, $t_bug_data->profile_id );
+	} else {
+		$row = user_get_profile_row( $t_bug_data->reporter_id, $t_bug_data->profile_id );
+	}
+
+	if ( is_blank( $t_bug_data->platform ) ) {
+		$t_bug_data->platform = $row['platform'];
+	}
+	if ( is_blank( $t_bug_data->os ) ) {
+		$t_bug_data->os = $row['os'];
+	}
+	if ( is_blank( $t_bug_data->os_build ) ) {
+		$t_bug_data->os_build = $row['os_build'];
+	}
+}
+
+helper_call_custom_function( 'issue_create_validate', array( $t_bug_data ) );
+
+# Validate the custom fields before adding the bug.
+$t_related_custom_field_ids = custom_field_get_linked_ids( $t_bug_data->project_id );
+foreach( $t_related_custom_field_ids as $t_id ) {
+	$t_def = custom_field_get_definition( $t_id );
+
+	# Produce an error if the field is required but wasn't posted
+	if ( !json_isset_custom_field( $t_id, $t_def['type'] ) &&
+		( $t_def['require_report'] ||
+			$t_def['type'] == CUSTOM_FIELD_TYPE_ENUM ||
+			$t_def['type'] == CUSTOM_FIELD_TYPE_LIST ||
+			$t_def['type'] == CUSTOM_FIELD_TYPE_MULTILIST ||
+			$t_def['type'] == CUSTOM_FIELD_TYPE_RADIO ) ) {
+		error_parameters( lang_get_defaulted( custom_field_get_field( $t_id, 'name' ) ) );
+		trigger_error( ERROR_EMPTY_FIELD, ERROR );
+	}
+	if ( !custom_field_validate( $t_id, json_get_custom_field( "custom_field_$t_id", $t_def['type'], NULL ) ) ) {
+		error_parameters( lang_get_defaulted( custom_field_get_field( $t_id, 'name' ) ) );
+		trigger_error( ERROR_CUSTOM_FIELD_INVALID_VALUE, ERROR );
+	}
+}
+
+# Allow plugins to pre-process bug data
+$t_bug_data = event_signal( 'EVENT_REPORT_BUG_DATA', $t_bug_data );
+
+# Create the bug
+$t_bug_id = $t_bug_data->create();
+
+# Mark the added issue as visited so that it appears on the last visited list.
+last_visited_issue( $t_bug_id );
+
+# Handle the file upload
+if ( !is_blank( $f_file['tmp_name'] ) && ( 0 < $f_file['size'] ) ) {
+	file_add( $t_bug_id, $f_file, 'bug' );
+}
+
+# Handle custom field submission
+foreach( $t_related_custom_field_ids as $t_id ) {
+	# Do not set custom field value if user has no write access.
+	if( !custom_field_has_write_access( $t_id, $t_bug_id ) ) {
+		continue;
+	}
+
+	$t_def = custom_field_get_definition( $t_id );
+	if( !custom_field_set_value( $t_id, $t_bug_id, gpc_get_custom_field( "custom_field_$t_id", $t_def['type'], '' ), false ) ) {
+		error_parameters( lang_get_defaulted( custom_field_get_field( $t_id, 'name' ) ) );
+		trigger_error( ERROR_CUSTOM_FIELD_INVALID_VALUE, ERROR );
+	}
+}
+
+$f_master_bug_id = gpc_get_int( 'm_id', 0 );
+$f_rel_type = gpc_get_int( 'rel_type', -1 );
+
+if ( $f_master_bug_id > 0 ) {
+	# it's a child generation... let's create the relationship and add some lines in the history
+
+	# update master bug last updated
+	bug_update_date( $f_master_bug_id );
+
+	# Add log line to record the cloning action
+	history_log_event_special( $t_bug_id, BUG_CREATED_FROM, '', $f_master_bug_id );
+	history_log_event_special( $f_master_bug_id, BUG_CLONED_TO, '', $t_bug_id );
+
+	if ( $f_rel_type >= 0 ) {
+		# Add the relationship
+		relationship_add( $t_bug_id, $f_master_bug_id, $f_rel_type );
+
+		# Add log line to the history (both issues)
+		history_log_event_special( $f_master_bug_id, BUG_ADD_RELATIONSHIP, relationship_get_complementary_type( $f_rel_type ), $t_bug_id );
+		history_log_event_special( $t_bug_id, BUG_ADD_RELATIONSHIP, $f_rel_type, $f_master_bug_id );
+
+		# Send the email notification
+		email_relationship_added( $f_master_bug_id, $t_bug_id, relationship_get_complementary_type( $f_rel_type ) );
+	}
+}
+
+helper_call_custom_function( 'issue_create_notify', array( $t_bug_id ) );
+
+# Allow plugins to post-process bug data with the new bug ID
+event_signal( 'EVENT_REPORT_BUG', array( $t_bug_data, $t_bug_id ) );
+
+email_new_bug( $t_bug_id );
+
+form_security_purge( 'bug_report' );
+
+
+/*
+if ( !$f_report_stay ) {
+	html_meta_redirect( 'view_all_bug_page.php' );
+}
+ */
+
+$t_output['result'] =  lang_get( 'operation_successful' ) ;
+
+echo json_encode($t_output);
+
+json_exit();

--- a/api/json/action_bug_report.php
+++ b/api/json/action_bug_report.php
@@ -112,14 +112,14 @@ foreach( $t_related_custom_field_ids as $t_id ) {
 	}
 
 	$t_def = custom_field_get_definition( $t_id );
-	if( !custom_field_set_value( $t_id, $t_bug_id, gpc_get_custom_field( "custom_field_$t_id", $t_def['type'], '' ), false ) ) {
+	if( !custom_field_set_value( $t_id, $t_bug_id, json_get_custom_field( "custom_field_$t_id", $t_def['type'], '' ), false ) ) {
 		error_parameters( lang_get_defaulted( custom_field_get_field( $t_id, 'name' ) ) );
 		trigger_error( ERROR_CUSTOM_FIELD_INVALID_VALUE, ERROR );
 	}
 }
 
-$f_master_bug_id = gpc_get_int( 'm_id', 0 );
-$f_rel_type = gpc_get_int( 'rel_type', -1 );
+$f_master_bug_id = json_get_int( 'm_id', 0 );
+$f_rel_type = json_get_int( 'rel_type', -1 );
 
 if ( $f_master_bug_id > 0 ) {
 	# it's a child generation... let's create the relationship and add some lines in the history

--- a/api/json/action_bug_report.php
+++ b/api/json/action_bug_report.php
@@ -161,6 +161,7 @@ if ( !$f_report_stay ) {
  */
 
 $t_output['result'] =  lang_get( 'operation_successful' ) ;
+$t_output['bug_id'] =  $t_bug_id;
 
 echo json_encode($t_output);
 

--- a/api/json/action_bug_report.php
+++ b/api/json/action_bug_report.php
@@ -84,7 +84,7 @@ foreach( $t_related_custom_field_ids as $t_id ) {
 		error_parameters( lang_get_defaulted( custom_field_get_field( $t_id, 'name' ) ) );
 		trigger_error( ERROR_EMPTY_FIELD, ERROR );
 	}
-	if ( !custom_field_validate( $t_id, json_get_custom_field( "custom_field_$t_id", $t_def['type'], NULL ) ) ) {
+	if ( !custom_field_validate( $t_id, json_get_custom_field( $t_id, $t_def['name'], $t_def['type'], NULL ) ) ) {
 		error_parameters( lang_get_defaulted( custom_field_get_field( $t_id, 'name' ) ) );
 		trigger_error( ERROR_CUSTOM_FIELD_INVALID_VALUE, ERROR );
 	}
@@ -112,7 +112,7 @@ foreach( $t_related_custom_field_ids as $t_id ) {
 	}
 
 	$t_def = custom_field_get_definition( $t_id );
-	if( !custom_field_set_value( $t_id, $t_bug_id, json_get_custom_field( "custom_field_$t_id", $t_def['type'], '' ), false ) ) {
+	if( !custom_field_set_value( $t_id, $t_bug_id, json_get_custom_field( $t_id, $t_def['name'], $t_def['type'], '' ), false ) ) {
 		error_parameters( lang_get_defaulted( custom_field_get_field( $t_id, 'name' ) ) );
 		trigger_error( ERROR_CUSTOM_FIELD_INVALID_VALUE, ERROR );
 	}

--- a/api/json/index.php
+++ b/api/json/index.php
@@ -1,0 +1,114 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * This page stores the reported bug
+ *
+ * @package MantisBT
+ * @copyright Copyright (C) 2000 - 2002  Kenzaburo Ito - kenito@300baud.org
+ * @copyright Copyright (C) 2002 - 2010  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ *
+ * @uses core.php
+ * @uses access_api.php
+ * @uses authentication_api.php
+ * @uses bug_api.php
+ * @uses config_api.php
+ * @uses constant_inc.php
+ * @uses custom_field_api.php
+ * @uses date_api.php
+ * @uses email_api.php
+ * @uses error_api.php
+ * @uses event_api.php
+ * @uses file_api.php
+ * @uses form_api.php
+ * @uses gpc_api.php
+ * @uses helper_api.php
+ * @uses history_api.php
+ * @uses html_api.php
+ * @uses lang_api.php
+ * @uses last_visited_api.php
+ * @uses print_api.php
+ * @uses profile_api.php
+ * @uses relationship_api.php
+ * @uses string_api.php
+ * @uses user_api.php
+ * @uses utility_api.php
+ */
+
+require_once( '../../core.php' );
+require_api( 'access_api.php' );
+require_api( 'authentication_api.php' );
+require_api( 'bug_api.php' );
+require_api( 'config_api.php' );
+require_api( 'constant_inc.php' );
+require_api( 'custom_field_api.php' );
+require_api( 'date_api.php' );
+require_api( 'email_api.php' );
+require_api( 'error_api.php' );
+require_api( 'event_api.php' );
+require_api( 'file_api.php' );
+require_api( 'form_api.php' );
+require_api( 'gpc_api.php' );
+require_api( 'helper_api.php' );
+require_api( 'history_api.php' );
+require_api( 'lang_api.php' );
+require_api( 'last_visited_api.php' );
+require_api( 'print_api.php' );
+require_api( 'profile_api.php' );
+require_api( 'relationship_api.php' );
+require_api( 'string_api.php' );
+require_api( 'user_api.php' );
+require_api( 'utility_api.php' );
+
+require_once( 'json_core.php' );
+
+//no tokens from json
+//form_security_validate( 'bug_report' );
+global $g_json_message;
+
+$json_message = json_decode(file_get_contents("php://input"));
+$g_json_message = $json_message;
+if (!$json_message) {
+	json_access_denied();
+	json_exit();
+}
+
+//this call sets $g_cache_current_user_id
+$user_id = json_auth_get_current_user_id($json_message);
+if (!$user_id) {
+	json_access_denied();
+	json_exit();
+}
+
+$project_id = json_auth_get_current_project_id($json_message);
+if (!$project_id) {
+	json_access_denied();
+	json_exit();
+}
+
+$json_action = '';
+if (isset($json_message->action)) {
+	$json_action = $json_message->action;
+}
+
+
+set_error_handler( 'json_error_handler' );
+
+
+if ($json_action == 'bug_report') {
+	require_once('action_bug_report.php');
+}

--- a/api/json/json_core.php
+++ b/api/json/json_core.php
@@ -20,6 +20,11 @@ function json_auth_get_current_user_id($json_message) {
 	//list($user_id , $user_pw) = explode($user_token
 
 	$t_user_table = db_get_table( 'user' );
+	//support older versions
+	if (empty($t_user_table) ) {
+		$t_user_table = db_get_table('mantis_user_table');
+	}
+
 	/** @todo error with an error saying they aren't logged in? Or redirect to the login page maybe? */
 	$query = "SELECT id
 				  FROM $t_user_table
@@ -208,3 +213,7 @@ function json_error_handler( $p_type, $p_error, $p_file, $p_line, $p_context ) {
 	}
 }
 
+
+function json_exit() {
+exit();
+}

--- a/api/json/json_core.php
+++ b/api/json/json_core.php
@@ -1,0 +1,122 @@
+<?php
+
+function json_auth_get_current_project_id($json_message) {
+	global $g_cache_current_project;
+
+	$project_id = $json_message->project_id;
+	if (!$project_id) {
+		$project_id = helper_get_current_project();
+	}
+	if($project_id >0)
+		$g_cache_current_project = (int) $t_project_id;
+
+	return $project_id;
+}
+
+function json_auth_get_current_user_id($json_message) {
+	global $g_cache_current_user_id, $g_cache_cookie_valid;
+
+	$user_token = $json_message->user_token;
+	//list($user_id , $user_pw) = explode($user_token
+
+	$t_user_table = db_get_table( 'user' );
+	/** @todo error with an error saying they aren't logged in? Or redirect to the login page maybe? */
+	$query = "SELECT id
+				  FROM $t_user_table
+				  WHERE MD5( CONCAT(username, ':', password))=" . db_param();
+	$result = db_query_bound( $query, Array( $user_token ) );
+
+	$t_user_id = (int) db_result( $result );
+	if ($t_user_id > 0 ) {
+		$g_cache_current_user_id = $t_user_id;
+		$g_cache_cookie_valid = true;
+	}
+	return $t_user_id;
+}
+
+function json_access_denied() {
+	header('Content-type: application/json');
+	echo json_encode( array('result'=>'fail') );
+}
+
+
+function json_get_string($key) {
+	global $g_json_message;
+	return (isset($g_json_message->{$key}))? $g_json_message->{$key}: "";
+}
+function json_get_int($key) {
+	global $g_json_message;
+	return (isset($g_json_message->{$key}))? (int)$g_json_message->{$key}: 0;
+}
+function json_get_bool($key) {
+	global $g_json_message;
+	return (isset($g_json_message->{$key}))? true:false;
+}
+
+function json_get_file( $p_var_name, $p_default = null ) {
+	global $g_json_message, $g_json_file_tmp_name;
+
+
+	$file_bin      = '';
+	$file_name     = '';
+	$file_tmp_name = '';
+	$file_type     = '';
+
+	//file type
+	if( isset( $g_json_message->{$p_var_name.'_type'} ) ) {
+		$file_type = $g_json_message->{$p_var_name.'_type'};
+	}
+
+	//file name
+	if( isset( $g_json_message->{$p_var_name.'_name'} ) ) {
+		$file_name = $g_json_message->{$p_var_name.'_name'};
+	}
+	//binary
+	if( isset( $g_json_message->{$p_var_name.'_base64'} ) ) {
+		$file_bin = base64_decode($g_json_message->{$p_var_name.'_base64'});
+	}
+	if( isset( $g_json_message->{$p_var_name.'_raw'} ) ) {
+		$file_bin = base64_decode($g_json_message->{$p_var_name.'_raw'});
+	}
+
+
+	//file tmp name
+	$file_tmp_name  = tempnam('/tmp', 'mantis_');
+	$f = @fopen($file_tmp_name, 'wb');
+   	if (!$f) {
+		return NULL;
+	}
+	fwrite($f, $file_bin, strlen($file_bin));
+	fclose($f);
+	$g_json_file_tmp_name = $file_tmp_name;
+
+	$file_struct = array();
+	$file_struct['name'] = $file_name;
+	$file_struct['type'] = $file_type;
+	$file_struct['tmp_name'] = $file_tmp_name;
+	$file_struct['size'] = strlen($file_bin);
+	unset($file_bin);
+
+	return $file_struct;
+}
+
+function json_exit() {
+	global $g_json_file_tmp_name;
+
+	if ($g_json_file_tmp_name != '') {
+		@unlink($g_json_file_tmp_name);
+	}
+	exit();
+}
+
+function json_error_handler( $p_type, $p_error, $p_file, $p_line, $p_context ) {
+
+	if ($p_type == E_USER_ERROR) {
+		header('Content-type: application/json');
+		$t_error_description = error_string( $p_error );
+		echo json_encode( array('result'=>'error', 'message'=>$t_error_description) );
+
+		json_exit();
+	}
+}
+

--- a/api/json/json_core.php
+++ b/api/json/json_core.php
@@ -106,6 +106,7 @@ function json_get_file( $p_var_name, $p_default = null ) {
 }
 
 function json_isset( $p_var_name ) {
+	global $g_json_message;
 	return (isset($g_json_message->{$p_var_name})) ? true : false;
 }
 
@@ -149,7 +150,13 @@ function json_isset_custom_field( $p_var_name, $p_custom_field_type ) {
  * @param mixed $p_default
  * @return string
  */
-function json_get_custom_field( $p_var_name, $p_custom_field_type, $p_default = null ) {
+function json_get_custom_field( $p_var_id, $p_var_name, $p_custom_field_type, $p_default = null ) {
+	if (json_isset('custom_field_' . $p_var_name)) {
+		$t_field_name = 'custom_field_' . $p_var_name;
+	} else {
+		$t_field_name = 'custom_field_' . $p_var_id;
+	}
+
 	switch( $p_custom_field_type ) {
 		case CUSTOM_FIELD_TYPE_MULTILIST:
 		case CUSTOM_FIELD_TYPE_CHECKBOX:
@@ -157,7 +164,7 @@ function json_get_custom_field( $p_var_name, $p_custom_field_type, $p_default = 
 		    if ( ($p_default !== null) && !is_array($p_default) ) {
 		        $p_default = array( $p_default );
 		    }
-			$t_values = json_get( $p_var_name, $p_default );
+			$t_values = json_get( $t_field_name, $p_default );
 			if( is_array( $t_values ) ) {
 				return implode( '|', $t_values );
 			} else {
@@ -165,9 +172,9 @@ function json_get_custom_field( $p_var_name, $p_custom_field_type, $p_default = 
 			}
 			break;
 		case CUSTOM_FIELD_TYPE_DATE:
-			$t_day = json_get_int( $p_var_name . '_day', 0 );
-			$t_month = json_get_int( $p_var_name . '_month', 0 );
-			$t_year = json_get_int( $p_var_name . '_year', 0 );
+			$t_day = json_get_int( $t_field_name . '_day', 0 );
+			$t_month = json_get_int( $t_field_name . '_month', 0 );
+			$t_year = json_get_int( $t_field_name . '_year', 0 );
 			if(( $t_year == 0 ) || ( $t_month == 0 ) || ( $t_day == 0 ) ) {
 				if( $p_default == null ) {
 					return '';
@@ -179,7 +186,7 @@ function json_get_custom_field( $p_var_name, $p_custom_field_type, $p_default = 
 			}
 			break;
 		default:
-			return json_get_string( $p_var_name, $p_default );
+			return json_get_string( $t_field_name, $p_default );
 	}
 }
 


### PR DESCRIPTION
Added the ability to create a new bug by POSTing JSON data.  This is a much quicker solution than SOAP to add into an existing project that wants to log any runtime bugs, or store site feedback.  The security consists of a token made of an MD5 hash of any $username.":".$hashedpassword which is kept secret and transmitted with any REST/JSON request.  It has been in production for about 4 months now.
