### PR TITLE
Allow db_fetch_array on empty resultset

### DIFF
--- a/core/database_api.php
+++ b/core/database_api.php
@@ -450,7 +450,7 @@ function db_affected_rows() {
 function db_fetch_array( &$p_result ) {
 	global $g_db, $g_db_type;
 
-	if( $p_result->EOF ) {
+	if( is_null( $p_result ) || $p_result->EOF ) {
 		return false;
 	}
 


### PR DESCRIPTION
When you execute a query which returns no results, an error is thrown when using it as parameter to db_fetch_array(), because the method tries to access the EOF property of the object which in that case is null. By adding an extra check on the passed p_result to see whether it is null, you can safely use db_fetch_array for instance in while loops, without having to always manually check whether or not the result has rows. This makes code more readable and faster.

Or would it in some cases be desired that an error is thrown ?
