### PR TITLE
Make plugin dependency fail with new Mantis release

### DIFF
--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -584,7 +584,7 @@ function plugin_dependency( $p_base_name, $p_required, $p_initialized = false ) 
 			$t_is_current_core_supported = false;
 			foreach( $t_required_array as $t_version_required ) {
 				$t_is_current_core_supported = $t_is_current_core_supported
-					|| version_compare( trim( $t_version_required ), $t_version_core, ">=" );
+					|| version_compare( trim( $t_version_required ), $t_version_core, '>=' );
 			}
 			if( !$t_is_current_core_supported ) {
 				$t_required_array[] = '<' . $t_version_core;


### PR DESCRIPTION
This is a follow-up of discussion in [Issue 17360](http://www.mantisbt.org/bugs/view.php?id=17360) (see also #234), which implements @grangeway's [suggestion](http://www.mantisbt.org/bugs/view.php?id=17360#c40643).

If a plugin's minimum dependency for _MantisCore_ is unspecified or lower than the current release (i.e. the plugin does not specifically list the current core version as supported) and the plugin does not define a maximum dependency, we add one with the current version's minor release (i.e. for 1.3.1 we would add '<1.3').

The purpose of this is to avoid compatibility issues by disabling plugins which have not been updated for a new Mantis release; authors have to revise their code (if necessary), and release a new version of the plugin with updated dependencies.
