### PR TITLE
Remove "show_avatar_threshold" config option

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -1034,15 +1034,8 @@ $g_sort_by_last_name = OFF;
  *   "http:/path/to/unknown.jpg" or "%path%images/no_avatar.png")
  *
  * @global int|string $g_show_avatar
- * @see $g_show_avatar_threshold
  */
 $g_show_avatar = OFF;
-
-/**
- * Only users above this threshold will have their avatar shown
- * @global int $g_show_avatar_threshold
- */
-$g_show_avatar_threshold = DEVELOPER;
 
 /**
  * Show release dates on changelog

--- a/core/obsolete.php
+++ b/core/obsolete.php
@@ -167,3 +167,4 @@ config_obsolete( 'dhtml_filters', 'use_dynamic_filters' );
 config_obsolete( 'use_iis' );
 config_obsolete( 'page_title', 'top_include_page' );
 config_obsolete( 'limit_email_domain', 'limit_email_domains' );
+config_obsolete( 'show_avatar_threshold' );

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -176,22 +176,6 @@ function print_successful_redirect( $p_redirect_to ) {
 	}
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 /**
  * Print avatar image for the given user ID
  *
@@ -207,14 +191,12 @@ function print_avatar( $p_user_id, $p_size = 80 ) {
 		return;
 	}
 
-	if( access_has_project_level( config_get( 'show_avatar_threshold' ), null, $p_user_id ) ) {
-		$t_avatar = user_get_avatar( $p_user_id, $p_size );
-		if( false !== $t_avatar ) {
-			$t_avatar_url = htmlspecialchars( $t_avatar[0] );
-			$t_width = $t_avatar[1];
-			$t_height = $t_avatar[2];
-			echo '<a rel="nofollow" href="http://site.gravatar.com"><img class="avatar" src="' . $t_avatar_url . '" alt="User avatar" width="' . $t_width . '" height="' . $t_height . '" /></a>';
-		}
+	$t_avatar = user_get_avatar( $p_user_id, $p_size );
+	if( false !== $t_avatar ) {
+		$t_avatar_url = htmlspecialchars( $t_avatar[0] );
+		$t_width = $t_avatar[1];
+		$t_height = $t_avatar[2];
+		echo '<a rel="nofollow" href="http://site.gravatar.com"><img class="avatar" src="' . $t_avatar_url . '" alt="User avatar" width="' . $t_width . '" height="' . $t_height . '" /></a>';
 	}
 }
 

--- a/docbook/Admin_Guide/en-US/Configuration.xml
+++ b/docbook/Admin_Guide/en-US/Configuration.xml
@@ -1047,12 +1047,6 @@ $g_language_choices_arr = array( 'english', 'french', 'german' );
 					</para>
                 </listitem>
             </varlistentry>
-            <varlistentry>
-                <term>$g_show_avatar_threshold</term>
-                <listitem>
-                    <para>The threshold of users for which MantisBT should attempt to show the avatar (default DEVELOPER).  Note that the threshold is related to the user for whom the avatar is being shown, rather than the user who is currently logged in.</para>
-                </listitem>
-            </varlistentry>
         </variablelist>
     </section>
 


### PR DESCRIPTION
I would like avatars to be always ON.  There is also suggestions to support avatar providers.  However, independent of these, there is no reason to hide avatars from users below a certain access level.
