### PR TITLE
Fix #0009034: CSV Export with special chars dont work properly

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2954,6 +2954,14 @@ $g_default_manage_tag_prefix = 'ALL';
 $g_csv_separator = ',';
 
 /**
+ * CSV Export
+ * Add Byte Order Mark (BOM) at the begining of the file, some tools need it (Excel)
+ * @global string $g_csv_add_bom
+ */
+$g_csv_add_bom = OFF;
+
+
+/**
  * The threshold required for users to be able to manage configuration of a project.
  * This includes workflow, email notifications, columns to view, and others.
  */

--- a/csv_export.php
+++ b/csv_export.php
@@ -78,6 +78,11 @@ header( 'Content-Disposition: attachment; filename="' . urlencode( file_clean_na
 # Get columns to be exported
 $t_columns = csv_get_columns();
 
+# export BOM
+if ( config_get( 'csv_add_bom' ) == ON ) {
+	echo "\xEF\xBB\xBF";
+}
+
 # export the titles
 $t_first_column = true;
 ob_start();


### PR DESCRIPTION
Adding "Byte Order Mark" at the begining of the file resolves the issue.

$g_csv_add_bom parameter with default = OFF, because of remarks on pull request 27

(sorry for so many pull requests... I'm learning git...)
