### PR TITLE
Remove set_include_path() calls

### DIFF
--- a/api/soap/mantisconnect.php
+++ b/api/soap/mantisconnect.php
@@ -14,8 +14,6 @@
  * @link http://www.mantisbt.org
  */
 
-set_include_path( '../../library' );
-
 # Path to MantisBT is assumed to be the grand parent directory.  If this is not
 # the case, then this variable should be set to the MantisBT path.
 # This can not be a configuration option, then MantisConnect configuration

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -798,6 +798,23 @@ function plugin_include( $p_basename, $p_child = null ) {
 }
 
 /**
+ * Allows a plugin page to require a plugin-specific API
+ * @param string $p_file The API to be included
+ * @param string $p_basename Plugin's basename (defaults to current plugin)
+ */
+function plugin_require_api( $p_file, $p_basename = null ) {
+	if( is_null( $p_basename ) ) {
+		$t_current = plugin_get_current();
+	} else {
+		$t_current = $p_basename;
+	}
+
+	$t_path = config_get_global( 'plugin_path' ) . $t_current . '/';
+
+	require_once( $t_path . $p_file );
+}
+
+/**
  * Register a plugin with MantisBT.
  * The plugin class must already be loaded before calling.
  * @param string $p_basename Plugin classname without 'Plugin' postfix

--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -63,10 +63,6 @@ class MantisGraphPlugin extends MantisPlugin  {
 	 */
 	function init() {
 		spl_autoload_register( array( 'MantisGraphPlugin', 'autoload' ) );
-
-		$t_path = config_get_global('plugin_path' ). plugin_get_current() . '/core/';
-
-		set_include_path(get_include_path() . PATH_SEPARATOR . $t_path);
 	}
 
 	/**

--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -31,14 +31,12 @@ if( OFF == plugin_config_get( 'eczlibrary' ) ) {
 	}
 	$t_jpgraph_path = plugin_config_get( 'jpgraph_path', '' );
 	if( $t_jpgraph_path !== '' ) {
-		set_include_path(get_include_path() . PATH_SEPARATOR . $t_jpgraph_path );
-		$ip = get_include_path();
-		require_once( 'jpgraph.php' );
-		require_once( 'jpgraph_line.php' );
-		require_once( 'jpgraph_bar.php' );
-		require_once( 'jpgraph_pie.php' );
-		require_once( 'jpgraph_pie3d.php' );
-		require_once( 'jpgraph_canvas.php' );
+		require_once( $t_jpgraph_path . 'jpgraph.php' );
+		require_once( $t_jpgraph_path . 'jpgraph_line.php' );
+		require_once( $t_jpgraph_path . 'jpgraph_bar.php' );
+		require_once( $t_jpgraph_path . 'jpgraph_pie.php' );
+		require_once( $t_jpgraph_path . 'jpgraph_pie3d.php' );
+		require_once( $t_jpgraph_path . 'jpgraph_canvas.php' );
 	} else {
 		require_lib( 'jpgraph/jpgraph.php' );
 		require_lib( 'jpgraph/jpgraph_line.php' );

--- a/plugins/MantisGraph/pages/bug_graph_bycategory.php
+++ b/plugins/MantisGraph/pages/bug_graph_bycategory.php
@@ -26,7 +26,7 @@
 require_once( 'core.php' );
 
 require_once( 'Period.php' );
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/bug_graph_bystatus.php
+++ b/plugins/MantisGraph/pages/bug_graph_bystatus.php
@@ -25,7 +25,7 @@
 require_once( 'core.php' );
 
 require_once( 'Period.php' );
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_bycategory.php
+++ b/plugins/MantisGraph/pages/summary_graph_bycategory.php
@@ -25,7 +25,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_bycategory_pct.php
+++ b/plugins/MantisGraph/pages/summary_graph_bycategory_pct.php
@@ -24,7 +24,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_bydeveloper.php
+++ b/plugins/MantisGraph/pages/summary_graph_bydeveloper.php
@@ -24,7 +24,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_bypriority.php
+++ b/plugins/MantisGraph/pages/summary_graph_bypriority.php
@@ -25,7 +25,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_bypriority_mix.php
+++ b/plugins/MantisGraph/pages/summary_graph_bypriority_mix.php
@@ -25,7 +25,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_bypriority_pct.php
+++ b/plugins/MantisGraph/pages/summary_graph_bypriority_pct.php
@@ -25,7 +25,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_byreporter.php
+++ b/plugins/MantisGraph/pages/summary_graph_byreporter.php
@@ -24,7 +24,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_byresolution.php
+++ b/plugins/MantisGraph/pages/summary_graph_byresolution.php
@@ -24,7 +24,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_byresolution_mix.php
+++ b/plugins/MantisGraph/pages/summary_graph_byresolution_mix.php
@@ -24,7 +24,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_byresolution_pct.php
+++ b/plugins/MantisGraph/pages/summary_graph_byresolution_pct.php
@@ -25,7 +25,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_byseverity.php
+++ b/plugins/MantisGraph/pages/summary_graph_byseverity.php
@@ -25,7 +25,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_byseverity_mix.php
+++ b/plugins/MantisGraph/pages/summary_graph_byseverity_mix.php
@@ -25,7 +25,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_byseverity_pct.php
+++ b/plugins/MantisGraph/pages/summary_graph_byseverity_pct.php
@@ -25,7 +25,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_bystatus.php
+++ b/plugins/MantisGraph/pages/summary_graph_bystatus.php
@@ -25,7 +25,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_bystatus_pct.php
+++ b/plugins/MantisGraph/pages/summary_graph_bystatus_pct.php
@@ -24,7 +24,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_cumulative_bydate.php
+++ b/plugins/MantisGraph/pages/summary_graph_cumulative_bydate.php
@@ -24,7 +24,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_imp_category.php
+++ b/plugins/MantisGraph/pages/summary_graph_imp_category.php
@@ -25,7 +25,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_imp_priority.php
+++ b/plugins/MantisGraph/pages/summary_graph_imp_priority.php
@@ -25,7 +25,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_imp_resolution.php
+++ b/plugins/MantisGraph/pages/summary_graph_imp_resolution.php
@@ -25,7 +25,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_imp_severity.php
+++ b/plugins/MantisGraph/pages/summary_graph_imp_severity.php
@@ -24,7 +24,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/plugins/MantisGraph/pages/summary_graph_imp_status.php
+++ b/plugins/MantisGraph/pages/summary_graph_imp_status.php
@@ -24,7 +24,7 @@
 
 require_once( 'core.php' );
 
-require_once( 'graph_api.php' );
+plugin_require_api( 'core/graph_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 


### PR DESCRIPTION
Since we know the full path to the files being included, it is not
necessary to change the include path.

Fixes #11549
