### PR TITLE
Allow choice of email validation method

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -530,10 +530,33 @@ $g_notify_flags['monitor'] = array(
 $g_email_receive_own = OFF;
 
 /**
- * set to OFF to disable email check
+ * Email addresses validation
+ *
+ * Determines if and how email addresses are validated. Possible values for
+ * this config are:
+ * - EMAIL_VALIDATE_PHP (default): validate using PHP's built-in method (see
+ *   {@link http://php.net/filter_var} with FILTER_SANITIZE_EMAIL filter
+ *   {@link http://php.net/filter.filters.validate}
+ *   This should be used with internet-facing installations.
+ *   Emails must have the form 'user@domain.tld'
+ * - EMAIL_VALIDATE_RFC5322: validate using an RFC5322-compliant regex
+ *   (see {@link http://squiloople.com/2009/12/20/email-address-validation/}.
+ *   This is useful for intranet installations, when relying on addresses
+ *   without a top-level domain (e.g. 'user@domain')
+ * - EMAIL_VALIDATE_AUTO: let PHPMailer's
+ *   {@link http://phpmailer.github.io/PHPMailer/classes/PHPMailer.html#method_validateAddress validateAddress()}
+ *   method pick the best validation pattern. On recent systems, this is
+ *   generally the same as EMAIL_VALIDATE_RFC5322.
+ * - OFF: disable email validation
+ *
+ * NOTE: Regardless of how this option is set, validation is not performed
+ * when using LDAP email (i.e. when $g_use_ldap_email = ON), as we assume that
+ * it is handled by the directory.
+ * @see $g_use_ldap_email
+ *
  * @global integer $g_validate_email
  */
-$g_validate_email = ON;
+$g_validate_email = EMAIL_VALIDATE_PHP;
 
 /**
  * set to OFF to disable email check

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -550,7 +550,7 @@ $g_email_receive_own = OFF;
  *   standard-compliant, with this you can.
  * - EMAIL_VALIDATE_AUTO: let PHPMailer's
  *   {@link http://phpmailer.github.io/PHPMailer/classes/PHPMailer.html#method_validateAddress validateAddress()}
- *   method pick the best validation pattern. As of PHPMailer v5.2.8 on recent
+ *   method pick the best validation pattern. As of PHPMailer v5.2.9, on recent
  *   systems, this is generally the same as EMAIL_VALIDATE_RFC5322.
  * - OFF: disable email validation
  *

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -534,29 +534,38 @@ $g_email_receive_own = OFF;
  *
  * Determines if and how email addresses are validated. Possible values for
  * this config are:
- * - EMAIL_VALIDATE_PHP (default): validate using PHP's built-in method (see
+ * - EMAIL_VALIDATE_HTML5 (default): validate using the pattern given by the
+ *   HTML5 specification for 'email' type form input elements
+ *   {@link http://www.w3.org/TR/html5/forms.html#valid-e-mail-address}
+ *   This is the more versatile and standard option, which should be used in
+ *   most situations.
+ * - EMAIL_VALIDATE_PHP: validate using PHP's built-in method (see
  *   {@link http://php.net/filter_var} with FILTER_SANITIZE_EMAIL filter
  *   {@link http://php.net/filter.filters.validate}
- *   This should be used with internet-facing installations.
- *   Emails must have the form 'user@domain.tld'
- * - EMAIL_VALIDATE_RFC5322: validate using an RFC5322-compliant regex
+ *   This considers addresses like 'user@domain' (i.e. without a top-level
+ *   domain) as invalid.
+ * - EMAIL_VALIDATE_RFC5322: validate using a fully RFC5322-compliant regex
  *   (see {@link http://squiloople.com/2009/12/20/email-address-validation/}.
- *   This is useful for intranet installations, when relying on addresses
- *   without a top-level domain (e.g. 'user@domain')
+ *   This probably overkill in most scenarios, but if you need to be fully
+ *   standard-compliant, with this you can.
  * - EMAIL_VALIDATE_AUTO: let PHPMailer's
  *   {@link http://phpmailer.github.io/PHPMailer/classes/PHPMailer.html#method_validateAddress validateAddress()}
- *   method pick the best validation pattern. On recent systems, this is
- *   generally the same as EMAIL_VALIDATE_RFC5322.
+ *   method pick the best validation pattern. As of PHPMailer v5.2.8 on recent
+ *   systems, this is generally the same as EMAIL_VALIDATE_RFC5322.
  * - OFF: disable email validation
  *
- * NOTE: Regardless of how this option is set, validation is not performed
+ * With internet-facing installations, it is strongly advised to use either
+ * the default HTML5 (recommended) or PHP methods (if you don't need to handle
+ * email addresses without a top-level domain).
+ *
+ * NOTE: Regardless of how this option is set, validation is never performed
  * when using LDAP email (i.e. when $g_use_ldap_email = ON), as we assume that
  * it is handled by the directory.
  * @see $g_use_ldap_email
  *
  * @global integer $g_validate_email
  */
-$g_validate_email = EMAIL_VALIDATE_PHP;
+$g_validate_email = EMAIL_VALIDATE_HTML5;
 
 /**
  * set to OFF to disable email check

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -532,31 +532,11 @@ $g_email_receive_own = OFF;
 /**
  * Email addresses validation
  *
- * Determines if and how email addresses are validated. Possible values for
- * this config are:
- * - EMAIL_VALIDATE_HTML5 (default): validate using the pattern given by the
+ * Determines whether email addresses are validated.
+ * - When ON (default), validation is performed using the pattern given by the
  *   HTML5 specification for 'email' type form input elements
  *   {@link http://www.w3.org/TR/html5/forms.html#valid-e-mail-address}
- *   This is the more versatile and standard option, which should be used in
- *   most situations.
- * - EMAIL_VALIDATE_PHP: validate using PHP's built-in method (see
- *   {@link http://php.net/filter_var} with FILTER_SANITIZE_EMAIL filter
- *   {@link http://php.net/filter.filters.validate}
- *   This considers addresses like 'user@domain' (i.e. without a top-level
- *   domain) as invalid.
- * - EMAIL_VALIDATE_RFC5322: validate using a fully RFC5322-compliant regex
- *   (see {@link http://squiloople.com/2009/12/20/email-address-validation/}.
- *   This probably overkill in most scenarios, but if you need to be fully
- *   standard-compliant, with this you can.
- * - EMAIL_VALIDATE_AUTO: let PHPMailer's
- *   {@link http://phpmailer.github.io/PHPMailer/classes/PHPMailer.html#method_validateAddress validateAddress()}
- *   method pick the best validation pattern. As of PHPMailer v5.2.9, on recent
- *   systems, this is generally the same as EMAIL_VALIDATE_RFC5322.
- * - OFF: disable email validation
- *
- * With internet-facing installations, it is strongly advised to use either
- * the default HTML5 (recommended) or PHP methods (if you don't need to handle
- * email addresses without a top-level domain).
+ * - When OFF, validation is disabled.
  *
  * NOTE: Regardless of how this option is set, validation is never performed
  * when using LDAP email (i.e. when $g_use_ldap_email = ON), as we assume that
@@ -565,7 +545,7 @@ $g_email_receive_own = OFF;
  *
  * @global integer $g_validate_email
  */
-$g_validate_email = EMAIL_VALIDATE_HTML5;
+$g_validate_email = ON;
 
 /**
  * set to OFF to disable email check

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -569,12 +569,6 @@ define( 'EMAIL_SHUTDOWN_SKIP', 0 );
 define( 'EMAIL_SHUTDOWN_GENERATED', 1 );
 define( 'EMAIL_SHUTDOWN_FORCE', 2 );
 
-# Email address validation types
-define( 'EMAIL_VALIDATE_PHP', 1 );
-define( 'EMAIL_VALIDATE_AUTO', 2 );
-define( 'EMAIL_VALIDATE_RFC5322', 3 );
-define( 'EMAIL_VALIDATE_HTML5', 4 );
-
 # Lengths - NOTE: these may represent hard-coded values in db schema and should not be changed.
 define( 'DB_FIELD_SIZE_USERNAME', 255 );
 define( 'DB_FIELD_SIZE_REALNAME', 255 );

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -573,6 +573,7 @@ define( 'EMAIL_SHUTDOWN_FORCE', 2 );
 define( 'EMAIL_VALIDATE_PHP', 1 );
 define( 'EMAIL_VALIDATE_AUTO', 2 );
 define( 'EMAIL_VALIDATE_RFC5322', 3 );
+define( 'EMAIL_VALIDATE_HTML5', 4 );
 
 # Lengths - NOTE: these may represent hard-coded values in db schema and should not be changed.
 define( 'DB_FIELD_SIZE_USERNAME', 255 );

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -569,6 +569,11 @@ define( 'EMAIL_SHUTDOWN_SKIP', 0 );
 define( 'EMAIL_SHUTDOWN_GENERATED', 1 );
 define( 'EMAIL_SHUTDOWN_FORCE', 2 );
 
+# Email address validation types
+define( 'EMAIL_VALIDATE_PHP', 1 );
+define( 'EMAIL_VALIDATE_AUTO', 2 );
+define( 'EMAIL_VALIDATE_RFC5322', 3 );
+
 # Lengths - NOTE: these may represent hard-coded values in db schema and should not be changed.
 define( 'DB_FIELD_SIZE_USERNAME', 255 );
 define( 'DB_FIELD_SIZE_REALNAME', 255 );

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -47,7 +47,7 @@
  * @uses user_pref_api.php
  * @uses utility_api.php
  *
- * @uses class.phpmailer.php PHPMailer library
+ * @uses PHPMailerAutoload.php PHPMailer library
  */
 
 require_api( 'access_api.php' );
@@ -74,7 +74,7 @@ require_api( 'user_api.php' );
 require_api( 'user_pref_api.php' );
 require_api( 'utility_api.php' );
 
-require_lib( 'phpmailer' . DIRECTORY_SEPARATOR . 'class.phpmailer.php' );
+require_lib( 'phpmailer/PHPMailerAutoload.php' );
 
 # reusable object of class SMTP
 $g_phpMailer = null;

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -136,9 +136,8 @@ function email_is_valid( $p_email ) {
 
 	# check email address is a valid format
 	log_event( LOG_EMAIL, "Validating address '$p_email' with method '$t_method'" );
-	$t_email = filter_var( $p_email, FILTER_SANITIZE_EMAIL );
-	if( PHPMailer::ValidateAddress( $t_email, $t_method ) ) {
-		$t_domain = substr( $t_email, strpos( $t_email, '@' ) + 1 );
+	if( PHPMailer::ValidateAddress( $p_email, $t_method ) ) {
+		$t_domain = substr( $p_email, strpos( $p_email, '@' ) + 1 );
 
 		# see if we're limited to a set of known domains
 		$t_limit_email_domains = config_get( 'limit_email_domains' );

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -137,6 +137,7 @@ function email_is_valid( $p_email ) {
 	}
 
 	# check email address is a valid format
+	log_event( LOG_EMAIL, "Validating address '$p_email' with method '$t_method'" );
 	$t_email = filter_var( $p_email, FILTER_SANITIZE_EMAIL );
 	if( PHPMailer::ValidateAddress( $t_email, $t_method ) ) {
 		$t_domain = substr( $t_email, strpos( $t_email, '@' ) + 1 );
@@ -149,6 +150,7 @@ function email_is_valid( $p_email ) {
 					return true; # no need to check mx record details (below) if we've explicity allowed the domain
 				}
 			}
+			log_event( LOG_EMAIL, "failed - not in limited domains list '$t_limit_email_domains'" );
 			return false;
 		}
 
@@ -165,11 +167,14 @@ function email_is_valid( $p_email ) {
 				if( checkdnsrr( $t_host, 'ANY' ) ) {
 					return true;
 				}
+				log_event( LOG_EMAIL, "failed - mx/dns record check" );
 			}
 		} else {
 			# Email format was valid but didn't check for valid mx records
 			return true;
 		}
+	} else {
+		log_event( LOG_EMAIL, "failed - invalid address" );
 	}
 
 	# Everything failed.  The email is invalid

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -131,6 +131,7 @@ function email_is_valid( $p_email ) {
 
 	# E-mail validation method
 	switch( $t_validate_email ) {
+		case EMAIL_VALIDATE_HTML5:   $t_method = 'html5'; break;
 		case EMAIL_VALIDATE_PHP:     $t_method = 'php';   break;
 		case EMAIL_VALIDATE_RFC5322: $t_method = 'pcre8'; break;
 		default:                     $t_method = 'auto';  break;

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -93,7 +93,8 @@ $g_email_shutdown_processing = EMAIL_SHUTDOWN_SKIP;
 /**
  * Regex for valid email addresses
  * @see string_insert_hrefs()
- *
+ * This pattern is consistent with email addresses validation logic
+ * @see $g_validate_email
  * Uses the standard HTML5 pattern defined in
  * {@link http://www.w3.org/TR/html5/forms.html#valid-e-mail-address}
  * Note: the original regex from the spec has been modified to
@@ -125,12 +126,13 @@ function email_is_valid( $p_email ) {
 	}
 
 	# E-mail validation method
-	switch( $t_validate_email ) {
-		case EMAIL_VALIDATE_HTML5:   $t_method = 'html5'; break;
-		case EMAIL_VALIDATE_PHP:     $t_method = 'php';   break;
-		case EMAIL_VALIDATE_RFC5322: $t_method = 'pcre8'; break;
-		default:                     $t_method = 'auto';  break;
-	}
+	# Note: PHPMailer offers alternative validation methods.
+	# It was decided in PR 172 (https://github.com/mantisbt/mantisbt/pull/172)
+	# to just default to HTML5 without over-complicating things for end users
+	# by offering a potentially confusing choice between the different methods.
+	# Refer to PHPMailer documentation for ValidateAddress method for details.
+	# @link https://github.com/PHPMailer/PHPMailer/blob/v5.2.9/class.phpmailer.php#L863
+	$t_method = 'html5';
 
 	# check email address is a valid format
 	log_event( LOG_EMAIL, "Validating address '$p_email' with method '$t_method'" );

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -91,24 +91,19 @@ $g_phpMailer = null;
 $g_email_shutdown_processing = EMAIL_SHUTDOWN_SKIP;
 
 /**
- * Use a simple perl regex for valid email addresses.  This is not a complete regex,
- * as it does not cover quoted addresses or domain literals, but it is simple and
- * covers the vast majority of all email addresses without being overly complex.
+ * Regex for valid email addresses
+ * @see string_insert_hrefs()
+ *
+ * Uses the standard HTML5 pattern defined in
+ * {@link http://www.w3.org/TR/html5/forms.html#valid-e-mail-address}
+ * Note: the original regex from the spec has been modified to
+ * - escape the '/' in the first character class definition
+ * - remove the '^' and '$' anchors to allow matching anywhere in a string
+ *
  * @return string
  */
 function email_regex_simple() {
-	static $s_email_regex = null;
-
-	if( is_null( $s_email_regex ) ) {
-		$t_recipient = '([a-z0-9!#*+\/=?^_{|}~-]+(?:\.[a-z0-9!#*+\/=?^_{|}~-]+)*)';
-
-		# a domain is one or more subdomains
-		$t_subdomain = '(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)';
-		$t_domain    = '(' . $t_subdomain . '(?:\.' . $t_subdomain . ')*)';
-
-		$s_email_regex = '/' . $t_recipient . '\@' . $t_domain . '/i';
-	}
-	return $s_email_regex;
+	return "/[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*/";
 }
 
 /**

--- a/docbook/Admin_Guide/en-US/config/email.xml
+++ b/docbook/Admin_Guide/en-US/config/email.xml
@@ -136,7 +136,50 @@
 		<varlistentry>
 			<term>$g_validate_email</term>
 			<listitem>
-				<para>Set to OFF to disable email checking. Default is ON.</para>
+				<para>Determines if and how email addresses are validated.
+					Possible values for this config option are:
+				</para>
+				<itemizedlist>
+					<listitem><para>
+						<literal>EMAIL_VALIDATE_PHP</literal> (default):
+						validate using PHP's built-in method (see
+						<ulink url="http://php.net/filter_var">
+							filter_var() function</ulink> with
+						<ulink url="http://php.net/filter.filters.validate">
+							FILTER_SANITIZE_EMAIL</ulink> filter).
+						This should be used with internet-facing
+						installations. Emails must have the form
+						<emphasis>user@domain.tld</emphasis>.
+					</para></listitem>
+					<listitem><para>
+						<literal>EMAIL_VALIDATE_RFC5322</literal>:
+						validate using an
+						<ulink url="http://squiloople.com/2009/12/20/email-address-validation/">
+							RFC5322-compliant regex</ulink>.
+						This is useful for intranet installations, when
+						relying addresses without a top-level domain (e.g.
+						<emphasis>user@domain</emphasis>).
+					</para></listitem>
+					<listitem><para>
+						<literal>EMAIL_VALIDATE_AUTO</literal>:
+						let PHPMailer's
+						<ulink url="http://phpmailer.github.io/PHPMailer/classes/PHPMailer.html#method_validateAddress">
+							validateAddress() method</ulink>
+						pick the best validation pattern.
+						On recent systems, this is generally the same as
+						<literal>EMAIL_VALIDATE_RFC5322</literal>.
+					</para></listitem>
+					<listitem><para>
+						<literal>OFF</literal>:
+						disable email check.
+					</para></listitem>
+				</itemizedlist>
+				<note><para>
+					Regardless of how this option is set, validation is
+					not performed when using LDAP email (i.e. when
+					$g_use_ldap_email = ON), as we assume that it is
+					handled by the directory.
+				</para></note>
 			</listitem>
 		</varlistentry>
 		<varlistentry>

--- a/docbook/Admin_Guide/en-US/config/email.xml
+++ b/docbook/Admin_Guide/en-US/config/email.xml
@@ -141,24 +141,35 @@
 				</para>
 				<itemizedlist>
 					<listitem><para>
-						<literal>EMAIL_VALIDATE_PHP</literal> (default):
+						<literal>EMAIL_VALIDATE_HTML5</literal> (default):
+						validate using the pattern given by the
+						<ulink url="http://www.w3.org/TR/html5/forms.html#valid-e-mail-address">
+							HTML5 specification for <emphasis>email</emphasis>
+							type form input elements</ulink>.
+							This is the more versatile and standard option,
+							which should be used in most situations.
+					</para></listitem>
+					<listitem><para>
+						<literal>EMAIL_VALIDATE_PHP</literal>:
 						validate using PHP's built-in method (see
 						<ulink url="http://php.net/filter_var">
 							filter_var() function</ulink> with
 						<ulink url="http://php.net/filter.filters.validate">
 							FILTER_SANITIZE_EMAIL</ulink> filter).
-						This should be used with internet-facing
-						installations. Emails must have the form
+						Emails must have the form
 						<emphasis>user@domain.tld</emphasis>.
+						<note><para>This considers addresses like
+							<emphasis>user@domain</emphasis> (i.e. without a
+							top-level domain) as invalid.
+						</para></note>
 					</para></listitem>
 					<listitem><para>
 						<literal>EMAIL_VALIDATE_RFC5322</literal>:
 						validate using an
 						<ulink url="http://squiloople.com/2009/12/20/email-address-validation/">
 							RFC5322-compliant regex</ulink>.
-						This is useful for intranet installations, when
-						relying addresses without a top-level domain (e.g.
-						<emphasis>user@domain</emphasis>).
+						This probably overkill in most scenarios, but if you
+						need to be fully standard-compliant, with this you can.
 					</para></listitem>
 					<listitem><para>
 						<literal>EMAIL_VALIDATE_AUTO</literal>:
@@ -166,7 +177,8 @@
 						<ulink url="http://phpmailer.github.io/PHPMailer/classes/PHPMailer.html#method_validateAddress">
 							validateAddress() method</ulink>
 						pick the best validation pattern.
-						On recent systems, this is generally the same as
+						As of PHPMailer v5.2.8 on recent systems, this is
+						generally the same as
 						<literal>EMAIL_VALIDATE_RFC5322</literal>.
 					</para></listitem>
 					<listitem><para>
@@ -175,10 +187,18 @@
 					</para></listitem>
 				</itemizedlist>
 				<note><para>
+					With internet-facing installations, it is strongly advised
+					to use either the default <emphasis>HTML5</emphasis>
+					(recommended) or <emphasis>PHP</emphasis> methods (if you
+					don't need to handle email addresses without a top-level
+					domain).
+				</para></note>
+				<note><para>
 					Regardless of how this option is set, validation is
-					not performed when using LDAP email (i.e. when
-					$g_use_ldap_email = ON), as we assume that it is
-					handled by the directory.
+					never performed when using LDAP email
+					(i.e. when $g_use_ldap_email = ON,
+					see <xref linkend="admin.config.auth.ldap" />),
+					as we assume that it is handled by the directory.
 				</para></note>
 			</listitem>
 		</varlistentry>

--- a/docbook/Admin_Guide/en-US/config/email.xml
+++ b/docbook/Admin_Guide/en-US/config/email.xml
@@ -136,63 +136,15 @@
 		<varlistentry>
 			<term>$g_validate_email</term>
 			<listitem>
-				<para>Determines if and how email addresses are validated.
-					Possible values for this config option are:
+				<para>Determines whether email addresses are validated.
 				</para>
-				<itemizedlist>
-					<listitem><para>
-						<literal>EMAIL_VALIDATE_HTML5</literal> (default):
-						validate using the pattern given by the
-						<ulink url="http://www.w3.org/TR/html5/forms.html#valid-e-mail-address">
-							HTML5 specification for <emphasis>email</emphasis>
-							type form input elements</ulink>.
-							This is the more versatile and standard option,
-							which should be used in most situations.
-					</para></listitem>
-					<listitem><para>
-						<literal>EMAIL_VALIDATE_PHP</literal>:
-						validate using PHP's built-in method (see
-						<ulink url="http://php.net/filter_var">
-							filter_var() function</ulink> with
-						<ulink url="http://php.net/filter.filters.validate">
-							FILTER_SANITIZE_EMAIL</ulink> filter).
-						Emails must have the form
-						<emphasis>user@domain.tld</emphasis>.
-						<note><para>This considers addresses like
-							<emphasis>user@domain</emphasis> (i.e. without a
-							top-level domain) as invalid.
-						</para></note>
-					</para></listitem>
-					<listitem><para>
-						<literal>EMAIL_VALIDATE_RFC5322</literal>:
-						validate using an
-						<ulink url="http://squiloople.com/2009/12/20/email-address-validation/">
-							RFC5322-compliant regex</ulink>.
-						This probably overkill in most scenarios, but if you
-						need to be fully standard-compliant, with this you can.
-					</para></listitem>
-					<listitem><para>
-						<literal>EMAIL_VALIDATE_AUTO</literal>:
-						let PHPMailer's
-						<ulink url="http://phpmailer.github.io/PHPMailer/classes/PHPMailer.html#method_validateAddress">
-							validateAddress() method</ulink>
-						pick the best validation pattern.
-						As of PHPMailer v5.2.9 on recent systems, this is
-						generally the same as
-						<literal>EMAIL_VALIDATE_RFC5322</literal>.
-					</para></listitem>
-					<listitem><para>
-						<literal>OFF</literal>:
-						disable email check.
-					</para></listitem>
-				</itemizedlist>
-				<note><para>
-					With internet-facing installations, it is strongly advised
-					to use either the default <emphasis>HTML5</emphasis>
-					(recommended) or <emphasis>PHP</emphasis> methods (if you
-					don't need to handle email addresses without a top-level
-					domain).
-				</para></note>
+				<para>When ON (default), validation is performed using the
+					pattern given by the
+					<ulink url="http://www.w3.org/TR/html5/forms.html#valid-e-mail-address">
+						HTML5 specification for <emphasis>email</emphasis>
+						type form input elements</ulink>.
+					When OFF, validation is disabled.
+				</para>
 				<note><para>
 					Regardless of how this option is set, validation is
 					never performed when using LDAP email

--- a/docbook/Admin_Guide/en-US/config/email.xml
+++ b/docbook/Admin_Guide/en-US/config/email.xml
@@ -177,7 +177,7 @@
 						<ulink url="http://phpmailer.github.io/PHPMailer/classes/PHPMailer.html#method_validateAddress">
 							validateAddress() method</ulink>
 						pick the best validation pattern.
-						As of PHPMailer v5.2.8 on recent systems, this is
+						As of PHPMailer v5.2.9 on recent systems, this is
 						generally the same as
 						<literal>EMAIL_VALIDATE_RFC5322</literal>.
 					</para></listitem>

--- a/library/README.libs
+++ b/library/README.libs
@@ -8,7 +8,7 @@ directory       | project         | version   | status
 adodb           | adodb           | v5.19     | patched [1][3]
 disposable      | disposable      | 1.1.0     | unpatched
 ezc             | ez Components   | 2009.2.1  | unpatched
-phpmailer       | PHPMailer       | 5.2.7     | unpatched [1]
+phpmailer       | PHPMailer       | 5.2.8     | unpatched [1]
 rssbuilder      | RSSBuilder      | 2.2.1     | patched [2]
 utf8            | phputf8         | 0.5       | unpatched
 securimage      | PHP Captcha     | 3.5.4     | unpatched [1]

--- a/library/README.libs
+++ b/library/README.libs
@@ -8,7 +8,7 @@ directory       | project         | version   | status
 adodb           | adodb           | v5.19     | patched [1][3]
 disposable      | disposable      | 1.1.0     | unpatched
 ezc             | ez Components   | 2009.2.1  | unpatched
-phpmailer       | PHPMailer       | 5.2.8     | unpatched [1]
+phpmailer       | PHPMailer       | 5.2.9     | unpatched [1]
 rssbuilder      | RSSBuilder      | 2.2.1     | patched [2]
 utf8            | phputf8         | 0.5       | unpatched
 securimage      | PHP Captcha     | 3.5.4     | unpatched [1]

--- a/library/README.libs
+++ b/library/README.libs
@@ -11,7 +11,7 @@ ezc             | ez Components   | 2009.2.1  | unpatched
 phpmailer       | PHPMailer       | 5.2.6     | unpatched [1]
 rssbuilder      | RSSBuilder      | 2.2.1     | patched [2]
 utf8            | phputf8         | 0.5       | unpatched
-securimage      | PHP Captcha     | 3.5.1     | unpatched [1]
+securimage      | PHP Captcha     | 3.5.4     | unpatched [1]
 -------------------------------------------------------------------
 
 [1] Library is tracked as a GIT submodule; refer to the corresponding

--- a/library/README.libs
+++ b/library/README.libs
@@ -23,7 +23,7 @@ securimage      | PHP Captcha     | 3.5.1     | unpatched [1]
 Upstream projects
 ==================
 adodb       -  http://adodb.sourceforge.net/  https://github.com/ADOdb/ADOdb
-disposable  -  http://github.com/vboctor/disposable_email_checker/tree/master
+disposable  -  http://github.com/vboctor/disposable_email_checker
 ezc         -  http://ezcomponents.org/
 phpmailer   -  https://github.com/PHPMailer/PHPMailer
 rssbuilder  -  http://code.google.com/p/flaimo-php/

--- a/library/README.libs
+++ b/library/README.libs
@@ -8,7 +8,7 @@ directory       | project         | version   | status
 adodb           | adodb           | v5.19     | patched [1][3]
 disposable      | disposable      | 1.1.0     | unpatched
 ezc             | ez Components   | 2009.2.1  | unpatched
-phpmailer       | PHPMailer       | 5.2.6     | unpatched [1]
+phpmailer       | PHPMailer       | 5.2.7     | unpatched [1]
 rssbuilder      | RSSBuilder      | 2.2.1     | patched [2]
 utf8            | phputf8         | 0.5       | unpatched
 securimage      | PHP Captcha     | 3.5.4     | unpatched [1]


### PR DESCRIPTION
Following implementation of 50d235ad101f61a6c6888316e827fd225ad4b9cd the
validation of email addresses was done by PHPMailer::validateAddress()
instead of filter_var() with FILTER_SANITIZE_EMAIL to allow RFC5322-
compliant emails like 'user@domain' that are rejected by PHP's method
which only accepts 'user@domain.tld'.

However, these 'top-level-domain-only' addresses are often considered as
invalid by SMTP servers but there is a strong use-case for them in
intranet environments.

To enable both scenarios, this commit introduces new constants for
$g_validate_email, allowing the admin to pick whether they want
validation using the PHP method (default) or strict RFC5322.

Backwards compatibility is maintained because EMAIL_VALIDATE_PHP == ON,
and validation can still be disabled with OFF.

Fixes #16894
