### PR TITLE
Fix #0016570: Page content is forgotten when user clicks [Back] button

### DIFF
--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -41,6 +41,8 @@
  * @uses version_api.php
  */
 
+$g_allow_browser_cache = 1;
+
 require_once( 'core.php' );
 require_api( 'access_api.php' );
 require_api( 'authentication_api.php' );
@@ -59,8 +61,6 @@ require_api( 'print_api.php' );
 require_api( 'relationship_api.php' );
 require_api( 'sponsorship_api.php' );
 require_api( 'version_api.php' );
-
-$g_allow_browser_cache = 1;
 
 $f_bug_id = gpc_get_int( 'id' );
 $t_bug = bug_get( $f_bug_id );

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -49,6 +49,8 @@
  * @uses version_api.php
  */
 
+$g_allow_browser_cache = 1;
+
 require_once( 'core.php' );
 require_api( 'access_api.php' );
 require_api( 'authentication_api.php' );
@@ -74,8 +76,6 @@ require_api( 'relationship_api.php' );
 require_api( 'string_api.php' );
 require_api( 'utility_api.php' );
 require_api( 'version_api.php' );
-
-$g_allow_browser_cache = 1;
 
 $f_master_bug_id = gpc_get_int( 'm_id', 0 );
 

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -46,6 +46,8 @@
  * @uses version_api.php
  */
 
+$g_allow_browser_cache = 1;
+
 require_once( 'core.php' );
 require_api( 'access_api.php' );
 require_api( 'authentication_api.php' );
@@ -70,8 +72,6 @@ require_api( 'user_api.php' );
 require_api( 'version_api.php' );
 
 require_css( 'status_config.php' );
-
-$g_allow_browser_cache = 1;
 
 $f_bug_id = gpc_get_int( 'bug_id' );
 


### PR DESCRIPTION
By default we disable $g_allow_browser_cache in all circumstances.

The config value is commented out in config_defaults.inc.php. In fact, thraxisp
added the config option in 2005 in the commented out state.

It would appear the DHX re-ordered this call when implemented require_api
- see:
  
  https://github.com/mantisbt/mantisbt/commit/2d5455cce290531359a55d353010258c6f3f6f34

The above code is only in 1.3 and not in the 1.2 series, so the above fix should
be safe to apply.

We probably need to consider whether we actually want to remove this configuration option

After all, it's a configuration option we've probably never had anyone use in 5 years
so I expect that the value of it is rather....
