### PR TITLE
Revise footer to be less verbose and more like 1.2.x

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -658,32 +658,30 @@ function html_footer( $p_file = null ) {
 		echo "\t</div>\n";
 	}
 
-	# Show optional user-specificed custom copyright statement
+	# Show MantisBT version and copyright statement
+	$t_version_suffix = '';
+	$t_copyright_years = ' 2000 - ' . date('Y');
+	if ( config_get( 'show_version' ) == ON ) {
+		$t_version_suffix = ' ' . htmlentities( MANTIS_VERSION . config_get_global( 'version_suffix' ) );
+	}
+
+	echo '<address id="mantisbt-copyright">' . "\n";
+	echo '<address id="version">Powered by <a href="http://www.mantisbt.org" title="bug tracking software">MantisBT ' . $t_version_suffix . "</a></address>\n";
+	echo "Copyright &copy;$t_copyright_years MantisBT Team";
+
+	# Show optional user-specified custom copyright statement
 	$t_copyright_statement = config_get( 'copyright_statement' );
 	if ( $t_copyright_statement ) {
 		echo "\t<address id=\"user-copyright\">$t_copyright_statement</address>\n";
 	}
 
-	# Show MantisBT version and copyright statement
-	$t_version_suffix = '';
-	$t_copyright_years = '';
-	if ( config_get( 'show_version' ) ) {
-		$t_version_suffix = htmlentities( ' ' . MANTIS_VERSION . config_get_global( 'version_suffix' ) );
-		$t_copyright_years = ' 2000 - ' . date('Y');
-	}
-	echo "\t",
-		'<address id="mantisbt-copyright">Powered by ',
-		'<a href="http://www.mantisbt.org/" title="Mantis Bug Tracker: a free and open source web based bug tracking system.">',
-		"Mantis Bug Tracker</a> (MantisBT)$t_version_suffix. ",
-		"Copyright &copy;$t_copyright_years MantisBT contributors. ",
-		'Licensed under the terms of the ',
-		'<a href="http://www.gnu.org/licenses/old-licenses/gpl-2.0.html" title="GNU General Public License (GPL) version 2">',
-		'GNU General Public License (GPL) version 2</a> or a later version.',
-		"</address>\n";
+	echo "</address>\n";
 
 	# Show contact information
-	$t_webmaster_contact_information = sprintf( lang_get( 'webmaster_contact_information' ), string_html_specialchars( config_get( 'webmaster_email' ) ) );
-	echo "\t<address id=\"webmaster-contact-information\">$t_webmaster_contact_information</address>\n";
+	if ( !is_page_name( 'login_page' ) ) {
+		$t_webmaster_contact_information = sprintf( lang_get( 'webmaster_contact_information' ), string_html_specialchars( config_get( 'webmaster_email' ) ) );
+		echo "\t<address id=\"webmaster-contact-information\">$t_webmaster_contact_information</address>\n";
+	}
 
 	event_signal( 'EVENT_LAYOUT_PAGE_FOOTER' );
 

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -620,7 +620,7 @@ $s_hide_content = 'Hide Content';
 $s_show_content = 'Show Content';
 
 # html_api.php
-$s_webmaster_contact_information = 'If you encounter problems accessing this bug tracker please <a href="mailto:%1$s" title="Contact the webmaster via e-mail.">contact us via e-mail</a> for assistance.';
+$s_webmaster_contact_information = 'Contact <a href="mailto:%1$s" title="Contact the webmaster via e-mail.">administrator</a> for assistance';
 $s_total_queries_executed = 'Total queries executed: %1$d';
 $s_unique_queries_executed = 'Unique queries executed: %1$d';
 $s_total_query_execution_time = 'Total query execution time: %1$s seconds';


### PR DESCRIPTION
- Don't show administrator email on login page -- it is useful for users hitting login issues but can disclose the address outside the organization - can move to always ON based on feedback.
- Show copyright years independent of show_version given that they currently are from 0 to today's year, so no disclosure of versioning anyway.
- User copyright message shows up after MantisBT copyright and before contact administrator message.
- Use much brief message for contacting administrator.  Remove usage of the word "us".

Here is a screenshot with show version ON and user logged in:
![screen shot 2014-01-12 at 9 55 00 pm](https://f.cloud.github.com/assets/6446/1898295/9f35be94-7c17-11e3-9f44-83762d1ac335.png)
