### PR TITLE
Update db_get_table() calls for table 'sponsorship'

### DIFF
--- a/account_sponsor_page.php
+++ b/account_sponsor_page.php
@@ -110,13 +110,12 @@ $t_project = helper_get_current_project();
 $t_user = auth_get_current_user_id();
 $t_resolved = config_get( 'bug_resolved_status_threshold' );
 $t_bug_table = db_get_table( 'bug' );
-$t_sponsor_table = db_get_table( 'sponsorship' );
 $t_payment = config_get( 'payment_enable', 0 );
 
 $t_project_clause = helper_project_specific_where( $t_project );
 
 $t_query = 'SELECT b.id as bug, s.id as sponsor, s.paid, b.project_id, b.fixed_in_version, b.status
-	FROM ' . $t_bug_table . ' b, ' . $t_sponsor_table . ' s
+	FROM ' . $t_bug_table . ' b, {sponsorship} s
 	WHERE s.user_id=' . db_param() . ' AND s.bug_id = b.id ' .
 	( $t_show_all ? '' : 'AND ( b.status < ' . db_param() . ' OR s.paid < ' . SPONSORSHIP_PAID . ')' ) . '
 	AND ' . $t_project_clause . '
@@ -231,7 +230,7 @@ if( $t_sponsor_count === 0 ) {
 <?php } # end sponsored issues
 
 $t_query = 'SELECT b.id as bug, s.id as sponsor, s.paid, b.project_id, b.fixed_in_version, b.status
-	FROM ' . $t_bug_table . ' b, ' . $t_sponsor_table . ' s
+	FROM ' . $t_bug_table . ' b, {sponsorship} s
 	WHERE b.handler_id=' . db_param() . ' AND s.bug_id = b.id ' .
 	( $t_show_all ? '' : 'AND ( b.status < ' . db_param() . ' OR s.paid < ' . SPONSORSHIP_PAID . ')' ) . '
 	AND ' . $t_project_clause . '

--- a/core/sponsorship_api.php
+++ b/core/sponsorship_api.php
@@ -111,13 +111,12 @@ function sponsorship_cache_row( $p_sponsorship_id, $p_trigger_errors = true ) {
 	global $g_cache_sponsorships;
 
 	$c_sponsorship_id = (int)$p_sponsorship_id;
-	$t_sponsorship_table = db_get_table( 'sponsorship' );
 
 	if( isset( $g_cache_sponsorships[$c_sponsorship_id] ) ) {
 		return $g_cache_sponsorships[$c_sponsorship_id];
 	}
 
-	$t_query = 'SELECT * FROM ' . $t_sponsorship_table . ' WHERE id=' . db_param();
+	$t_query = 'SELECT * FROM {sponsorship} WHERE id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $c_sponsorship_id ) );
 
 	if( 0 == db_num_rows( $t_result ) ) {
@@ -176,9 +175,7 @@ function sponsorship_get_id( $p_bug_id, $p_user_id = null ) {
 		$c_user_id = (int)$p_user_id;
 	}
 
-	$t_sponsorship_table = db_get_table( 'sponsorship' );
-
-	$t_query = 'SELECT id FROM ' . $t_sponsorship_table . ' WHERE bug_id=' . db_param() . ' AND user_id = ' . db_param();
+	$t_query = 'SELECT id FROM {sponsorship} WHERE bug_id=' . db_param() . ' AND user_id = ' . db_param();
 	$t_result = db_query_bound( $t_query, array( (int)$p_bug_id, $c_user_id ), 1 );
 
 	if( db_num_rows( $t_result ) == 0 ) {
@@ -229,9 +226,7 @@ function sponsorship_get_all_ids( $p_bug_id ) {
 		return $s_cache_sponsorship_bug_ids[$c_bug_id];
 	}
 
-	$t_sponsorship_table = db_get_table( 'sponsorship' );
-
-	$t_query = 'SELECT * FROM ' . $t_sponsorship_table . ' WHERE bug_id = ' . db_param();
+	$t_query = 'SELECT * FROM {sponsorship} WHERE bug_id = ' . db_param();
 	$t_result = db_query_bound( $t_query, array( $c_bug_id ) );
 
 	$t_sponsorship_ids = array();
@@ -319,8 +314,6 @@ function sponsorship_set( SponsorshipData $p_sponsorship ) {
 		}
 	}
 
-	$t_sponsorship_table = db_get_table( 'sponsorship' );
-
 	$c_id = (int)$p_sponsorship->id;
 	$c_bug_id = (int)$p_sponsorship->bug_id;
 	$c_user_id = (int)$p_sponsorship->user_id;
@@ -332,12 +325,13 @@ function sponsorship_set( SponsorshipData $p_sponsorship ) {
 	# if new sponsorship
 	if( $c_id == 0 ) {
 		# Insert
-		$t_query = 'INSERT INTO ' . $t_sponsorship_table . '
+		$t_query = 'INSERT INTO {sponsorship}
 				    ( bug_id, user_id, amount, logo, url, date_submitted, last_updated )
 				  VALUES
 				    (' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ')';
 
 		db_query_bound( $t_query, array( $c_bug_id, $c_user_id, $c_amount, $c_logo, $c_url, $c_now, $c_now ) );
+		$t_sponsorship_table = db_get_table( 'sponsorship' );
 		$t_sponsorship_id = db_insert_id( $t_sponsorship_table );
 
 		history_log_event_special( $c_bug_id, BUG_ADD_SPONSORSHIP, $c_user_id, $c_amount );
@@ -350,7 +344,7 @@ function sponsorship_set( SponsorshipData $p_sponsorship ) {
 		}
 
 		# Update
-		$t_query = 'UPDATE ' . $t_sponsorship_table . '
+		$t_query = 'UPDATE {sponsorship}
 					SET	bug_id = ' . db_param() . ',
 						user_id = ' . db_param() . ',
 						amount = ' . db_param() . ',
@@ -384,9 +378,7 @@ function sponsorship_set( SponsorshipData $p_sponsorship ) {
  * @return void
  */
 function sponsorship_delete_all( $p_bug_id ) {
-	$t_sponsorship_table = db_get_table( 'sponsorship' );
-
-	$t_query = 'DELETE FROM ' . $t_sponsorship_table . ' WHERE bug_id=' . db_param();
+	$t_query = 'DELETE FROM {sponsorship} WHERE bug_id=' . db_param();
 	db_query_bound( $t_query, array( (int)$p_bug_id ) );
 
 	sponsorship_clear_cache( );
@@ -409,10 +401,8 @@ function sponsorship_delete( $p_sponsorship_id ) {
 
 	$t_sponsorship = sponsorship_get( $p_sponsorship_id );
 
-	$t_sponsorship_table = db_get_table( 'sponsorship' );
-
 	# Delete the bug entry
-	$t_query = 'DELETE FROM ' . $t_sponsorship_table . ' WHERE id=' . db_param();
+	$t_query = 'DELETE FROM {sponsorship} WHERE id=' . db_param();
 	db_query_bound( $t_query, array( (int)$p_sponsorship_id ) );
 
 	sponsorship_clear_cache( $p_sponsorship_id );
@@ -432,9 +422,7 @@ function sponsorship_delete( $p_sponsorship_id ) {
 function sponsorship_update_paid( $p_sponsorship_id, $p_paid ) {
 	$t_sponsorship = sponsorship_get( $p_sponsorship_id );
 
-	$t_sponsorship_table = db_get_table( 'sponsorship' );
-
-	$t_query = 'UPDATE ' . $t_sponsorship_table . ' SET last_updated=' . db_param() . ', paid=' . db_param() . ' WHERE id=' . db_param();
+	$t_query = 'UPDATE {sponsorship} SET last_updated=' . db_param() . ', paid=' . db_param() . ' WHERE id=' . db_param();
 	db_query_bound( $t_query, array( db_now(), (int)$p_paid, (int)$p_sponsorship_id ) );
 
 	history_log_event_special( $t_sponsorship->bug_id, BUG_PAID_SPONSORSHIP, $t_sponsorship->user_id, $p_paid );
@@ -449,9 +437,7 @@ function sponsorship_update_paid( $p_sponsorship_id, $p_paid ) {
  * @return boolean
  */
 function sponsorship_update_date( $p_sponsorship_id ) {
-	$t_sponsorship_table = db_get_table( 'sponsorship' );
-
-	$t_query = 'UPDATE ' . $t_sponsorship_table . ' SET last_updated=' . db_param() . ' WHERE id=' . db_param();
+	$t_query = 'UPDATE {sponsorship} SET last_updated=' . db_param() . ' WHERE id=' . db_param();
 	db_query_bound( $t_query, array( db_now(), (int)$p_sponsorship_id ) );
 
 	sponsorship_clear_cache( $p_sponsorship_id );


### PR DESCRIPTION
#216 adds support for the new table name syntax,

allowing us to replace db_get_table calls within queries.

Calls to db_get_table that are used by other database function,
i.e. db_insert_id, db_field_exists are deliberately left unchanged at this
stage.

This is aimed at breaking down the future DB API changes into manageable
chunks, and to aid the review process after 1.3 for 2.0.

This Pull request deals with calls for the 'sponsorship' table only,
for ease of review, and syncing until merged.
