### PR TITLE
Bump minimum supported version of postgres for next mantis release.

### DIFF
--- a/admin/check/check_database_inc.php
+++ b/admin/check/check_database_inc.php
@@ -286,7 +286,6 @@ if( db_is_mysql() ) {
 		'9.2' => '2017-09-30',
 		'9.1' => '2016-09-30',
 		'9.0' => '2015-09-30',
-		'8.4' => '2014-07-31',
 	);
 	$t_support_url = 'http://www.postgresql.org/support/versioning/';
 

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -42,7 +42,7 @@ define( 'CONFIGURED_PASSWORD', '______' );
 define( 'DB_MIN_VERSION_ADODB', '5.19' ); # For mssql, oracle and pgsql
 define( 'DB_MIN_VERSION_MSSQL', '9.0.0' );
 define( 'DB_MIN_VERSION_MYSQL', '5.0.8' );   # See #16584
-define( 'DB_MIN_VERSION_PGSQL', '8.4' );     # Earliest supported version as of Jan 2014
+define( 'DB_MIN_VERSION_PGSQL', '9.0' );     # Earliest supported version as of August 2014
 
 # error types
 define( 'ERROR', E_USER_ERROR );


### PR DESCRIPTION
The 8.4 series of postgres was EOL, end of July 2014, and this
can be confirmed by http://www.postgresql.org/about/news/1534/

To aid in testing support for different database engines, we should drop
version 8.4 for new mantis installations.
