### PR TITLE
Dropping deprecated database API function db_query()

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1328,7 +1328,7 @@ function bug_delete( $p_bug_id ) {
 	bug_clear_cache( $p_bug_id );
 	bug_text_clear_cache( $p_bug_id );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -328,7 +328,7 @@ function bugnote_delete_all( $p_bug_id ) {
 		WHERE bug_id=" . db_param();
 	$result = db_query_bound( $query, array( (int)$p_bug_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -527,7 +527,7 @@ function bugnote_set_time_tracking( $p_bugnote_id, $p_time_tracking ) {
 	$query = "UPDATE $t_bugnote_table SET time_tracking = " . db_param() . " WHERE id=" . db_param();
 	db_query_bound( $query, array( $c_bugnote_time_tracking, $p_bugnote_id ) );
 
-	# db_query errors if there was a problem so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -542,7 +542,7 @@ function bugnote_date_update( $p_bugnote_id ) {
 	$t_query = "UPDATE $t_bugnote_table SET last_modified=" . db_param() . " WHERE id=" . db_param();
 	db_query_bound( $t_query, array( db_now(), $p_bugnote_id ) );
 
-	# db_query errors if there was a problem so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 

--- a/core/category_api.php
+++ b/core/category_api.php
@@ -138,7 +138,7 @@ function category_exists( $p_category_id ) {
 				  VALUES ( " . db_param() . ', ' . db_param() . ' )';
 	db_query_bound( $t_query, array( $p_project_id, $p_name ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return db_insert_id( $t_category_table );
 }
 
@@ -174,7 +174,7 @@ function category_exists( $p_category_id ) {
 		}
 	}
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -211,7 +211,7 @@ function category_exists( $p_category_id ) {
 				  WHERE category_id=" . db_param();
 	db_query_bound( $t_query, array( $p_new_category_id, $p_category_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 

--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -460,7 +460,7 @@ function custom_field_update( $p_field_id, $p_def_array ) {
 
 		custom_field_clear_cache( $p_field_id );
 
-		# db_query errors on failure so:
+		# db_query_bound() errors on failure so:
 		return true;
 	}
 
@@ -488,7 +488,7 @@ function custom_field_link( $p_field_id, $p_project_id ) {
 				  VALUES ( " . db_param() . ', ' . db_param() . ')';
 	db_query_bound( $t_query, array( $p_field_id, $p_project_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -511,7 +511,7 @@ function custom_field_unlink( $p_field_id, $p_project_id ) {
 				  		project_id = " . db_param();
 	db_query_bound( $t_query, array( $p_field_id, $p_project_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -540,7 +540,7 @@ function custom_field_destroy( $p_field_id ) {
 
 	custom_field_clear_cache( $p_field_id );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -559,7 +559,7 @@ function custom_field_unlink_all( $p_project_id ) {
 	$t_query = "DELETE FROM $t_custom_field_project_table WHERE project_id=" . db_param();
 	db_query_bound( $t_query, array( $p_project_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -577,7 +577,7 @@ function custom_field_delete_all_values( $p_bug_id ) {
 	$t_query = "DELETE FROM $t_custom_field_string_table WHERE bug_id=" . db_param();
 	db_query_bound( $t_query, array( $p_bug_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -1239,7 +1239,7 @@ function custom_field_set_value( $p_field_id, $p_bug_id, $p_value, $p_log_insert
 
 	custom_field_clear_cache( $p_field_id );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -278,51 +278,6 @@ function db_check_identifier_size( $p_identifier ) {
  * @global array of previous executed queries for profiling
  * @global adodb database connection object
  * @global boolean indicating whether queries array is populated
- * @param string $p_query Query string to execute
- * @param int $p_limit Number of results to return
- * @param int $p_offset offset query results for paging
- * @return ADORecordSet|bool adodb result set or false if the query failed.
- * @deprecated db_query_bound should be used in preference to this function. This function will likely be removed in 1.2.0 final
- */
-function db_query( $p_query, $p_limit = -1, $p_offset = -1 ) {
-	global $g_queries_array, $g_db, $g_db_log_queries;
-
-	$t_start = microtime(true);
-
-	if( db_is_oracle() ) {
-		$p_query = db_oracle_adapt_query_syntax( $p_query );
-	}
-
-	if(( $p_limit != -1 ) || ( $p_offset != -1 ) ) {
-		$t_result = $g_db->SelectLimit( $p_query, $p_limit, $p_offset );
-	} else {
-		$t_result = $g_db->Execute( $p_query );
-	}
-
-	$t_elapsed = number_format( microtime(true) - $t_start, 4 );
-
-	if( ON == $g_db_log_queries ) {
-		log_event( LOG_DATABASE, array( $p_query, $t_elapsed) );
-		array_push( $g_queries_array, array( $p_query, $t_elapsed ) );
-	} else {
-		array_push( $g_queries_array, array( '', $t_elapsed ) );
-	}
-
-	if( !$t_result ) {
-		db_error( $p_query );
-		trigger_error( ERROR_DB_QUERY_FAILED, ERROR );
-		return false;
-	} else {
-		return $t_result;
-	}
-}
-
-/**
- * execute query, requires connection to be opened
- * An error will be triggered if there is a problem executing the query.
- * @global array of previous executed queries for profiling
- * @global adodb database connection object
- * @global boolean indicating whether queries array is populated
  * @param string $p_query Parameterlised Query string to execute
  * @param array $arr_parms array of parameters matching $p_query
  * @param int $p_limit Number of results to return
@@ -765,7 +720,7 @@ function db_prepare_string( $p_string ) {
 /**
  * Prepare a binary string before DB insertion
  * Use of this function is required for some DB types, to properly encode
- * BLOB fields prior to calling db_query_bound() or db_query()
+ * BLOB fields prior to calling db_query_bound()
  * @param string $p_string raw binary data
  * @return string prepared database query string
  */

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -397,7 +397,7 @@ function file_delete_attachments( $p_bug_id ) {
 				  WHERE bug_id=" . db_param();
 	db_query_bound( $query, array( $p_bug_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -4696,7 +4696,7 @@ function filter_db_delete_filter( $p_filter_id ) {
 	$query = 'DELETE FROM ' . $t_filters_table . ' WHERE id=' . db_param();
 	$result = db_query_bound( $query, array( $c_filter_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 

--- a/core/news_api.php
+++ b/core/news_api.php
@@ -101,7 +101,7 @@ function news_delete( $p_news_id ) {
 	$t_query = "DELETE FROM $t_news_table WHERE id=" . db_param();
 	db_query_bound( $t_query, array( $p_news_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -116,7 +116,7 @@ function news_delete_all( $p_project_id ) {
 	$t_query = "DELETE FROM $t_news_table WHERE project_id=" . db_param();
 	db_query_bound( $t_query, array( (int)$p_project_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -156,7 +156,7 @@ function news_update( $p_news_id, $p_project_id, $p_view_state, $p_announcement,
 
 	db_query_bound( $t_query, array( $p_view_state, $p_announcement, $p_headline, $p_body, $p_project_id, db_now(), $p_news_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 

--- a/core/profile_api.php
+++ b/core/profile_api.php
@@ -110,7 +110,7 @@ function profile_delete( $p_user_id, $p_profile_id ) {
 				  WHERE id=" . db_param() . " AND user_id=" . db_param();
 	db_query_bound( $query, array( $p_profile_id, $p_user_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -416,7 +416,7 @@ function project_delete( $p_project_id ) {
 
 	project_clear_cache( $p_project_id );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -467,7 +467,7 @@ function project_update( $p_project_id, $p_name, $p_description, $p_status, $p_v
 
 	project_clear_cache( $p_project_id );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -788,7 +788,7 @@ function project_add_user( $p_project_id, $p_user_id, $p_access_level ) {
 
 	db_query_bound( $query, array( $c_project_id, $c_user_id, $c_access_level ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -808,7 +808,7 @@ function project_update_user_access( $p_project_id, $p_user_id, $p_access_level 
 
 	db_query_bound( $query, array( $c_access_level, $c_project_id, $c_user_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -841,7 +841,7 @@ function project_remove_user( $p_project_id, $p_user_id ) {
 
 	db_query_bound( $query, array( $c_project_id, $c_user_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -866,7 +866,7 @@ function project_remove_all_users( $p_project_id, $p_access_level_limit = null )
 		db_query_bound( $t_query, array( $p_project_id ) );
 	}
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1395,7 +1395,7 @@ function user_increment_login_count( $p_user_id ) {
 
 	user_clear_cache( $p_user_id );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -1526,7 +1526,7 @@ function user_set_field( $p_user_id, $p_field_name, $p_field_value ) {
 
 	user_set_fields($p_user_id, array ( $p_field_name => $p_field_value ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -1569,7 +1569,7 @@ function user_set_password( $p_user_id, $p_password, $p_allow_protected = false 
 				  WHERE id=" . db_param();
 	db_query_bound( $query, array( $c_password, $c_cookie_string, $c_user_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 

--- a/core/user_pref_api.php
+++ b/core/user_pref_api.php
@@ -448,7 +448,7 @@ function user_pref_insert( $p_user_id, $p_project_id, $p_prefs ) {
 			 ' VALUES ( ' . $t_params_string . ')';
 	db_query_bound( $query, $t_values  );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -506,7 +506,7 @@ function user_pref_delete( $p_user_id, $p_project_id = ALL_PROJECTS ) {
 
 	user_pref_clear_cache( $p_user_id, $p_project_id );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -529,7 +529,7 @@ function user_pref_delete_all( $p_user_id ) {
 
 	user_pref_clear_cache( $p_user_id );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 
@@ -548,7 +548,7 @@ function user_pref_delete_project( $p_project_id ) {
 	$query = 'DELETE FROM ' . $t_user_pref_table . ' WHERE project_id=' . db_param();
 	db_query_bound( $query, array( $p_project_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 

--- a/core/version_api.php
+++ b/core/version_api.php
@@ -238,7 +238,7 @@ function version_add( $p_project_id, $p_version, $p_released = VERSION_FUTURE, $
 	$t_version_id = db_insert_id( $t_project_version_table );
 	
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return $t_version_id;
 }
 
@@ -387,7 +387,7 @@ function version_remove_all( $p_project_id ) {
 				  WHERE project_id=" . db_param();
 	db_query_bound( $query, array( $c_project_id ) );
 
-	# db_query errors on failure so:
+	# db_query_bound() errors on failure so:
 	return true;
 }
 


### PR DESCRIPTION
Following recent commits [1] db_query() is no longer used in MantisBT.

Considering that the function is marked as deprecated since 1.2.0a2
(April 2008), it is time to effectively remove it.

Fixes #16898

[1] 3be86ce37bb469b211663da03f61ac2b28500d91, 7d76827617e97d7356e7eb4f2f66736e4c4d41b0, cf596c27b2a2e2aac67749b546cece9c23b4bbb1 and 0db530a855f92752aaa4bcf355df3ecba9af8226
