### PR TITLE
Fix 0013409 : Plugin database error with config_table and the value field as an text

### DIFF
--- a/core/config_api.php
+++ b/core/config_api.php
@@ -331,6 +331,9 @@ function config_set( $p_option, $p_value, $p_user = NO_USER, $p_project = ALL_PR
 	} else if( is_int( $p_value ) || is_numeric( $p_value ) ) {
 		$t_type = CONFIG_TYPE_INT;
 		$c_value = (string) $p_value;
+	} else if( is_bool( $p_value ) ) {
+		$t_type = CONFIG_TYPE_INT;
+		$c_value = (string)(int)$p_value;				
 	} else {
 		$t_type = CONFIG_TYPE_STRING;
 		$c_value = $p_value;


### PR DESCRIPTION
as the config_table::value is type as text (for MS SQL) , the plugin_api crash on database errors.
the idea is to convert int & float into string to perform the query 
