### PR TITLE
add sorting of due_date ASC to display not set always last

### DIFF
--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -951,7 +951,13 @@ function filter_get_query_sort_data( &$p_filter, $p_show_sticky, $p_query_clause
 						}
 					}
 				}
-
+			# if sorting in due_date always displayed definded first
+			} else if ( 'due_date' == $c_sort ){
+				if ( 'ASC' == $c_dir ){
+					$p_query_clauses['order'][] = "($t_bug_table.$c_sort = 1), $t_bug_table.$c_sort $c_dir";
+				} else {
+					$p_query_clauses['order'][] = "$t_bug_table.$c_sort $c_dir";
+				}
 			# standard column
 			} else {
 				if ( 'last_updated' == $c_sort ) {


### PR DESCRIPTION
If you have enable due_date and you want to sort than to see the bugs with the first due_date you get the bugs without due_date instead. Now i fix this Bug to see alway due_date undefined as last
