### PR TITLE
Backport DB API changes functionality to set table name.

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -3203,7 +3203,7 @@ $g_create_short_url = 'http://tinyurl.com/create.php?url=%s';
  * should be set to blank or kept as short as possible (e.g. 'm')
  * @global string $g_db_table_prefix
  */
-$g_db_table_prefix = 'mantis_';
+$g_db_table_prefix = 'mantis';
 
 /**
  * plugin table prefix

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -354,8 +354,16 @@ function db_query_bound( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_
 	static $s_prefix;
 	static $s_suffix;
 	if( $s_prefix === null ) {
-		$s_prefix = config_get_global( 'db_table_prefix' );
-		$s_suffix = config_get_global( 'db_table_suffix' );
+		# Determine table prefix and suffixes including trailing and leading '_'
+		$s_prefix = trim( config_get_global( 'db_table_prefix' ) );
+		$s_suffix = trim( config_get_global( 'db_table_suffix' ) );
+
+		if( !empty( $s_prefix ) && '_' != substr( $s_prefix, -1 ) ) {
+			$s_prefix .= '_';
+		}
+		if( !empty( $s_suffix ) && '_' != substr( $s_suffix, 0, 1 ) ) {
+			$s_suffix = '_' . $s_suffix;
+		}
 	}
 
 	$p_query = strtr($p_query, array(


### PR DESCRIPTION
This would allow the use of the new syntax i.e.:

-$t_query = 'SELECT COUNT(_) AS unused_user_count FROM ' . $t_user_table . '
+$t_query = 'SELECT COUNT(_) AS unused_user_count FROM {user}

Whilst still allowing use of the old syntax, to give developers and plugin
authors the opportunity to start migrating code to the new syntax ready
for the 2.x.

By doing this, it also helps us extend the life of 1.3 - as it stands, if we
release test versions of mantis with the new DB layer about within a month of
the final 1.3 release as previously agreed, we could reach the stage where we
have support issues from our side for the 1.3 release.
