### PR TITLE
fix #15333 - Recaptcha at signup

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -280,6 +280,13 @@
 	 * @global int $g_signup_use_captcha
 	 */
 	$g_signup_use_captcha	= ON;
+	
+	/**
+	 * Type of captcha : GD_CAPTCHA or RECAPTCHA
+	 * WARNING : To use RECAPTCHA, mantis server needs access to internet
+	 * @global int $g_signup_captcha_type
+	 */
+	$g_signup_captcha_type	= GD_CAPTCHA;
 
 	/**
 	 * absolute path (with trailing slash!) to folder which contains your TrueType-Font files
@@ -294,6 +301,19 @@
 	 * @global string $g_font_per_captcha
 	 */
 	$g_font_per_captcha	= 'arial.ttf';
+	
+	/**
+	 * ReCaptcha default Public Key
+	 * @global string $g_recaptcha_publickey
+	 */
+	$g_recaptcha_publickey = '6Lf4ztoSAAAAANAKxXRfcFO68S7I-8Oe0vjN8dhT';
+	
+	/**
+	 * ReCaptcha default Private Key
+	 * @global string $g_recaptcha_privatekey
+	 */
+	$g_recaptcha_privatekey = '6Lf4ztoSAAAAAJynlCF8trpFxG0Hg73rzC-eyie_';
+
 
 	/**
 	 * Setting to disable the 'lost your password' feature.

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -538,3 +538,7 @@ define( 'DB_FIELD_SIZE_PASSWORD', 32);
 define( 'PASSWORD_MAX_SIZE_BEFORE_HASH', 1024 );
 
 define( 'SECONDS_PER_DAY', 86400 );
+
+# Captcha type
+define( 'GD_CAPTCHA', 1);
+define( 'RECAPTCHA', 2);

--- a/core/http_api.php
+++ b/core/http_api.php
@@ -142,7 +142,7 @@ function http_security_headers() {
 				$t_avatar_img_allow = "; img-src 'self' http://www.gravatar.com:80";
 			}
 		}
-		header( "X-Content-Security-Policy: allow 'self'; options inline-script eval-script$t_avatar_img_allow; frame-ancestors 'none'" );
+				header( "X-Content-Security-Policy: allow 'self' www.google.com; options inline-script eval-script$t_avatar_img_allow; frame-ancestors 'none'" );
 	}
 }
 

--- a/library/README.libs
+++ b/library/README.libs
@@ -12,6 +12,7 @@ phpmailer       | PHPMailer       | 5.2.1    | unpatched
 projax          | projax          |          | unpatched
 rssbuilder      | RSSBuilder      | 2.2.1    | patched: removed __autoload function
 utf8            | phputf8         | 0.5      | unpatched
+recaptcha       | recaptcha       | 1.11     | unpatched
 
 Upstream projects
 ==================
@@ -23,3 +24,4 @@ phpmailer  -  http://code.google.com/a/apache-extras.org/p/phpmailer/
 projax     -  http://script.aculo.us/downloads / http://www.ngcoders.com/projax/
 rssbuilder -  http://code.google.com/p/flaimo-php/
 utf8       -  http://sourceforge.net/projects/phputf8
+recaptcha  -  http://code.google.com/p/recaptcha/

--- a/library/recaptcha/LICENSE
+++ b/library/recaptcha/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2007 reCAPTCHA -- http://recaptcha.net
+AUTHORS:
+  Mike Crawford
+  Ben Maurer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/library/recaptcha/README
+++ b/library/recaptcha/README
@@ -1,0 +1,7 @@
+reCAPTCHA README
+================
+
+The reCAPTCHA PHP Lirary helps you use the reCAPTCHA API. Documentation
+for this library can be found at
+
+	http://recaptcha.net/plugins/php

--- a/library/recaptcha/recaptchalib.php
+++ b/library/recaptcha/recaptchalib.php
@@ -1,0 +1,277 @@
+<?php
+/*
+ * This is a PHP library that handles calling reCAPTCHA.
+ *    - Documentation and latest version
+ *          http://recaptcha.net/plugins/php/
+ *    - Get a reCAPTCHA API Key
+ *          https://www.google.com/recaptcha/admin/create
+ *    - Discussion group
+ *          http://groups.google.com/group/recaptcha
+ *
+ * Copyright (c) 2007 reCAPTCHA -- http://recaptcha.net
+ * AUTHORS:
+ *   Mike Crawford
+ *   Ben Maurer
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * The reCAPTCHA server URL's
+ */
+define("RECAPTCHA_API_SERVER", "http://www.google.com/recaptcha/api");
+define("RECAPTCHA_API_SECURE_SERVER", "https://www.google.com/recaptcha/api");
+define("RECAPTCHA_VERIFY_SERVER", "www.google.com");
+
+/**
+ * Encodes the given data into a query string format
+ * @param $data - array of string elements to be encoded
+ * @return string - encoded request
+ */
+function _recaptcha_qsencode ($data) {
+        $req = "";
+        foreach ( $data as $key => $value )
+                $req .= $key . '=' . urlencode( stripslashes($value) ) . '&';
+
+        // Cut the last '&'
+        $req=substr($req,0,strlen($req)-1);
+        return $req;
+}
+
+
+
+/**
+ * Submits an HTTP POST to a reCAPTCHA server
+ * @param string $host
+ * @param string $path
+ * @param array $data
+ * @param int port
+ * @return array response
+ */
+function _recaptcha_http_post($host, $path, $data, $port = 80) {
+
+        $req = _recaptcha_qsencode ($data);
+
+        $http_request  = "POST $path HTTP/1.0\r\n";
+        $http_request .= "Host: $host\r\n";
+        $http_request .= "Content-Type: application/x-www-form-urlencoded;\r\n";
+        $http_request .= "Content-Length: " . strlen($req) . "\r\n";
+        $http_request .= "User-Agent: reCAPTCHA/PHP\r\n";
+        $http_request .= "\r\n";
+        $http_request .= $req;
+
+        $response = '';
+        if( false == ( $fs = @fsockopen($host, $port, $errno, $errstr, 10) ) ) {
+                die ('Could not open socket');
+        }
+
+        fwrite($fs, $http_request);
+
+        while ( !feof($fs) )
+                $response .= fgets($fs, 1160); // One TCP-IP packet
+        fclose($fs);
+        $response = explode("\r\n\r\n", $response, 2);
+
+        return $response;
+}
+
+
+
+/**
+ * Gets the challenge HTML (javascript and non-javascript version).
+ * This is called from the browser, and the resulting reCAPTCHA HTML widget
+ * is embedded within the HTML form it was called from.
+ * @param string $pubkey A public key for reCAPTCHA
+ * @param string $error The error given by reCAPTCHA (optional, default is null)
+ * @param boolean $use_ssl Should the request be made over ssl? (optional, default is false)
+
+ * @return string - The HTML to be embedded in the user's form.
+ */
+function recaptcha_get_html ($pubkey, $error = null, $use_ssl = false)
+{
+	if ($pubkey == null || $pubkey == '') {
+		die ("To use reCAPTCHA you must get an API key from <a href='https://www.google.com/recaptcha/admin/create'>https://www.google.com/recaptcha/admin/create</a>");
+	}
+	
+	if ($use_ssl) {
+                $server = RECAPTCHA_API_SECURE_SERVER;
+        } else {
+                $server = RECAPTCHA_API_SERVER;
+        }
+
+        $errorpart = "";
+        if ($error) {
+           $errorpart = "&amp;error=" . $error;
+        }
+        return '<script type="text/javascript" src="'. $server . '/challenge?k=' . $pubkey . $errorpart . '"></script>
+
+	<noscript>
+  		<iframe src="'. $server . '/noscript?k=' . $pubkey . $errorpart . '" height="300" width="500" frameborder="0"></iframe><br/>
+  		<textarea name="recaptcha_challenge_field" rows="3" cols="40"></textarea>
+  		<input type="hidden" name="recaptcha_response_field" value="manual_challenge"/>
+	</noscript>';
+}
+
+
+
+
+/**
+ * A ReCaptchaResponse is returned from recaptcha_check_answer()
+ */
+class ReCaptchaResponse {
+        var $is_valid;
+        var $error;
+}
+
+
+/**
+  * Calls an HTTP POST function to verify if the user's guess was correct
+  * @param string $privkey
+  * @param string $remoteip
+  * @param string $challenge
+  * @param string $response
+  * @param array $extra_params an array of extra variables to post to the server
+  * @return ReCaptchaResponse
+  */
+function recaptcha_check_answer ($privkey, $remoteip, $challenge, $response, $extra_params = array())
+{
+	if ($privkey == null || $privkey == '') {
+		die ("To use reCAPTCHA you must get an API key from <a href='https://www.google.com/recaptcha/admin/create'>https://www.google.com/recaptcha/admin/create</a>");
+	}
+
+	if ($remoteip == null || $remoteip == '') {
+		die ("For security reasons, you must pass the remote ip to reCAPTCHA");
+	}
+
+	
+	
+        //discard spam submissions
+        if ($challenge == null || strlen($challenge) == 0 || $response == null || strlen($response) == 0) {
+                $recaptcha_response = new ReCaptchaResponse();
+                $recaptcha_response->is_valid = false;
+                $recaptcha_response->error = 'incorrect-captcha-sol';
+                return $recaptcha_response;
+        }
+
+        $response = _recaptcha_http_post (RECAPTCHA_VERIFY_SERVER, "/recaptcha/api/verify",
+                                          array (
+                                                 'privatekey' => $privkey,
+                                                 'remoteip' => $remoteip,
+                                                 'challenge' => $challenge,
+                                                 'response' => $response
+                                                 ) + $extra_params
+                                          );
+
+        $answers = explode ("\n", $response [1]);
+        $recaptcha_response = new ReCaptchaResponse();
+
+        if (trim ($answers [0]) == 'true') {
+                $recaptcha_response->is_valid = true;
+        }
+        else {
+                $recaptcha_response->is_valid = false;
+                $recaptcha_response->error = $answers [1];
+        }
+        return $recaptcha_response;
+
+}
+
+/**
+ * gets a URL where the user can sign up for reCAPTCHA. If your application
+ * has a configuration page where you enter a key, you should provide a link
+ * using this function.
+ * @param string $domain The domain where the page is hosted
+ * @param string $appname The name of your application
+ */
+function recaptcha_get_signup_url ($domain = null, $appname = null) {
+	return "https://www.google.com/recaptcha/admin/create?" .  _recaptcha_qsencode (array ('domains' => $domain, 'app' => $appname));
+}
+
+function _recaptcha_aes_pad($val) {
+	$block_size = 16;
+	$numpad = $block_size - (strlen ($val) % $block_size);
+	return str_pad($val, strlen ($val) + $numpad, chr($numpad));
+}
+
+/* Mailhide related code */
+
+function _recaptcha_aes_encrypt($val,$ky) {
+	if (! function_exists ("mcrypt_encrypt")) {
+		die ("To use reCAPTCHA Mailhide, you need to have the mcrypt php module installed.");
+	}
+	$mode=MCRYPT_MODE_CBC;   
+	$enc=MCRYPT_RIJNDAEL_128;
+	$val=_recaptcha_aes_pad($val);
+	return mcrypt_encrypt($enc, $ky, $val, $mode, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+}
+
+
+function _recaptcha_mailhide_urlbase64 ($x) {
+	return strtr(base64_encode ($x), '+/', '-_');
+}
+
+/* gets the reCAPTCHA Mailhide url for a given email, public key and private key */
+function recaptcha_mailhide_url($pubkey, $privkey, $email) {
+	if ($pubkey == '' || $pubkey == null || $privkey == "" || $privkey == null) {
+		die ("To use reCAPTCHA Mailhide, you have to sign up for a public and private key, " .
+		     "you can do so at <a href='http://www.google.com/recaptcha/mailhide/apikey'>http://www.google.com/recaptcha/mailhide/apikey</a>");
+	}
+	
+
+	$ky = pack('H*', $privkey);
+	$cryptmail = _recaptcha_aes_encrypt ($email, $ky);
+	
+	return "http://www.google.com/recaptcha/mailhide/d?k=" . $pubkey . "&c=" . _recaptcha_mailhide_urlbase64 ($cryptmail);
+}
+
+/**
+ * gets the parts of the email to expose to the user.
+ * eg, given johndoe@example,com return ["john", "example.com"].
+ * the email is then displayed as john...@example.com
+ */
+function _recaptcha_mailhide_email_parts ($email) {
+	$arr = preg_split("/@/", $email );
+
+	if (strlen ($arr[0]) <= 4) {
+		$arr[0] = substr ($arr[0], 0, 1);
+	} else if (strlen ($arr[0]) <= 6) {
+		$arr[0] = substr ($arr[0], 0, 3);
+	} else {
+		$arr[0] = substr ($arr[0], 0, 4);
+	}
+	return $arr;
+}
+
+/**
+ * Gets html to display an email address given a public an private key.
+ * to get a key, go to:
+ *
+ * http://www.google.com/recaptcha/mailhide/apikey
+ */
+function recaptcha_mailhide_html($pubkey, $privkey, $email) {
+	$emailparts = _recaptcha_mailhide_email_parts ($email);
+	$url = recaptcha_mailhide_url ($pubkey, $privkey, $email);
+	
+	return htmlentities($emailparts[0]) . "<a href='" . htmlentities ($url) .
+		"' onclick=\"window.open('" . htmlentities ($url) . "', '', 'toolbar=0,scrollbars=0,location=0,statusbar=0,menubar=0,resizable=0,width=500,height=300'); return false;\" title=\"Reveal this e-mail address\">...</a>@" . htmlentities ($emailparts [1]);
+
+}
+
+
+?>

--- a/signup.php
+++ b/signup.php
@@ -32,6 +32,8 @@
 	$f_username		= strip_tags( gpc_get_string( 'username' ) );
 	$f_email		= strip_tags( gpc_get_string( 'email' ) );
 	$f_captcha		= gpc_get_string( 'captcha', '' );
+	$f_recaptcha_response   = gpc_get_string( 'recaptcha_response_field', '');
+	$f_recaptcha_challenge  = gpc_get_string( 'recaptcha_challenge_field', '');
 	$f_public_key	= gpc_get_int( 'public_key', '' );
 
 	$f_username = trim( $f_username );
@@ -49,14 +51,29 @@
 		exit;
 	}
 
-	if( ON == config_get( 'signup_use_captcha' ) && get_gd_version() > 0 	&&
-				helper_call_custom_function( 'auth_can_change_password', array() ) ) {
-		# captcha image requires GD library and related option to ON
-		$t_key = utf8_strtolower( utf8_substr( md5( config_get( 'password_confirm_hash_magic_string' ) . $f_public_key ), 1, 5) );
-
-		if ( $t_key != $f_captcha ) {
-			trigger_error( ERROR_SIGNUP_NOT_MATCHING_CAPTCHA, ERROR );
+	if( ON == config_get( 'signup_use_captcha' ) ) {
+		
+		if( GD_CAPTCHA == config_get( 'signup_captcha_type' )&& get_gd_version() > 0
+			&& helper_call_custom_function( 'auth_can_change_password', array() ) ) {
+			# captcha image requires GD library and related option to ON
+			$t_key = utf8_strtolower( utf8_substr( md5( config_get( 'password_confirm_hash_magic_string' ) . $f_public_key ), 1, 5) );
+	
+			if ( $t_key != $f_captcha ) {
+				trigger_error( ERROR_SIGNUP_NOT_MATCHING_CAPTCHA, ERROR );
+			}
 		}
+		
+		if( RECAPTCHA == config_get( 'signup_captcha_type' ) ) {
+			require_once('library/recaptcha/recaptchalib.php');
+		  	$t_recaptcha = recaptcha_check_answer (config_get('recaptcha_privatekey'), $_SERVER["REMOTE_ADDR"],$f_recaptcha_challenge,$f_recaptcha_response);
+		
+			if (!$t_recaptcha->is_valid) {
+				# What happens when the CAPTCHA was entered incorrectly
+				trigger_error( ERROR_SIGNUP_NOT_MATCHING_CAPTCHA, ERROR );
+				# more infos in $t_recaptcha->error
+			}
+		}
+	
 	}
 
 	email_ensure_not_disposable( $f_email );

--- a/signup_page.php
+++ b/signup_page.php
@@ -67,23 +67,50 @@
 </tr>
 <?php
 	$t_allow_passwd = helper_call_custom_function( 'auth_can_change_password', array() );
-	if( ON == config_get( 'signup_use_captcha' ) && get_gd_version() > 0 && ( true == $t_allow_passwd ) ) {
-		# captcha image requires GD library and related option to ON
-?>
-<tr class="row-1">
-	<td class="category">
-		<?php echo lang_get( 'signup_captcha_request' ) ?>:
-	</td>
-	<td>
-		<?php print_captcha_input( 'captcha', '' ) ?>
-	</td>
-	<td>
-		<img src="make_captcha_img.php?public_key=<?php echo $t_key ?>" alt="visual captcha" />
-		<input type="hidden" name="public_key" value="<?php echo $t_key ?>" />
-	</td>
-</tr>
-<?php
+	if( ON == config_get( 'signup_use_captcha' ) && ( true == $t_allow_passwd ) ){
+		
+		# gd captcha image requires GD library and related option to ON
+		if( GD_CAPTCHA == config_get( 'signup_captcha_type' ) && get_gd_version() > 0 ) {
+			
+				?>
+				<tr class="row-1">
+					<td class="category">
+						<?php echo lang_get( 'signup_captcha_request' ) ?>:
+					</td>
+					<td>
+						<?php print_captcha_input( 'captcha', '' ) ?>
+					</td>
+					<td>
+					<?php 
+					# We check open_basedir & cie to have readable error here, else errors and warning will be in the img
+					if(is_readable(get_font_path())){
+					?>
+						<img src="make_captcha_img.php?public_key=<?php echo $t_key ?>" alt="visual captcha" />
+						<input type="hidden" name="public_key" value="<?php echo $t_key ?>" />
+					<?php } ?>
+					</td>
+				</tr>				
+				<?php
+		}		
+		
+		if( RECAPTCHA == config_get( 'signup_captcha_type' ) ) {
+			?>	
+			<tr class="row-1">
+				<td class="category">
+					<?php echo lang_get( 'signup_captcha_request' ) ?>:
+				</td>
+				<td colspan="2">
+				<?php 
+				require_once('library/recaptcha/recaptchalib.php');
+				echo recaptcha_get_html( config_get('recaptcha_publickey') )
+				?>
+				</td>
+			</tr>
+			<?php 
+		}
 	}
+
+	
 	if( false == $t_allow_passwd ) {
 ?>
 <tr class="row-1">


### PR DESCRIPTION
add option to use recaptcha instead of generated captcha (GD)
server needs connection to internet to have recaptcha validation working
recaptcha use for the moment my public and private global keys (you can and must use your keys)
by default GD captcha is used

i have also added an improvement for having error shown  with open base dir restriction when using GD captcha
