### PR TITLE
Update db_get_table() calls for table 'user_print_pref'

### DIFF
--- a/print_all_bug_options_inc.php
+++ b/print_all_bug_options_inc.php
@@ -97,8 +97,6 @@ function edit_printing_prefs( $p_user_id = null, $p_error_if_protected = true, $
 		user_ensure_unprotected( $p_user_id );
 	}
 
-	$t_user_print_pref_table = db_get_table( 'user_print_pref' );
-
 	if( is_blank( $p_redirect_url ) ) {
 		$p_redirect_url = 'print_all_bug_page.php';
 	}
@@ -108,7 +106,7 @@ function edit_printing_prefs( $p_user_id = null, $p_error_if_protected = true, $
 	$t_field_name_count = count( $t_field_name_arr );
 
 	# Grab the data
-	$t_query = 'SELECT print_pref FROM ' . $t_user_print_pref_table . ' WHERE user_id=' . db_param();
+	$t_query = 'SELECT print_pref FROM {user_print_pref} WHERE user_id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_user_id ) );
 
 	## OOPS, No entry in the database yet.	Lets make one
@@ -121,14 +119,14 @@ function edit_printing_prefs( $p_user_id = null, $p_error_if_protected = true, $
 
 		# all fields are added by default
 		$t_query = 'INSERT
-				INTO ' . $t_user_print_pref_table . '
+				INTO {user_print_pref}
 				(user_id, print_pref)
 				VALUES
 				(' . db_param() . ',' . db_param() . ')';
 		db_query_bound( $t_query, array( $p_user_id, $t_default ) );
 
 		# Rerun select query
-		$t_query = 'SELECT print_pref FROM ' . $t_user_print_pref_table . ' WHERE user_id=' . db_param();
+		$t_query = 'SELECT print_pref FROM {user_print_pref} WHERE user_id=' . db_param();
 		$t_result = db_query_bound( $t_query, array( $p_user_id ) );
 	}
 

--- a/print_all_bug_options_reset.php
+++ b/print_all_bug_options_reset.php
@@ -69,8 +69,7 @@ for( $i=0; $i<$t_field_name_count; $i++ ) {
 $t_default = implode( '', $t_default_arr );
 
 # reset to defaults
-$t_user_print_pref_table = db_get_table( 'user_print_pref' );
-$t_query = 'UPDATE ' . $t_user_print_pref_table . ' SET print_pref=' . db_param() . ' WHERE user_id=' . db_param();
+$t_query = 'UPDATE {user_print_pref} SET print_pref=' . db_param() . ' WHERE user_id=' . db_param();
 
 $t_result = db_query_bound( $t_query, array( $t_default, $t_user_id ) );
 

--- a/print_all_bug_options_update.php
+++ b/print_all_bug_options_update.php
@@ -80,8 +80,7 @@ $t_user_id = $f_user_id;
 $c_export = implode( '', $t_prefs_arr );
 
 # update preferences
-$t_user_print_pref_table = db_get_table( 'user_print_pref' );
-$t_query = 'UPDATE ' . $t_user_print_pref_table . ' SET print_pref=' . db_param() . ' WHERE user_id=' . db_param();
+$t_query = 'UPDATE {user_print_pref} SET print_pref=' . db_param() . ' WHERE user_id=' . db_param();
 
 $t_result = db_query_bound( $t_query, array( $c_export, $t_user_id ) );
 


### PR DESCRIPTION
#216 adds support for the new table name syntax,

allowing us to replace db_get_table calls within queries.

Calls to db_get_table that are used by other database function,
i.e. db_insert_id, db_field_exists are deliberately left unchanged at this
stage.

This is aimed at breaking down the future DB API changes into manageable
chunks, and to aid the review process after 1.3 for 2.0.

This Pull request deals with calls for the 'user_print_pref' table only,
for ease of review, and syncing until merged.
