### PR TITLE
Update db_get_table() calls for table 'user_pref'

### DIFF
--- a/core/profile_api.php
+++ b/core/profile_api.php
@@ -299,9 +299,7 @@ function profile_get_all_for_project( $p_project_id ) {
  * @return string
  */
 function profile_get_default( $p_user_id ) {
-	$t_mantis_user_pref_table = db_get_table( 'user_pref' );
-
-	$t_query = 'SELECT default_profile FROM ' . $t_mantis_user_pref_table . ' WHERE user_id=' . db_param();
+	$t_query = 'SELECT default_profile FROM {user_pref} WHERE user_id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_user_id ) );
 
 	$t_default_profile = (int)db_result( $t_result, 0, 0 );

--- a/core/user_pref_api.php
+++ b/core/user_pref_api.php
@@ -304,8 +304,7 @@ function user_pref_cache_row( $p_user_id, $p_project_id = ALL_PROJECTS, $p_trigg
 		return $g_cache_user_pref[(int)$p_user_id][(int)$p_project_id];
 	}
 
-	$t_user_pref_table = db_get_table( 'user_pref' );
-	$t_query = 'SELECT * FROM ' . $t_user_pref_table . ' WHERE user_id=' . db_param() . ' AND project_id=' . db_param();
+	$t_query = 'SELECT * FROM {user_pref} WHERE user_id=' . db_param() . ' AND project_id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( (int)$p_user_id, (int)$p_project_id ) );
 
 	$t_row = db_fetch_array( $t_result );
@@ -350,9 +349,7 @@ function user_pref_cache_array_rows( array $p_user_id_array, $p_project_id = ALL
 		return;
 	}
 
-	$t_user_pref_table = db_get_table( 'user_pref' );
-
-	$t_query = 'SELECT * FROM ' . $t_user_pref_table . ' WHERE user_id IN (' . implode( ',', $c_user_id_array ) . ') AND project_id=' . db_param();
+	$t_query = 'SELECT * FROM {user_pref} WHERE user_id IN (' . implode( ',', $c_user_id_array ) . ') AND project_id=' . db_param();
 
 	$t_result = db_query_bound( $t_query, array( (int)$p_project_id ) );
 
@@ -440,9 +437,8 @@ function user_pref_insert( $p_user_id, $p_project_id, UserPreferences $p_prefs )
 	$t_vars_string = implode( ', ', array_keys( $s_vars ) );
 	$t_params_string = implode( ',', $t_params );
 
-	$t_user_pref_table = db_get_table( 'user_pref' );
-	$t_query = 'INSERT INTO ' . $t_user_pref_table .
-			 ' (user_id, project_id, ' . $t_vars_string . ') VALUES ( ' . $t_params_string . ')';
+	$t_query = 'INSERT INTO {user_pref}
+			  (user_id, project_id, ' . $t_vars_string . ') VALUES ( ' . $t_params_string . ')';
 	db_query_bound( $t_query, $t_values );
 
 	return true;
@@ -476,8 +472,7 @@ function user_pref_update( $p_user_id, $p_project_id, UserPreferences $p_prefs )
 	$t_values[] = $p_user_id;
 	$t_values[] = $p_project_id;
 
-	$t_user_pref_table = db_get_table( 'user_pref' );
-	$t_query = 'UPDATE ' . $t_user_pref_table . ' SET ' . $t_pairs_string . '
+	$t_query = 'UPDATE {user_pref} SET ' . $t_pairs_string . '
 				  WHERE user_id=' . db_param() . ' AND project_id=' . db_param();
 	db_query_bound( $t_query, $t_values );
 
@@ -494,8 +489,7 @@ function user_pref_update( $p_user_id, $p_project_id, UserPreferences $p_prefs )
 function user_pref_delete( $p_user_id, $p_project_id = ALL_PROJECTS ) {
 	user_ensure_unprotected( $p_user_id );
 
-	$t_user_pref_table = db_get_table( 'user_pref' );
-	$t_query = 'DELETE FROM ' . $t_user_pref_table . '
+	$t_query = 'DELETE FROM {user_pref}
 				  WHERE user_id=' . db_param() . ' AND
 				  		project_id=' . db_param();
 	db_query_bound( $t_query, array( $p_user_id, $p_project_id ) );
@@ -516,8 +510,7 @@ function user_pref_delete( $p_user_id, $p_project_id = ALL_PROJECTS ) {
 function user_pref_delete_all( $p_user_id ) {
 	user_ensure_unprotected( $p_user_id );
 
-	$t_user_pref_table = db_get_table( 'user_pref' );
-	$t_query = 'DELETE FROM ' . $t_user_pref_table . ' WHERE user_id=' . db_param();
+	$t_query = 'DELETE FROM {user_pref} WHERE user_id=' . db_param();
 	db_query_bound( $t_query, array( $p_user_id ) );
 
 	user_pref_clear_cache( $p_user_id );
@@ -533,8 +526,7 @@ function user_pref_delete_all( $p_user_id ) {
  * @return void
  */
 function user_pref_delete_project( $p_project_id ) {
-	$t_user_pref_table = db_get_table( 'user_pref' );
-	$t_query = 'DELETE FROM ' . $t_user_pref_table . ' WHERE project_id=' . db_param();
+	$t_query = 'DELETE FROM {user_pref} WHERE project_id=' . db_param();
 	db_query_bound( $t_query, array( $p_project_id ) );
 }
 


### PR DESCRIPTION
#216 adds support for the new table name syntax,

allowing us to replace db_get_table calls within queries.

Calls to db_get_table that are used by other database function,
i.e. db_insert_id, db_field_exists are deliberately left unchanged at this
stage.

This is aimed at breaking down the future DB API changes into manageable
chunks, and to aid the review process after 1.3 for 2.0.

This Pull request deals with calls for the 'user_pref' table only,
for ease of review, and syncing until merged.
