### PR TITLE
use strtolower over utf8_strtolower for choice of get|post.

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1420,7 +1420,7 @@ function html_button( $p_action, $p_button_text, $p_fields = null, $p_method = '
 		$p_fields = array();
 	}
 
-	if( utf8_strtolower( $p_method ) == 'get' ) {
+	if( strtolower( $p_method ) == 'get' ) {
 		$t_method = 'get';
 	} else {
 		$t_method = 'post';


### PR DESCRIPTION
We should probably consider whether to change this function to use a user defined constant.
