### PR TITLE
Fixes #17185: Read-only access via api should be available to VIEWER

### DIFF
--- a/api/soap/mc_config_defaults_inc.php
+++ b/api/soap/mc_config_defaults_inc.php
@@ -15,7 +15,7 @@
  */
 
 # Minimum global access level required to access webservice for readonly operations.
-$g_mc_readonly_access_level_threshold = REPORTER;
+$g_mc_readonly_access_level_threshold = VIEWER;
 
 # Minimum global access level required to access webservice for read/write operations.
 $g_mc_readwrite_access_level_threshold = REPORTER;


### PR DESCRIPTION
There is no reason for the APIs to have a higher access level than the GUI. We can keep the configuration option but it should default the right behavior. I initially had it higher when the API was completely new.
