### PR TITLE
Remove 'content_expire' config option

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -1084,12 +1084,6 @@ $g_cookie_time_length = 30000000;
 $g_allow_permanent_cookie = ON;
 
 /**
- * minutes to wait before document is stale (in minutes)
- * @global int $g_content_expire
- */
-$g_content_expire = 0;
-
-/**
  * The time (in seconds) to allow for page execution during long processes
  *  such as upgrading your database.
  * The default value of 0 indicates that the page should be allowed to
@@ -4173,7 +4167,7 @@ $g_show_log_threshold = ADMINISTRATOR;
  */
 $g_global_settings = array(
 	'global_settings', 'admin_checks', 'allow_signup', 'allow_anonymous_login',
-	'anonymous_account', 'compress_html', 'content_expire', 'allow_permanent_cookie',
+	'anonymous_account', 'compress_html', 'allow_permanent_cookie',
 	'cookie_time_length', 'cookie_path', 'cookie_domain',
 	'cookie_prefix', 'string_cookie', 'project_cookie', 'view_all_cookie',
 	'manage_config_cookie', 'manage_user_cookie', 'logout_cookie',

--- a/core/obsolete.php
+++ b/core/obsolete.php
@@ -187,3 +187,4 @@ config_obsolete( 'mc_version_when_not_found', 'webservice_version_when_not_found
 env_obsolete( 'MANTIS_CONFIG', 'MANTIS_CONFIG_FOLDER' );
 config_obsolete( 'colour_project' );
 config_obsolete( 'colour_global' );
+config_obsolete( 'content_expire' );

--- a/docbook/Admin_Guide/en-US/Configuration.xml
+++ b/docbook/Admin_Guide/en-US/Configuration.xml
@@ -1073,14 +1073,6 @@ $g_language_choices_arr = array( 'english', 'french', 'german' );
                 </listitem>
             </varlistentry>
             <varlistentry>
-                <term>$g_content_expire</term>
-                <listitem>
-                    <para>Time to wait before document is stale (in minutes). This is
-                        used in meta_inc.php. Default is 0 (expires right away).
-                    </para>
-                </listitem>
-            </varlistentry>
-            <varlistentry>
                 <term>$g_long_process_timeout</term>
                 <listitem>
                     <para>This timeout is used by pages which does time consuming


### PR DESCRIPTION
This removes a config option previously removed 7 years ago by 4071c8717a23db909dca4df01692f157e58344d1
