### PR TITLE
The value stored in the config table may be a string, boolean, or intege...

### DIFF
--- a/core/config_api.php
+++ b/core/config_api.php
@@ -376,7 +376,7 @@ function config_set( $p_option, $p_value, $p_user = NO_USER, $p_project = ALL_PR
 						project_id = ' . db_param() . ' AND
 						user_id = ' . db_param();
 			$t_params = array(
-				$c_value,
+				(string)$c_value,
 				$t_type,
 				(int)$p_access,
 				$p_option,
@@ -389,7 +389,7 @@ function config_set( $p_option, $p_value, $p_user = NO_USER, $p_project = ALL_PR
 					VALUES
 					(' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ',' . db_param() . ' )';
 			$t_params = array(
-				$c_value,
+				(string)$c_value,
 				$t_type,
 				(int)$p_access,
 				$p_option,


### PR DESCRIPTION
...r.

For better compatibility across the db layers, we should always cast this
to a string, to match the underlying data type.
