### PR TITLE
Reorder migrations 184 and 185

### DIFF
--- a/admin/schema.php
+++ b/admin/schema.php
@@ -608,6 +608,6 @@ $upgrade[] = Array( 'CreateIndexSQL', Array( 'idx_tag_name', db_get_table( 'tag'
 $upgrade[] = Array( 'CreateIndexSQL', Array( 'idx_bug_tag_tag_id', db_get_table( 'bug_tag' ), 'tag_id' ) );
 $upgrade[] = Array( 'CreateIndexSQL', Array( 'idx_email_id', db_get_table( 'email' ), 'email_id', array( 'DROP' ) ), Array( 'db_index_exists', Array( db_get_table( 'email' ), 'idx_email_id') ) );
 $upgrade[] = Array( 'UpdateFunction', 'correct_multiselect_custom_fields_db_format' );
-$upgrade[] = Array( 'UpdateFunction', "stored_filter_migrate" );
 $upgrade[] = Array( 'AddColumnSQL', Array( db_get_table( 'custom_field_string' ), "
 	text		XL  			NULL DEFAULT NULL " ) );
+$upgrade[] = Array( 'UpdateFunction', "stored_filter_migrate" );


### PR DESCRIPTION
In order to ease the inclusion in the 1.2 branch of the 
memo custom field type, we need a predictable migration order. Currently
the master branch is ahead with two migrations of the 1.2 branch: 
- a stored_filter_migrate migration
- the migration which creates the table needed for the textarea custom
  field type

The 'stored_filter_migrate' migration is not a likely candidate for the
1.2 branch, but since it is applied first we can not 'skip' it for 
the 1.2 branch, as we would end up with different migrations for the
same schema level between 1.2 and master, as noted by Roland Becker [1](http://www.mantisbt.org/bugs/view.php?id=6626#c29308).

As suggested by Roland, this commit swaps the two migrations to allow
for the 1.2.x branch to safely receive the textarea custom field
migration. There is no real chance for 1.3 installs breaking, as the
only possible conflict will arise if an installation is at a commit
between c42ac12 and 839f1d6 , that is between Apr 23 2010 and Aug 25
2010. Even in this unlikely event, manual interventation can solve the
problem . Given that there is no release or pre-release of 1.3 , I
strongly believe that it is worth the gains of adding textarea fields
to 1.2.

Affects #6626: Support "Memo" custom field type
