### PR TITLE
Make sure db prefix / suffix is consistently applied

### DIFF
--- a/core/database_api.php
+++ b/core/database_api.php
@@ -959,16 +959,20 @@ function db_get_table( $p_name ) {
 		$t_table = $p_name;
 	}
 
-	$t_prefix = config_get_global( 'db_table_prefix' );
-	$t_suffix = config_get_global( 'db_table_suffix' );
-
-	if( $t_prefix ) {
-		$t_table = $t_prefix . '_' . $t_table;
+	# Determine table prefix including trailing '_'
+	$t_prefix = trim( config_get_global( 'db_table_prefix' ) );
+	if( !empty( $t_prefix ) && '_' != substr( $t_prefix, -1 ) ) {
+		$t_prefix .= '_';
 	}
-	$t_table .= $t_suffix;
+	# Determine table suffix including leading '_'
+	$t_suffix = trim( config_get_global( 'db_table_suffix' ) );
+	if( !empty( $t_suffix ) && '_' != substr( $t_suffix, 0, 1 ) ) {
+		$t_suffix = '_' . $t_suffix;
+	}
 
+	# Physical table name
+	$t_table = $t_prefix . $t_table . $t_suffix;
 	db_check_identifier_size( $t_table );
-
 	return $t_table;
 }
 

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -195,16 +195,13 @@ function plugin_table( $p_name, $p_basename = null ) {
 		$t_current = $p_basename;
 	}
 
-	$t_table_name = config_get_global( 'db_table_prefix' );
-	if( !empty( $t_table_name ) ) {
-		$t_table_name .= '_';
+	# Determine plugin table prefix including trailing '_'
+	$t_prefix = trim( config_get_global( 'db_table_plugin_prefix' ) );
+	if( !empty( $t_prefix ) && '_' != substr( $t_prefix, -1 ) ) {
+		$t_prefix .= '_';
 	}
-	$t_table_name .=
-		config_get_global( 'db_table_plugin_prefix' ) .
-		$t_current . '_' . $p_name .
-		config_get_global( 'db_table_suffix' );
 
-	return $t_table_name;
+	return db_get_table( $t_prefix . $t_current . '_' . $p_name );
 }
 
 /**


### PR DESCRIPTION
Modifies the db_get_table() and plugin_table() functions to ensure that
we build a correct table name based on the user's config settings, e.g.
- trim leading/trailing whitespace
- do not add underscores if already present

Fixes #17355, regression issue introduced by commit
5a84e9db76162e378b9a1b0dea129d1f7ce127e9 where plugin_table() no longer
inserts an underscore after $g_db_table_plugin_prefix
