### PR TITLE
Fixes #16853: Provide a way to disable relationships feature.

### DIFF
--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -155,7 +155,7 @@
 	$tpl_show_additional_information = !is_blank( $tpl_bug->additional_information ) && in_array( 'additional_info', $t_fields );
 	$tpl_show_steps_to_reproduce = !is_blank( $tpl_bug->steps_to_reproduce ) && in_array( 'steps_to_reproduce', $t_fields );
 	$tpl_show_monitor_box = !$tpl_force_readonly;
-	$tpl_show_relationships_box = !$tpl_force_readonly;
+	$tpl_show_relationships_box = !$tpl_force_readonly && config_get( 'relationship_enable' ) == ON;
 	$tpl_show_upload_form = !$tpl_force_readonly && !bug_is_readonly( $f_bug_id );
 	$tpl_show_history = $f_history;
 	$tpl_show_profiles = config_get( 'enable_profiles' );

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -3420,6 +3420,16 @@
 	 *********************/
 
 	/**
+	 * Enable relationships feature.
+	 */
+	$g_relationship_enable = ON;
+
+	/**
+	 * Specifies the threshold for user to add/delete relationships.
+	 */
+	$g_relationship_edit_threshold = UPDATER;
+
+	/**
 	 * Enable relationship graphs support.
 	 * Show issue relationships using graphs.
 	 *

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2817,7 +2817,9 @@ function filter_draw_selection_area2( $p_page_number, $p_for_screen = true, $p_e
 				<a href="<?php echo $t_filters_url . FILTER_PROPERTY_FILTER_BY_DATE;?>" id="do_filter_by_date_filter"><?php echo lang_get( 'use_date_filters' )?>:</a>
 			</td>
 			<td class="small-caption" valign="top" colspan="2">
+				<?php if ( ON == config_get( 'relationship_enable' ) ) { ?>
 				<a href="<?php echo $t_filters_url . FILTER_PROPERTY_RELATIONSHIP_TYPE;?>" id="relationship_type_filter"><?php echo lang_get( 'bug_relationships' )?>:</a>
+				<?php } ?>
 			</td>
 			<?php if( $t_filter_cols > 8 ) {
 			echo '<td class="small-caption" valign="top" colspan="' . ( $t_filter_cols - 8 ) . '">&#160;</td>';
@@ -2929,7 +2931,7 @@ function filter_draw_selection_area2( $p_page_number, $p_for_screen = true, $p_e
 			</td>
 
 			<td class="small-caption" valign="top" colspan="2" id="relationship_type_filter_target">
-							<?php
+				<?php if ( ON == config_get( 'relationship_enable' ) ) {
 								echo '<input type="hidden" name="', FILTER_PROPERTY_RELATIONSHIP_TYPE, '" value="', string_attribute( $t_filter[FILTER_PROPERTY_RELATIONSHIP_TYPE]), '" />';
 		echo '<input type="hidden" name="', FILTER_PROPERTY_RELATIONSHIP_BUG, '" value="', string_attribute( $t_filter[FILTER_PROPERTY_RELATIONSHIP_BUG] ), '" />';
 		$c_rel_type = $t_filter[FILTER_PROPERTY_RELATIONSHIP_TYPE];
@@ -2940,7 +2942,7 @@ function filter_draw_selection_area2( $p_page_number, $p_for_screen = true, $p_e
 			echo relationship_get_description_for_history( $c_rel_type ) . ' ' . $c_rel_bug;
 		}
 
-		?>
+		} ?>
 			</td>
 			<?php if( $t_filter_cols > 8 ) {
 			echo '<td class="small-caption" valign="top" colspan="' . ( $t_filter_cols - 8 ) . '">&#160;</td>';

--- a/core/relationship_api.php
+++ b/core/relationship_api.php
@@ -825,9 +825,7 @@ function relationship_view_box( $p_bug_id ) {
 <?php
 	# bug not read-only and user authenticated
 	if( !bug_is_readonly( $p_bug_id ) ) {
-
-		# user access level at least updater
-		if( access_has_bug_level( config_get( 'update_bug_threshold' ), $p_bug_id ) ) {
+		if ( access_has_bug_level( config_get( 'relationship_edit_threshold' ), $p_bug_id ) ) {
 			?>
 <tr class="row-1">
 	<td class="category"><?php echo lang_get( 'add_new_relationship' )?></td>

--- a/docbook/administration_guide/en/configuration.sgml
+++ b/docbook/administration_guide/en/configuration.sgml
@@ -3023,9 +3023,27 @@
     </section>
 
     <section id="admin.config.relationship">
-        <title>Relationship Graphs</title>
+        <title>Relationships</title>
 
         <variablelist>
+            <varlistentry>
+                <term>$g_relationship_enable</term>
+                <listitem>
+                    <para>
+                        This enables or disables the relationship feature.  Possible values are ON or OFF.
+                        Default is ON.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
+                <term>$g_relationship_edit_threshold</term>
+                <listitem>
+                    <para>
+                        The access level threshold for users to add or delete relationships.
+                        Default is UPDATER.
+                    </para>
+                </listitem>
+            </varlistentry>
             <varlistentry>
                 <term>$g_relationship_graph_enable</term>
                 <listitem>


### PR DESCRIPTION
Add configuration to enable/disable relationship feature as well as define the threshold for users to update relationships independent on the generic update threshold.

I started off with ON/OFF, then thought about implementing a threshold to control that, but that would complicate the filtering story for all projects, etc. Hence, I opted for ON/OFF and either adding a new threshold for edit or I'm OK with just going back to the generic update threshold.
