### PR TITLE
Fix_0014193:graph_unreadable_date_axis

### DIFF
--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -492,7 +492,8 @@ function graph_bydate( $p_metrics, $p_labels, $p_title, $p_graph_width = 300, $p
 
 		$graph->xAxis->labelCallback =  'graph_date_format';
 		$graph->xAxis->axisLabelRenderer = new ezcGraphAxisRotatedLabelRenderer();
-		$graph->xAxis->axisLabelRenderer->angle = -45;
+		$graph->xAxis->axisLabelRenderer->angle = -60;
+		$graph->xAxis->axisSpace = .15;
 
 		$graph->legend->position      = ezcGraph::BOTTOM;
 		$graph->legend->background    = '#FFFFFF80';
@@ -503,6 +504,7 @@ function graph_bydate( $p_metrics, $p_labels, $p_title, $p_graph_width = 300, $p
 		$graph->driver->options->imageFormat = IMG_JPEG;
 
 		$graph->title = $p_title . ' ' . lang_get( 'by_date' );
+		$graph->title->maxHeight = .03;
 		$graph->options->font = $t_graph_font ;
 
 		$graph->renderToOutput( $p_graph_width, $p_graph_height);


### PR DESCRIPTION
This correction is about use of "eczlibrary" (not JpGraph)

In "View Issues" > "Graph", the date axis is "2012-0.." and the title is really big.

I fixe axisSpace, modify axis angle, and define maxHeight for the title.

(see #0014193, I add a screen shot)
