### PR TITLE
fix #17011 Graph « Cumulative by date » is not displayed in Summary > Advanced Summary

### DIFF
--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -888,7 +888,7 @@ function create_cumulative_bydate() {
 								AND $t_history_table.field_name = 'status' )
 						OR $t_history_table.id is NULL )
 			ORDER BY $t_bug_table.id, date_modified ASC";
-	$result = db_query_bound( $query, array( $t_res_val, $t_res_val ) );
+	$result = db_query_bound( $query, array( $t_res_val, (string)$t_res_val ) );
 	$bug_count = db_num_rows( $result );
 
 	$t_last_id = 0;


### PR DESCRIPTION
This fix an issue in Summary > Advanced Summary with SQL Server
SQL Server fails to execute the query for the first graph (cumulative by date)
This is because it's expecting a parameter of type VARCHAR and receive an integer
