### PR TITLE
Update db_get_table() calls for table 'bug_file' and 'project_file'

### DIFF
--- a/admin/move_attachments_page.php
+++ b/admin/move_attachments_page.php
@@ -48,9 +48,8 @@ function get_attachment_stats( $p_file_type, $p_in_db ) {
 	}
 	switch( $p_file_type ) {
 		case 'project':
-			$t_file_table = db_get_table( 'project_file' );
 			$t_query = "SELECT p.id, p.name, COUNT(f.id) stats
-				FROM $t_file_table f
+				FROM {project_file} f
 				LEFT JOIN $t_project_table p ON p.id = f.project_id
 				WHERE content $t_compare
 				GROUP BY p.id, p.name
@@ -58,9 +57,8 @@ function get_attachment_stats( $p_file_type, $p_in_db ) {
 			break;
 		case 'bug':
 		default:
-			$t_file_table = db_get_table( 'bug_file' );
 			$t_query = "SELECT p.id, p.name, COUNT(f.id) stats
-				FROM $t_file_table f
+				FROM {bug_file} f
 				JOIN $t_bug_table b ON b.id = f.bug_id
 				JOIN $t_project_table p ON p.id = b.project_id
 				WHERE content $t_compare

--- a/api/soap/mc_file_api.php
+++ b/api/soap/mc_file_api.php
@@ -189,12 +189,10 @@ function mci_file_get( $p_file_id, $p_type, $p_user_id ) {
 	$t_query = '';
 	switch( $p_type ) {
 		case 'bug':
-			$t_bug_file_table = db_get_table( 'bug_file' );
-			$t_query = 'SELECT * FROM ' . $t_bug_file_table . ' WHERE id=' . db_param();
+			$t_query = 'SELECT * FROM {bug_file} WHERE id=' . db_param();
 			break;
 		case 'doc':
-			$t_project_file_table = db_get_table( 'project_file' );
-			$t_query = 'SELECT * FROM ' . $t_project_file_table . ' WHERE id=' . db_param();
+			$t_query = 'SELECT * FROM {project_file} WHERE id=' . db_param();
 			break;
 		default:
 			return SoapObjectsFactory::newSoapFault( 'Server', 'Invalid file type '. $p_type . ' .' );

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -695,7 +695,6 @@ function mc_project_get_attachments( $p_username, $p_password, $p_project_id ) {
 		return mci_soap_fault_access_denied( $t_user_id );
 	}
 
-	$t_project_file_table = db_get_table( 'project_file' );
 	$t_project_table = db_get_table( 'project' );
 	$t_project_user_list_table = db_get_table( 'project_user_list' );
 	$t_user_table = db_get_table( 'user' );
@@ -727,7 +726,7 @@ function mc_project_get_attachments( $p_username, $p_password, $p_project_id ) {
 	}
 
 	$t_query = 'SELECT pft.id, pft.project_id, pft.filename, pft.file_type, pft.filesize, pft.title, pft.description, pft.date_added, pft.user_id
-		FROM ' . $t_project_file_table . ' pft
+		FROM {project_file} pft
 		LEFT JOIN ' . $t_project_table . ' pt ON pft.project_id = pt.id
 		LEFT JOIN ' . $t_project_user_list_table . ' pult
 		ON pft.project_id = pult.project_id AND pult.user_id = ' . db_param() . '

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1516,10 +1516,8 @@ function bug_get_bugnote_stats( $p_bug_id ) {
  * @uses file_api.php
  */
 function bug_get_attachments( $p_bug_id ) {
-	$t_bug_file_table = db_get_table( 'bug_file' );
-
 	$t_query = 'SELECT id, title, diskfile, filename, filesize, file_type, date_added, user_id
-		                FROM ' . $t_bug_file_table . '
+		                FROM {bug_file}
 		                WHERE bug_id=' . db_param() . '
 		                ORDER BY date_added';
 	$t_db_result = db_query_bound( $t_query, array( $p_bug_id ) );

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -97,8 +97,7 @@ function file_bug_attachment_count( $p_bug_id ) {
 
 	# Otherwise build the cache and return the attachment count
 	#   for the given bug (if any).
-	$t_bug_file_table = db_get_table( 'bug_file' );
-	$t_query = 'SELECT bug_id, COUNT(bug_id) AS attachments FROM ' . $t_bug_file_table . ' GROUP BY bug_id';
+	$t_query = 'SELECT bug_id, COUNT(bug_id) AS attachments FROM {bug_file} GROUP BY bug_id';
 	$t_result = db_query_bound( $t_query );
 
 	$t_file_count = 0;
@@ -364,8 +363,7 @@ function file_delete_attachments( $p_bug_id ) {
 	$t_method = config_get( 'file_upload_method' );
 
 	# Delete files from disk
-	$t_bug_file_table = db_get_table( 'bug_file' );
-	$t_query = 'SELECT diskfile, filename FROM ' . $t_bug_file_table . ' WHERE bug_id=' . db_param();
+	$t_query = 'SELECT diskfile, filename FROM {bug_file} WHERE bug_id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_bug_id ) );
 
 	$t_file_count = db_num_rows( $t_result );
@@ -396,13 +394,12 @@ function file_delete_attachments( $p_bug_id ) {
  * @return void
  */
 function file_delete_project_files( $p_project_id ) {
-	$t_project_file_table = db_get_table( 'project_file' );
 	$t_method = config_get( 'file_upload_method' );
 
 	# Delete the file physically (if stored via DISK)
 	if( DISK == $t_method ) {
 		# Delete files from disk
-		$t_query = 'SELECT diskfile, filename FROM ' . $t_project_file_table . ' WHERE project_id=' . db_param();
+		$t_query = 'SELECT diskfile, filename FROM {project_file} WHERE project_id=' . db_param();
 		$t_result = db_query_bound( $t_query, array( (int)$p_project_id ) );
 
 		$t_file_count = db_num_rows( $t_result );
@@ -416,7 +413,7 @@ function file_delete_project_files( $p_project_id ) {
 	}
 
 	# Delete the corresponding database records
-	$t_query = 'DELETE FROM ' . $t_project_file_table . ' WHERE project_id=' . db_param();
+	$t_query = 'DELETE FROM {project_file} WHERE project_id=' . db_param();
 	db_query_bound( $t_query, array( (int)$p_project_id ) );
 }
 
@@ -561,16 +558,13 @@ function file_generate_unique_name( $p_filepath ) {
  * @return boolean true if unique
  */
 function diskfile_is_name_unique( $p_name, $p_filepath ) {
-	$t_bug_file_table = db_get_table( 'bug_file' );
-	$t_project_file_table = db_get_table( 'project_file' );
-
 	$c_name = $p_filepath . $p_name;
 
 	$t_query = 'SELECT count(*)
 		FROM (
-			SELECT diskfile FROM ' . $t_bug_file_table . '
+			SELECT diskfile FROM {bug_file}
 			UNION
-			SELECT diskfile FROM ' . $t_project_file_table . '
+			SELECT diskfile FROM {project_file}
 			) f
 		WHERE diskfile=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $c_name ) );
@@ -853,12 +847,10 @@ function file_get_content( $p_file_id, $p_type = 'bug' ) {
 	$t_query = '';
 	switch( $p_type ) {
 		case 'bug':
-			$t_bug_file_table = db_get_table( 'bug_file' );
-			$t_query = 'SELECT * FROM ' . $t_bug_file_table . ' WHERE id=' . db_param();
+			$t_query = 'SELECT * FROM {bug_file} WHERE id=' . db_param();
 			break;
 		case 'doc':
-			$t_project_file_table = db_get_table( 'project_file' );
-			$t_query = 'SELECT * FROM ' . $t_project_file_table . ' WHERE id=' . db_param();
+			$t_query = 'SELECT * FROM {project_file} WHERE id=' . db_param();
 			break;
 		default:
 			return false;
@@ -961,8 +953,7 @@ function file_move_bug_attachments( $p_bug_id, $p_project_id_to ) {
 
 	# Initialize the update query to update a single row
 	$c_bug_id = (int)$p_bug_id;
-	$t_bug_file_table = db_get_table( 'bug_file' );
-	$t_query_disk_attachment_update = 'UPDATE ' . $t_bug_file_table . '
+	$t_query_disk_attachment_update = 'UPDATE {bug_file}
 	                                 SET folder=' . db_param() . '
 	                                 WHERE bug_id=' . db_param() . '
 	                                 AND id =' . db_param();
@@ -1003,9 +994,7 @@ function file_move_bug_attachments( $p_bug_id, $p_project_id_to ) {
  * @return void
  */
 function file_copy_attachments( $p_source_bug_id, $p_dest_bug_id ) {
-	$t_mantis_bug_file_table = db_get_table( 'bug_file' );
-
-	$t_query = 'SELECT * FROM ' . $t_mantis_bug_file_table . ' WHERE bug_id = ' . db_param();
+	$t_query = 'SELECT * FROM {bug_file} WHERE bug_id = ' . db_param();
 	$t_result = db_query_bound( $t_query, array( $p_source_bug_id ) );
 	$t_count = db_num_rows( $t_result );
 

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1876,8 +1876,7 @@ function print_bug_attachment_preview_text( array $p_attachment ) {
 			}
 			break;
 		case DATABASE:
-			$t_bug_file_table = db_get_table( 'bug_file' );
-			$t_query = 'SELECT * FROM ' . $t_bug_file_table . ' WHERE id=' . db_param();
+			$t_query = 'SELECT * FROM {bug_file} WHERE id=' . db_param();
 			$t_result = db_query_bound( $t_query, array( (int)$p_attachment['id'] ) );
 			$t_row = db_fetch_array( $t_result );
 			$t_content = $t_row['content'];

--- a/file_download.php
+++ b/file_download.php
@@ -81,12 +81,10 @@ $c_file_id = (integer)$f_file_id;
 $t_query = '';
 switch( $f_type ) {
 	case 'bug':
-		$t_bug_file_table = db_get_table( 'bug_file' );
-		$t_query = 'SELECT * FROM ' . $t_bug_file_table . ' WHERE id=' . db_param();
+		$t_query = 'SELECT * FROM {bug_file} WHERE id=' . db_param();
 		break;
 	case 'doc':
-		$t_project_file_table = db_get_table( 'project_file' );
-		$t_query = 'SELECT * FROM ' . $t_project_file_table . ' WHERE id=' . db_param();
+		$t_query = 'SELECT * FROM {project_file} WHERE id=' . db_param();
 		break;
 	default:
 		access_denied();

--- a/proj_doc_delete.php
+++ b/proj_doc_delete.php
@@ -62,8 +62,7 @@ $t_project_id = file_get_field( $f_file_id, 'project_id', 'project' );
 
 access_ensure_project_level( config_get( 'upload_project_file_threshold' ), $t_project_id );
 
-$t_project_file_table = db_get_table( 'project_file' );
-$t_query = 'SELECT title FROM ' . $t_project_file_table . ' WHERE id=' . db_param();
+$t_query = 'SELECT title FROM {project_file} WHERE id=' . db_param();
 $t_result = db_query_bound( $t_query, array( $f_file_id ) );
 $t_title = db_result( $t_result );
 

--- a/proj_doc_edit_page.php
+++ b/proj_doc_edit_page.php
@@ -62,8 +62,7 @@ $t_project_id = file_get_field( $f_file_id, 'project_id', 'project' );
 
 access_ensure_project_level( config_get( 'upload_project_file_threshold' ), $t_project_id );
 
-$t_proj_file_table = db_get_table( 'project_file' );
-$t_query = 'SELECT * FROM ' . $t_proj_file_table . ' WHERE id=' . db_param();
+$t_query = 'SELECT * FROM {project_file} WHERE id=' . db_param();
 $t_result = db_query_bound( $t_query, array( $t_file_id ) );
 $t_row = db_fetch_array( $t_result );
 extract( $t_row, EXTR_PREFIX_ALL, 'v' );

--- a/proj_doc_page.php
+++ b/proj_doc_page.php
@@ -66,7 +66,6 @@ if( OFF == config_get( 'enable_project_documentation' ) || !file_is_uploading_en
 $g_project_override = $f_project_id;
 
 $t_user_id = auth_get_current_user_id();
-$t_project_file_table = db_get_table( 'project_file' );
 $t_project_table = db_get_table( 'project' );
 $t_project_user_list_table = db_get_table( 'project_user_list' );
 $t_pub = VS_PUBLIC;
@@ -95,7 +94,7 @@ if( is_array( $t_reqd_access ) ) {
 }
 
 $t_query = 'SELECT pft.id, pft.project_id, pft.filename, pft.filesize, pft.title, pft.description, pft.date_added
-			FROM ' . $t_project_file_table . ' pft
+			FROM {project_file} pft
 				LEFT JOIN ' . $t_project_table . ' pt ON pft.project_id = pt.id
 				LEFT JOIN ' . $t_project_user_list_table . ' pult
 					ON pft.project_id = pult.project_id AND pult.user_id = ' . db_param() . '

--- a/proj_doc_update.php
+++ b/proj_doc_update.php
@@ -74,8 +74,6 @@ if( is_blank( $f_title ) ) {
 	trigger_error( ERROR_EMPTY_FIELD, ERROR );
 }
 
-$t_project_file_table = db_get_table( 'project_file' );
-
 # @todo (thraxisp) this code should probably be integrated into file_api to share methods used to store files
 
 if( isset( $f_file['tmp_name'] ) && is_uploaded_file( $f_file['tmp_name'] ) ) {
@@ -116,13 +114,13 @@ if( isset( $f_file['tmp_name'] ) && is_uploaded_file( $f_file['tmp_name'] ) ) {
 			# @todo Such errors should be checked in the admin checks
 			trigger_error( ERROR_GENERIC, ERROR );
 	}
-	$t_query = 'UPDATE ' . $t_project_file_table . '
+	$t_query = 'UPDATE {project_file}
 		SET title=' . db_param() . ', description=' . db_param() . ', date_added=' . db_param() . ',
 			filename=' . db_param() . ', filesize=' . db_param() . ', file_type=' .db_param() . ', content=' .db_param() . '
 			WHERE id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $f_title, $f_description, db_now(), $f_file['name'], $t_file_size, $f_file['type'], $c_content, $f_file_id ) );
 } else {
-	$t_query = 'UPDATE ' . $t_project_file_table . '
+	$t_query = 'UPDATE {project_file}
 			SET title=' . db_param() . ', description=' . db_param() . '
 			WHERE id=' . db_param();
 	$t_result = db_query_bound( $t_query, array( $f_title, $f_description, $f_file_id ) );


### PR DESCRIPTION
#216 adds support for the new table name syntax,

allowing us to replace db_get_table calls within queries.

Calls to db_get_table that are used by other database function,
i.e. db_insert_id, db_field_exists are deliberately left unchanged at this
stage.

This is aimed at breaking down the future DB API changes into manageable
chunks, and to aid the review process after 1.3 for 2.0.

This Pull request deals with calls for the 'project_file' and 'bug_file' tables only,
for ease of review, and syncing until merged.
