### PR TITLE
Update db_get_table() calls for table 'user'

### DIFF
--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -585,8 +585,7 @@ function auth_generate_unique_cookie_string() {
  * @access public
  */
 function auth_is_cookie_string_unique( $p_cookie_string ) {
-	$t_user_table = db_get_table( 'user' );
-	$t_query = 'SELECT COUNT(*) FROM ' . $t_user_table . ' WHERE cookie_string=' . db_param();
+	$t_query = 'SELECT COUNT(*) FROM {user} WHERE cookie_string=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_cookie_string ) );
 
 	$t_count = db_result( $t_result );
@@ -792,9 +791,7 @@ function auth_is_cookie_valid( $p_cookie_string ) {
 	}
 
 	# look up cookie in the database to see if it is valid
-	$t_user_table = db_get_table( 'user' );
-
-	$t_query = 'SELECT * FROM ' . $t_user_table . ' WHERE cookie_string=' . db_param();
+	$t_query = 'SELECT * FROM {user} WHERE cookie_string=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_cookie_string ) );
 
 	# return true if a matching cookie was found
@@ -826,10 +823,8 @@ function auth_get_current_user_id() {
 		return $t_user_id;
 	}
 
-	$t_user_table = db_get_table( 'user' );
-
 	# @todo error with an error saying they aren't logged in? Or redirect to the login page maybe?
-	$t_query = 'SELECT id FROM ' . $t_user_table . ' WHERE cookie_string=' . db_param();
+	$t_query = 'SELECT id FROM {user} WHERE cookie_string=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $t_cookie_string ) );
 
 	$t_user_id = (int)db_result( $t_result );

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1898,11 +1898,10 @@ function bug_get_monitors( $p_bug_id ) {
 	}
 
 	$t_bug_monitor_table = db_get_table( 'bug_monitor' );
-	$t_user_table = db_get_table( 'user' );
 
 	# get the bugnote data
 	$t_query = 'SELECT user_id, enabled
-			FROM ' . $t_bug_monitor_table . ' m, ' . $t_user_table . ' u
+			FROM ' . $t_bug_monitor_table . ' m, {user} u
 			WHERE m.bug_id=' . db_param() . ' AND m.user_id = u.id
 			ORDER BY u.realname, u.username';
 	$t_result = db_query_bound( $t_query, array( $p_bug_id ) );

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -630,10 +630,9 @@ function bugnote_stats_get_events_array( $p_bug_id, $p_from, $p_to ) {
 
 	$t_results = array();
 
-	$t_user_table = db_get_table( 'user' );
 	$t_bugnote_table = db_get_table( 'bugnote' );
 	$t_query = 'SELECT username, realname, SUM(time_tracking) AS sum_time_tracking
-				FROM ' . $t_user_table . ' u, ' . $t_bugnote_table . ' bn
+				FROM {user} u, ' . $t_bugnote_table . ' bn
 				WHERE u.id = bn.reporter_id AND bn.time_tracking != 0 AND
 				bn.bug_id = ' . db_param() . $t_from_where . $t_to_where .
 				' GROUP BY u.username, u.realname';
@@ -690,10 +689,9 @@ function bugnote_stats_get_project_array( $p_project_id, $p_from, $p_to, $p_cost
 	$t_results = array();
 
 	$t_bug_table = db_get_table( 'bug' );
-	$t_user_table = db_get_table( 'user' );
 	$t_bugnote_table = db_get_table( 'bugnote' );
 	$t_query = 'SELECT username, realname, summary, bn.bug_id, SUM(time_tracking) AS sum_time_tracking
-			FROM ' . $t_user_table . ' u, ' . $t_bugnote_table . ' bn, ' . $t_bug_table . ' b
+			FROM {user} u, ' . $t_bugnote_table . ' bn, ' . $t_bug_table . ' b
 			WHERE u.id = bn.reporter_id AND bn.time_tracking != 0 AND bn.bug_id = b.id
 			' . $t_project_where . $t_from_where . $t_to_where . '
 			GROUP BY bn.bug_id, u.username, u.realname, b.summary

--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -644,7 +644,6 @@ function custom_field_get_linked_ids( $p_project_id = ALL_PROJECTS ) {
 		if( ALL_PROJECTS == $p_project_id ) {
 			$t_project_user_list_table = db_get_table( 'project_user_list' );
 			$t_project_table = db_get_table( 'project' );
-			$t_user_table = db_get_table( 'user' );
 			$t_user_id = auth_get_current_user_id();
 
 			# Select only the ids of custom fields in projects the user has access to
@@ -658,7 +657,7 @@ function custom_field_get_linked_ids( $p_project_id = ALL_PROJECTS ) {
 						ON pt.id = cfpt.project_id AND pt.enabled = ' . db_prepare_bool( true ) . '
 					LEFT JOIN ' . $t_project_user_list_table . ' pult
 						ON pult.project_id = cfpt.project_id AND pult.user_id = ' . db_param() . '
-					, ' . $t_user_table . ' ut
+					, {user} ut
 				WHERE ut.id = ' . db_param() . '
 					AND (  pt.view_state = ' . VS_PUBLIC . '
 						OR pult.user_id = ut.id

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -631,7 +631,6 @@ function project_get_all_user_rows( $p_project_id = ALL_PROJECTS, $p_access_leve
 		return array();
 	}
 
-	$t_user_table = db_get_table( 'user' );
 	$t_project_user_list_table = db_get_table( 'project_user_list' );
 
 	$t_on = ON;
@@ -691,7 +690,7 @@ function project_get_all_user_rows( $p_project_id = ALL_PROJECTS, $p_access_leve
 
 	if( $p_include_global_users ) {
 		$t_query = 'SELECT id, username, realname, access_level
-				FROM ' . $t_user_table . '
+				FROM {user}
 				WHERE enabled = ' . db_param() . '
 					AND access_level ' . $t_global_access_clause;
 
@@ -706,7 +705,7 @@ function project_get_all_user_rows( $p_project_id = ALL_PROJECTS, $p_access_leve
 	if( $c_project_id != ALL_PROJECTS ) {
 		# Get the project overrides
 		$t_query = 'SELECT u.id, u.username, u.realname, l.access_level
-				FROM ' . $t_project_user_list_table . ' l, ' . $t_user_table . ' u
+				FROM ' . $t_project_user_list_table . ' l, {user} u
 				WHERE l.user_id = u.id
 				AND u.enabled = ' . db_param() . '
 				AND l.project_id = ' . db_param();

--- a/core/tag_api.php
+++ b/core/tag_api.php
@@ -759,14 +759,13 @@ function tag_stats_related( $p_tag_id, $p_limit = 5 ) {
 	$t_tag_table = db_get_table( 'tag' );
 	$t_bug_tag_table = db_get_table( 'bug_tag' );
 	$t_project_user_list_table = db_get_table( 'project_user_list' );
-	$t_user_table = db_get_table( 'user' );
 
 	$c_user_id = auth_get_current_user_id();
 
 	$t_subquery = 'SELECT b.id FROM ' . $t_bug_table . ' b
 					LEFT JOIN ' . $t_project_user_list_table . ' p
 						ON p.project_id=b.project_id AND p.user_id=' . db_param() . # 2nd Param
-					' JOIN ' . $t_user_table . ' u
+					' JOIN {user} u
 						ON u.id=' . db_param() . # 3rd Param
 					' JOIN ' . $t_bug_tag_table . ' t
 						ON t.bug_id=b.id

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -78,9 +78,7 @@ function user_cache_row( $p_user_id, $p_trigger_errors = true ) {
 		return $g_cache_user[$p_user_id];
 	}
 
-	$t_user_table = db_get_table( 'user' );
-
-	$t_query = 'SELECT * FROM ' . $t_user_table . ' WHERE id=' . db_param();
+	$t_query = 'SELECT * FROM {user} WHERE id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_user_id ) );
 
 	if( 0 == db_num_rows( $t_result ) ) {
@@ -121,8 +119,7 @@ function user_cache_array_rows( array $p_user_id_array ) {
 		return;
 	}
 
-	$t_user_table = db_get_table( 'user' );
-	$t_query = 'SELECT * FROM ' . $t_user_table . ' WHERE id IN (' . implode( ',', $c_user_id_array ) . ')';
+	$t_query = 'SELECT * FROM {user} WHERE id IN (' . implode( ',', $c_user_id_array ) . ')';
 	$t_result = db_query_bound( $t_query );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -239,9 +236,7 @@ function user_ensure_exists( $p_user_id ) {
  * @return boolean
  */
 function user_is_name_unique( $p_username ) {
-	$t_user_table = db_get_table( 'user' );
-
-	$t_query = 'SELECT username FROM ' . $t_user_table . ' WHERE username=' . db_param();
+	$t_query = 'SELECT username FROM {user} WHERE username=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_username ), 1 );
 
 	if( db_num_rows( $t_result ) > 0 ) {
@@ -291,8 +286,7 @@ function user_is_realname_unique( $p_username, $p_realname ) {
 		}
 
 		# check to see if the realname is unique
-		$t_user_table = db_get_table( 'user' );
-		$t_query = 'SELECT id FROM ' . $t_user_table . ' WHERE realname=' . db_param();
+		$t_query = 'SELECT id FROM {user} WHERE realname=' . db_param();
 		$t_result = db_query_bound( $t_query, array( $p_realname ) );
 
 		$t_users = array();
@@ -467,8 +461,7 @@ function user_is_enabled( $p_user_id ) {
  * @return integer
  */
 function user_count_level( $p_level = ANYBODY ) {
-	$t_user_table = db_get_table( 'user' );
-	$t_query = 'SELECT COUNT(id) FROM ' . $t_user_table . ' WHERE access_level>=' . db_param();
+	$t_query = 'SELECT COUNT(id) FROM {user} WHERE access_level>=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_level ) );
 
 	# Get the list of connected users
@@ -496,10 +489,8 @@ function user_get_logged_in_user_ids( $p_session_duration_in_minutes ) {
 	# Generate timestamp
 	$t_last_timestamp_threshold = mktime( date( 'H' ), date( 'i' ) - 1 * $t_session_duration_in_minutes, date( 's' ), date( 'm' ), date( 'd' ), date( 'Y' ) );
 
-	$t_user_table = db_get_table( 'user' );
-
 	# Execute query
-	$t_query = 'SELECT id FROM ' . $t_user_table . ' WHERE last_visit > ' . db_param();
+	$t_query = 'SELECT id FROM {user} WHERE last_visit > ' . db_param();
 	$t_result = db_query_bound( $t_query, array( $t_last_timestamp_threshold ), 1 );
 
 	# Get the list of connected users
@@ -544,7 +535,7 @@ function user_create( $p_username, $p_password, $p_email = '',
 	$t_cookie_string = auth_generate_unique_cookie_string();
 	$t_user_table = db_get_table( 'user' );
 
-	$t_query = 'INSERT INTO ' . $t_user_table . '
+	$t_query = 'INSERT INTO {user}
 				    ( username, email, password, date_created, last_visit,
 				     enabled, access_level, login_count, cookie_string, realname )
 				  VALUES
@@ -672,12 +663,10 @@ function user_delete( $p_user_id ) {
 	# Remove project specific access levels
 	user_delete_project_specific_access_levels( $p_user_id );
 
-	$t_user_table = db_get_table( 'user' );
-
 	# unset non-unique realname flags if necessary
 	if( config_get( 'differentiate_duplicates' ) ) {
 		$c_realname = user_get_field( $p_user_id, 'realname' );
-		$t_query = 'SELECT id FROM ' . $t_user_table . ' WHERE realname=' . db_param();
+		$t_query = 'SELECT id FROM {user} WHERE realname=' . db_param();
 		$t_result = db_query_bound( $t_query, array( $c_realname ) );
 
 		$t_users = array();
@@ -699,7 +688,7 @@ function user_delete( $p_user_id ) {
 	user_clear_cache( $p_user_id );
 
 	# Remove account
-	$t_query = 'DELETE FROM ' . $t_user_table . ' WHERE id=' . db_param();
+	$t_query = 'DELETE FROM {user} WHERE id=' . db_param();
 	db_query_bound( $t_query, array( $c_user_id ) );
 
 	return true;
@@ -717,9 +706,7 @@ function user_get_id_by_name( $p_username ) {
 		return $t_user['id'];
 	}
 
-	$t_user_table = db_get_table( 'user' );
-
-	$t_query = 'SELECT * FROM ' . $t_user_table . ' WHERE username=' . db_param();
+	$t_query = 'SELECT * FROM {user} WHERE username=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_username ) );
 
 	$t_row = db_fetch_array( $t_result );
@@ -742,9 +729,7 @@ function user_get_id_by_email( $p_email ) {
 		return $t_user['id'];
 	}
 
-	$t_user_table = db_get_table( 'user' );
-
-	$t_query = 'SELECT * FROM ' . $t_user_table . ' WHERE email=' . db_param();
+	$t_query = 'SELECT * FROM {user} WHERE email=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_email ) );
 
 	$t_row = db_fetch_array( $t_result );
@@ -768,8 +753,7 @@ function user_get_id_by_realname( $p_realname ) {
 		return $t_user['id'];
 	}
 
-	$t_user_table = db_get_table( 'user' );
-	$t_query = 'SELECT * FROM ' . $t_user_table . ' WHERE realname=' . db_param();
+	$t_query = 'SELECT * FROM {user} WHERE realname=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_realname ) );
 
 	$t_row = db_fetch_array( $t_result );
@@ -1209,7 +1193,6 @@ function user_get_assigned_projects( $p_user_id ) {
  */
 function user_get_unassigned_by_project_id( $p_project_id = null ) {
 	$t_mantis_project_user_list_table = db_get_table( 'project_user_list' );
-	$t_mantis_user_table = db_get_table( 'user' );
 
 	if( null === $p_project_id ) {
 		$p_project_id = helper_get_current_project();
@@ -1217,7 +1200,7 @@ function user_get_unassigned_by_project_id( $p_project_id = null ) {
 
 	$t_adm = config_get_global( 'admin_site_threshold' );
 	$t_query = 'SELECT DISTINCT u.id, u.username, u.realname
-				FROM ' . $t_mantis_user_table . ' u
+				FROM {user} u
 				LEFT JOIN ' . $t_mantis_project_user_list_table . ' p
 				ON p.user_id=u.id AND p.project_id=' . db_param() . '
 				WHERE u.access_level<' . db_param() . ' AND
@@ -1391,9 +1374,7 @@ function user_update_last_visit( $p_user_id ) {
 	$c_user_id = (int)$p_user_id;
 	$c_value = db_now();
 
-	$t_user_table = db_get_table( 'user' );
-
-	$t_query = 'UPDATE ' . $t_user_table . ' SET last_visit=' . db_param() . ' WHERE id=' . db_param();
+	$t_query = 'UPDATE {user} SET last_visit=' . db_param() . ' WHERE id=' . db_param();
 
 	db_query_bound( $t_query, array( $c_value, $c_user_id ) );
 
@@ -1410,9 +1391,7 @@ function user_update_last_visit( $p_user_id ) {
  * @return boolean always true
  */
 function user_increment_login_count( $p_user_id ) {
-	$t_user_table = db_get_table( 'user' );
-
-	$t_query = 'UPDATE ' . $t_user_table . ' SET login_count=login_count+1 WHERE id=' . db_param();
+	$t_query = 'UPDATE {user} SET login_count=login_count+1 WHERE id=' . db_param();
 
 	db_query_bound( $t_query, array( (int)$p_user_id ) );
 
@@ -1428,9 +1407,7 @@ function user_increment_login_count( $p_user_id ) {
  * @return boolean always true
  */
 function user_reset_failed_login_count_to_zero( $p_user_id ) {
-	$t_user_table = db_get_table( 'user' );
-
-	$t_query = 'UPDATE ' . $t_user_table . ' SET failed_login_count=0 WHERE id=' . db_param();
+	$t_query = 'UPDATE {user} SET failed_login_count=0 WHERE id=' . db_param();
 	db_query_bound( $t_query, array( (int)$p_user_id ) );
 
 	user_clear_cache( $p_user_id );
@@ -1445,9 +1422,7 @@ function user_reset_failed_login_count_to_zero( $p_user_id ) {
  * @return boolean always true
  */
 function user_increment_failed_login_count( $p_user_id ) {
-	$t_user_table = db_get_table( 'user' );
-
-	$t_query = 'UPDATE ' . $t_user_table . ' SET failed_login_count=failed_login_count+1 WHERE id=' . db_param();
+	$t_query = 'UPDATE {user} SET failed_login_count=failed_login_count+1 WHERE id=' . db_param();
 	db_query_bound( $t_query, array( $p_user_id ) );
 
 	user_clear_cache( $p_user_id );
@@ -1462,9 +1437,7 @@ function user_increment_failed_login_count( $p_user_id ) {
  * @return boolean always true
  */
 function user_reset_lost_password_in_progress_count_to_zero( $p_user_id ) {
-	$t_user_table = db_get_table( 'user' );
-
-	$t_query = 'UPDATE ' . $t_user_table . ' SET lost_password_request_count=0 WHERE id=' . db_param();
+	$t_query = 'UPDATE {user} SET lost_password_request_count=0 WHERE id=' . db_param();
 	db_query_bound( $t_query, array( $p_user_id ) );
 
 	user_clear_cache( $p_user_id );
@@ -1479,9 +1452,7 @@ function user_reset_lost_password_in_progress_count_to_zero( $p_user_id ) {
  * @return boolean always true
  */
 function user_increment_lost_password_in_progress_count( $p_user_id ) {
-	$t_user_table = db_get_table( 'user' );
-
-	$t_query = 'UPDATE ' . $t_user_table . '
+	$t_query = 'UPDATE {user}
 				SET lost_password_request_count=lost_password_request_count+1
 				WHERE id=' . db_param();
 	db_query_bound( $t_query, array( $p_user_id ) );
@@ -1503,9 +1474,7 @@ function user_set_fields( $p_user_id, array $p_fields ) {
 		user_ensure_unprotected( $p_user_id );
 	}
 
-	$t_user_table = db_get_table( 'user' );
-
-	$t_query = 'UPDATE ' . $t_user_table;
+	$t_query = 'UPDATE {user}';
 	$t_parameters = array();
 
 	foreach ( $p_fields as $t_field_name => $t_field_value ) {
@@ -1570,9 +1539,8 @@ function user_set_password( $p_user_id, $p_password, $p_allow_protected = false 
 	$c_cookie_string = auth_generate_unique_cookie_string();
 
 	$c_password = auth_process_plain_password( $p_password );
-	$c_user_table = db_get_table( 'user' );
 
-	$t_query = 'UPDATE ' . $c_user_table . '
+	$t_query = 'UPDATE {user}
 				  SET password=' . db_param() . ', cookie_string=' . db_param() . '
 				  WHERE id=' . db_param();
 	db_query_bound( $t_query, array( $c_password, $c_cookie_string, (int)$p_user_id ) );

--- a/lost_pwd.php
+++ b/lost_pwd.php
@@ -71,10 +71,8 @@ $f_email = gpc_get_string( 'email' );
 
 email_ensure_valid( $f_email );
 
-$t_user_table = db_get_table( 'user' );
-
 # @todo Consider moving this query to user_api.php
-$t_query = 'SELECT id FROM ' . $t_user_table . ' WHERE username = ' . db_param() . ' AND email = ' . db_param() . ' AND enabled=' . db_param();
+$t_query = 'SELECT id FROM {user} WHERE username = ' . db_param() . ' AND email = ' . db_param() . ' AND enabled=' . db_param();
 $t_result = db_query_bound( $t_query, array( $f_username, $f_email, true ) );
 
 if( 0 == db_num_rows( $t_result ) ) {

--- a/manage_user_page.php
+++ b/manage_user_page.php
@@ -65,12 +65,12 @@ $f_save          = gpc_get_bool( 'save' );
 $f_filter        = utf8_strtoupper( gpc_get_string( 'filter', config_get( 'default_manage_user_prefix' ) ) );
 $f_page_number   = gpc_get_int( 'page_number', 1 );
 
-$t_user_table = db_get_table( 'user' );
 $t_cookie_name = config_get( 'manage_users_cookie' );
 $t_lock_image = '<img src="' . config_get( 'icon_path' ) . 'protected.gif" width="8" height="15" alt="' . lang_get( 'protected' ) . '" />';
 $c_filter = '';
 
 # Clean up the form variables
+$t_user_table = db_get_table( 'user' );
 if( !db_field_exists( $f_sort, $t_user_table ) ) {
 	$c_sort = 'username';
 } else {
@@ -124,7 +124,7 @@ print_manage_menu( 'manage_user_page.php' );
 # New Accounts Form BEGIN
 
 $t_days_old = 7 * SECONDS_PER_DAY;
-$t_query = 'SELECT COUNT(*) AS new_user_count FROM ' . $t_user_table . '
+$t_query = 'SELECT COUNT(*) AS new_user_count FROM {user}
 	WHERE '.db_helper_compare_days( (string)db_now(), 'date_created', '<= ' . $t_days_old );
 $t_result = db_query_bound( $t_query );
 $t_row = db_fetch_array( $t_result );
@@ -132,7 +132,7 @@ $t_new_user_count = $t_row['new_user_count'];
 
 # Never Logged In Form BEGIN
 
-$t_query = 'SELECT COUNT(*) AS unused_user_count FROM ' . $t_user_table . '
+$t_query = 'SELECT COUNT(*) AS unused_user_count FROM {user}
 	WHERE ( login_count = 0 ) AND ( date_created = last_visit )';
 $t_result = db_query_bound( $t_query );
 $t_row = db_fetch_array( $t_result );
@@ -207,12 +207,12 @@ if( 1 == $c_show_disabled ) {
 }
 
 if( 0 == $c_hide_inactive ) {
-	$t_query = 'SELECT count(*) as user_count FROM ' . $t_user_table . ' WHERE ' . $t_where . $t_show_disabled_cond;
+	$t_query = 'SELECT count(*) as user_count FROM {user} WHERE ' . $t_where . $t_show_disabled_cond;
 	$t_result = db_query_bound( $t_query, $t_where_params );
 	$t_row = db_fetch_array( $t_result );
 	$t_total_user_count = $t_row['user_count'];
 } else {
-	$t_query = 'SELECT count(*) as user_count FROM ' . $t_user_table . '
+	$t_query = 'SELECT count(*) as user_count FROM {user}
 			WHERE ' . $t_where . ' AND ' . db_helper_compare_days( '' . db_now() . '', 'last_visit', '< ' . $t_days_old )
 			. $t_show_disabled_cond;
 	$t_result = db_query_bound( $t_query, $t_where_params );
@@ -237,10 +237,10 @@ if( $f_page_number < 1 ) {
 
 
 if( 0 == $c_hide_inactive ) {
-	$t_query = 'SELECT * FROM ' . $t_user_table . ' WHERE ' . $t_where . ' ' . $t_show_disabled_cond . ' ORDER BY ' . $c_sort . ' ' . $c_dir;
+	$t_query = 'SELECT * FROM {user} WHERE ' . $t_where . ' ' . $t_show_disabled_cond . ' ORDER BY ' . $c_sort . ' ' . $c_dir;
 	$t_result = db_query_bound( $t_query, $t_where_params, $p_per_page, $t_offset );
 } else {
-	$t_query = 'SELECT * FROM ' . $t_user_table . '
+	$t_query = 'SELECT * FROM {user}
 			WHERE ' . $t_where . ' AND ' . db_helper_compare_days( '' . db_now() . '', 'last_visit', '< ' . $t_days_old ) . '
 			' . $t_show_disabled_cond . ' ORDER BY ' . $c_sort . ' ' . $c_dir;
 	$t_result = db_query_bound( $t_query, $t_where_params, $p_per_page, $t_offset );

--- a/manage_user_prune.php
+++ b/manage_user_prune.php
@@ -53,12 +53,11 @@ auth_reauthenticate();
 
 access_ensure_global_level( config_get( 'manage_user_threshold' ) );
 
-$t_user_table = db_get_table( 'user' );
 
 # Delete the users who have never logged in and are older than 1 week
 $t_days_old = (int)7 * SECONDS_PER_DAY;
 
-$t_query = 'SELECT id, access_level FROM ' . $t_user_table . '
+$t_query = 'SELECT id, access_level FROM {user}
 		WHERE ( login_count = 0 ) AND ( date_created = last_visit ) AND ' . db_helper_compare_days( 0, 'date_created', '> ' . $t_days_old );
 $t_result = db_query_bound( $t_query, array( db_now() ) );
 

--- a/manage_user_update.php
+++ b/manage_user_update.php
@@ -130,8 +130,6 @@ $c_enabled = db_prepare_bool( $f_enabled );
 $c_user_id = (int)$f_user_id;
 $c_access_level = (int)$f_access_level;
 
-$t_user_table = db_get_table( 'user' );
-
 $t_old_protected = $t_user['protected'];
 
 # Ensure that users aren't escalating privileges of accounts beyond their
@@ -158,7 +156,7 @@ if( ( $f_access_level >= $t_admin_threshold ) && ( !user_is_administrator( $f_us
 #  then proceed with a full update.
 $t_query_params = array();
 if( $f_protected && $t_old_protected ) {
-	$t_query = 'UPDATE ' . $t_user_table . '
+	$t_query = 'UPDATE {user}
 			SET username=' . db_param() . ', email=' . db_param() . ',
 				protected=' . db_param() . ', realname=' . db_param() . '
 			WHERE id=' . db_param();
@@ -166,7 +164,7 @@ if( $f_protected && $t_old_protected ) {
 	# Prevent e-mail notification for a change that did not happen
 	$f_access_level = $t_old_access_level;
 } else {
-	$t_query = 'UPDATE ' . $t_user_table . '
+	$t_query = 'UPDATE {user}
 			SET username=' . db_param() . ', email=' . db_param() . ',
 				access_level=' . db_param() . ', enabled=' . db_param() . ',
 				protected=' . db_param() . ', realname=' . db_param() . '

--- a/proj_doc_page.php
+++ b/proj_doc_page.php
@@ -69,7 +69,6 @@ $t_user_id = auth_get_current_user_id();
 $t_project_file_table = db_get_table( 'project_file' );
 $t_project_table = db_get_table( 'project' );
 $t_project_user_list_table = db_get_table( 'project_user_list' );
-$t_user_table = db_get_table( 'user' );
 $t_pub = VS_PUBLIC;
 $t_priv = VS_PRIVATE;
 $t_admin = config_get_global( 'admin_site_threshold' );
@@ -100,7 +99,7 @@ $t_query = 'SELECT pft.id, pft.project_id, pft.filename, pft.filesize, pft.title
 				LEFT JOIN ' . $t_project_table . ' pt ON pft.project_id = pt.id
 				LEFT JOIN ' . $t_project_user_list_table . ' pult
 					ON pft.project_id = pult.project_id AND pult.user_id = ' . db_param() . '
-				LEFT JOIN ' . $t_user_table . ' ut ON ut.id = ' . db_param() . '
+				LEFT JOIN {user} ut ON ut.id = ' . db_param() . '
 			WHERE pft.project_id in (' . implode( ',', $t_projects ) . ') AND
 				( ( ( pt.view_state = ' . db_param() . ' OR pt.view_state is null ) AND pult.user_id is null AND ut.access_level ' . $t_access_clause . ' ) OR
 					( ( pult.user_id = ' . db_param() . ' ) AND ( pult.access_level ' . $t_access_clause . ' ) ) OR


### PR DESCRIPTION
#216 adds support for the new table name syntax,

allowing us to replace db_get_table calls within queries.

Calls to db_get_table that are used by other database function,
i.e. db_insert_id, db_field_exists are deliberately left unchanged at this
stage.

This is aimed at breaking down the future DB API changes into manageable
chunks, and to aid the review process after 1.3 for 2.0.

This Pull request deals with calls for the 'user' table only,
for ease of review, and syncing until merged.
