### PR TITLE
Update db_get_table() calls for table 'user_profile'

### DIFF
--- a/core/profile_api.php
+++ b/core/profile_api.php
@@ -79,7 +79,7 @@ function profile_create( $p_user_id, $p_platform, $p_os, $p_os_build, $p_descrip
 	$t_user_profile_table = db_get_table( 'user_profile' );
 
 	# Add profile
-	$t_query = 'INSERT INTO ' . $t_user_profile_table . '
+	$t_query = 'INSERT INTO {user_profile}
 				    ( user_id, platform, os, os_build, description )
 				  VALUES
 				    ( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
@@ -103,10 +103,8 @@ function profile_delete( $p_user_id, $p_profile_id ) {
 		user_ensure_unprotected( $p_user_id );
 	}
 
-	$t_user_profile_table = db_get_table( 'user_profile' );
-
 	# Delete the profile
-	$t_query = 'DELETE FROM ' . $t_user_profile_table . ' WHERE id=' . db_param() . ' AND user_id=' . db_param();
+	$t_query = 'DELETE FROM {user_profile} WHERE id=' . db_param() . ' AND user_id=' . db_param();
 	db_query_bound( $t_query, array( $p_profile_id, $p_user_id ) );
 }
 
@@ -143,10 +141,8 @@ function profile_update( $p_user_id, $p_profile_id, $p_platform, $p_os, $p_os_bu
 		trigger_error( ERROR_EMPTY_FIELD, ERROR );
 	}
 
-	$t_user_profile_table = db_get_table( 'user_profile' );
-
 	# Add item
-	$t_query = 'UPDATE ' . $t_user_profile_table . '
+	$t_query = 'UPDATE {user_profile}
 				  SET platform=' . db_param() . ',
 				  	  os=' . db_param() . ',
 					  os_build=' . db_param() . ',
@@ -162,9 +158,7 @@ function profile_update( $p_user_id, $p_profile_id, $p_platform, $p_os, $p_os_bu
  * @return array
  */
 function profile_get_row( $p_user_id, $p_profile_id ) {
-	$t_user_profile_table = db_get_table( 'user_profile' );
-
-	$t_query = 'SELECT * FROM ' . $t_user_profile_table . ' WHERE id=' . db_param() . ' AND user_id=' . db_param();
+	$t_query = 'SELECT * FROM {user_profile} WHERE id=' . db_param() . ' AND user_id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_profile_id, $p_user_id ) );
 
 	return db_fetch_array( $t_result );
@@ -177,9 +171,7 @@ function profile_get_row( $p_user_id, $p_profile_id ) {
  * @todo relationship of this function to profile_get_row?
  */
 function profile_get_row_direct( $p_profile_id ) {
-	$t_user_profile_table = db_get_table( 'user_profile' );
-
-	$t_query = 'SELECT * FROM ' . $t_user_profile_table . ' WHERE id=' . db_param();
+	$t_query = 'SELECT * FROM {user_profile} WHERE id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_profile_id ) );
 
 	return db_fetch_array( $t_result );
@@ -192,8 +184,6 @@ function profile_get_row_direct( $p_profile_id ) {
  * @return array
  */
 function profile_get_all_rows( $p_user_id, $p_all_users = false ) {
-	$t_user_profile_table = db_get_table( 'user_profile' );
-
 	$t_query_where = 'user_id = ' . db_param();
 	$t_param[] = (int)$p_user_id;
 
@@ -202,9 +192,7 @@ function profile_get_all_rows( $p_user_id, $p_all_users = false ) {
 		$t_param[] = ALL_USERS;
 	}
 
-	$t_query = 'SELECT * FROM ' . $t_user_profile_table . '
-				  WHERE ' . $t_query_where . '
-				  ORDER BY platform, os, os_build';
+	$t_query = 'SELECT * FROM {user_profile} WHERE ' . $t_query_where . ' ORDER BY platform, os, os_build';
 	$t_result = db_query_bound( $t_query, $t_param );
 
 	$t_rows = array();
@@ -249,10 +237,8 @@ function profile_get_field_all_for_user( $p_field, $p_user_id = null ) {
 			trigger_error( ERROR_GENERIC, ERROR );
 	}
 
-	$t_user_profile_table = db_get_table( 'user_profile' );
-
 	$t_query = 'SELECT DISTINCT ' . $c_field . '
-				  FROM ' . $t_user_profile_table . '
+				  FROM {user_profile}
 				  WHERE ( user_id=' . db_param() . ' ) OR ( user_id = 0 )
 				  ORDER BY ' . $c_field;
 	$t_result = db_query_bound( $t_query, array( $c_user_id ) );
@@ -275,10 +261,9 @@ function profile_get_all_for_project( $p_project_id ) {
 	$t_project_where = helper_project_specific_where( $p_project_id );
 
 	$t_bug_table = db_get_table( 'bug' );
-	$t_user_profile_table = db_get_table( 'user_profile' );
 
 	$t_query = 'SELECT DISTINCT(up.id), up.user_id, up.platform, up.os, up.os_build
-				  FROM ' . $t_user_profile_table . ' up, ' . $t_bug_table . ' b
+				  FROM {user_profile} up, ' . $t_bug_table . ' b
 				  WHERE ' . $t_project_where . '
 				  AND up.id = b.profile_id
 				  ORDER BY platform, os, os_build';

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -631,10 +631,8 @@ function user_delete_project_specific_access_levels( $p_user_id ) {
 function user_delete_profiles( $p_user_id ) {
 	user_ensure_unprotected( $p_user_id );
 
-	$t_user_profile_table = db_get_table( 'user_profile' );
-
 	# Remove associated profiles
-	$t_query = 'DELETE FROM ' . $t_user_profile_table . ' WHERE user_id=' . db_param();
+	$t_query = 'DELETE FROM {user_profile} WHERE user_id=' . db_param();
 	db_query_bound( $t_query, array( (int)$p_user_id ) );
 
 	user_clear_cache( $p_user_id );
@@ -1293,8 +1291,7 @@ function user_get_reported_open_bug_count( $p_user_id, $p_project_id = ALL_PROJE
  * @return array
  */
 function user_get_profile_row( $p_user_id, $p_profile_id ) {
-	$t_user_profile_table = db_get_table( 'user_profile' );
-	$t_query = 'SELECT * FROM ' . $t_user_profile_table . '
+	$t_query = 'SELECT * FROM {user_profile}
 				  WHERE id=' . db_param() . ' AND
 						user_id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_profile_id, $p_user_id ) );


### PR DESCRIPTION
#216 adds support for the new table name syntax,

allowing us to replace db_get_table calls within queries.

Calls to db_get_table that are used by other database function,
i.e. db_insert_id, db_field_exists are deliberately left unchanged at this
stage.

This is aimed at breaking down the future DB API changes into manageable
chunks, and to aid the review process after 1.3 for 2.0.

This Pull request deals with calls for the 'user_profile' table only,
for ease of review, and syncing until merged.
