### PR TITLE
Change default db type from mysql to mysqli

### DIFF
--- a/admin/check/check_database_inc.php
+++ b/admin/check/check_database_inc.php
@@ -91,11 +91,19 @@ check_print_test_row(
 		. '. The version of PHP installed on this server does not have support for this database type.' )
 );
 
+if( db_is_mysql() ) {
+	check_print_test_warn_row(
+		'PHP support for MySQL driver',
+		'mysql' != $t_database_type,
+		array( false => "'mysql' driver is deprecated as of PHP 5.5.0, please use 'mysqli' instead" )
+	);
+}
+
 if ( db_is_mssql() ) {
 
 	check_print_test_warn_row(
 		'PHP support for Microsoft SQL Server driver',
-		'mssql' != config_get_global( 'db_type' ),
+		'mssql' != $t_database_type,
 		array( false => "'mssql' driver is no longer supported in PHP >= 5.3, please use 'mssqlnative' instead" )
 	);
 

--- a/admin/install.php
+++ b/admin/install.php
@@ -522,18 +522,21 @@ if( !$g_database_upgrade ) {
 
 		<select id="db_type" name="db_type">
 <?php
-			// Build selection list of available DB types
+			# Build selection list of available DB types
 			$t_db_list = array(
-				'mysql'       => 'MySQL (default)',
-				'mysqli'      => 'MySQLi',
+				'mysqli'      => 'MySQL Improved',
+				'mysql'       => 'MySQL',
 				'mssql'       => 'Microsoft SQL Server',
 				'mssqlnative' => 'Microsoft SQL Server Native Driver',
 				'pgsql'       => 'PostgreSQL',
 				'oci8'        => 'Oracle',
 				'db2'         => 'IBM DB2',
 			);
-
-			// mssql is not supported with PHP >= 5.3
+			# mysql is deprecated as of PHP 5.5.0
+			if( version_compare( phpversion(), '5.5.0' ) >= 0 ) {
+				unset( $t_db_list['mysql']);
+			}
+			# mssql is not supported with PHP >= 5.3
 			if( version_compare( phpversion(), '5.3' ) >= 0 ) {
 				unset( $t_db_list['mssql']);
 			}

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -74,8 +74,8 @@ $g_db_schema			= '';
  *
  * RDBMS           db_type       PHP ext   Comments
  * -----           -------       -------   --------
- * MySQL           mysql         mysql     default
- *                 mysqli        mysqli
+ * MySQL           mysql         mysql
+ *                 mysqli        mysqli    default
  * PostgreSQL      pgsql         pgsql
  * MS SQL Server   mssqlnative   sqlsrv    experimental
  * Oracle          oci8          oci8      experimental
@@ -83,7 +83,7 @@ $g_db_schema			= '';
  *
  * @global string $g_db_type
  */
-$g_db_type				= 'mysql';
+$g_db_type				= 'mysqli';
 
 /**
  * adodb Data Source Name

--- a/docbook/Admin_Guide/en-US/Configuration.xml
+++ b/docbook/Admin_Guide/en-US/Configuration.xml
@@ -74,14 +74,14 @@
 							<tbody>
 								<row>
 									<entry morerows='1' valign='middle'>MySQL</entry>
-									<entry>mysql</entry>
-									<entry>mysql</entry>
+									<entry>mysqli</entry>
+									<entry>mysqli</entry>
 									<entry>default</entry>
 								</row>
 								<row>
-									<entry>mysqli</entry>
-									<entry>mysqli</entry>
-									<entry></entry>
+									<entry>mysql</entry>
+									<entry>mysql</entry>
+									<entry>Deprecated as of PHP 5.5.0</entry>
 								</row>
 								<row>
 									<entry>PostgreSQL</entry>

--- a/docbook/Admin_Guide/en-US/Installation.xml
+++ b/docbook/Admin_Guide/en-US/Installation.xml
@@ -259,7 +259,7 @@
 								<entry>MySQL</entry>
 								<entry>5.0.8</entry>
 								<entry>5.5.x or above</entry>
-								<entry>PHP extension: mysql/mysqli</entry>
+								<entry>PHP extension: mysqli (recommended) or mysql</entry>
 							</row>
 							<row>
 								<entry>PostgreSQL</entry>


### PR DESCRIPTION
The mysql extension is deprecated as of PHP 5.5.0 [1] so we use mysqli
as our default database type.

Commit includes relevant changes in installer, admin checks and
documentation (admin guide).

[1] http://php.net/intro.mysql
