### PR TITLE
Update db_get_table() calls for table 'plugin'

### DIFF
--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -622,8 +622,7 @@ function plugin_is_installed( $p_basename ) {
 		}
 	}
 
-	$t_plugin_table = db_get_table( 'plugin' );
-	$t_query = 'SELECT COUNT(*) FROM ' . $t_plugin_table . ' WHERE basename=' . db_param();
+	$t_query = 'SELECT COUNT(*) FROM {plugin} WHERE basename=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_basename ) );
 	return( 0 < db_result( $t_result ) );
 }
@@ -649,9 +648,7 @@ function plugin_install( MantisPlugin $p_plugin ) {
 		return null;
 	}
 
-	$t_plugin_table = db_get_table( 'plugin' );
-
-	$t_query = 'INSERT INTO ' . $t_plugin_table . ' ( basename, enabled )
+	$t_query = 'INSERT INTO {plugin} ( basename, enabled )
 				VALUES ( ' . db_param() . ', \'1\' )';
 	db_query_bound( $t_query, array( $p_plugin->basename ) );
 
@@ -766,9 +763,7 @@ function plugin_uninstall( MantisPlugin $p_plugin ) {
 		return;
 	}
 
-	$t_plugin_table = db_get_table( 'plugin' );
-
-	$t_query = 'DELETE FROM ' . $t_plugin_table . ' WHERE basename=' . db_param();
+	$t_query = 'DELETE FROM {plugin} WHERE basename=' . db_param();
 	db_query_bound( $t_query, array( $p_plugin->basename ) );
 
 	plugin_push_current( $p_plugin->basename );
@@ -924,9 +919,7 @@ function plugin_register_installed() {
 	}
 
 	# register plugins installed via the interface/database
-	$t_plugin_table = db_get_table( 'plugin' );
-
-	$t_query = 'SELECT basename, priority, protected FROM ' . $t_plugin_table . ' WHERE enabled=' . db_param() . ' ORDER BY priority DESC';
+	$t_query = 'SELECT basename, priority, protected FROM {plugin} WHERE enabled=' . db_param() . ' ORDER BY priority DESC';
 	$t_result = db_query_bound( $t_query, array( true ) );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {

--- a/manage_plugin_update.php
+++ b/manage_plugin_update.php
@@ -48,9 +48,7 @@ form_security_validate( 'manage_plugin_update' );
 auth_reauthenticate();
 access_ensure_global_level( config_get( 'manage_plugin_threshold' ) );
 
-$t_plugin_table	= db_get_table( 'plugin' );
-
-$t_query = 'SELECT basename FROM ' . $t_plugin_table;
+$t_query = 'SELECT basename FROM {plugin}';
 $t_result = db_query_bound( $t_query );
 
 while( $t_row = db_fetch_array( $t_result ) ) {
@@ -65,7 +63,7 @@ while( $t_row = db_fetch_array( $t_result ) ) {
 	$f_priority = gpc_get_int( 'priority_'.$t_basename, 3 );
 	$f_protected = gpc_get_bool( 'protected_'.$t_basename, 0 );
 
-	$t_query = 'UPDATE ' . $t_plugin_table . ' SET priority=' . db_param() . ', protected=' . db_param() .
+	$t_query = 'UPDATE {plugin} SET priority=' . db_param() . ', protected=' . db_param() .
 		' WHERE basename=' . db_param();
 
 	db_query_bound( $t_query, array( $f_priority, $f_protected, $t_basename ) );


### PR DESCRIPTION
#216 adds support for the new table name syntax,

allowing us to replace db_get_table calls within queries.

Calls to db_get_table that are used by other database function,
i.e. db_insert_id, db_field_exists are deliberately left unchanged at this
stage.

This is aimed at breaking down the future DB API changes into manageable
chunks, and to aid the review process after 1.3 for 2.0.

This Pull request deals with calls for the 'plugin' table only,
for ease of review, and syncing until merged.
