### PR TITLE
Modified 'mc_project_get_categories' soap api call to return id & name

### DIFF
--- a/api/soap/mantisconnect.php
+++ b/api/soap/mantisconnect.php
@@ -82,7 +82,7 @@ if ( !mci_is_webservice_call() ) {
 require_once( 'mc_core.php' );
 
 $server = new SoapServer("mantisconnect.wsdl",
-		array('features' => SOAP_USE_XSI_ARRAY_TYPE + SOAP_SINGLE_ELEMENT_ARRAYS)
+		array('features' => SOAP_USE_XSI_ARRAY_TYPE + SOAP_SINGLE_ELEMENT_ARRAYS, 'cache_wsdl' => WSDL_CACHE_NONE)
 );
 
 $server->addFunction(SOAP_FUNCTIONS_ALL);

--- a/api/soap/mantisconnect.wsdl
+++ b/api/soap/mantisconnect.wsdl
@@ -177,6 +177,19 @@
    />
   </xsd:all>
  </xsd:complexType>
+ <xsd:complexType name="CategoryData">
+  <xsd:all>
+   <xsd:element name="id" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="CategoryDataArray">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:CategoryData[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType> 
  <xsd:complexType name="HistoryDataArray">
   <xsd:complexContent>
    <xsd:restriction base="SOAP-ENC:Array">
@@ -621,7 +634,7 @@
   <part name="password" type="xsd:string" />
   <part name="project_id" type="xsd:integer" /></message>
 <message name="mc_project_get_categoriesResponse">
-  <part name="return" type="tns:StringArray" /></message>
+  <part name="return" type="tns:CategoryDataArray" /></message>
 <message name="mc_project_add_categoryRequest">
   <part name="username" type="xsd:string" />
   <part name="password" type="xsd:string" />

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -200,7 +200,10 @@ function mc_project_get_categories( $p_username, $p_password, $p_project_id ) {
 	$t_result = array();
 	$t_cat_array = category_get_all_rows( $p_project_id );
 	foreach( $t_cat_array as $t_category_row ) {
-		$t_result[] = $t_category_row['name'];
+		$t_categories = array();
+		$t_categories['id'] = $t_category_row['id'];
+		$t_categories['name'] = $t_category_row['name'];
+		$t_result[] = $t_categories;
 	}
 	return $t_result;
 }


### PR DESCRIPTION
Modified 'mc_project_get_categories' soap api call to return id & name rather than just an array of the names.
-this wouldn't work without adding 'WSDL_CACHE_NONE' to the soap server parameters (not sure why)

Considering categories are submitted by their id, I found it a bit baffling that getting a list of the categories for a project did not include the ids.. This should return both.
