### PR TITLE
Update core/tag_api.php

### DIFF
--- a/core/tag_api.php
+++ b/core/tag_api.php
@@ -462,13 +462,16 @@ function tag_get_candidates_for_bug( $p_bug_id ) {
 	$t_params = array();
 	if ( 0 != $p_bug_id ) {
 		$t_bug_tag_table = db_get_table( 'mantis_bug_tag_table' );
+		
+		$t_params[] = $p_bug_id;
 
-		if ( db_is_mssql() ) {
-			$t_params[] = $p_bug_id;
+		if ( config_get_global( 'db_type' ) == 'odbc_mssql' ) {
 			$query = "SELECT t.id FROM $t_tag_table t
 					LEFT JOIN $t_bug_tag_table b ON t.id=b.tag_id
 					WHERE b.bug_id IS NULL OR b.bug_id != " . db_param();
 			$result = db_query_bound( $query, $t_params );
+
+			$t_params = null;
 
 			$t_subquery_results = array();
 
@@ -488,7 +491,6 @@ function tag_get_candidates_for_bug( $p_bug_id ) {
 					WHERE b.bug_id IS NULL OR b.bug_id != " . db_param() .
 				')';
 		}
-		$t_params[] = $p_bug_id;
 	} else {
 		$query = 'SELECT id, name, description FROM ' . $t_tag_table;
 	}


### PR DESCRIPTION
Changed the condition check on like 466:
    from: if ( db_is_mssql() ) {
    to  : if ( config_get_global( 'db_type' ) == 'odbc_mssql' ) {

Added: $t_params[] = null; to line 473
Also, moved: $t_params[] = $p_bug_id; from both line 493 and 467 to line 492 

Reason for condition change? This branch of code was put into place to handle a deficiency in the odbc_mssql driver that doesn't allow for bound subqueries. This is not needed for the other mssql drivers, yet using db_is_mssql() returns true for all mssql drivers indiscriminately yet is not needed in the other drivers.

Reason for $t_params[] changes? $t_params only needs to be set once. It is needed for the query in the mssql condition block for the first query only to grab the list of tags that aren't specific to this bug. Afterwards in the second query, $t_params needs to be null or it results in the database returning an error due to no '?' replacements. Therefore, after running the first query, we need to set this to null. If the condition fails and the dbtype is not mssql (or 'odbc_mssql') then $t_params is already set.

The multiple query setup in the "true" condition is a really bad way to do this. I'm not going to mess with it, however, since the tag count probably won't get too high in any general scenario.
