### PR TITLE
Fixes #15870: Deserialization issues caused by mc_config_get_string()

### DIFF
--- a/api/soap/mc_config_api.php
+++ b/api/soap/mc_config_api.php
@@ -24,6 +24,47 @@ function mc_config_get_string( $p_username, $p_password, $p_config_var ) {
 		return SoapObjectsFactory::newSoapFault( 'Client', "Config '$p_config_var' is undefined" );
 	}
 
-	return config_get( $p_config_var );
+	$t_value = config_get( $p_config_var );
+
+	# If array, serialize to string to avoid php error relating to serializing array as string.
+	if ( is_array( $t_value ) ) {
+		$t_value = mci_serialize_array( $t_value );
+	}
+
+	return $t_value;
+}
+
+/**
+ * Serialize a standard or associative array to a string.
+ * Elements are going to be separated by a new line.
+ * Key and value are going to eb separated by a tab.
+ * Nested arrays are not supported.  Type of keys/values doesn't affect the output.
+ * @param $p_array The array to serialize.
+ */
+function mci_serialize_array( $p_array ) {
+	$t_associative = array_keys( $p_array ) !== range( 0, count( $p_array ) - 1 );
+	$t_result = '';
+	$t_key_value_separator = "\t";
+	$t_value_separator = "\n";
+
+	if ( $t_associative ) {
+		foreach ( $p_array as $t_key => $t_value ) {
+			if ( !empty( $t_result ) ) {
+				$t_result .= $t_value_separator;
+			}
+
+			$t_result .= $t_key . $t_key_value_separator . $t_value;
+		}
+	} else {
+		foreach ( $p_array as $t_value ) {
+			if ( !empty( $t_result ) ) {
+				$t_result .= $t_value_separator;
+			}
+
+			$t_result .= $t_value;
+		}
+	}
+
+	return $t_result;
 }
 


### PR DESCRIPTION
A simple fix to avoid php errors when a client app requests a config option that has an array value.  Some config options are always arrays others can be a threshold vs. an array.  With this change, we will avoid the php error and return a string that is easy parse.

This fix is proposed for both master-1.2.x and master.  In master, we can add new API that returns structured data.  And ones that reduce the need to retrieve configs to simulate web app behaviors.

See the associated issue for discussions we had sometime back.
