### PR TITLE
Fixes #17246: Date custom fields can't store dates pre-1970.

### DIFF
--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -1022,7 +1022,8 @@ function custom_field_validate( $p_field_id, $p_value ) {
 
 			break;
 		case CUSTOM_FIELD_TYPE_DATE:
-			# gpc_get_cf for date returns the value from strftime
+			# gpc_get_cf for date returns the value from strtotime
+			# For 32 bit systems, supported range will be 13 Dec 1901 20:45:54 UTC to 19 Jan 2038 03:14:07 UTC
 			$t_valid &= ( $p_value == null ) || ( $p_value !== false );
 			break;
 		case CUSTOM_FIELD_TYPE_CHECKBOX:


### PR DESCRIPTION
If a user is to use custom fields for "date of birth", they will always get invalid date. The reason is that the validation assumes only dates are valid when their value is greater than 0. Though strtotime() returns 0 for 1970-01-01, false for invalid values, and negative for values before 1970.

PHP versions before 5.1 used to return -1 for invalid values. But that is not longer the case.
http://us3.php.net/manual/en/function.strtotime.php
