### PR TITLE
Update db_get_table() calls for table 'project'

### DIFF
--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -212,7 +212,6 @@ $t_edit_value           = gpc_get_string( 'value', '' );
 
 # Apply filters
 $t_config_table  = db_get_table( 'config' );
-$t_project_table = db_get_table( 'project' );
 
 # Get users in db having specific configs
 $t_query = 'SELECT DISTINCT user_id FROM ' . $t_config_table . ' WHERE user_id <> ' . db_param() ;
@@ -238,7 +237,7 @@ $t_users_list = array(
 # Get projects in db with specific configs
 $t_query = 'SELECT DISTINCT project_id, pt.name as project_name
 	FROM ' . $t_config_table . ' ct
-	JOIN ' . $t_project_table . ' pt ON pt.id = ct.project_id
+	JOIN {project} pt ON pt.id = ct.project_id
 	WHERE project_id!=0
 	ORDER BY project_name';
 $t_result = db_query_bound( $t_query );

--- a/admin/move_attachments_page.php
+++ b/admin/move_attachments_page.php
@@ -39,7 +39,6 @@ $f_file_type = gpc_get( 'type', 'bug' );
 
 function get_attachment_stats( $p_file_type, $p_in_db ) {
 	$t_bug_table = db_get_table( 'bug' );
-	$t_project_table = db_get_table( 'project' );
 
 	if( $p_in_db ) {
 		$t_compare = "<> ''";
@@ -50,7 +49,7 @@ function get_attachment_stats( $p_file_type, $p_in_db ) {
 		case 'project':
 			$t_query = "SELECT p.id, p.name, COUNT(f.id) stats
 				FROM {project_file} f
-				LEFT JOIN $t_project_table p ON p.id = f.project_id
+				LEFT JOIN {project} p ON p.id = f.project_id
 				WHERE content $t_compare
 				GROUP BY p.id, p.name
 				ORDER BY p.name";
@@ -60,7 +59,7 @@ function get_attachment_stats( $p_file_type, $p_in_db ) {
 			$t_query = "SELECT p.id, p.name, COUNT(f.id) stats
 				FROM {bug_file} f
 				JOIN $t_bug_table b ON b.id = f.bug_id
-				JOIN $t_project_table p ON p.id = b.project_id
+				JOIN {project} p ON p.id = b.project_id
 				WHERE content $t_compare
 				GROUP BY p.id, p.name
 				ORDER BY p.name";

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -695,7 +695,6 @@ function mc_project_get_attachments( $p_username, $p_password, $p_project_id ) {
 		return mci_soap_fault_access_denied( $t_user_id );
 	}
 
-	$t_project_table = db_get_table( 'project' );
 	$t_project_user_list_table = db_get_table( 'project_user_list' );
 	$t_user_table = db_get_table( 'user' );
 	$t_pub = VS_PUBLIC;
@@ -727,7 +726,7 @@ function mc_project_get_attachments( $p_username, $p_password, $p_project_id ) {
 
 	$t_query = 'SELECT pft.id, pft.project_id, pft.filename, pft.file_type, pft.filesize, pft.title, pft.description, pft.date_added, pft.user_id
 		FROM {project_file} pft
-		LEFT JOIN ' . $t_project_table . ' pt ON pft.project_id = pt.id
+		LEFT JOIN {project} pt ON pft.project_id = pt.id
 		LEFT JOIN ' . $t_project_user_list_table . ' pult
 		ON pft.project_id = pult.project_id AND pult.user_id = ' . db_param() . '
 		LEFT JOIN ' . $t_user_table . ' ut ON ut.id = ' . db_param() . '

--- a/core/category_api.php
+++ b/core/category_api.php
@@ -347,10 +347,9 @@ function category_cache_array_rows_by_project( array $p_project_id_array ) {
 	}
 
 	$t_category_table = db_get_table( 'category' );
-	$t_project_table = db_get_table( 'project' );
 
 	$t_query = 'SELECT c.*, p.name AS project_name FROM ' . $t_category_table . ' c
-				LEFT JOIN ' . $t_project_table . ' p
+				LEFT JOIN {project} p
 					ON c.project_id=p.id
 				WHERE project_id IN ( ' . implode( ', ', $c_project_id_array ) . ' )
 				ORDER BY c.name ';
@@ -444,7 +443,6 @@ function category_get_all_rows( $p_project_id, $p_inherit = null, $p_sort_by_pro
 	$c_project_id = (int)$p_project_id;
 
 	$t_category_table = db_get_table( 'category' );
-	$t_project_table = db_get_table( 'project' );
 
 	if( $c_project_id == ALL_PROJECTS ) {
 		$t_inherit = false;
@@ -464,7 +462,7 @@ function category_get_all_rows( $p_project_id, $p_inherit = null, $p_sort_by_pro
 	}
 
 	$t_query = 'SELECT c.*, p.name AS project_name FROM ' . $t_category_table . ' c
-				LEFT JOIN ' . $t_project_table . ' p
+				LEFT JOIN {project} p
 					ON c.project_id=p.id
 				WHERE ' . $t_project_where . ' ORDER BY c.name';
 	$t_result = db_query_bound( $t_query );
@@ -504,10 +502,9 @@ function category_cache_array_rows( array $p_cat_id_array ) {
 	}
 
 	$t_category_table = db_get_table( 'category' );
-	$t_project_table = db_get_table( 'project' );
 
 	$t_query = 'SELECT c.*, p.name AS project_name FROM ' . $t_category_table . ' c
-				LEFT JOIN ' . $t_project_table . ' p
+				LEFT JOIN {project} p
 					ON c.project_id=p.id
 				WHERE c.id IN (' . implode( ',', $c_cat_id_array ) . ')';
 	$t_result = db_query_bound( $t_query );

--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -643,7 +643,6 @@ function custom_field_get_linked_ids( $p_project_id = ALL_PROJECTS ) {
 
 		if( ALL_PROJECTS == $p_project_id ) {
 			$t_project_user_list_table = db_get_table( 'project_user_list' );
-			$t_project_table = db_get_table( 'project' );
 			$t_user_id = auth_get_current_user_id();
 
 			# Select only the ids of custom fields in projects the user has access to
@@ -653,7 +652,7 @@ function custom_field_get_linked_ids( $p_project_id = ALL_PROJECTS ) {
 			$t_query = 'SELECT DISTINCT cft.id
 				FROM ' . $t_custom_field_table . ' cft
 					JOIN ' . $t_custom_field_project_table . ' cfpt ON cfpt.field_id = cft.id
-					JOIN ' . $t_project_table . ' pt
+					JOIN {project} pt
 						ON pt.id = cfpt.project_id AND pt.enabled = ' . db_prepare_bool( true ) . '
 					LEFT JOIN ' . $t_project_user_list_table . ' pult
 						ON pult.project_id = cfpt.project_id AND pult.user_id = ' . db_param() . '

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1062,7 +1062,6 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 	$t_category_table = db_get_table( 'category' );
 	$t_custom_field_string_table = db_get_table( 'custom_field_string' );
 	$t_bugnote_text_table = db_get_table( 'bugnote_text' );
-	$t_project_table = db_get_table( 'project' );
 	$t_bug_monitor_table = db_get_table( 'bug_monitor' );
 	$t_limit_reporters = config_get( 'limit_reporters' );
 	$t_bug_relationship_table = db_get_table( 'bug_relationship' );
@@ -1111,9 +1110,7 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 	# clauses are requested by the user ( all matching -> AND, any matching -> OR )
 	$t_where_clauses = array();
 
-	$t_project_where_clauses =  array(
-		$t_project_table . '.enabled = ' . db_param(),
-	);
+	$t_project_where_clauses =  array( '{project}.enabled = ' . db_param() );
 	$t_where_params = array(
 		1,
 	);
@@ -1126,7 +1123,7 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 	);
 
 	$t_join_clauses = array(
-		' JOIN ' . $t_project_table . ' ON ' . $t_project_table . '.id = ' . $t_bug_table . '.project_id',
+		' JOIN {project} ON {project}.id = ' . $t_bug_table . '.project_id',
 	);
 
 	# normalize the project filtering into an array $t_project_ids

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1077,10 +1077,9 @@ function print_project_user_list_option_list( $p_project_id = null ) {
  */
 function print_project_user_list_option_list2( $p_user_id ) {
 	$t_mantis_project_user_list_table = db_get_table( 'project_user_list' );
-	$t_mantis_project_table = db_get_table( 'project' );
 
 	$t_query = 'SELECT DISTINCT p.id, p.name
-				FROM ' . $t_mantis_project_table . ' p
+				FROM {project} p
 				LEFT JOIN ' . $t_mantis_project_user_list_table . ' u
 				ON p.id=u.project_id AND u.user_id=' . db_param() . '
 				WHERE p.enabled = ' . db_param() . ' AND

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -74,8 +74,7 @@ function project_table_empty() {
 	}
 
 	# Otherwise, check if the projects table contains at least one project.
-	$t_project_table = db_get_table( 'project' );
-	$t_query = 'SELECT * FROM ' . $t_project_table;
+	$t_query = 'SELECT * FROM {project}';
 	$t_result = db_query_bound( $t_query, array(), 1 );
 
 	return db_num_rows( $t_result ) == 0;
@@ -103,9 +102,7 @@ function project_cache_row( $p_project_id, $p_trigger_errors = true ) {
 		return false;
 	}
 
-	$t_project_table = db_get_table( 'project' );
-
-	$t_query = 'SELECT * FROM ' . $t_project_table . ' WHERE id=' . db_param();
+	$t_query = 'SELECT * FROM {project} WHERE id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_project_id ) );
 
 	if( 0 == db_num_rows( $t_result ) ) {
@@ -146,9 +143,7 @@ function project_cache_array_rows( array $p_project_id_array ) {
 		return;
 	}
 
-	$t_project_table = db_get_table( 'project' );
-
-	$t_query = 'SELECT * FROM ' . $t_project_table . ' WHERE id IN (' . implode( ',', $c_project_id_array ) . ')';
+	$t_query = 'SELECT * FROM {project} WHERE id IN (' . implode( ',', $c_project_id_array ) . ')';
 	$t_result = db_query_bound( $t_query );
 
 	$t_projects_found = array();
@@ -172,9 +167,7 @@ function project_cache_all() {
 	global $g_cache_project, $g_cache_project_all;
 
 	if( !$g_cache_project_all ) {
-		$t_project_table = db_get_table( 'project' );
-
-		$t_query = 'SELECT * FROM ' . $t_project_table;
+		$t_query = 'SELECT * FROM {project}';
 		$t_result = db_query_bound( $t_query );
 		$t_count = db_num_rows( $t_result );
 		for( $i = 0;$i < $t_count;$i++ ) {
@@ -244,9 +237,7 @@ function project_ensure_exists( $p_project_id ) {
  * @return boolean
  */
 function project_is_name_unique( $p_name ) {
-	$t_project_table = db_get_table( 'project' );
-
-	$t_query = 'SELECT COUNT(*) FROM ' . $t_project_table . ' WHERE name=' . db_param();
+	$t_query = 'SELECT COUNT(*) FROM {project} WHERE name=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_name ) );
 
 	if( 0 == db_result( $t_result ) ) {
@@ -345,7 +336,7 @@ function project_create( $p_name, $p_description, $p_status, $p_view_state = VS_
 
 	$t_project_table = db_get_table( 'project' );
 
-	$t_query = 'INSERT INTO ' . $t_project_table . '
+	$t_query = 'INSERT INTO {project}
 					( name, status, enabled, view_state, file_path, description, inherit_global )
 				  VALUES
 					( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ')';
@@ -398,8 +389,7 @@ function project_delete( $p_project_id ) {
 	user_pref_delete_project( $p_project_id );
 
 	# Delete the project entry
-	$t_project_table = db_get_table( 'project' );
-	$t_query = 'DELETE FROM ' . $t_project_table . ' WHERE id=' . db_param();
+	$t_query = 'DELETE FROM {project} WHERE id=' . db_param();
 
 	db_query_bound( $t_query, array( $p_project_id ) );
 
@@ -450,9 +440,7 @@ function project_update( $p_project_id, $p_name, $p_description, $p_status, $p_v
 		$p_file_path = validate_project_file_path( $p_file_path );
 	}
 
-	$t_project_table = db_get_table( 'project' );
-
-	$t_query = 'UPDATE ' . $t_project_table . '
+	$t_query = 'UPDATE {project}
 				  SET name=' . db_param() . ',
 					status=' . db_param() . ',
 					enabled=' . db_param() . ',
@@ -495,9 +483,7 @@ function project_copy_custom_fields( $p_destination_id, $p_source_id ) {
  * @return integer
  */
 function project_get_id_by_name( $p_project_name ) {
-	$t_project_table = db_get_table( 'project' );
-
-	$t_query = 'SELECT id FROM ' . $t_project_table . ' WHERE name = ' . db_param();
+	$t_query = 'SELECT id FROM {project} WHERE name = ' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_project_name ), 1 );
 
 	if( db_num_rows( $t_result ) == 0 ) {

--- a/core/project_hierarchy_api.php
+++ b/core/project_hierarchy_api.php
@@ -155,9 +155,8 @@ function project_hierarchy_cache( $p_show_disabled = false ) {
 
 	$t_enabled_clause = $p_show_disabled ? '1=1' : 'p.enabled = ' . db_param();
 
-	$t_project_table = db_get_table( 'project' );
 	$t_query = 'SELECT DISTINCT p.id, ph.parent_id, p.name, p.inherit_global, ph.inherit_parent
-				  FROM ' . $t_project_table . ' p
+				  FROM {project} p
 				  LEFT JOIN {project_hierarchy} ph
 				    ON ph.child_id = p.id
 				  WHERE ' . $t_enabled_clause . '

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -746,7 +746,6 @@ function summary_print_by_category() {
  */
 function summary_print_by_project( array $p_projects = array(), $p_level = 0, array $p_cache = null ) {
 	$t_mantis_bug_table = db_get_table( 'bug' );
-	$t_mantis_project_table = db_get_table( 'project' );
 
 	$t_project_id = helper_get_current_project();
 

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -972,14 +972,13 @@ function user_get_accessible_projects( $p_user_id, $p_show_disabled = false ) {
 	if( access_has_global_level( config_get( 'private_project_threshold' ), $p_user_id ) ) {
 		$t_projects = project_hierarchy_get_subprojects( ALL_PROJECTS, $p_show_disabled );
 	} else {
-		$t_project_table = db_get_table( 'project' );
 		$t_project_user_list_table = db_get_table( 'project_user_list' );
 
 		$t_public = VS_PUBLIC;
 		$t_private = VS_PRIVATE;
 
 		$t_query = 'SELECT p.id, p.name, ph.parent_id
-						  FROM ' . $t_project_table . ' p
+						  FROM {project} p
 						  LEFT JOIN ' . $t_project_user_list_table . ' u
 						    ON p.id=u.project_id AND u.user_id=' . db_param() . '
 						  LEFT JOIN {project_hierarchy} ph
@@ -1037,7 +1036,6 @@ function user_get_accessible_subprojects( $p_user_id, $p_project_id, $p_show_dis
 		}
 	}
 
-	$t_project_table = db_get_table( 'project' );
 	$t_project_user_list_table = db_get_table( 'project_user_list' );
 
 	db_param_push();
@@ -1045,7 +1043,7 @@ function user_get_accessible_subprojects( $p_user_id, $p_project_id, $p_show_dis
 	if( access_has_global_level( config_get( 'private_project_threshold' ), $p_user_id ) ) {
 		$t_enabled_clause = $p_show_disabled ? '' : 'p.enabled = ' . db_param() . ' AND';
 		$t_query = 'SELECT DISTINCT p.id, p.name, ph.parent_id
-					  FROM ' . $t_project_table . ' p
+					  FROM {project} p
 					  LEFT JOIN {project_hierarchy} ph
 					    ON ph.child_id = p.id
 					  WHERE ' . $t_enabled_clause . '
@@ -1054,7 +1052,7 @@ function user_get_accessible_subprojects( $p_user_id, $p_project_id, $p_show_dis
 		$t_result = db_query_bound( $t_query, ( $p_show_disabled ? array() : array( true ) ) );
 	} else {
 		$t_query = 'SELECT DISTINCT p.id, p.name, ph.parent_id
-					  FROM ' . $t_project_table . ' p
+					  FROM {project} p
 					  LEFT JOIN ' . $t_project_user_list_table . ' u
 					    ON p.id = u.project_id AND u.user_id=' . db_param() . '
 					  LEFT JOIN {project_hierarchy} ph
@@ -1162,10 +1160,9 @@ function user_get_all_accessible_projects( $p_user_id, $p_project_id ) {
  */
 function user_get_assigned_projects( $p_user_id ) {
 	$t_mantis_project_user_list_table = db_get_table( 'project_user_list' );
-	$t_mantis_project_table = db_get_table( 'project' );
 
 	$t_query = 'SELECT DISTINCT p.id, p.name, p.view_state, u.access_level
-				FROM ' . $t_mantis_project_table . ' p
+				FROM {project} p
 				LEFT JOIN ' . $t_mantis_project_user_list_table . ' u
 				ON p.id=u.project_id
 				WHERE p.enabled = \'1\' AND

--- a/proj_doc_page.php
+++ b/proj_doc_page.php
@@ -66,7 +66,6 @@ if( OFF == config_get( 'enable_project_documentation' ) || !file_is_uploading_en
 $g_project_override = $f_project_id;
 
 $t_user_id = auth_get_current_user_id();
-$t_project_table = db_get_table( 'project' );
 $t_project_user_list_table = db_get_table( 'project_user_list' );
 $t_pub = VS_PUBLIC;
 $t_priv = VS_PRIVATE;
@@ -95,7 +94,7 @@ if( is_array( $t_reqd_access ) ) {
 
 $t_query = 'SELECT pft.id, pft.project_id, pft.filename, pft.filesize, pft.title, pft.description, pft.date_added
 			FROM {project_file} pft
-				LEFT JOIN ' . $t_project_table . ' pt ON pft.project_id = pt.id
+				LEFT JOIN {project} pt ON pft.project_id = pt.id
 				LEFT JOIN ' . $t_project_user_list_table . ' pult
 					ON pft.project_id = pult.project_id AND pult.user_id = ' . db_param() . '
 				LEFT JOIN {user} ut ON ut.id = ' . db_param() . '


### PR DESCRIPTION
#216 adds support for the new table name syntax,

allowing us to replace db_get_table calls within queries.

Calls to db_get_table that are used by other database function,
i.e. db_insert_id, db_field_exists are deliberately left unchanged at this
stage.

This is aimed at breaking down the future DB API changes into manageable
chunks, and to aid the review process after 1.3 for 2.0.

This Pull request deals with calls for the 'project' table only,
for ease of review, and syncing until merged.
