### PR TITLE
Update manage_columns_inc.php

### DIFF
--- a/manage_columns_inc.php
+++ b/manage_columns_inc.php
@@ -64,7 +64,7 @@
 ?>
 
 <div align="center">
-<form name="report_bug_form" method="post" <?php if ( file_allow_bug_upload() ) { echo 'enctype="multipart/form-data"'; } ?> action="manage_config_columns_set.php">
+<form name="manage_columns_form" method="post" action="manage_config_columns_set.php">
 <?php echo form_security_field( 'manage_config_columns_set' ) ?>
 <table class="width50" cellspacing="1">
 


### PR DESCRIPTION
Removed the unnecessary 'enctype="multipart/form-data"' that was preventing columns update by always generating a "connection reset" at the client level.
Take advantage of that change to aptly rename the form.
