### PR TITLE
helper_mantis_url() fix

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -235,6 +235,9 @@ $g_short_path = $t_path;
 
 /**
  * Used to link to manual for User Documentation.
+ * This can be either a full URL or a relative path to the MantisBT root.
+ * If a relative path does not exist, the link will fall back to the online
+ * documentation at http://www.mantisbt.org. No check is performed on URLs.
  * @global string $g_manual_url
  */
 $g_manual_url = 'doc/en-US/Admin_Guide/html-desktop/';

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1224,11 +1224,37 @@ function print_account_menu( $p_page = '' ) {
  * @return null
  */
 function print_doc_menu( $p_page = '' ) {
-	$t_documentation_html = config_get( 'manual_url' );
-	$t_pages[$t_documentation_html] = array( 'url'=>$t_documentation_html, 'label'=>'user_documentation' );
-	$t_pages['proj_doc_page.php'] = array( 'url'=>'proj_doc_page.php', 'label'=>'project_documentation' );
+	# User Documentation
+	$t_doc_url = config_get( 'manual_url' );
+	if( is_null( parse_url( $t_doc_url, PHP_URL_SCHEME ) ) ) {
+		# URL has no scheme, so it is relative to MantisBT root
+		if( is_blank( $t_doc_url ) ||
+			!file_exists( config_get_global( 'absolute_path' ) . $t_doc_url )
+		) {
+			# Local documentation not available, use online docs
+			$t_doc_url = 'http://www.mantisbt.org/documentation.php';
+		} else {
+			$t_doc_url = helper_mantis_url( $t_doc_url );
+		}
+	}
+
+	$t_pages[$t_doc_url] = array(
+		'url'   => $t_doc_url,
+		'label' => 'user_documentation'
+	);
+
+	# Project Documentation
+	$t_pages['proj_doc_page.php'] = array(
+		'url'   => helper_mantis_url( 'proj_doc_page.php' ),
+		'label' => 'project_documentation'
+	);
+
+	# Add File
 	if( file_allow_project_upload() ) {
-		$t_pages['proj_doc_add_page.php'] = array( 'url'=>'proj_doc_add_page.php', 'label'=>'add_file' );
+		$t_pages['proj_doc_add_page.php'] = array(
+			'url'   => helper_mantis_url( 'proj_doc_add_page.php' ),
+			'label' => 'add_file'
+		);
 	}
 
 	# Remove the link from the current page
@@ -1242,7 +1268,7 @@ function print_doc_menu( $p_page = '' ) {
 		if( $t_page['url'] == '' ) {
 			echo '<li>', lang_get( $t_page['label'] ), '</li>';
 		} else {
-			echo '<li><a href="'. helper_mantis_url( $t_page['url'] ) .'">' . lang_get( $t_page['label'] ) . '</a></li>';
+			echo '<li><a href="'. $t_page['url'] .'">' . lang_get( $t_page['label'] ) . '</a></li>';
 		}
 	}
 	echo '</ul>';


### PR DESCRIPTION
When helper_mantis_url(), received an absolute URL, it would blindly append it at the end of $g_short_path, thus generating broken link.

I added logic to the function, to make it return the parameter as-is when the URL starts with a `/` or `http(s)://` as it seemed more logical to do this, rather than implement some hack in proj_doc_page.php 

See http://www.mantisbt.org/bugs/view.php?id=16995
