### PR TITLE
0017336: Hide non-mysql experimental DB's for new installation whilst we get proven DB Layer into Mantis

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -524,11 +524,11 @@ if( !$g_database_upgrade ) {
 			$t_db_list = array(
 				'mysqli'      => 'MySQL Improved',
 				'mysql'       => 'MySQL',
-				'mssql'       => 'Microsoft SQL Server',
-				'mssqlnative' => 'Microsoft SQL Server Native Driver',
-				'pgsql'       => 'PostgreSQL',
-				'oci8'        => 'Oracle',
-				'db2'         => 'IBM DB2',
+			//	'mssql'       => 'Microsoft SQL Server',
+			//	'mssqlnative' => 'Microsoft SQL Server Native Driver',
+			//	'pgsql'       => 'PostgreSQL',
+			//	'oci8'        => 'Oracle',
+			//	'db2'         => 'IBM DB2',
 			);
 			# mysql is deprecated as of PHP 5.5.0
 			if( version_compare( phpversion(), '5.5.0' ) >= 0 ) {

--- a/docbook/Admin_Guide/en-US/Installation.xml
+++ b/docbook/Admin_Guide/en-US/Installation.xml
@@ -218,10 +218,12 @@
 					<para>Database</para>
 					<para>MantisBT requires a database to store its data.
 						The supported RDBMS are:
-							MySQL (recommended),
+							MySQL (recommended)
+						Experimental Support is provided for:
 							PostgreSQL,
 							Microsoft SQL Server and
 							Oracle.
+						For the 1.3 release, please contact us for assistance if you would like to use the experimental support for a new installation.
 					</para>
 					<note><para>
 						There is also experimental support for DB2, although


### PR DESCRIPTION
There's a rather lengthly explanation to go with this in the bug report - http://www.mantisbt.org/bugs/view.php?id=17336

So as not to confuse things, I won't repeat here.
