### PR TITLE
Fix: adm_config_report.php filtering does not check config option is val...

### DIFF
--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -182,6 +182,7 @@ if( $t_filter_save ) {
 } else {
 	# Retrieve the filter from the cookie if it exists
 	$t_cookie_string = gpc_get_cookie( $t_cookie_name, null );
+
 	if( null !== $t_cookie_string ) {
 		$t_cookie_contents = explode( ':', $t_cookie_string );
 
@@ -192,6 +193,16 @@ if( $t_filter_save ) {
 		if( $t_filter_project_value != META_FILTER_NONE && !project_exists( $t_filter_project_value ) ) {
 			$t_filter_project_value = ALL_PROJECTS;
 		}
+	}
+}
+
+if( !is_blank( $t_filter_config_value ) && (int)$t_filter_config_value !== META_FILTER_NONE ) {
+	// check that config value exists
+	if( @config_get_global( $t_filter_config_value ) === null ) {
+		$t_cookie_path = config_get( 'cookie_path' );
+		gpc_clear_cookie( $t_cookie_name, $t_cookie_path );
+
+		trigger_error( ERROR_GENERIC, ERROR );
 	}
 }
 


### PR DESCRIPTION
...id

I've left this throwing ERROR_GENERIC as the only time this should be able
to be hit is if we have invalid input to start with.
