### PR TITLE
Fix layout for bug note avatar and move it to the left side

### DIFF
--- a/bugnote_view_inc.php
+++ b/bugnote_view_inc.php
@@ -158,8 +158,9 @@ $num_notes = count( $t_bugnotes );
 <tr class="bugnote <?php echo $t_bugnote_css ?>" id="c<?php echo $t_bugnote->id ?>">
         <td class="bugnote-meta">
 		<?php print_avatar( $t_bugnote->reporter_id ); ?>
-		<span class="small bugnote-permalink"><a rel="bookmark" href="<?php echo string_get_bugnote_view_url($t_bugnote->bug_id, $t_bugnote->id) ?>" title="<?php echo lang_get( 'bugnote_link_title' ) ?>"><?php echo htmlentities( config_get_global( 'bugnote_link_tag' ) ) . $t_bugnote_id_formatted ?></a></span><br />
+		<p class="compact"><span class="small bugnote-permalink"><a rel="bookmark" href="<?php echo string_get_bugnote_view_url($t_bugnote->bug_id, $t_bugnote->id) ?>" title="<?php echo lang_get( 'bugnote_link_title' ) ?>"><?php echo htmlentities( config_get_global( 'bugnote_link_tag' ) ) . $t_bugnote_id_formatted ?></a></span></p>
 
+		<p class="compact">
 		<span class="bugnote-reporter">
 		<?php
 			print_user( $t_bugnote->reporter_id );
@@ -178,19 +179,19 @@ $num_notes = count( $t_bugnotes );
 		<?php if ( VS_PRIVATE == $t_bugnote->view_state ) { ?>
 		<span class="small bugnote-view-state">[ <?php echo lang_get( 'private' ) ?> ]</span>
 		<?php } ?>
-		<br />
-		<span class="small bugnote-date-submitted"><?php echo date( $t_normal_date_format, $t_bugnote->date_submitted ); ?></span><br />
+		</p>
+		<p class="compact"><span class="small bugnote-date-submitted"><?php echo date( $t_normal_date_format, $t_bugnote->date_submitted ); ?></span></p>
 		<?php
 		if ( $t_bugnote_modified ) {
-			echo '<span class="small bugnote-last-modified">' . lang_get( 'last_edited') . lang_get( 'word_separator' ) . date( $t_normal_date_format, $t_bugnote->last_modified ) . '</span><br />';
+			echo '<p class="compact"><span class="small bugnote-last-modified">' . lang_get( 'last_edited') . lang_get( 'word_separator' ) . date( $t_normal_date_format, $t_bugnote->last_modified ) . '</span></p>';
 			$t_revision_count = bug_revision_count( $f_bug_id, REV_BUGNOTE, $t_bugnote->id );
 			if ( $t_revision_count >= 1) {
 				$t_view_num_revisions_text = sprintf( lang_get( 'view_num_revisions' ), $t_revision_count );
-				echo '<span class="small bugnote-revisions-link"><a href="bug_revision_view_page.php?bugnote_id=' . $t_bugnote->id . '">' . $t_view_num_revisions_text . '</a></span><br />';
+				echo '<p class="compact"><span class="small bugnote-revisions-link"><a href="bug_revision_view_page.php?bugnote_id=' . $t_bugnote->id . '">' . $t_view_num_revisions_text . '</a></span></p>';
 			}
 		}
 		?>
-		<br /><div class="small bugnote-buttons">
+		<div class="small bugnote-buttons">
 		<?php
 			# bug must be open to be editable
 			if ( !bug_is_readonly( $f_bug_id ) ) {

--- a/css/default.css
+++ b/css/default.css
@@ -7,6 +7,7 @@ body {
 }
 
 p				{ font-family: Verdana, Arial, Helvetica, sans-serif; }
+p.compact		{ margin: 0;}
 
 pre				{ margin-top: 0px; margin-bottom: 0px; }
 
@@ -328,7 +329,8 @@ div.quick-summary-right	{ width: 49%; padding: 2px; text-align: right; float: ri
 
 .avatar
 {
-	float: right;
+	float: left;
+	margin-right: 3px;
 	border: 0;
 	border-radius: 5px;
 }


### PR DESCRIPTION
The text next to the avatar in the bug notes was being pushed under the avatar.  This change fixes that and moves the avatar to the left of the text which is more standard with other conventions.  As we add avatars elsewhere in MantisBT, they will also be on the left side.

Before the change:
![screen shot 2014-01-18 at 6 30 15 pm](https://f.cloud.github.com/assets/6446/1948789/b3a16538-80b1-11e3-87a5-5844d6d341c5.png)

After the change:
![screen shot 2014-01-18 at 6 29 49 pm](https://f.cloud.github.com/assets/6446/1948790/bf9ea8aa-80b1-11e3-8d12-0db4b857f21f.png)
