### PR TITLE
MantisBT / MantisTouch redirect improvements

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -3968,8 +3968,7 @@
 	 * - 'http://MyOwnMantisTouch.com/'
 	 * - ''
 	 */
-	$g_mantistouch_url = '';
-
+	$g_mantistouch_url = file_exists( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . "m" ) ? $g_path . 'm/' : '';
 
 	# Temporary variables should not remain defined in global scope
 	unset( $t_protocol, $t_host, $t_hosts, $t_port, $t_self, $t_path, $t_use_iis );

--- a/core.php
+++ b/core.php
@@ -113,6 +113,19 @@ require_once( 'mobile_api.php' );
 if ( strlen( $GLOBALS['g_mantistouch_url'] ) > 0 && mobile_is_mobile_browser() ) {
 	$t_url = sprintf( $GLOBALS['g_mantistouch_url'], $GLOBALS['g_path'] );
 
+	$t_issue_id = '';
+	if ( strstr( $_SERVER['SCRIPT_NAME'], 'view.php' ) !== false ) {
+		$t_issue_id = (int)$_GET['id'];
+	}
+
+	if ( !empty( $t_issue_id ) )  {
+		if ( strstr( $t_url, 'url=' ) !== false ) {
+			$t_url .= '&issue_id=' . $t_issue_id;
+		} else {
+			$t_url .= '?issue_id=' . $t_issue_id;
+		}
+	}
+
 	if ( OFF == $g_use_iis ) {
 		header( 'Status: 302' );
 	}

--- a/core/mobile_api.php
+++ b/core/mobile_api.php
@@ -29,6 +29,11 @@
  * @return boolean<p>True if Mobile Browser, False on PC Browser</p>
  */
 function mobile_is_mobile_browser() {
+	// If api call rather than browser then return false.
+	if ( strstr( $_SERVER['SCRIPT_NAME'], '/api/' ) !== false ) {
+		return false;
+	}
+
 	$_SERVER['ALL_HTTP'] = isset( $_SERVER['ALL_HTTP'] ) ? $_SERVER['ALL_HTTP'] : '';
 
 	$t_mobile_browser = false;


### PR DESCRIPTION
In an attempt to get MantisBT / MantisTouch redirection to work better on mantishub.com several issues were fixed.

Fixes #16768: Default mantistouch_url correctly when MantisTouch is installed in 'm' subfolder.
Fixes #16769: MantisTouch redirect can break soap api based on user agent sent.
Fixes #16770: Redirect from MantisBT issue to MantisTouch should go to the same issue page on MantisTouch.
