### PR TITLE
Fixes #16848: Remove main page from main menu when news feature is OFF

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -745,7 +745,9 @@ function print_menu() {
 		$t_menu_options = array();
 
 		# Main Page
-		$t_menu_options[] = '<a href="' . helper_mantis_url( 'main_page.php' ) . '">' . lang_get( 'main_link' ) . '</a>';
+		if ( config_get( 'news_enabled' ) == ON ) {
+			$t_menu_options[] = '<a href="' . helper_mantis_url( 'main_page.php' ) . '">' . lang_get( 'main_link' ) . '</a>';
+		}
 
 		# Plugin / Event added options
 		$t_event_menu_options = event_signal( 'EVENT_MENU_MAIN_FRONT' );


### PR DESCRIPTION
The main page was really designed to include the news which has been deprecated for a while.  Hence, the main page is useless for most users.  This change hides it unless the news feature is ON.

This is until the news feature is completely removed.
