### PR TITLE
Fixes #17233: Fix the license in the SOAP API file headers

### DIFF
--- a/api/soap/mantisconnect.php
+++ b/api/soap/mantisconnect.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
 #
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_account_api.php
+++ b/api/soap/mc_account_api.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_config_api.php
+++ b/api/soap/mc_config_api.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_config_defaults_inc.php
+++ b/api/soap/mc_config_defaults_inc.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_core.php
+++ b/api/soap/mc_core.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_custom_field_api.php
+++ b/api/soap/mc_custom_field_api.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_enum_api.php
+++ b/api/soap/mc_enum_api.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_file_api.php
+++ b/api/soap/mc_file_api.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_filter_api.php
+++ b/api/soap/mc_filter_api.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_issue_attachment_api.php
+++ b/api/soap/mc_issue_attachment_api.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_project_attachment_api.php
+++ b/api/soap/mc_project_attachment_api.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_tag_api.php
+++ b/api/soap/mc_tag_api.php
@@ -15,9 +15,11 @@
 # along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
+ * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_user_pref_api.php
+++ b/api/soap/mc_user_pref_api.php
@@ -1,16 +1,25 @@
 <?php
-# MantisConnect - A webservice interface to Mantis Bug Tracker
-# Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
-# This program is distributed under dual licensing.  These include
-# GPL and a commercial licenses.  Victor Boctor reserves the right to
-# change the license of future releases.
-# See docs/ folder for more details
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
  * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 

--- a/api/soap/mc_user_profile_api.php
+++ b/api/soap/mc_user_profile_api.php
@@ -15,9 +15,11 @@
 # along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * MantisConnect - A webservice interface to Mantis Bug Tracker
+ * A webservice interface to Mantis Bug Tracker
  *
  * @package MantisBT
+ * @copyright Copyright 2004  Victor Boctor - vboctor@users.sourceforge.net
+ * @copyright Copyright 2005  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
 


### PR DESCRIPTION
The SOAP API file headers still reflect the license from the time the web service was part of the MantisConnect product.

I've contributed the web service to MantisBT and hence it should honer the same license when distributed with MantisBT.
