### PR TITLE
Remove use of deprecated pattern modifier in string_insert_hrefs()

### DIFF
--- a/core/string_api.php
+++ b/core/string_api.php
@@ -460,7 +460,6 @@ function string_process_bugnote_link( $p_string, $p_include_anchor = true, $p_de
  */
 function string_insert_hrefs( $p_string ) {
 	static $s_url_regex = null;
-	static $s_url_replace = null;
 	static $s_email_regex = null;
 	static $s_anchor_regex = '/(<a[^>]*>.*?<\/a>)/is';
 
@@ -492,18 +491,21 @@ function string_insert_hrefs( $p_string ) {
 		$t_url_part1 = "${t_url_chars}";
 		$t_url_part2 = "(?:\(${t_url_chars_in_parens}*\)|\[${t_url_chars_in_brackets}*\]|${t_url_chars2})";
 
-		$s_url_regex = "/(${t_url_protocol}(${t_url_part1}*?${t_url_part2}+))/sue";
-
-		# URL replacement
-		$t_url_href    = "href=\"'.rtrim('\\1','.').'\"";
-		$s_url_replace = "'<a ${t_url_href}>\\1</a> [<a ${t_url_href} target=\"_blank\">^</a>]'";
+		$s_url_regex = "/(${t_url_protocol}(${t_url_part1}*?${t_url_part2}+))/su";
 
 		# e-mail regex
 		$s_email_regex = substr_replace( email_regex_simple(), '(?:mailto:)?', 1, 0 );
 	}
 
 	# Find any URL in a string and replace it by a clickable link
-	$p_string = preg_replace( $s_url_regex, $s_url_replace, $p_string );
+	$p_string = preg_replace_callback(
+		$s_url_regex,
+		function ($p_match) {
+			$t_url_href = 'href="' . rtrim( $p_match[1], '.' ) . '"';
+			return "<a ${t_url_href}>${p_match[1]}</a> [<a ${t_url_href} target=\"_blank\">^</a>]";
+		},
+		$p_string
+	);
 	if( $t_change_quotes ) {
 		ini_set( 'magic_quotes_sybase', true );
 	}


### PR DESCRIPTION
string_insert_hrefs() relied on PREG_REPLACE_EVAL ('e') pattern modifier
for preg_replace() to apply rtrim() function to subpatterns.

In PHP 5.5, this feature has been deprecated for security reasons [1] so
we rely on preg_replace_callback() instead.

Fixes #17292

[1] http://php.net/reference.pcre.pattern.modifiers.php#reference.pcre.pattern.modifiers.eval
