### PR TITLE
Fix_0014461 : customize characters to escape in CSV files(new feature)

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2718,6 +2718,15 @@
 	$g_csv_add_bom = OFF;
 
 	/**
+	 * CSV Export
+	 * Customize the characters that force a string to be escape before writing it to csv file,
+	 * in addition of csv_separator, new_line and "
+	 * example : $g_csv_escape_characters = ';,\'\t'
+	 * @global string $g_csv_add_bom
+	 */
+	$g_csv_escape_characters = '';
+
+	/**
 	 * threshold for users to view the system configurations
 	 * @global int $g_view_configuration_threshold
 	 */

--- a/core/csv_api.php
+++ b/core/csv_api.php
@@ -48,6 +48,18 @@ function csv_get_separator() {
 }
 
 /**
+ * get the characters that force a string to be escape before writing it to csv file
+ * @return string
+ * @access public
+ */
+function csv_get_escape_characters() {
+	static $s_escape_characters = null;
+	if ( $s_escape_characters === null )
+		$s_escape_characters = config_get( 'csv_escape_characters' );
+	return $s_escape_characters;
+}
+
+/**
  * if all projects selected, default to <username>.csv, otherwise default to
  * <projectname>.csv.
  * @return string filename
@@ -72,7 +84,7 @@ function csv_get_default_filename() {
  * @access public
  */
 function csv_escape_string( $p_str ) {
-		$t_escaped = str_split( '"' . csv_get_separator() . csv_get_newline() );
+		$t_escaped = str_split( '"' . csv_get_separator() . csv_get_newline() . csv_get_escape_characters() );
 		$t_must_escape = false;
 		while( ( $t_char = current( $t_escaped ) ) !== false && !$t_must_escape ) {
 			$t_must_escape = strpos( $p_str, $t_char ) !== false;


### PR DESCRIPTION
by default, nothing change : $g_csv_escape_characters = '';

but if that constant is modified every string written in a CSV file and
containing such characters will be escaped.

With the provided sample :
  1,l'interface,today,values 4;8;6;9,text with tabulation\t
will be written :
  1,"l'interface",today,"values 4;8;6;9","text with tabulation\t"
