### PR TITLE
Improve api: generate_random* functions shouldn't take a seed parameter

### DIFF
--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -477,7 +477,7 @@ function auth_does_password_match( $p_user_id, $p_test_password ) {
  * @return string 16 character random password
  * @access public
  */
-function auth_generate_random_password( $p_email ) {
+function auth_generate_random_password() {
 	# !TODO: create memorable passwords?
 	return crypto_generate_uri_safe_nonce( 16 );
 }

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -477,8 +477,7 @@ function user_create( $p_username, $p_password, $p_email = '',
 	user_ensure_realname_unique( $p_username, $p_realname );
 	email_ensure_valid( $p_email );
 
-	$t_seed = $p_email . $p_username;
-	$t_cookie_string = auth_generate_unique_cookie_string( $t_seed );
+	$t_cookie_string = auth_generate_unique_cookie_string();
 	$t_user_table = db_get_table( 'user' );
 
 	$query = "INSERT INTO $t_user_table
@@ -540,10 +539,8 @@ function user_signup( $p_username, $p_email = null ) {
 
 	$p_email = trim( $p_email );
 
-	$t_seed = $p_email . $p_username;
-
 	# Create random password
-	$t_password = auth_generate_random_password( $t_seed );
+	$t_password = auth_generate_random_password();
 
 	return user_create( $p_username, $t_password, $p_email );
 }
@@ -1362,8 +1359,7 @@ function user_set_password( $p_user_id, $p_password, $p_allow_protected = false 
 
 	# When the password is changed, invalidate the cookie to expire sessions that
 	# may be active on all browsers.
-	$t_seed = $t_email . $t_username;
-	$c_cookie_string = auth_generate_unique_cookie_string( $t_seed );
+	$c_cookie_string = auth_generate_unique_cookie_string();
 
 	$c_user_id = db_prepare_int( $p_user_id );
 	$c_password = auth_process_plain_password( $p_password );
@@ -1426,8 +1422,7 @@ function user_reset_password( $p_user_id, $p_send_email = true ) {
 	if(( ON == config_get( 'send_reset_password' ) ) && ( ON == config_get( 'enable_email_notification' ) ) ) {
 
 		# Create random password
-		$t_email = user_get_field( $p_user_id, 'email' );
-		$t_password = auth_generate_random_password( $t_email );
+		$t_password = auth_generate_random_password();
 		$t_password2 = auth_process_plain_password( $t_password );
 
 		user_set_field( $p_user_id, 'password', $t_password2 );

--- a/manage_user_create.php
+++ b/manage_user_create.php
@@ -94,8 +94,7 @@ email_ensure_not_disposable( $f_email );
 if ( ( ON == config_get( 'send_reset_password' ) ) && ( ON == config_get( 'enable_email_notification' ) ) ) {
 	# Check code will be sent to the user directly via email. Dummy password set to random
 	# Create random password
-	$t_seed = $f_email . $f_username;
-	$f_password	= auth_generate_random_password( $t_seed );
+	$f_password	= auth_generate_random_password();
 } else {
 	# Password won't to be sent by email. It entered by the admin
 	# Now, if the password is empty, confirm that that is what we wanted


### PR DESCRIPTION
generate_random*() functions shouldn't take a seed parameter; random is random!
