### PR TITLE
Update db_get_table() calls for table 'news'

### DIFF
--- a/core/news_api.php
+++ b/core/news_api.php
@@ -69,7 +69,7 @@ function news_create( $p_project_id, $p_poster_id, $p_view_state, $p_announcemen
 
 	$t_news_table = db_get_table( 'news' );
 
-	$t_query = 'INSERT INTO ' . $t_news_table . '
+	$t_query = 'INSERT INTO {news}
 	    		  ( project_id, poster_id, date_posted, last_modified,
 	    		    view_state, announcement, headline, body )
 				VALUES
@@ -96,8 +96,7 @@ function news_create( $p_project_id, $p_poster_id, $p_view_state, $p_announcemen
  * @return void
  */
 function news_delete( $p_news_id ) {
-	$t_news_table = db_get_table( 'news' );
-	$t_query = 'DELETE FROM ' . $t_news_table . ' WHERE id=' . db_param();
+	$t_query = 'DELETE FROM {news} WHERE id=' . db_param();
 	db_query_bound( $t_query, array( $p_news_id ) );
 }
 
@@ -108,8 +107,7 @@ function news_delete( $p_news_id ) {
  * @return void
  */
 function news_delete_all( $p_project_id ) {
-	$t_news_table = db_get_table( 'news' );
-	$t_query = 'DELETE FROM ' . $t_news_table . ' WHERE project_id=' . db_param();
+	$t_query = 'DELETE FROM {news} WHERE project_id=' . db_param();
 	db_query_bound( $t_query, array( (int)$p_project_id ) );
 }
 
@@ -135,10 +133,8 @@ function news_update( $p_news_id, $p_project_id, $p_view_state, $p_announcement,
 		trigger_error( ERROR_EMPTY_FIELD, ERROR );
 	}
 
-	$t_news_table = db_get_table( 'news' );
-
 	# Update entry
-	$t_query = 'UPDATE ' . $t_news_table . '
+	$t_query = 'UPDATE {news}
 				  SET view_state=' . db_param() . ',
 					announcement=' . db_param() . ',
 					headline=' . db_param() . ',
@@ -157,8 +153,7 @@ function news_update( $p_news_id, $p_project_id, $p_view_state, $p_announcement,
  * @return array news article
  */
 function news_get_row( $p_news_id ) {
-	$t_news_table = db_get_table( 'news' );
-	$t_query = 'SELECT * FROM ' . $t_news_table . ' WHERE id=' . db_param();
+	$t_query = 'SELECT * FROM {news} WHERE id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_news_id ) );
 
 	$t_row = db_fetch_array( $t_result );
@@ -178,10 +173,9 @@ function news_get_row( $p_news_id ) {
  * @return int news count
  */
 function news_get_count( $p_project_id, $p_global = true ) {
-	$t_news_table = db_get_table( 'news' );
 	$t_project_where = helper_project_specific_where( $p_project_id );
 
-	$t_query = 'SELECT COUNT(*) FROM ' . $t_news_table . ' WHERE ' . $t_project_where;
+	$t_query = 'SELECT COUNT(*) FROM {news} WHERE ' . $t_project_where;
 
 	if( $p_global ) {
 		$t_query .= ' OR project_id=' . ALL_PROJECTS;
@@ -207,8 +201,7 @@ function news_get_rows( $p_project_id, $p_global = true ) {
 		$t_projects[] = ALL_PROJECTS;
 	}
 
-	$t_news_table = db_get_table( 'news' );
-	$t_query = 'SELECT * FROM ' . $t_news_table;
+	$t_query = 'SELECT * FROM {news}';
 
 	if( 1 == count( $t_projects ) ) {
 		$c_project_id = $t_projects[0];
@@ -273,14 +266,13 @@ function news_get_limited_rows( $p_offset, $p_project_id = null ) {
 		$t_projects[] = ALL_PROJECTS;
 	}
 
-	$t_news_table = db_get_table( 'news' );
 	$t_news_view_limit = config_get( 'news_view_limit' );
 	$t_news_view_limit_days = config_get( 'news_view_limit_days' ) * SECONDS_PER_DAY;
 
 	switch( config_get( 'news_limit_method' ) ) {
 		case 0:
 			# BY_LIMIT - Select the news posts
-			$t_query = 'SELECT * FROM ' . $t_news_table;
+			$t_query = 'SELECT * FROM {news}';
 
 			if( 1 == count( $t_projects ) ) {
 				$c_project_id = $t_projects[0];
@@ -296,8 +288,7 @@ function news_get_limited_rows( $p_offset, $p_project_id = null ) {
 			break;
 		case 1:
 			# BY_DATE - Select the news posts
-			$t_query = 'SELECT *
-						FROM ' . $t_news_table . ' WHERE
+			$t_query = 'SELECT * FROM {news} WHERE
 						( ' . db_helper_compare_days( 0, 'date_posted', '< ' . $t_news_view_limit_days ) . '
 						 OR announcement = ' . db_param() . ' ) ';
 			$t_params = array(

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -403,18 +403,13 @@ function print_tag_option_list( $p_bug_id = 0 ) {
  * @return void
  */
 function print_news_item_option_list() {
-	$t_mantis_news_table = db_get_table( 'news' );
-
 	$t_project_id = helper_get_current_project();
 
 	$t_global = access_has_global_level( config_get_global( 'admin_site_threshold' ) );
 	if( $t_global ) {
-		$t_query = 'SELECT id, headline, announcement, view_state
-				FROM ' . $t_mantis_news_table . '
-				ORDER BY date_posted DESC';
+		$t_query = 'SELECT id, headline, announcement, view_state FROM {news} ORDER BY date_posted DESC';
 	} else {
-		$t_query = 'SELECT id, headline, announcement, view_state
-				FROM ' . $t_mantis_news_table . '
+		$t_query = 'SELECT id, headline, announcement, view_state FROM {news}
 				WHERE project_id=' . db_param() . '
 				ORDER BY date_posted DESC';
 	}


### PR DESCRIPTION
#216 adds support for the new table name syntax,

allowing us to replace db_get_table calls within queries.

Calls to db_get_table that are used by other database function,
i.e. db_insert_id, db_field_exists are deliberately left unchanged at this
stage.

This is aimed at breaking down the future DB API changes into manageable
chunks, and to aid the review process after 1.3 for 2.0.

This Pull request deals with calls for the 'news' table only,
for ease of review, and syncing until merged.
