### PR TITLE
Add bolded styling to the project list dropdown

### DIFF
--- a/core/print_api.php
+++ b/core/print_api.php
@@ -586,7 +586,7 @@ function print_project_option_list( $p_project_id = null, $p_include_all_project
 			$t_can_report = access_has_project_level( $t_report_bug_threshold, $t_id, $t_user_id );
 		}
 
-		echo '<option value="' . $t_id . '"';
+		echo '<option style="font-weight:bold;" value="' . $t_id . '"';
 		check_selected( (int)$p_project_id, $t_id );
 		check_disabled( $t_id == $p_filter_project_id || !$t_can_report );
 		echo '>' . string_attribute( project_get_field( $t_id, 'name' ) ) . '</option>' . "\n";


### PR DESCRIPTION
Bolds the top level project names in the project list dropdown at the top right
of the screen. This makes top level project categories much easier to
distinguish from lower level projects.
