### PR TITLE
Add horizontal ruler before start of debug output

### DIFF
--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -165,6 +165,7 @@ function log_print_to_page() {
 		$t_total_queries_count = 0;
 		$t_total_event_count = count( $g_log_events );
 
+		echo "\t<hr />\n";
 		echo "\n\n<!--Mantis Debug Log Output-->";
 		if( $t_total_event_count == 0 ) {
 			echo "<!--END Mantis Debug Log Output-->\n\n";


### PR DESCRIPTION
Add horizontal ruler before start of debug output

This helps seperate any debug output from the page generation within Mantis.
