### PR TITLE
Fix_012293:Small changes to include global categories in graph

### DIFF
--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -752,7 +752,7 @@ function create_category_summary() {
 
 	$query = "SELECT id, name
 				FROM $t_cat_table
-				WHERE $specific_where
+				WHERE $specific_where or project_id=" . ALL_PROJECTS . "
 				ORDER BY name";
 	$result = db_query_bound( $query );
 	$category_count = db_num_rows( $result );
@@ -769,7 +769,8 @@ function create_category_summary() {
 		if ( isset($t_metrics[$t_cat_name]) ) {
 			$t_metrics[$t_cat_name] = $t_metrics[$t_cat_name] + db_result( $result2, 0, 0 );
 		} else {
-			$t_metrics[$t_cat_name] = db_result( $result2, 0, 0 );
+      if (db_result( $result2, 0, 0 ) > 0)
+					$t_metrics[$t_cat_name] = db_result( $result2, 0, 0 );
 		}
 	}
 


### PR DESCRIPTION
see http://www.mantisbt.org/bugs/view.php?id=12293

there is 2 parts in the modification :
- including global categories in the SELECT order, even if they are not used by any project granted to the user
- hiding categories in the graph result when they are not used

I think that the 2nd part is important because it permits to hide categories that are not in the project.
