### PR TITLE
Fix Content-Security-Policy Headers

### DIFF
--- a/core/http_api.php
+++ b/core/http_api.php
@@ -153,7 +153,7 @@ function http_security_headers() {
 				$t_avatar_img_allow = "; img-src 'self' http://www.gravatar.com:80";
 			}
 		}
-		header( 'X-Content-Security-Policy: allow \'self\';' . $t_avatar_img_allow . '; frame-ancestors \'none\'' );
+		header( 'Content-Security-Policy: default-src \'self\';' . $t_avatar_img_allow . '; frame-ancestors \'none\'' );
 		if( http_is_protocol_https() ) {
 			header( 'Strict-Transport-Security: max-age=7776000' );
 		}


### PR DESCRIPTION
Firefox complains when accessing mantis 1.3 about the deprecated headers.

X-Content-Security-Policy is replaced by Content Security Policy
