### PR TITLE
Update db_get_table() calls for table 'tokens'

### DIFF
--- a/core/install_helper_functions_api.php
+++ b/core/install_helper_functions_api.php
@@ -622,8 +622,7 @@ function install_check_config_serialization() {
  * This ensures it is not possible to execute code during un-serialization
  */
 function install_check_token_serialization() {
-	$t_tokens_table = db_get_table( 'tokens' );
-	$query = 'SELECT * FROM ' . $t_tokens_table . ' WHERE type=1 or type=2 or type=5';
+	$query = 'SELECT * FROM {tokens} WHERE type=1 or type=2 or type=5';
 
 	$t_result = db_query_bound( $query );
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -637,7 +636,7 @@ function install_check_token_serialization() {
 
 		$t_json_token = json_encode( $t_token );
 
-		$t_query = 'UPDATE ' . $t_tokens_table . ' SET value=' .db_param() . ' WHERE id=' .db_param();
+		$t_query = 'UPDATE {tokens} SET value=' .db_param() . ' WHERE id=' .db_param();
 		db_query_bound( $t_query, array( $t_json_token, $t_id ) );
 	}
 

--- a/core/tokens_api.php
+++ b/core/tokens_api.php
@@ -44,8 +44,7 @@ $g_tokens_purged = false;
  * @return boolean True if token exists
  */
 function token_exists( $p_token_id ) {
-	$t_tokens_table = db_get_table( 'tokens' );
-	$t_query = 'SELECT id FROM ' . $t_tokens_table . ' WHERE id=' . db_param();
+	$t_query = 'SELECT id FROM {tokens} WHERE id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_token_id ), 1 );
 
 	$t_row = db_fetch_array( $t_result );
@@ -80,9 +79,7 @@ function token_get( $p_type, $p_user_id = null ) {
 	$c_type = (int)$p_type;
 	$c_user_id = (int)( $p_user_id == null ? auth_get_current_user_id() : $p_user_id );
 
-	$t_tokens_table = db_get_table( 'tokens' );
-
-	$t_query = 'SELECT * FROM ' . $t_tokens_table . ' WHERE type=' . db_param() . ' AND owner=' . db_param();
+	$t_query = 'SELECT * FROM {tokens} WHERE type=' . db_param() . ' AND owner=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $c_type, $c_user_id ) );
 
 	$t_row = db_fetch_array( $t_result );
@@ -137,8 +134,7 @@ function token_touch( $p_token_id, $p_expiry = TOKEN_EXPIRY ) {
 	token_ensure_exists( $p_token_id );
 
 	$c_token_expiry = time() + $p_expiry;
-	$t_tokens_table = db_get_table( 'tokens' );
-	$t_query = 'UPDATE ' . $t_tokens_table . ' SET expiry=' . db_param() . ' WHERE id=' . db_param();
+	$t_query = 'UPDATE {tokens} SET expiry=' . db_param() . ' WHERE id=' . db_param();
 	db_query_bound( $t_query, array( $c_token_expiry, $p_token_id ) );
 }
 
@@ -155,8 +151,7 @@ function token_delete( $p_type, $p_user_id = null ) {
 		$c_user_id = (int)$p_user_id;
 	}
 
-	$t_tokens_table = db_get_table( 'tokens' );
-	$t_query = 'DELETE FROM ' . $t_tokens_table . ' WHERE type=' . db_param() . ' AND owner=' . db_param();
+	$t_query = 'DELETE FROM {tokens} WHERE type=' . db_param() . ' AND owner=' . db_param();
 	db_query_bound( $t_query, array( $p_type, $c_user_id ) );
 }
 
@@ -172,8 +167,7 @@ function token_delete_by_owner( $p_user_id = null ) {
 		$c_user_id = (int)$p_user_id;
 	}
 
-	$t_tokens_table = db_get_table( 'tokens' );
-	$t_query = 'DELETE FROM ' . $t_tokens_table . ' WHERE owner=' . db_param();
+	$t_query = 'DELETE FROM {tokens} WHERE owner=' . db_param();
 	db_query_bound( $t_query, array( $c_user_id ) );
 }
 
@@ -198,7 +192,7 @@ function token_create( $p_type, $p_value, $p_expiry = TOKEN_EXPIRY, $p_user_id =
 
 	$t_tokens_table = db_get_table( 'tokens' );
 
-	$t_query = 'INSERT INTO ' . $t_tokens_table . '
+	$t_query = 'INSERT INTO {tokens}
 					( type, value, timestamp, expiry, owner )
 					VALUES ( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
 	db_query_bound( $t_query, array( $c_type, (string)$p_value, $c_timestamp, $c_expiry, $c_user_id ) );
@@ -217,8 +211,7 @@ function token_update( $p_token_id, $p_value, $p_expiry = TOKEN_EXPIRY ) {
 	$c_token_id = (int)$p_token_id;
 	$c_expiry = time() + $p_expiry;
 
-	$t_tokens_table = db_get_table( 'tokens' );
-	$t_query = 'UPDATE ' . $t_tokens_table . '
+	$t_query = 'UPDATE {tokens}
 					SET value=' . db_param() . ', expiry=' . db_param() . '
 					WHERE id=' . db_param();
 	db_query_bound( $t_query, array( (string)$p_value, $c_expiry, $c_token_id ) );
@@ -232,8 +225,7 @@ function token_update( $p_token_id, $p_value, $p_expiry = TOKEN_EXPIRY ) {
  * @return boolean always true.
  */
 function token_delete_by_type( $p_token_type ) {
-	$t_tokens_table = db_get_table( 'tokens' );
-	$t_query = 'DELETE FROM ' . $t_tokens_table . ' WHERE type=' . db_param();
+	$t_query = 'DELETE FROM {tokens} WHERE type=' . db_param();
 	db_query_bound( $t_query, array( $p_token_type ) );
 
 	return true;
@@ -247,9 +239,7 @@ function token_delete_by_type( $p_token_type ) {
 function token_purge_expired( $p_token_type = null ) {
 	global $g_tokens_purged;
 
-	$t_tokens_table = db_get_table( 'tokens' );
-
-	$t_query = 'DELETE FROM ' . $t_tokens_table . ' WHERE ' . db_param() . ' > expiry';
+	$t_query = 'DELETE FROM {tokens} WHERE ' . db_param() . ' > expiry';
 	if( !is_null( $p_token_type ) ) {
 		$t_query .= ' AND type=' . db_param();
 		db_query_bound( $t_query, array( db_now(), (int)$p_token_type ) );


### PR DESCRIPTION
#216 adds support for the new table name syntax,

allowing us to replace db_get_table calls within queries.

Calls to db_get_table that are used by other database function,
i.e. db_insert_id, db_field_exists are deliberately left unchanged at this
stage.

This is aimed at breaking down the future DB API changes into manageable
chunks, and to aid the review process after 1.3 for 2.0.

This Pull request deals with calls for the 'tokens' table only,
for ease of review, and syncing until merged.
