### PR TITLE
Remove inbuilt php long arrays

### DIFF
--- a/api/soap/mantisconnect.php
+++ b/api/soap/mantisconnect.php
@@ -40,15 +40,10 @@ require_once( $t_mantis_dir . 'core.php' );
  * @return boolean
  */
 function mci_is_webservice_call() {
-	global $QUERY_STRING;
-	global $_SERVER;
-
 	if( isset( $_SERVER['QUERY_STRING'] ) ) {
 		$t_qs = $_SERVER['QUERY_STRING'];
 	} else if( isset( $GLOBALS['QUERY_STRING'] ) ) {
 		$t_qs = $GLOBALS['QUERY_STRING'];
-	} else if( isset( $QUERY_STRING ) && $QUERY_STRING != '' ) {
-		$t_qs = $QUERY_STRING;
 	}
 
 	if( isset( $t_qs ) && preg_match( '/wsdl/', $t_qs ) ) {


### PR DESCRIPTION
PHP Long arrays are deprecated and removed in php 5.4.

We already check both $_SERVER and $GLOBALS
so there's no need to check for $QUERY_STRING itself.
