### PR TITLE
Fixes #16416: Improve first login experience by auto-redirecting to crea...

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -974,7 +974,7 @@ if( 7 == $t_install_state ) {
 <p><a href="../login_page.php">Continue</a> to log into Mantis</p>
 <?php
 	} else {?>
-<p>Please log in as the administrator and <a href="../manage_proj_create_page.php">create</a> your first project.
+<p>Please log in as the administrator and <a href="../login_page.php">create</a> your first project.
 
 <?php
 	}

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -56,6 +56,24 @@ $g_cache_project_missing = array();
 $g_cache_project_all = false;
 
 # --------------------
+# Checks if there exists at least one project.
+function project_any() {
+	global $g_cache_project;
+
+	# If projects already cached, use the cache.
+	if ( isset( $g_cache_project ) && count( $g_cache_project ) > 0 ) {
+		return true;
+	}
+
+	# Otherwise, check if the projects table contains at least one project.
+	$t_project_table = db_get_table( 'mantis_project_table' );
+	$query = "SELECT * FROM $t_project_table";
+	$result = db_query_bound( $query, array(), /* limit */ 1 );
+
+	return db_num_rows( $result ) > 0;
+}
+
+# --------------------
 # Cache a project row if necessary and return the cached copy
 #  If the second parameter is true (default), trigger an error
 #  if the project can't be found.  If the second parameter is

--- a/login_cookie_test.php
+++ b/login_cookie_test.php
@@ -27,11 +27,18 @@
 	  */
 	require_once( 'core.php' );
 
-	$f_return = gpc_get_string( 'return', config_get( 'default_home_page' ) );
-
-	$c_return = string_prepare_header( $f_return );
-
 	if ( auth_is_user_authenticated() ) {
+		$f_return = gpc_get_string( 'return' );
+		$c_return = string_prepare_header( $f_return );
+
+		# If this is the first login for an instance, then redirect to create project page.
+		# Use lack of projects as a hint for such scenario.
+		if ( is_blank( $f_return ) || $f_return == 'index.php' ) {
+			if ( current_user_is_administrator() && !project_any() ) {
+				$c_return = 'manage_proj_create_page.php';
+			}
+		}
+
 		$t_redirect_url = $c_return;
 	} else {
 		$t_redirect_url = 'login_page.php?cookie_error=1';


### PR DESCRIPTION
At the moment the installer redirects to create project page. However, if MantisBT is pre-installed, the user lands in My View Page without knowing what to do. We should handle the "first login" experience in MantisBT itself rather than the installation and provide a helpful getting started over time. For now, we should start with auto-redirecting to create project page if user is administrator and there aren't at least 1 project in the database.
