### PR TITLE
Fixes #17075: Import plugins should be able to set last_updated field to...

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1510,7 +1510,9 @@ function bug_set_field( $p_bug_id, $p_field_name, $p_value ) {
 	db_query_bound( $query, Array( $c_value, $c_bug_id ) );
 
 	# updated the last_updated date
-	bug_update_date( $p_bug_id );
+	if ( $p_field_name != 'last_updated' ) {
+		bug_update_date( $p_bug_id );
+	}
 
 	# log changes except for duplicate_id which is obsolete and should be removed in
 	# MantisBT 1.3.


### PR DESCRIPTION
... a date in the past.

The fix is to not auto-set the last_updated, when it is the same field being updated.
