### PR TITLE
Fixes #16917: Complex Type fails when array is terminated by semi-colon

### DIFF
--- a/adm_config_set.php
+++ b/adm_config_set.php
@@ -142,7 +142,7 @@ function process_complex_value( $p_value, $p_trimquotes = false ) {
 
 	# Parsing regex initialization
 	if( is_null( $s_regex_array ) ) {
-		$s_regex_array = '^array[\s]*\((.*)\)[;]{0,1}$';
+		$s_regex_array = '^array[\s]*\((.*)\)[;]*$';
 		$s_regex_string =
 			# unquoted string (word)
 			'[\w]+' . '|' .


### PR DESCRIPTION
In the Manage - Manage Configuration page, when a semi-colon is at the end of the array() definition, the field is treated as a string instead of a complex array.  This can happen easily when users are copying and pasting from config_defaults_inc.php and applying their changes.
