### PR TITLE
Do not reauthenticate user when verifying signup

### DIFF
--- a/account_page.php
+++ b/account_page.php
@@ -73,10 +73,14 @@ require_api( 'string_api.php' );
 require_api( 'user_api.php' );
 require_api( 'utility_api.php' );
 
+$t_account_verification = defined( 'ACCOUNT_VERIFICATION_INC' );
+
 #============ Permissions ============
 auth_ensure_user_authenticated();
 
-auth_reauthenticate();
+if( !$t_account_verification  ) {
+	auth_reauthenticate();
+}
 
 current_user_ensure_unprotected();
 
@@ -153,12 +157,18 @@ if ( $t_verify || $t_reset_password ) {
 				<span class="display-label"><span><?php echo lang_get( 'username' ) ?></span></span>
 				<span class="input"><span class="field-value"><?php echo string_display_line( $u_username ) ?></span></span>
 				<span class="label-style"></span>
-			</div>
+			</div><?php
+			# When verifying account, set a token and don't display current password
+			if( $t_account_verification ) {
+				token_set( TOKEN_ACCOUNT_VERIFY, true, TOKEN_EXPIRY_AUTHENTICATED, $u_id );
+			} else {
+			?>
 			<div class="field-container">
 				<label for="password" <?php if ( $t_force_pw_reset ) { ?> class="required" <?php } ?>><span><?php echo lang_get( 'current_password' ) ?></span></label>
 				<span class="input"><input id="password-current" type="password" name="password_current" size="32" maxlength="<?php echo auth_get_password_max_size(); ?>" /></span>
 				<span class="label-style"></span>
-			</div>
+			</div><?php
+			} ?>
 			<div class="field-container">
 				<label for="password" <?php if ( $t_force_pw_reset ) { ?> class="required" <?php } ?>><span><?php echo lang_get( 'password' ) ?></span></label>
 				<span class="input"><input id="password" type="password" name="password" size="32" maxlength="<?php echo auth_get_password_max_size(); ?>" /></span>
@@ -227,7 +237,7 @@ if ( $t_verify || $t_reset_password ) {
 					$t_access_level = get_enum_element( 'access_levels', $t_access_level );
 					$t_view_state = get_enum_element( 'project_view_state', $t_view_state );
 
-					echo '<li><span class="project-name">' . $t_project_name . '</span> <span class="access-level">' . $t_access_level . '</span> <span class="view-state">' . $t_view_state . '</span></li>'; 
+					echo '<li><span class="project-name">' . $t_project_name . '</span> <span class="access-level">' . $t_access_level . '</span> <span class="view-state">' . $t_view_state . '</span></li>';
 				}
 				echo '</ul>';
 				echo '</div>';

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -471,6 +471,7 @@ define( 'TOKEN_GRAPH', 2 );
 define( 'TOKEN_LAST_VISITED', 3 );
 define( 'TOKEN_AUTHENTICATED', 4 );
 define( 'TOKEN_COLLAPSE', 5 );
+define( 'TOKEN_ACCOUNT_VERIFY', 6 );
 define( 'TOKEN_USER', 1000 );
 
 # token expirations

--- a/verify.php
+++ b/verify.php
@@ -78,5 +78,6 @@ auth_attempt_script_login( user_get_field( $f_user_id, 'username' ) );
 
 user_increment_login_count( $f_user_id );
 
-include ( dirname( __FILE__ ) . '/account_page.php' );
 
+define( 'ACCOUNT_VERIFICATION_INC', true );
+include ( dirname( __FILE__ ) . '/account_page.php' );


### PR DESCRIPTION
Issue #14486 introduced a regression, preventing users from verifying
their account creation as Mantis was requesting their current password,
which they can't possibly know.

Fixes #16621
