### PR TITLE
Update db_get_table() calls for table 'project_user_list'

### DIFF
--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -695,7 +695,6 @@ function mc_project_get_attachments( $p_username, $p_password, $p_project_id ) {
 		return mci_soap_fault_access_denied( $t_user_id );
 	}
 
-	$t_project_user_list_table = db_get_table( 'project_user_list' );
 	$t_user_table = db_get_table( 'user' );
 	$t_pub = VS_PUBLIC;
 	$t_priv = VS_PRIVATE;
@@ -727,7 +726,7 @@ function mc_project_get_attachments( $p_username, $p_password, $p_project_id ) {
 	$t_query = 'SELECT pft.id, pft.project_id, pft.filename, pft.file_type, pft.filesize, pft.title, pft.description, pft.date_added, pft.user_id
 		FROM {project_file} pft
 		LEFT JOIN {project} pt ON pft.project_id = pt.id
-		LEFT JOIN ' . $t_project_user_list_table . ' pult
+		LEFT JOIN {project_user_list} pult
 		ON pft.project_id = pult.project_id AND pult.user_id = ' . db_param() . '
 		LEFT JOIN ' . $t_user_table . ' ut ON ut.id = ' . db_param() . '
 		WHERE pft.project_id in (' . implode( ',', $t_projects ) . ') AND

--- a/core/access_api.php
+++ b/core/access_api.php
@@ -118,8 +118,7 @@ function access_cache_matrix_project( $p_project_id ) {
 	}
 
 	if( !in_array( (int)$p_project_id, $g_cache_access_matrix_project_ids ) ) {
-		$t_project_user_list_table = db_get_table( 'project_user_list' );
-		$t_query = 'SELECT user_id, access_level FROM ' . $t_project_user_list_table . ' WHERE project_id=' . db_param();
+		$t_query = 'SELECT user_id, access_level FROM {project_user_list} WHERE project_id=' . db_param();
 		$t_result = db_query_bound( $t_query, array( (int)$p_project_id ) );
 		while( $t_row = db_fetch_array( $t_result ) ) {
 			$g_cache_access_matrix[(int)$t_row['user_id']][(int)$p_project_id] = (int)$t_row['access_level'];
@@ -149,8 +148,7 @@ function access_cache_matrix_user( $p_user_id ) {
 	global $g_cache_access_matrix, $g_cache_access_matrix_user_ids;
 
 	if( !in_array( (int)$p_user_id, $g_cache_access_matrix_user_ids ) ) {
-		$t_project_user_list_table = db_get_table( 'project_user_list' );
-		$t_query = 'SELECT project_id, access_level FROM ' . $t_project_user_list_table . ' WHERE user_id=' . db_param();
+		$t_query = 'SELECT project_id, access_level FROM {project_user_list} WHERE user_id=' . db_param();
 		$t_result = db_query_bound( $t_query, array( (int)$p_user_id ) );
 
 		# make sure we always have an array to return

--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -642,7 +642,6 @@ function custom_field_get_linked_ids( $p_project_id = ALL_PROJECTS ) {
 		db_param_push();
 
 		if( ALL_PROJECTS == $p_project_id ) {
-			$t_project_user_list_table = db_get_table( 'project_user_list' );
 			$t_user_id = auth_get_current_user_id();
 
 			# Select only the ids of custom fields in projects the user has access to
@@ -654,7 +653,7 @@ function custom_field_get_linked_ids( $p_project_id = ALL_PROJECTS ) {
 					JOIN ' . $t_custom_field_project_table . ' cfpt ON cfpt.field_id = cft.id
 					JOIN {project} pt
 						ON pt.id = cfpt.project_id AND pt.enabled = ' . db_prepare_bool( true ) . '
-					LEFT JOIN ' . $t_project_user_list_table . ' pult
+					LEFT JOIN {project_user_list} pult
 						ON pult.project_id = cfpt.project_id AND pult.user_id = ' . db_param() . '
 					, {user} ut
 				WHERE ut.id = ' . db_param() . '

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1076,11 +1076,9 @@ function print_project_user_list_option_list( $p_project_id = null ) {
  * @return void
  */
 function print_project_user_list_option_list2( $p_user_id ) {
-	$t_mantis_project_user_list_table = db_get_table( 'project_user_list' );
-
 	$t_query = 'SELECT DISTINCT p.id, p.name
 				FROM {project} p
-				LEFT JOIN ' . $t_mantis_project_user_list_table . ' u
+				LEFT JOIN {project_user_list} u
 				ON p.id=u.project_id AND u.user_id=' . db_param() . '
 				WHERE p.enabled = ' . db_param() . ' AND
 					u.user_id IS NULL

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -268,9 +268,7 @@ function project_ensure_name_unique( $p_name ) {
  * @return boolean
  */
 function project_includes_user( $p_project_id, $p_user_id ) {
-	$t_project_user_list_table = db_get_table( 'project_user_list' );
-
-	$t_query = 'SELECT COUNT(*) FROM ' . $t_project_user_list_table . '
+	$t_query = 'SELECT COUNT(*) FROM {project_user_list}
 				  WHERE project_id=' . db_param() . ' AND
 						user_id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_project_id, $p_user_id ) );
@@ -560,10 +558,8 @@ function project_get_local_user_access_level( $p_project_id, $p_user_id ) {
 		return false;
 	}
 
-	$t_project_user_list_table = db_get_table( 'project_user_list' );
-
 	$t_query = 'SELECT access_level
-				  FROM ' . $t_project_user_list_table . '
+				  FROM {project_user_list}
 				  WHERE user_id=' . db_param() . ' AND project_id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( (int)$p_user_id, $p_project_id ) );
 
@@ -581,9 +577,7 @@ function project_get_local_user_access_level( $p_project_id, $p_user_id ) {
  * @return array
  */
 function project_get_local_user_rows( $p_project_id ) {
-	$t_project_user_list_table = db_get_table( 'project_user_list' );
-
-	$t_query = 'SELECT * FROM ' . $t_project_user_list_table . ' WHERE project_id=' . db_param();
+	$t_query = 'SELECT * FROM {project_user_list} WHERE project_id=' . db_param();
 
 	$t_result = db_query_bound( $t_query, array( (int)$p_project_id ) );
 
@@ -616,8 +610,6 @@ function project_get_all_user_rows( $p_project_id = ALL_PROJECTS, $p_access_leve
 	if( NOBODY == $p_access_level ) {
 		return array();
 	}
-
-	$t_project_user_list_table = db_get_table( 'project_user_list' );
 
 	$t_on = ON;
 	$t_users = array();
@@ -691,7 +683,7 @@ function project_get_all_user_rows( $p_project_id = ALL_PROJECTS, $p_access_leve
 	if( $c_project_id != ALL_PROJECTS ) {
 		# Get the project overrides
 		$t_query = 'SELECT u.id, u.username, u.realname, l.access_level
-				FROM ' . $t_project_user_list_table . ' l, {user} u
+				FROM {project_user_list} l, {user} u
 				WHERE l.user_id = u.id
 				AND u.enabled = ' . db_param() . '
 				AND l.project_id = ' . db_param();
@@ -752,15 +744,13 @@ function project_get_upload_path( $p_project_id ) {
  * @return void
  */
 function project_add_user( $p_project_id, $p_user_id, $p_access_level ) {
-	$t_project_user_list_table = db_get_table( 'project_user_list' );
-
 	$t_access_level = (int)$p_access_level;
 	if( DEFAULT_ACCESS_LEVEL == $t_access_level ) {
 		# Default access level for this user
 		$t_access_level = user_get_access_level( $p_user_id );
 	}
 
-	$t_query = 'INSERT INTO ' . $t_project_user_list_table . '
+	$t_query = 'INSERT INTO {project_user_list}
 				    ( project_id, user_id, access_level )
 				  VALUES
 				    ( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ')';
@@ -777,9 +767,7 @@ function project_add_user( $p_project_id, $p_user_id, $p_access_level ) {
  * @return void
  */
 function project_update_user_access( $p_project_id, $p_user_id, $p_access_level ) {
-	$t_project_user_list_table = db_get_table( 'project_user_list' );
-
-	$t_query = 'UPDATE ' . $t_project_user_list_table . '
+	$t_query = 'UPDATE {project_user_list}
 				  SET access_level=' . db_param() . '
 				  WHERE	project_id=' . db_param() . ' AND
 						user_id=' . db_param();
@@ -810,9 +798,7 @@ function project_set_user_access( $p_project_id, $p_user_id, $p_access_level ) {
  * @return void
  */
 function project_remove_user( $p_project_id, $p_user_id ) {
-	$t_project_user_list_table = db_get_table( 'project_user_list' );
-
-	$t_query = 'DELETE FROM ' . $t_project_user_list_table . '
+	$t_query = 'DELETE FROM {project_user_list}
 				  WHERE project_id=' . db_param() . ' AND user_id=' . db_param();
 
 	db_query_bound( $t_query, array( (int)$p_project_id, (int)$p_user_id ) );
@@ -828,9 +814,7 @@ function project_remove_user( $p_project_id, $p_user_id ) {
  * @return void
  */
 function project_remove_all_users( $p_project_id, $p_access_level_limit = null ) {
-	$t_project_user_list_table = db_get_table( 'project_user_list' );
-
-	$t_query = 'DELETE FROM ' . $t_project_user_list_table . ' WHERE project_id = ' . db_param();
+	$t_query = 'DELETE FROM {project_user_list} WHERE project_id = ' . db_param();
 
 	if( $p_access_level_limit !== null ) {
 		$t_query .= ' AND access_level <= ' . db_param();

--- a/core/tag_api.php
+++ b/core/tag_api.php
@@ -742,12 +742,11 @@ function tag_stats_attached( $p_tag_id ) {
 function tag_stats_related( $p_tag_id, $p_limit = 5 ) {
 	$t_bug_table = db_get_table( 'bug' );
 	$t_bug_tag_table = db_get_table( 'bug_tag' );
-	$t_project_user_list_table = db_get_table( 'project_user_list' );
 
 	$c_user_id = auth_get_current_user_id();
 
 	$t_subquery = 'SELECT b.id FROM ' . $t_bug_table . ' b
-					LEFT JOIN ' . $t_project_user_list_table . ' p
+					LEFT JOIN {project_user_list} p
 						ON p.project_id=b.project_id AND p.user_id=' . db_param() . # 2nd Param
 					' JOIN {user} u
 						ON u.id=' . db_param() . # 3rd Param

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -612,9 +612,7 @@ function user_signup( $p_username, $p_email = null ) {
 function user_delete_project_specific_access_levels( $p_user_id ) {
 	user_ensure_unprotected( $p_user_id );
 
-	$t_project_user_list_table = db_get_table( 'project_user_list' );
-
-	$t_query = 'DELETE FROM ' . $t_project_user_list_table . ' WHERE user_id=' . db_param();
+	$t_query = 'DELETE FROM {project_user_list} WHERE user_id=' . db_param();
 	db_query_bound( $t_query, array( (int)$p_user_id ) );
 
 	user_clear_cache( $p_user_id );
@@ -972,14 +970,12 @@ function user_get_accessible_projects( $p_user_id, $p_show_disabled = false ) {
 	if( access_has_global_level( config_get( 'private_project_threshold' ), $p_user_id ) ) {
 		$t_projects = project_hierarchy_get_subprojects( ALL_PROJECTS, $p_show_disabled );
 	} else {
-		$t_project_user_list_table = db_get_table( 'project_user_list' );
-
 		$t_public = VS_PUBLIC;
 		$t_private = VS_PRIVATE;
 
 		$t_query = 'SELECT p.id, p.name, ph.parent_id
 						  FROM {project} p
-						  LEFT JOIN ' . $t_project_user_list_table . ' u
+						  LEFT JOIN {project_user_list} u
 						    ON p.id=u.project_id AND u.user_id=' . db_param() . '
 						  LEFT JOIN {project_hierarchy} ph
 						    ON ph.child_id = p.id
@@ -1036,8 +1032,6 @@ function user_get_accessible_subprojects( $p_user_id, $p_project_id, $p_show_dis
 		}
 	}
 
-	$t_project_user_list_table = db_get_table( 'project_user_list' );
-
 	db_param_push();
 
 	if( access_has_global_level( config_get( 'private_project_threshold' ), $p_user_id ) ) {
@@ -1053,7 +1047,7 @@ function user_get_accessible_subprojects( $p_user_id, $p_project_id, $p_show_dis
 	} else {
 		$t_query = 'SELECT DISTINCT p.id, p.name, ph.parent_id
 					  FROM {project} p
-					  LEFT JOIN ' . $t_project_user_list_table . ' u
+					  LEFT JOIN {project_user_list} u
 					    ON p.id = u.project_id AND u.user_id=' . db_param() . '
 					  LEFT JOIN {project_hierarchy} ph
 					    ON ph.child_id = p.id
@@ -1159,11 +1153,9 @@ function user_get_all_accessible_projects( $p_user_id, $p_project_id ) {
  *		The array contains the id, name, view state, and project access level for the user.
  */
 function user_get_assigned_projects( $p_user_id ) {
-	$t_mantis_project_user_list_table = db_get_table( 'project_user_list' );
-
 	$t_query = 'SELECT DISTINCT p.id, p.name, p.view_state, u.access_level
 				FROM {project} p
-				LEFT JOIN ' . $t_mantis_project_user_list_table . ' u
+				LEFT JOIN {project_user_list} u
 				ON p.id=u.project_id
 				WHERE p.enabled = \'1\' AND
 					u.user_id=' . db_param() . '
@@ -1185,8 +1177,6 @@ function user_get_assigned_projects( $p_user_id ) {
  * @return array List of users not assigned to the specified project
  */
 function user_get_unassigned_by_project_id( $p_project_id = null ) {
-	$t_mantis_project_user_list_table = db_get_table( 'project_user_list' );
-
 	if( null === $p_project_id ) {
 		$p_project_id = helper_get_current_project();
 	}
@@ -1194,7 +1184,7 @@ function user_get_unassigned_by_project_id( $p_project_id = null ) {
 	$t_adm = config_get_global( 'admin_site_threshold' );
 	$t_query = 'SELECT DISTINCT u.id, u.username, u.realname
 				FROM {user} u
-				LEFT JOIN ' . $t_mantis_project_user_list_table . ' p
+				LEFT JOIN {project_user_list} p
 				ON p.user_id=u.id AND p.project_id=' . db_param() . '
 				WHERE u.access_level<' . db_param() . ' AND
 					u.enabled = ' . db_param() . ' AND

--- a/proj_doc_page.php
+++ b/proj_doc_page.php
@@ -66,7 +66,6 @@ if( OFF == config_get( 'enable_project_documentation' ) || !file_is_uploading_en
 $g_project_override = $f_project_id;
 
 $t_user_id = auth_get_current_user_id();
-$t_project_user_list_table = db_get_table( 'project_user_list' );
 $t_pub = VS_PUBLIC;
 $t_priv = VS_PRIVATE;
 $t_admin = config_get_global( 'admin_site_threshold' );
@@ -95,7 +94,7 @@ if( is_array( $t_reqd_access ) ) {
 $t_query = 'SELECT pft.id, pft.project_id, pft.filename, pft.filesize, pft.title, pft.description, pft.date_added
 			FROM {project_file} pft
 				LEFT JOIN {project} pt ON pft.project_id = pt.id
-				LEFT JOIN ' . $t_project_user_list_table . ' pult
+				LEFT JOIN {project_user_list} pult
 					ON pft.project_id = pult.project_id AND pult.user_id = ' . db_param() . '
 				LEFT JOIN {user} ut ON ut.id = ' . db_param() . '
 			WHERE pft.project_id in (' . implode( ',', $t_projects ) . ') AND


### PR DESCRIPTION
#216 adds support for the new table name syntax,

allowing us to replace db_get_table calls within queries.

Calls to db_get_table that are used by other database function,
i.e. db_insert_id, db_field_exists are deliberately left unchanged at this
stage.

This is aimed at breaking down the future DB API changes into manageable
chunks, and to aid the review process after 1.3 for 2.0.

This Pull request deals with calls for the 'project_user_list' table only,
for ease of review, and syncing until merged.
