### PR TITLE
Fix #0013538: API auth check on specific functions rework / not needed

### DIFF
--- a/core/access_api.php
+++ b/core/access_api.php
@@ -224,7 +224,7 @@ function access_get_global_level( $p_user_id = null ) {
 	# Deal with not logged in silently in this case
 	# @@@ we may be able to remove this and just error
 	#     and once we default to anon login, we can remove it for sure
-	if( !auth_is_user_authenticated() ) {
+	if( empty($p_user_id) && !auth_is_user_authenticated() ) {
 		return false;
 	}
 
@@ -278,14 +278,14 @@ function access_ensure_global_level( $p_access_level, $p_user_id = null ) {
  * @access public
  */
 function access_get_project_level( $p_project_id = null, $p_user_id = null ) {
-	# Deal with not logged in silently in this case
-	/** @todo we may be able to remove this and just error and once we default to anon login, we can remove it for sure */
-	if( !auth_is_user_authenticated() ) {
-		return ANYBODY;
-	}
-
 	if( null === $p_user_id ) {
 		$p_user_id = auth_get_current_user_id();
+	}
+
+	# Deal with not logged in silently in this case
+	/** @todo we may be able to remove this and just error and once we default to anon login, we can remove it for sure */
+	if( empty($p_user_id) && !auth_is_user_authenticated() ) {
+		return ANYBODY;
 	}
 
 	if( null === $p_project_id ) {
@@ -405,15 +405,15 @@ function access_has_any_project( $p_access_level, $p_user_id = null ) {
  * @access public
  */
 function access_has_bug_level( $p_access_level, $p_bug_id, $p_user_id = null ) {
+	if( $p_user_id === null ) {
+		$p_user_id = auth_get_current_user_id();
+	}
+
 	# Deal with not logged in silently in this case
 	# @@@ we may be able to remove this and just error
 	#     and once we default to anon login, we can remove it for sure
-	if( !auth_is_user_authenticated() ) {
+	if( empty($p_user_id) && !auth_is_user_authenticated() ) {
 		return false;
-	}
-
-	if( $p_user_id === null ) {
-		$p_user_id = auth_get_current_user_id();
 	}
 
 	$t_project_id = bug_get_field( $p_bug_id, 'project_id' );


### PR DESCRIPTION
Some functions (`access_get_global_level`, `access_get_project_level` and `access_has_bug_level`) on the Access API requires a authenticated user in order to return correct values, FALSE otherwise.
However, these functions can be used by plugins while not authenticated (for the record, I saw this problem when using Source - and a sequence of calls started from checkin.php).
So, I changed the code a bit to allow the execution proceeds and functions do their work if `$p_user_id` is provided (this parameter was there already).
