### PR TITLE
Use hash_hmac() rather than hash()

### DIFF
--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -485,17 +485,15 @@ function auth_generate_random_password( $p_email ) {
 /**
  * Generate a confirmation code to validate password reset requests.
  * @param int $p_user_id User ID to generate a confirmation code for
- * @return string Confirmation code (384bit) encoded according to the base64 with URI safe alphabet approach described in RFC4648
+ * @return string Confirmation code (512bit) encoded according to the base64 with URI safe alphabet approach described in RFC4648
  * @access public
  */
 function auth_generate_confirm_hash( $p_user_id ) {
 	$t_password = user_get_field( $p_user_id, 'password' );
 	$t_last_visit = user_get_field( $p_user_id, 'last_visit' );
 
-	$t_confirm_hash_raw = hash( 'whirlpool', 'confirm_hash' . config_get_global( 'crypto_master_salt' ) . $t_password . $t_last_visit, true );
-	# Note: We truncate the last 8 bits from the hash output so that base64
-	# encoding can be performed without any trailing padding.
-	$t_confirm_hash_base64_encoded = base64_encode( substr( $t_confirm_hash_raw, 0, 63 ) );
+	$t_confirm_hash_raw = hash_hmac( 'sha512', 'confirm_hash' . $t_password . $t_last_visit, config_get_global( 'crypto_master_salt' ), true );
+	$t_confirm_hash_base64_encoded = base64_encode( $t_confirm_hash_raw );
 	$t_confirm_hash = strtr( $t_confirm_hash_base64_encoded, '+/', '-_' );
 
 	return $t_confirm_hash;

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -493,7 +493,7 @@ function auth_generate_confirm_hash( $p_user_id ) {
 	$t_last_visit = user_get_field( $p_user_id, 'last_visit' );
 
 	$t_confirm_hash_raw = hash_hmac( 'sha512', 'confirm_hash' . $t_password . $t_last_visit, config_get_global( 'crypto_master_salt' ), true );
-	$t_confirm_hash_base64_encoded = base64_encode( substr( $t_confirm_hash_raw, 48 );
+	$t_confirm_hash_base64_encoded = base64_encode( substr( $t_confirm_hash_raw, 48 ) );
 	$t_confirm_hash = strtr( $t_confirm_hash_base64_encoded, '+/', '-_' );
 
 	return $t_confirm_hash;

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -485,7 +485,7 @@ function auth_generate_random_password( $p_email ) {
 /**
  * Generate a confirmation code to validate password reset requests.
  * @param int $p_user_id User ID to generate a confirmation code for
- * @return string Confirmation code (512bit) encoded according to the base64 with URI safe alphabet approach described in RFC4648
+ * @return string Confirmation code (128bit) encoded according to the base64 with URI safe alphabet approach described in RFC4648
  * @access public
  */
 function auth_generate_confirm_hash( $p_user_id ) {
@@ -493,7 +493,7 @@ function auth_generate_confirm_hash( $p_user_id ) {
 	$t_last_visit = user_get_field( $p_user_id, 'last_visit' );
 
 	$t_confirm_hash_raw = hash_hmac( 'sha512', 'confirm_hash' . $t_password . $t_last_visit, config_get_global( 'crypto_master_salt' ), true );
-	$t_confirm_hash_base64_encoded = base64_encode( $t_confirm_hash_raw );
+	$t_confirm_hash_base64_encoded = base64_encode( substr( $t_confirm_hash_raw, 48 );
 	$t_confirm_hash = strtr( $t_confirm_hash_base64_encoded, '+/', '-_' );
 
 	return $t_confirm_hash;

--- a/core/crypto_api.php
+++ b/core/crypto_api.php
@@ -124,7 +124,7 @@ function crypto_generate_random_string( $p_bytes, $p_require_strong_generator = 
 			}
 			$t_random_segment .= $i;
 			$t_random_segment .= $t_secret_key;
-			$t_random_bytes .= hash( 'whirlpool', $t_random_segment, true );
+			$t_random_bytes .= hash( 'sha512', $t_random_segment, true );
 		}
 		$t_random_string = substr( $t_random_bytes, 0, $p_bytes );
 		if ( $t_random_string === false ) {

--- a/core/rss_api.php
+++ b/core/rss_api.php
@@ -46,7 +46,7 @@ require_api( 'user_api.php' );
  * cookie and password. If the user changes their user name or password, this
  * RSS authentication key will become invalidated.
  * @param int $p_user_id User ID for the user which the key is being calculated for
- * @return string RSS authentication key (512bit) encoded according to the base64 with URI safe alphabet approach described in RFC4648
+ * @return string RSS authentication key (128bit) encoded according to the base64 with URI safe alphabet approach described in RFC4648
  */
 function rss_calculate_key( $p_user_id = null ) {
 	if( $p_user_id === null ) {
@@ -60,7 +60,7 @@ function rss_calculate_key( $p_user_id = null ) {
 	$t_cookie = user_get_field( $t_user_id, 'cookie_string' );
 
 	$t_key_raw = hash_hmac( 'sha512', 'rss_key' . $t_username . $t_password . $t_cookie, config_get_global( 'crypto_master_salt' ), true );
-	$t_key_base64_encoded = base64_encode( $t_key_raw ) );
+	$t_key_base64_encoded = base64_encode( substr( $t_key_raw, 48 ) );
 	$t_key = strtr( $t_key_base64_encoded, '+/', '-_' );
 
 	return $t_key;

--- a/core/rss_api.php
+++ b/core/rss_api.php
@@ -46,7 +46,7 @@ require_api( 'user_api.php' );
  * cookie and password. If the user changes their user name or password, this
  * RSS authentication key will become invalidated.
  * @param int $p_user_id User ID for the user which the key is being calculated for
- * @return string RSS authentication key (384bit) encoded according to the base64 with URI safe alphabet approach described in RFC4648
+ * @return string RSS authentication key (512bit) encoded according to the base64 with URI safe alphabet approach described in RFC4648
  */
 function rss_calculate_key( $p_user_id = null ) {
 	if( $p_user_id === null ) {
@@ -59,10 +59,8 @@ function rss_calculate_key( $p_user_id = null ) {
 	$t_password = user_get_field( $t_user_id, 'password' );
 	$t_cookie = user_get_field( $t_user_id, 'cookie_string' );
 
-	$t_key_raw = hash( 'whirlpool', 'rss_key' . config_get_global( 'crypto_master_salt' ) . $t_username . $t_password . $t_cookie, true );
-	# Note: We truncate the last 8 bits from the hash output so that base64
-	# encoding can be performed without any trailing padding.
-	$t_key_base64_encoded = base64_encode( substr( $t_key_raw, 0, 63 ) );
+	$t_key_raw = hash_hmac( 'sha512', 'rss_key' . $t_username . $t_password . $t_cookie, config_get_global( 'crypto_master_salt' ), true );
+	$t_key_base64_encoded = base64_encode( $t_key_raw ) );
 	$t_key = strtr( $t_key_base64_encoded, '+/', '-_' );
 
 	return $t_key;

--- a/core/session_api.php
+++ b/core/session_api.php
@@ -102,7 +102,7 @@ class MantisPHPSession extends MantisSession {
 		global $g_cookie_secure_flag_enabled;
 		global $g_cookie_httponly_flag_enabled;
 
-		$this->key = hash( 'whirlpool', 'session_key' . config_get_global( 'crypto_master_salt' ), false );
+		$this->key = hash_hmac( 'sha512', 'session_key', config_get_global( 'crypto_master_salt' ), false );
 
 		# Save session information where specified or with PHP's default
 		$t_session_save_path = config_get_global( 'session_save_path' );

--- a/make_captcha_img.php
+++ b/make_captcha_img.php
@@ -39,7 +39,7 @@ require_api( 'utility_api.php' );
 
 $f_public_key = gpc_get_string( 'public_key' );
 
-$t_private_key = substr( hash( 'whirlpool', 'captcha' . config_get_global( 'crypto_master_salt' ) . $f_public_key, false ), 0, 5 );
+$t_private_key = substr( hash_hmac( 'sha512', 'captcha' . $f_public_key, config_get_global( 'crypto_master_salt' ), false ), 0, 5 );
 $t_system_font_folder = get_font_path();
 $t_font_per_captcha = config_get( 'font_per_captcha' );
 

--- a/signup.php
+++ b/signup.php
@@ -77,7 +77,7 @@ if ( OFF == config_get_global( 'allow_signup' ) ) {
 if( ON == config_get( 'signup_use_captcha' ) && get_gd_version() > 0 	&&
 			helper_call_custom_function( 'auth_can_change_password', array() ) ) {
 	# captcha image requires GD library and related option to ON
-	$t_private_key = substr( hash( 'whirlpool', 'captcha' . config_get_global( 'crypto_master_salt' ) . $f_public_key, false ), 0, 5 );
+	$t_private_key = substr( hash_hmac( 'sha512', 'captcha' . $f_public_key, config_get_global( 'crypto_master_salt' ), false ), 0, 5 );
 
 	if ( $t_private_key != $f_captcha ) {
 		trigger_error( ERROR_SIGNUP_NOT_MATCHING_CAPTCHA, ERROR );


### PR DESCRIPTION
whirlpool is slow compared to sha512; it doesn't make any sense to use it there

substr() on binary is a bad idea
