### PR TITLE
Fix: Email processing occurs in the wrong order.

### DIFF
--- a/core/email_queue_api.php
+++ b/core/email_queue_api.php
@@ -205,13 +205,12 @@ function email_queue_delete( $p_email_id ) {
 
 /**
  * Get array of email queue id's
- * @param string $p_sort_order 'ASC' or 'DESC' (defaults to DESC)
  * @return array
  */
-function email_queue_get_ids( $p_sort_order = 'DESC' ) {
+function email_queue_get_ids() {
 	$t_email_table = db_get_table( 'email' );
 
-	$query = "SELECT email_id FROM $t_email_table ORDER BY email_id $p_sort_order";
+	$query = "SELECT email_id FROM $t_email_table ORDER BY email_id ASC";
 	$t_result = db_query_bound( $query );
 
 	$t_ids = array();


### PR DESCRIPTION
The purpose of the email queue is to allow batch processing emails to speed up web page response.

Our aim should be to ensure the email table is as close to empty at all times,
(if cron jobs are not used, we try to clear the table at the end of the web page request)

Therefore:

a) There's no need to define a custom sort order for the table. In the ideal world, where the table is empty, the sort order is going to be irrelevant

b) Emails should be sent in the order they are generated. Therefore, they should always be processed in ASCending order.

After this, I plan on looking at how we handle emails that previously errored to ensure that users are notified of problems in some way, and we avoid performance issues, as email troubleshooting is one of our more popular support issues with end users
