### PR TITLE
Shorten db_query_bound to db_query

### DIFF
--- a/account_sponsor_page.php
+++ b/account_sponsor_page.php
@@ -120,7 +120,7 @@ $t_query = 'SELECT b.id as bug, s.id as sponsor, s.paid, b.project_id, b.fixed_i
 	AND ' . $t_project_clause . '
 	ORDER BY s.paid ASC, b.project_id ASC, b.fixed_in_version ASC, b.status ASC, b.id DESC';
 
-$t_result = db_query_bound( $t_query, $t_show_all ? array( $t_user ) : array( $t_user , $t_resolved ) );
+$t_result = db_query( $t_query, $t_show_all ? array( $t_user ) : array( $t_user , $t_resolved ) );
 
 $t_sponsors = array();
 while( $t_row = db_fetch_array( $t_result ) ) {
@@ -235,7 +235,7 @@ $t_query = 'SELECT b.id as bug, s.id as sponsor, s.paid, b.project_id, b.fixed_i
 	AND ' . $t_project_clause . '
 	ORDER BY s.paid ASC, b.project_id ASC, b.fixed_in_version ASC, b.status ASC, b.id DESC';
 
-$t_result = db_query_bound( $t_query, $t_show_all ? array( $t_user ) : array( $t_user , $t_resolved ) );
+$t_result = db_query( $t_query, $t_show_all ? array( $t_user ) : array( $t_user , $t_resolved ) );
 
 $t_sponsors = array();
 while( $t_row = db_fetch_array( $t_result ) ) {

--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -214,7 +214,7 @@ $t_edit_value           = gpc_get_string( 'value', '' );
 
 # Get users in db having specific configs
 $t_query = 'SELECT DISTINCT user_id FROM {config} WHERE user_id <> ' . db_param() ;
-$t_result = db_query_bound( $t_query, array( ALL_USERS ) );
+$t_result = db_query( $t_query, array( ALL_USERS ) );
 if( $t_filter_user_value != META_FILTER_NONE && $t_filter_user_value != ALL_USERS ) {
 	# Make sure the filter value exists in the list
 	$t_users_list[$t_filter_user_value] = user_get_name( $t_filter_user_value );
@@ -239,7 +239,7 @@ $t_query = 'SELECT DISTINCT project_id, pt.name as project_name
 	JOIN {project} pt ON pt.id = ct.project_id
 	WHERE project_id!=0
 	ORDER BY project_name';
-$t_result = db_query_bound( $t_query );
+$t_result = db_query( $t_query );
 $t_projects_list[META_FILTER_NONE] = '[' . lang_get( 'any' ) . ']';
 $t_projects_list[ALL_PROJECTS] = lang_get( 'all_projects' );
 while( $t_row = db_fetch_array( $t_result ) ) {
@@ -249,7 +249,7 @@ while( $t_row = db_fetch_array( $t_result ) ) {
 
 # Get config list used in db
 $t_query = 'SELECT DISTINCT config_id FROM {config} ORDER BY config_id';
-$t_result = db_query_bound( $t_query );
+$t_result = db_query( $t_query );
 $t_configs_list[META_FILTER_NONE] = '[' . lang_get( 'any' ) . ']';
 if( $t_filter_config_value != META_FILTER_NONE ) {
 	# Make sure the filter value exists in the list
@@ -281,7 +281,7 @@ if( $t_where != '' ) {
 
 $t_query = 'SELECT config_id, user_id, project_id, type, value, access_reqd
 	FROM {config} ' . $t_where . ' ORDER BY user_id, project_id, config_id ';
-$t_result = db_query_bound( $t_query, $t_param );
+$t_result = db_query( $t_query, $t_param );
 ?>
 
 <!-- FILTER FORM -->

--- a/admin/check/check_database_inc.php
+++ b/admin/check/check_database_inc.php
@@ -376,7 +376,7 @@ if( db_is_mysql() ) {
 			break;
 	}
 
-	$t_result = db_query_bound( 'SHOW TABLE STATUS' );
+	$t_result = db_query( 'SHOW TABLE STATUS' );
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		if( $t_row[$t_field_comment] !== 'VIEW' &&
 		    preg_match( '/^' . $t_table_prefix_regex_safe . '.+?' . $t_table_suffix_regex_safe . '$/', $t_row[$t_field_name] )
@@ -392,7 +392,7 @@ if( db_is_mysql() ) {
 
 	foreach( db_get_table_list() as $t_table ) {
 		if( preg_match( '/^' . $t_table_prefix_regex_safe . '.+?' . $t_table_suffix_regex_safe . '$/', $t_table ) ) {
-			$t_result = db_query_bound( 'SHOW FULL FIELDS FROM ' . $t_table );
+			$t_result = db_query( 'SHOW FULL FIELDS FROM ' . $t_table );
 			while( $t_row = db_fetch_array( $t_result ) ) {
 				if( $t_row[$t_field_collation] === null ) {
 					continue;

--- a/admin/db_stats.php
+++ b/admin/db_stats.php
@@ -52,7 +52,7 @@ function print_info_row( $p_description, $p_value ) {
 function helper_table_row_count( $p_table ) {
 	$t_table = $p_table;
 	$t_query = 'SELECT COUNT(*) FROM ' . $t_table;
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 	$t_count = db_result( $t_result );
 
 	return $t_count;

--- a/admin/move_attachments.php
+++ b/admin/move_attachments.php
@@ -65,7 +65,7 @@ function move_attachments_to_db( $p_type, $p_projects ) {
 	# Process projects list
 	foreach( $p_projects as $t_project ) {
 		# Retrieve attachments for the project
-		$t_result = db_query_bound( $t_query, array( $t_project ) );
+		$t_result = db_query( $t_query, array( $t_project ) );
 
 		# Project upload path
 		$t_upload_path = project_get_field( $t_project, 'file_path' );
@@ -99,13 +99,13 @@ function move_attachments_to_db( $p_type, $p_projects ) {
 					if( db_is_oracle() ) {
 						db_update_blob( $t_file_table, 'content', $c_content, "id=" . (int)$t_row['id'] );
 						$t_query = "UPDATE $t_file_table SET folder='' WHERE id = " . db_param();
-						$t_result2 = db_query_bound( $t_query, array( (int)$t_row['id'] ) );
+						$t_result2 = db_query( $t_query, array( (int)$t_row['id'] ) );
 					} else {
 						$t_update_query = "UPDATE $t_file_table
 										SET folder = " . db_param() . ",
 										content = " . db_param() . "
 										WHERE id = " . db_param();
-						$t_result2 = db_query_bound( $t_update_query,
+						$t_result2 = db_query( $t_update_query,
 							array( '', $c_content, (int)$t_row['id'] )
 						);
 					}
@@ -176,7 +176,7 @@ function move_attachments_to_disk( $p_type, array $p_projects ) {
 	# Process projects list
 	foreach( $p_projects as $t_project ) {
 		# Retrieve attachments for the project
-		$t_result = db_query_bound( $t_query, array( $t_project ) );
+		$t_result = db_query( $t_query, array( $t_project ) );
 
 		# Project upload path
 		$t_upload_path = project_get_upload_path( $t_project );
@@ -215,7 +215,7 @@ function move_attachments_to_disk( $p_type, array $p_projects ) {
 									WHERE id = ' . db_param();
 								break;
 						}
-						$t_update_result = db_query_bound(
+						$t_update_result = db_query(
 							$t_update_query,
 							array( $t_upload_path, $t_row['id'] )
 						);

--- a/admin/move_attachments_page.php
+++ b/admin/move_attachments_page.php
@@ -63,7 +63,7 @@ function get_attachment_stats( $p_file_type, $p_in_db ) {
 				ORDER BY p.name";
 			break;
 	}
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 	$t_stats = array();
 
 	while( $t_row = db_fetch_array( $t_result ) ) {

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -516,7 +516,7 @@ function mci_filter_db_get_available_queries( $p_project_id = null, $p_user_id =
 					AND (is_public = ' . db_param() . '
 						OR user_id = ' . db_param() . ')
 					ORDER BY is_public DESC, name ASC';
-	$t_result = db_query_bound( $t_query, array( $t_project_id, db_prepare_bool( true ), $t_user_id ) );
+	$t_result = db_query( $t_query, array( $t_project_id, db_prepare_bool( true ), $t_user_id ) );
 	$t_query_count = db_num_rows( $t_result );
 
 	for( $i = 0;$i < $t_query_count;$i++ ) {

--- a/api/soap/mc_file_api.php
+++ b/api/soap/mc_file_api.php
@@ -147,7 +147,7 @@ function mci_file_add( $p_id, $p_name, $p_content, $p_file_type, $p_table, $p_ti
 				    . db_param() . ', ' . db_param() . ', ' . db_param() . ', '
 				    . db_param() . ', ' . db_param() . ', ' . db_param() . ', '
 				    . db_param() . ' )';
-	db_query_bound( $t_query, array(
+	db_query( $t_query, array(
 		$t_id, $p_title, $p_desc,
 		$t_unique_name, $p_name, $t_file_path,
 		$t_file_size, $p_file_type, db_now(),
@@ -161,7 +161,7 @@ function mci_file_add( $p_id, $p_name, $p_content, $p_file_type, $p_table, $p_ti
 		db_update_blob( $t_file_table, 'content', $c_content, "diskfile='$t_unique_name'" );
 	} else {
 		$t_query = "UPDATE $t_file_table SET content=" . db_param() . " WHERE id = " . db_param();
-		db_query_bound( $t_query, array( $c_content, $t_attachment_id ) );
+		db_query( $t_query, array( $c_content, $t_attachment_id ) );
 	}
 
 	if( 'bug' == $p_table ) {
@@ -198,7 +198,7 @@ function mci_file_get( $p_file_id, $p_type, $p_user_id ) {
 			return SoapObjectsFactory::newSoapFault( 'Server', 'Invalid file type '. $p_type . ' .' );
 	}
 
-	$t_result = db_query_bound( $t_query, array( $p_file_id ) );
+	$t_result = db_query( $t_query, array( $p_file_id ) );
 
 	if( $t_result->EOF ) {
 		return SoapObjectsFactory::newSoapFault( 'Client', 'Unable to find an attachment with type ' . $p_type. ' and id ' . $p_file_id . ' .' );

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -565,7 +565,7 @@ function mc_issue_get_id_from_summary( $p_username, $p_password, $p_summary ) {
 
 	$t_query = 'SELECT id FROM {bug} WHERE summary = ' . db_param();
 
-	$t_result = db_query_bound( $t_query, array( $p_summary ), 1 );
+	$t_result = db_query( $t_query, array( $p_summary ), 1 );
 
 	if( db_num_rows( $t_result ) == 0 ) {
 		return 0;

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -734,7 +734,7 @@ function mc_project_get_attachments( $p_username, $p_password, $p_project_id ) {
 		( ut.access_level = ' . db_param() . ' ) )
 		ORDER BY pt.name ASC, pft.title ASC';
 
-	$t_result = db_query_bound( $t_query, array( $t_user_id, $t_user_id, $t_pub, $t_user_id, $t_admin ) );
+	$t_result = db_query( $t_query, array( $t_user_id, $t_user_id, $t_pub, $t_user_id, $t_admin ) );
 	$t_num_files = db_num_rows( $t_result );
 
 	$t_attachments = array();

--- a/changelog_page.php
+++ b/changelog_page.php
@@ -225,7 +225,7 @@ foreach( $t_project_ids as $t_project_id ) {
 		$t_issue_parents = array();
 		$t_issue_handlers = array();
 
-		$t_result = db_query_bound( $t_query, array( $t_project_id, $t_version ) );
+		$t_result = db_query( $t_query, array( $t_project_id, $t_version ) );
 
 		while( $t_row = db_fetch_array( $t_result ) ) {
 			# hide private bugs if user doesn't have access to view them.

--- a/core/access_api.php
+++ b/core/access_api.php
@@ -119,7 +119,7 @@ function access_cache_matrix_project( $p_project_id ) {
 
 	if( !in_array( (int)$p_project_id, $g_cache_access_matrix_project_ids ) ) {
 		$t_query = 'SELECT user_id, access_level FROM {project_user_list} WHERE project_id=' . db_param();
-		$t_result = db_query_bound( $t_query, array( (int)$p_project_id ) );
+		$t_result = db_query( $t_query, array( (int)$p_project_id ) );
 		while( $t_row = db_fetch_array( $t_result ) ) {
 			$g_cache_access_matrix[(int)$t_row['user_id']][(int)$p_project_id] = (int)$t_row['access_level'];
 		}
@@ -149,7 +149,7 @@ function access_cache_matrix_user( $p_user_id ) {
 
 	if( !in_array( (int)$p_user_id, $g_cache_access_matrix_user_ids ) ) {
 		$t_query = 'SELECT project_id, access_level FROM {project_user_list} WHERE user_id=' . db_param();
-		$t_result = db_query_bound( $t_query, array( (int)$p_user_id ) );
+		$t_result = db_query( $t_query, array( (int)$p_user_id ) );
 
 		# make sure we always have an array to return
 		$g_cache_access_matrix[(int)$p_user_id] = array();

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -586,7 +586,7 @@ function auth_generate_unique_cookie_string() {
  */
 function auth_is_cookie_string_unique( $p_cookie_string ) {
 	$t_query = 'SELECT COUNT(*) FROM {user} WHERE cookie_string=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_cookie_string ) );
+	$t_result = db_query( $t_query, array( $p_cookie_string ) );
 
 	$t_count = db_result( $t_result );
 
@@ -631,7 +631,7 @@ function auth_get_current_user_cookie( $p_login_anonymous = true ) {
 
 					# get anonymous information if database is available
 					$t_query = 'SELECT id, cookie_string FROM {user} WHERE username = ' . db_param();
-					$t_result = db_query_bound( $t_query, array( config_get( 'anonymous_account' ) ) );
+					$t_result = db_query( $t_query, array( config_get( 'anonymous_account' ) ) );
 
 					if( $t_row = db_fetch_array( $t_result ) ) {
 						$t_cookie = $t_row['cookie_string'];
@@ -792,7 +792,7 @@ function auth_is_cookie_valid( $p_cookie_string ) {
 
 	# look up cookie in the database to see if it is valid
 	$t_query = 'SELECT * FROM {user} WHERE cookie_string=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_cookie_string ) );
+	$t_result = db_query( $t_query, array( $p_cookie_string ) );
 
 	# return true if a matching cookie was found
 	if( 1 == db_num_rows( $t_result ) ) {
@@ -825,7 +825,7 @@ function auth_get_current_user_id() {
 
 	# @todo error with an error saying they aren't logged in? Or redirect to the login page maybe?
 	$t_query = 'SELECT id FROM {user} WHERE cookie_string=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $t_cookie_string ) );
+	$t_result = db_query( $t_query, array( $t_cookie_string ) );
 
 	$t_user_id = (int)db_result( $t_result );
 

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -402,7 +402,7 @@ class BugData {
 
 		$t_query = 'SELECT COUNT(*) FROM {bugnote}
 					  WHERE bug_id =' . db_param() . ' ' . $t_restriction;
-		$t_result = db_query_bound( $t_query, array( $this->id ) );
+		$t_result = db_query( $t_query, array( $this->id ) );
 
 		return db_result( $t_result );
 	}
@@ -467,7 +467,7 @@ class BugData {
 					    ( description, steps_to_reproduce, additional_information )
 					  VALUES
 					    ( ' . db_param() . ',' . db_param() . ',' . db_param() . ')';
-		db_query_bound( $t_query, array( $this->description, $this->steps_to_reproduce, $this->additional_information ) );
+		db_query( $t_query, array( $this->description, $this->steps_to_reproduce, $this->additional_information ) );
 
 		# Get the id of the text information we just inserted
 		# NOTE: this is guaranteed to be the correct one.
@@ -484,7 +484,7 @@ class BugData {
 			# if a default user is associated with the category and we know at this point
 			# that that the bug was not assigned to somebody, then assign it automatically.
 			$t_query = 'SELECT user_id FROM {category} WHERE id=' . db_param();
-			$t_result = db_query_bound( $t_query, array( $this->category_id ) );
+			$t_result = db_query( $t_query, array( $this->category_id ) );
 			$t_handler = db_result( $t_result );
 
 			if( $t_handler !== false ) {
@@ -518,7 +518,7 @@ class BugData {
 					      ' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',
 					      ' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ')';
 
-		db_query_bound( $t_query, array( $this->project_id, $this->reporter_id, $this->handler_id, $this->duplicate_id, $this->priority, $this->severity, $this->reproducibility, $t_status, $this->resolution, $this->projection, $this->category_id, $this->date_submitted, $this->last_updated, $this->eta, $t_text_id, $this->os, $this->os_build, $this->platform, $this->version, $this->build, $this->profile_id, $this->summary, $this->view_state, $this->sponsorship_total, $this->sticky, $this->fixed_in_version, $this->target_version, $this->due_date ) );
+		db_query( $t_query, array( $this->project_id, $this->reporter_id, $this->handler_id, $this->duplicate_id, $this->priority, $this->severity, $this->reproducibility, $t_status, $this->resolution, $this->projection, $this->category_id, $this->date_submitted, $this->last_updated, $this->eta, $t_text_id, $this->os, $this->os_build, $this->platform, $this->version, $this->build, $this->profile_id, $this->summary, $this->view_state, $this->sponsorship_total, $this->sticky, $this->fixed_in_version, $this->target_version, $this->due_date ) );
 
 		$this->id = db_insert_id( db_get_table( 'bug' ) );
 
@@ -601,7 +601,7 @@ class BugData {
 		$t_fields[] = $this->due_date;
 		$t_fields[] = $this->id;
 
-		db_query_bound( $t_query, $t_fields );
+		db_query( $t_query, $t_fields );
 
 		bug_clear_cache( $this->id );
 
@@ -642,7 +642,7 @@ class BugData {
 								steps_to_reproduce=' . db_param() . ',
 								additional_information=' . db_param() . '
 							WHERE id=' . db_param();
-			db_query_bound( $t_query, array( $this->description, $this->steps_to_reproduce, $this->additional_information, $t_bug_text_id ) );
+			db_query( $t_query, array( $this->description, $this->steps_to_reproduce, $this->additional_information, $t_bug_text_id ) );
 
 			bug_text_clear_cache( $c_bug_id );
 
@@ -739,7 +739,7 @@ function bug_cache_row( $p_bug_id, $p_trigger_errors = true ) {
 	$c_bug_id = (int)$p_bug_id;
 
 	$t_query = 'SELECT * FROM {bug} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $c_bug_id ) );
+	$t_result = db_query( $t_query, array( $c_bug_id ) );
 
 	if( 0 == db_num_rows( $t_result ) ) {
 		$g_cache_bug[$c_bug_id] = false;
@@ -779,7 +779,7 @@ function bug_cache_array_rows( array $p_bug_id_array ) {
 	}
 
 	$t_query = 'SELECT * FROM {bug} WHERE id IN (' . implode( ',', $c_bug_id_array ) . ')';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		bug_add_to_cache( $t_row );
@@ -843,7 +843,7 @@ function bug_text_cache_row( $p_bug_id, $p_trigger_errors = true ) {
 
 	$t_query = 'SELECT bt.* FROM {bug_text} bt, {bug} b
 				  WHERE b.id=' . db_param() . ' AND b.bug_text_id = bt.id';
-	$t_result = db_query_bound( $t_query, array( $c_bug_id ) );
+	$t_result = db_query( $t_query, array( $c_bug_id ) );
 
 	if( 0 == db_num_rows( $t_result ) ) {
 		$g_cache_bug_text[$c_bug_id] = false;
@@ -1091,7 +1091,7 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
 	# COPY CUSTOM FIELDS
 	if( $p_copy_custom_fields ) {
 		$t_query = 'SELECT field_id, bug_id, value FROM {custom_field_string} WHERE bug_id=' . db_param();
-		$t_result = db_query_bound( $t_query, array( $t_bug_id ) );
+		$t_result = db_query( $t_query, array( $t_bug_id ) );
 
 		while( $t_bug_custom = db_fetch_array( $t_result ) ) {
 			$c_field_id = (int)$t_bug_custom['field_id'];
@@ -1101,7 +1101,7 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
 			$t_query = 'INSERT INTO {custom_field_string}
 						   ( field_id, bug_id, value )
 						   VALUES (' . db_param() . ', ' . db_param() . ', ' . db_param() . ')';
-			db_query_bound( $t_query, array( $c_field_id, $c_new_bug_id, $c_value ) );
+			db_query( $t_query, array( $c_field_id, $c_new_bug_id, $c_value ) );
 		}
 	}
 
@@ -1113,20 +1113,20 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
 	# Copy bugnotes
 	if( $p_copy_bugnotes ) {
 		$t_query = 'SELECT * FROM {bugnote} WHERE bug_id=' . db_param();
-		$t_result = db_query_bound( $t_query, array( $t_bug_id ) );
+		$t_result = db_query( $t_query, array( $t_bug_id ) );
 
 		while( $t_bug_note = db_fetch_array( $t_result ) ) {
 			$t_bugnote_text_id = $t_bug_note['bugnote_text_id'];
 
 			$t_query2 = 'SELECT * FROM {bugnote_text} WHERE id=' . db_param();
-			$t_result2 = db_query_bound( $t_query2, array( $t_bugnote_text_id ) );
+			$t_result2 = db_query( $t_query2, array( $t_bugnote_text_id ) );
 
 			$t_bugnote_text_insert_id = -1;
 			if( $t_bugnote_text = db_fetch_array( $t_result2 ) ) {
 				$t_query2 = 'INSERT INTO {bugnote_text}
 							   ( note )
 							   VALUES ( ' . db_param() . ' )';
-				db_query_bound( $t_query2, array( $t_bugnote_text['note'] ) );
+				db_query( $t_query2, array( $t_bugnote_text['note'] ) );
 				$t_bugnote_text_insert_id = db_insert_id( db_get_table( 'bugnote_text' ) );
 			}
 
@@ -1138,7 +1138,7 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
 						   			' . db_param() . ',
 						   			' . db_param() . ',
 						   			' . db_param() . ')';
-			db_query_bound( $t_query2, array( $t_new_bug_id, $t_bug_note['reporter_id'], $t_bugnote_text_insert_id, $t_bug_note['view_state'], $t_bug_note['date_submitted'], $t_bug_note['last_modified'] ) );
+			db_query( $t_query2, array( $t_new_bug_id, $t_bug_note['reporter_id'], $t_bugnote_text_insert_id, $t_bug_note['view_state'], $t_bug_note['date_submitted'], $t_bug_note['last_modified'] ) );
 		}
 	}
 
@@ -1158,7 +1158,7 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
 		# @todo problem with this code: the generated history trail is incorrect because the note IDs are those of the original bug, not the copied ones
 		# @todo actually, does it even make sense to copy the history ?
 		$t_query = 'SELECT * FROM {bug_history} WHERE bug_id = ' . db_param();
-		$t_result = db_query_bound( $t_query, array( $t_bug_id ) );
+		$t_result = db_query( $t_query, array( $t_bug_id ) );
 
 		while( $t_bug_history = db_fetch_array( $t_result ) ) {
 			$t_query = 'INSERT INTO {bug_history}
@@ -1166,7 +1166,7 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
 						  VALUES ( ' . db_param() . ',' . db_param() . ',' . db_param() . ',
 						  		   ' . db_param() . ',' . db_param() . ',' . db_param() . ',
 						  		   ' . db_param() . ' );';
-			db_query_bound( $t_query, array( $t_bug_history['user_id'], $t_new_bug_id, $t_bug_history['date_modified'], $t_bug_history['field_name'], $t_bug_history['old_value'], $t_bug_history['new_value'], $t_bug_history['type'] ) );
+			db_query( $t_query, array( $t_bug_history['user_id'], $t_new_bug_id, $t_bug_history['date_modified'], $t_bug_history['field_name'], $t_bug_history['old_value'], $t_bug_history['new_value'], $t_bug_history['type'] ) );
 		}
 	} else {
 		# Create a "New Issue" history entry
@@ -1280,11 +1280,11 @@ function bug_delete( $p_bug_id ) {
 	$t_bug_text_id = bug_get_field( $p_bug_id, 'bug_text_id' );
 
 	$t_query = 'DELETE FROM {bug_text} WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $t_bug_text_id ) );
+	db_query( $t_query, array( $t_bug_text_id ) );
 
 	# Delete the bug entry
 	$t_query = 'DELETE FROM {bug} WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $c_bug_id ) );
+	db_query( $t_query, array( $c_bug_id ) );
 
 	bug_clear_cache( $p_bug_id );
 	bug_text_clear_cache( $p_bug_id );
@@ -1301,7 +1301,7 @@ function bug_delete_all( $p_project_id ) {
 	$c_project_id = (int)$p_project_id;
 
 	$t_query = 'SELECT id FROM {bug} WHERE project_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $c_project_id ) );
+	$t_result = db_query( $t_query, array( $c_project_id ) );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		bug_delete( $t_row['id'] );
@@ -1435,7 +1435,7 @@ function bug_get_newest_bugnote_timestamp( $p_bug_id ) {
 	$c_bug_id = (int)$p_bug_id;
 
 	$t_query = 'SELECT last_modified FROM {bugnote} WHERE bug_id=' . db_param() . ' ORDER BY last_modified DESC';
-	$t_result = db_query_bound( $t_query, array( $c_bug_id ), 1 );
+	$t_result = db_query( $t_query, array( $c_bug_id ), 1 );
 	$t_row = db_result( $t_result );
 
 	if( false === $t_row ) {
@@ -1464,7 +1464,7 @@ function bug_get_bugnote_stats( $p_bug_id ) {
 
 	# @todo - optimise - max(), count()
 	$t_query = 'SELECT last_modified FROM {bugnote} WHERE bug_id=' . db_param() . ' ORDER BY last_modified ASC';
-	$t_result = db_query_bound( $t_query, array( $c_bug_id ) );
+	$t_result = db_query( $t_query, array( $c_bug_id ) );
 
 	$t_bugnote_count = 0;
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -1496,7 +1496,7 @@ function bug_get_attachments( $p_bug_id ) {
 		                FROM {bug_file}
 		                WHERE bug_id=' . db_param() . '
 		                ORDER BY date_added';
-	$t_db_result = db_query_bound( $t_query, array( $p_bug_id ) );
+	$t_db_result = db_query( $t_query, array( $p_bug_id ) );
 
 	$t_result = array();
 
@@ -1582,7 +1582,7 @@ function bug_set_field( $p_bug_id, $p_field_name, $p_value ) {
 
 	# Update fields
 	$t_query = 'UPDATE {bug} SET ' . $p_field_name . '=' . db_param() . ' WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $c_value, $c_bug_id ) );
+	db_query( $t_query, array( $c_value, $c_bug_id ) );
 
 	# updated the last_updated date
 	if( $p_field_name != 'last_updated' ) {
@@ -1639,7 +1639,7 @@ function bug_assign( $p_bug_id, $p_user_id, $p_bugnote_text = '', $p_bugnote_pri
 		$t_query = 'UPDATE {bug}
 					  SET handler_id=' . db_param() . ', status=' . db_param() . '
 					  WHERE id=' . db_param();
-		db_query_bound( $t_query, array( $p_user_id, $t_ass_val, $p_bug_id ) );
+		db_query( $t_query, array( $p_user_id, $t_ass_val, $p_bug_id ) );
 
 		# log changes
 		history_log_event_direct( $p_bug_id, 'status', $h_status, $t_ass_val );
@@ -1809,7 +1809,7 @@ function bug_reopen( $p_bug_id, $p_bugnote_text = '', $p_time_tracking = '0:00',
  */
 function bug_update_date( $p_bug_id ) {
 	$t_query = 'UPDATE {bug} SET last_updated=' . db_param() . ' WHERE id=' . db_param();
-	db_query_bound( $t_query, array( db_now(), $p_bug_id ) );
+	db_query( $t_query, array( db_now(), $p_bug_id ) );
 
 	bug_clear_cache( $p_bug_id );
 
@@ -1842,7 +1842,7 @@ function bug_monitor( $p_bug_id, $p_user_id ) {
 
 	# Insert monitoring record
 	$t_query = 'INSERT INTO {bug_monitor} ( user_id, bug_id ) VALUES (' . db_param() . ',' . db_param() . ')';
-	db_query_bound( $t_query, array( $c_user_id, $c_bug_id ) );
+	db_query( $t_query, array( $c_user_id, $c_bug_id ) );
 
 	# log new monitoring action
 	history_log_event_special( $c_bug_id, BUG_MONITOR, $c_user_id );
@@ -1871,7 +1871,7 @@ function bug_get_monitors( $p_bug_id ) {
 			FROM {bug_monitor} m, {user} u
 			WHERE m.bug_id=' . db_param() . ' AND m.user_id = u.id
 			ORDER BY u.realname, u.username';
-	$t_result = db_query_bound( $t_query, array( $p_bug_id ) );
+	$t_result = db_query( $t_query, array( $p_bug_id ) );
 
 	$t_users = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -1898,14 +1898,14 @@ function bug_monitor_copy( $p_source_bug_id, $p_dest_bug_id ) {
 	$c_dest_bug_id = (int)$p_dest_bug_id;
 
 	$t_query = 'SELECT user_id FROM {bug_monitor} WHERE bug_id = ' . db_param();
-	$t_result = db_query_bound( $t_query, array( $c_source_bug_id ) );
+	$t_result = db_query( $t_query, array( $c_source_bug_id ) );
 
 	while( $t_bug_monitor = db_fetch_array( $t_result ) ) {
 		if( user_exists( $t_bug_monitor['user_id'] ) &&
 			!user_is_monitoring_bug( $t_bug_monitor['user_id'], $c_dest_bug_id ) ) {
 			$t_query = 'INSERT INTO {bug_monitor} ( user_id, bug_id )
 				VALUES ( ' . db_param() . ', ' . db_param() . ' )';
-			db_query_bound( $t_query, array( $t_bug_monitor['user_id'], $c_dest_bug_id ) );
+			db_query( $t_query, array( $t_bug_monitor['user_id'], $c_dest_bug_id ) );
 			history_log_event_special( $c_dest_bug_id, BUG_MONITOR, $t_bug_monitor['user_id'] );
 		}
 	}
@@ -1931,7 +1931,7 @@ function bug_unmonitor( $p_bug_id, $p_user_id ) {
 		$t_db_query_params[] = $p_user_id;
 	}
 
-	db_query_bound( $t_query, $t_db_query_params );
+	db_query( $t_query, $t_db_query_params );
 
 	# log new un-monitor action
 	history_log_event_special( $p_bug_id, BUG_UNMONITOR, (int)$p_user_id );

--- a/core/bug_revision_api.php
+++ b/core/bug_revision_api.php
@@ -65,7 +65,7 @@ function bug_revision_add( $p_bug_id, $p_user_id, $p_type, $p_value, $p_bugnote_
 		) VALUES ( ' .
 			db_param() . ', ' . db_param() . ', ' . db_param() . ', ' .
 			db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
-	db_query_bound( $t_query, array(
+	db_query( $t_query, array(
 			$p_bug_id, $p_bugnote_id, $p_user_id,
 			$t_timestamp, $p_type, $p_value ) );
 
@@ -79,7 +79,7 @@ function bug_revision_add( $p_bug_id, $p_user_id, $p_type, $p_value, $p_bugnote_
  */
 function bug_revision_exists( $p_revision_id ) {
 	$t_query = 'SELECT id FROM {bug_revision} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_revision_id ) );
+	$t_result = db_query( $t_query, array( $p_revision_id ) );
 
 	if( !db_result( $t_result ) ) {
 		return false;
@@ -95,7 +95,7 @@ function bug_revision_exists( $p_revision_id ) {
  */
 function bug_revision_get( $p_revision_id ) {
 	$t_query = 'SELECT * FROM {bug_revision} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_revision_id ) );
+	$t_result = db_query( $t_query, array( $p_revision_id ) );
 
 	$t_row = db_fetch_array( $t_result );
 	if( !$t_row ) {
@@ -147,7 +147,7 @@ function bug_revision_drop( $p_revision_id ) {
 		}
 
 		$t_query .= ' )';
-		db_query_bound( $t_query, $p_revision_id );
+		db_query( $t_query, $p_revision_id );
 		foreach( $p_revision_id as $t_rev_id ) {
 			if( $t_revisions[$t_rev_id]['type'] == REV_BUGNOTE ) {
 				history_log_event_special( $t_revisions[$t_rev_id]['bug_id'], BUGNOTE_REVISION_DROPPED, bugnote_format_id( $t_rev_id ), $t_revisions[$t_rev_id]['bugnote_id'] );
@@ -158,7 +158,7 @@ function bug_revision_drop( $p_revision_id ) {
 	} else {
 		$t_revision = bug_revision_get( $p_revision_id );
 		$t_query = 'DELETE FROM {bug_revision} WHERE id=' . db_param();
-		db_query_bound( $t_query, array( $p_revision_id ) );
+		db_query( $t_query, array( $p_revision_id ) );
 		if( $t_revision['type'] == REV_BUGNOTE ) {
 			history_log_event_special( $t_revision['bug_id'], BUGNOTE_REVISION_DROPPED, bugnote_format_id( $p_revision_id ), $t_revision['bugnote_id'] );
 		} else {
@@ -190,7 +190,7 @@ function bug_revision_count( $p_bug_id, $p_type = REV_ANY, $p_bugnote_id = 0 ) {
 		$t_query .= ' AND bugnote_id=0';
 	}
 
-	$t_result = db_query_bound( $t_query, $t_params );
+	$t_result = db_query( $t_query, $t_params );
 
 	return db_result( $t_result );
 }
@@ -204,10 +204,10 @@ function bug_revision_count( $p_bug_id, $p_type = REV_ANY, $p_bugnote_id = 0 ) {
 function bug_revision_delete( $p_bug_id, $p_bugnote_id = 0 ) {
 	if( $p_bugnote_id < 1 ) {
 		$t_query = 'DELETE FROM {bug_revision} WHERE bug_id=' . db_param();
-		db_query_bound( $t_query, array( $p_bug_id ) );
+		db_query( $t_query, array( $p_bug_id ) );
 	} else {
 		$t_query = 'DELETE FROM {bug_revision} WHERE bugnote_id=' . db_param();
-		db_query_bound( $t_query, array( $p_bugnote_id ) );
+		db_query( $t_query, array( $p_bugnote_id ) );
 	}
 }
 
@@ -235,7 +235,7 @@ function bug_revision_last( $p_bug_id, $p_type = REV_ANY, $p_bugnote_id = 0 ) {
 	}
 
 	$t_query .= ' ORDER BY timestamp DESC';
-	$t_result = db_query_bound( $t_query, $t_params, 1 );
+	$t_result = db_query( $t_query, $t_params, 1 );
 
 	$t_row = db_fetch_array( $t_result );
 	if( $t_row ) {
@@ -269,7 +269,7 @@ function bug_revision_list( $p_bug_id, $p_type = REV_ANY, $p_bugnote_id = 0 ) {
 	}
 
 	$t_query .= ' ORDER BY id DESC';
-	$t_result = db_query_bound( $t_query, $t_params );
+	$t_result = db_query( $t_query, $t_params );
 
 	$t_revisions = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -287,7 +287,7 @@ function bug_revision_list( $p_bug_id, $p_type = REV_ANY, $p_bugnote_id = 0 ) {
  */
 function bug_revision_like( $p_rev_id ) {
 	$t_query = 'SELECT bug_id, bugnote_id, type FROM {bug_revision} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_rev_id ) );
+	$t_result = db_query( $t_query, array( $p_rev_id ) );
 
 	$t_row = db_fetch_array( $t_result );
 
@@ -315,7 +315,7 @@ function bug_revision_like( $p_rev_id ) {
 	}
 
 	$t_query .= ' ORDER BY id DESC';
-	$t_result = db_query_bound( $t_query, $t_params );
+	$t_result = db_query( $t_query, $t_params );
 
 	$t_revisions = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -125,7 +125,7 @@ class BugnoteData {
  */
 function bugnote_exists( $p_bugnote_id ) {
 	$t_query = 'SELECT COUNT(*) FROM {bugnote} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_bugnote_id ) );
+	$t_result = db_query( $t_query, array( $p_bugnote_id ) );
 
 	if( 0 == db_result( $t_result ) ) {
 		return false;
@@ -210,7 +210,7 @@ function bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking = '0:00', $p_
 
 	# insert bugnote text
 	$t_query = 'INSERT INTO {bugnote_text} ( note ) VALUES ( ' . db_param() . ' )';
-	db_query_bound( $t_query, array( $t_bugnote_text ) );
+	db_query( $t_query, array( $t_bugnote_text ) );
 
 	# retrieve bugnote text id number
 	$t_bugnote_text_id = db_insert_id( db_get_table( 'bugnote_text' ) );
@@ -238,7 +238,7 @@ function bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking = '0:00', $p_
 		$c_bug_id, $p_user_id, $t_bugnote_text_id, $t_view_state,
 		$c_date_submitted, $c_last_modified, $c_type, $p_attr,
 		$c_time_tracking );
-	db_query_bound( $t_query, $t_params );
+	db_query( $t_query, $t_params );
 
 	# get bugnote id
 	$t_bugnote_id = db_insert_id( db_get_table( 'bugnote' ) );
@@ -276,11 +276,11 @@ function bugnote_delete( $p_bugnote_id ) {
 
 	# Remove the bugnote
 	$t_query = 'DELETE FROM {bugnote} WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $p_bugnote_id ) );
+	db_query( $t_query, array( $p_bugnote_id ) );
 
 	# Remove the bugnote text
 	$t_query = 'DELETE FROM {bugnote_text} WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $t_bugnote_text_id ) );
+	db_query( $t_query, array( $t_bugnote_text_id ) );
 
 	# log deletion of bug
 	history_log_event_special( $t_bug_id, BUGNOTE_DELETED, bugnote_format_id( $p_bugnote_id ) );
@@ -297,18 +297,18 @@ function bugnote_delete( $p_bugnote_id ) {
 function bugnote_delete_all( $p_bug_id ) {
 	# Delete the bugnote text items
 	$t_query = 'SELECT bugnote_text_id FROM {bugnote} WHERE bug_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( (int)$p_bug_id ) );
+	$t_result = db_query( $t_query, array( (int)$p_bug_id ) );
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_bugnote_text_id = $t_row['bugnote_text_id'];
 
 		# Delete the corresponding bugnote texts
 		$t_query = 'DELETE FROM {bugnote_text} WHERE id=' . db_param();
-		db_query_bound( $t_query, array( $t_bugnote_text_id ) );
+		db_query( $t_query, array( $t_bugnote_text_id ) );
 	}
 
 	# Delete the corresponding bugnotes
 	$t_query = 'DELETE FROM {bugnote} WHERE bug_id=' . db_param();
-	db_query_bound( $t_query, array( (int)$p_bug_id ) );
+	db_query( $t_query, array( (int)$p_bug_id ) );
 }
 
 /**
@@ -322,7 +322,7 @@ function bugnote_get_text( $p_bugnote_id ) {
 
 	# grab the bugnote text
 	$t_query = 'SELECT note FROM {bugnote_text} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $t_bugnote_text_id ) );
+	$t_result = db_query( $t_query, array( $t_bugnote_text_id ) );
 
 	return db_result( $t_result );
 }
@@ -352,7 +352,7 @@ function bugnote_get_field( $p_bugnote_id, $p_field_name ) {
 	}
 
 	$t_query = 'SELECT ' . $p_field_name . ' FROM {bugnote} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_bugnote_id ), 1 );
+	$t_result = db_query( $t_query, array( $p_bugnote_id ), 1 );
 
 	return db_result( $t_result );
 }
@@ -365,7 +365,7 @@ function bugnote_get_field( $p_bugnote_id, $p_field_name ) {
  */
 function bugnote_get_latest_id( $p_bug_id ) {
 	$t_query = 'SELECT id FROM {bugnote} WHERE bug_id=' . db_param() . ' ORDER by last_modified DESC';
-	$t_result = db_query_bound( $t_query, array( (int)$p_bug_id ), 1 );
+	$t_result = db_query( $t_query, array( (int)$p_bug_id ), 1 );
 
 	return (int)db_result( $t_result );
 }
@@ -458,7 +458,7 @@ function bugnote_get_all_bugnotes( $p_bug_id ) {
 		$t_bugnotes = array();
 
 		# BUILD bugnotes array
-		$t_result = db_query_bound( $t_query, array( $p_bug_id ) );
+		$t_result = db_query( $t_query, array( $p_bug_id ) );
 
 		while( $t_row = db_fetch_array( $t_result ) ) {
 			$t_bugnote = new BugnoteData;
@@ -496,7 +496,7 @@ function bugnote_set_time_tracking( $p_bugnote_id, $p_time_tracking ) {
 	$c_bugnote_time_tracking = helper_duration_to_minutes( $p_time_tracking );
 
 	$t_query = 'UPDATE {bugnote} SET time_tracking = ' . db_param() . ' WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $c_bugnote_time_tracking, $p_bugnote_id ) );
+	db_query( $t_query, array( $c_bugnote_time_tracking, $p_bugnote_id ) );
 }
 
 /**
@@ -507,7 +507,7 @@ function bugnote_set_time_tracking( $p_bugnote_id, $p_time_tracking ) {
  */
 function bugnote_date_update( $p_bugnote_id ) {
 	$t_query = 'UPDATE {bugnote} SET last_modified=' . db_param() . ' WHERE id=' . db_param();
-	db_query_bound( $t_query, array( db_now(), $p_bugnote_id ) );
+	db_query( $t_query, array( db_now(), $p_bugnote_id ) );
 }
 
 /**
@@ -535,7 +535,7 @@ function bugnote_set_text( $p_bugnote_id, $p_bugnote_text ) {
 	}
 
 	$t_query = 'UPDATE {bugnote_text} SET note=' . db_param() . ' WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $p_bugnote_text, $t_bugnote_text_id ) );
+	db_query( $t_query, array( $p_bugnote_text, $t_bugnote_text_id ) );
 
 	# updated the last_updated date
 	bugnote_date_update( $p_bugnote_id );
@@ -568,7 +568,7 @@ function bugnote_set_view_state( $p_bugnote_id, $p_private ) {
 	}
 
 	$t_query = 'UPDATE {bugnote} SET view_state=' . db_param() . ' WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $t_view_state, $p_bugnote_id ) );
+	db_query( $t_query, array( $t_view_state, $p_bugnote_id ) );
 
 	history_log_event_special( $t_bug_id, BUGNOTE_STATE_CHANGED, $t_view_state, bugnote_format_id( $p_bugnote_id ) );
 
@@ -619,7 +619,7 @@ function bugnote_stats_get_events_array( $p_bug_id, $p_from, $p_to ) {
 				bn.bug_id = ' . db_param() . $t_from_where . $t_to_where .
 				' GROUP BY u.username, u.realname';
 
-	$t_result = db_query_bound( $t_query, array( $p_bug_id ) );
+	$t_result = db_query( $t_query, array( $p_bug_id ) );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_results[] = $t_row;
@@ -676,7 +676,7 @@ function bugnote_stats_get_project_array( $p_project_id, $p_from, $p_to, $p_cost
 			' . $t_project_where . $t_from_where . $t_to_where . '
 			GROUP BY bn.bug_id, u.username, u.realname, b.summary
 			ORDER BY bn.bug_id';
-	$t_result = db_query_bound( $t_query, $t_params );
+	$t_result = db_query( $t_query, $t_params );
 
 	$t_cost_min = $p_cost / 60.0;
 

--- a/core/category_api.php
+++ b/core/category_api.php
@@ -62,7 +62,7 @@ function category_exists( $p_category_id ) {
 	}
 
 	$t_query = 'SELECT COUNT(*) FROM {category} WHERE id=' . db_param();
-	$t_count = db_result( db_query_bound( $t_query, array( $p_category_id ) ) );
+	$t_count = db_result( db_query( $t_query, array( $p_category_id ) ) );
 
 	if( 0 < $t_count ) {
 		return true;
@@ -94,7 +94,7 @@ function category_ensure_exists( $p_category_id ) {
 function category_is_unique( $p_project_id, $p_name ) {
 	$t_query = 'SELECT COUNT(*) FROM {category}
 					WHERE project_id=' . db_param() . ' AND ' . db_helper_like( 'name' );
-	$t_count = db_result( db_query_bound( $t_query, array( $p_project_id, $p_name ) ) );
+	$t_count = db_result( db_query( $t_query, array( $p_project_id, $p_name ) ) );
 
 	if( 0 < $t_count ) {
 		return false;
@@ -134,9 +134,9 @@ function category_add( $p_project_id, $p_name ) {
 
 	$t_query = 'INSERT INTO {category} ( project_id, name )
 				  VALUES ( ' . db_param() . ', ' . db_param() . ' )';
-	db_query_bound( $t_query, array( $p_project_id, $p_name ) );
+	db_query( $t_query, array( $p_project_id, $p_name ) );
 
-	# db_query_bound() errors on failure so:
+	# db_query() errors on failure so:
 	return db_insert_id( db_get_table( 'category' ) );
 }
 
@@ -158,12 +158,12 @@ function category_update( $p_category_id, $p_name, $p_assigned_to ) {
 
 	$t_query = 'UPDATE {category} SET name=' . db_param() . ', user_id=' . db_param() . '
 				  WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $p_name, $p_assigned_to, $p_category_id ) );
+	db_query( $t_query, array( $p_name, $p_assigned_to, $p_category_id ) );
 
 	# Add bug history entries if we update the category's name
 	if( $t_old_category['name'] != $p_name ) {
 		$t_query = 'SELECT id FROM {bug} WHERE category_id=' . db_param();
-		$t_result = db_query_bound( $t_query, array( $p_category_id ) );
+		$t_result = db_query( $t_query, array( $p_category_id ) );
 
 		while( $t_bug_row = db_fetch_array( $t_result ) ) {
 			history_log_event_direct( $t_bug_row['id'], 'category', $t_old_category['name'], $p_name );
@@ -187,11 +187,11 @@ function category_remove( $p_category_id, $p_new_category_id = 0 ) {
 	}
 
 	$t_query = 'DELETE FROM {category} WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $p_category_id ) );
+	db_query( $t_query, array( $p_category_id ) );
 
 	# update bug history entries
 	$t_query = 'SELECT id FROM {bug} WHERE category_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_category_id ) );
+	$t_result = db_query( $t_query, array( $p_category_id ) );
 
 	while( $t_bug_row = db_fetch_array( $t_result ) ) {
 		history_log_event_direct( $t_bug_row['id'], 'category', $t_category_row['name'], category_full_name( $p_new_category_id, false ) );
@@ -199,7 +199,7 @@ function category_remove( $p_category_id, $p_new_category_id = 0 ) {
 
 	# update bug data
 	$t_query = 'UPDATE {bug} SET category_id=' . db_param() . ' WHERE category_id=' . db_param();
-	db_query_bound( $t_query, array( $p_new_category_id, $p_category_id ) );
+	db_query( $t_query, array( $p_new_category_id, $p_category_id ) );
 }
 
 /**
@@ -220,7 +220,7 @@ function category_remove_all( $p_project_id, $p_new_category_id = 0 ) {
 
 	# get a list of affected categories
 	$t_query = 'SELECT id FROM {category} WHERE project_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_project_id ) );
+	$t_result = db_query( $t_query, array( $p_project_id ) );
 
 	$t_category_ids = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -236,7 +236,7 @@ function category_remove_all( $p_project_id, $p_new_category_id = 0 ) {
 
 	# update bug history entries
 	$t_query = 'SELECT id, category_id FROM {bug} WHERE category_id IN ( ' . $t_category_ids . ' )';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	while( $t_bug_row = db_fetch_array( $t_result ) ) {
 		history_log_event_direct( $t_bug_row['id'], 'category', category_full_name( $t_bug_row['category_id'], false ), category_full_name( $p_new_category_id, false ) );
@@ -244,11 +244,11 @@ function category_remove_all( $p_project_id, $p_new_category_id = 0 ) {
 
 	# update bug data
 	$t_query = 'UPDATE {bug} SET category_id=' . db_param() . ' WHERE category_id IN ( ' . $t_category_ids . ' )';
-	db_query_bound( $t_query, array( $p_new_category_id ) );
+	db_query( $t_query, array( $p_new_category_id ) );
 
 	# delete categories
 	$t_query = 'DELETE FROM {category} WHERE project_id=' . db_param();
-	db_query_bound( $t_query, array( $p_project_id ) );
+	db_query( $t_query, array( $p_project_id ) );
 
 	return true;
 }
@@ -269,7 +269,7 @@ function category_get_row( $p_category_id ) {
 	}
 
 	$t_query = 'SELECT * FROM {category} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_category_id ) );
+	$t_result = db_query( $t_query, array( $p_category_id ) );
 	$t_row = db_fetch_array( $t_result );
 	if( !$t_row ) {
 		trigger_error( ERROR_CATEGORY_NOT_FOUND, ERROR );
@@ -340,7 +340,7 @@ function category_cache_array_rows_by_project( array $p_project_id_array ) {
 					ON c.project_id=p.id
 				WHERE project_id IN ( ' . implode( ', ', $c_project_id_array ) . ' )
 				ORDER BY c.name ';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	$t_rows = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -450,7 +450,7 @@ function category_get_all_rows( $p_project_id, $p_inherit = null, $p_sort_by_pro
 				LEFT JOIN {project} p
 					ON c.project_id=p.id
 				WHERE ' . $t_project_where . ' ORDER BY c.name';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 	$t_rows = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_rows[] = $t_row;
@@ -490,7 +490,7 @@ function category_cache_array_rows( array $p_cat_id_array ) {
 				LEFT JOIN {project} p
 					ON c.project_id=p.id
 				WHERE c.id IN (' . implode( ',', $c_cat_id_array ) . ')';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$g_category_cache[(int)$t_row['id']] = $t_row;
@@ -536,7 +536,7 @@ function category_get_id_by_name( $p_category_name, $p_project_id, $p_trigger_er
 	$t_project_name = project_get_name( $p_project_id );
 
 	$t_query = 'SELECT id FROM {category} WHERE name=' . db_param() . ' AND project_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_category_name, (int)$p_project_id ) );
+	$t_result = db_query( $t_query, array( $p_category_name, (int)$p_project_id ) );
 	$t_id = db_result( $t_result );
 	if( $t_id === false ) {
 		if( $p_trigger_errors ) {

--- a/core/cfdefs/cfdef_standard.php
+++ b/core/cfdefs/cfdef_standard.php
@@ -412,7 +412,7 @@ function cfdef_prepare_list_value_to_database( $p_value ) {
  */
 function cfdef_prepare_list_distinct_values( array $p_field_def ) {
 	$t_query = 'SELECT possible_values FROM {custom_field} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_field_def['id'] ) );
+	$t_result = db_query( $t_query, array( $p_field_def['id'] ) );
 
 	$t_row = db_fetch_array( $t_result );
 	if( !$t_row ) {

--- a/core/config_api.php
+++ b/core/config_api.php
@@ -135,7 +135,7 @@ function config_get( $p_option, $p_default = null, $p_user = null, $p_project = 
 
 			if( !$g_cache_filled ) {
 				$t_query = 'SELECT config_id, user_id, project_id, type, value, access_reqd FROM {config}';
-				$t_result = db_query_bound( $t_query );
+				$t_result = db_query( $t_query );
 				while( false <> ( $t_row = db_fetch_array( $t_result ) ) ) {
 					$t_config = $t_row['config_id'];
 					$t_user = $t_row['user_id'];
@@ -363,7 +363,7 @@ function config_set( $p_option, $p_value, $p_user = NO_USER, $p_project = ALL_PR
 				WHERE config_id = ' . db_param() . ' AND
 					project_id = ' . db_param() . ' AND
 					user_id = ' . db_param();
-		$t_result = db_query_bound( $t_query, array( $p_option, (int)$p_project, (int)$p_user ) );
+		$t_result = db_query( $t_query, array( $p_option, (int)$p_project, (int)$p_user ) );
 
 		$t_params = array();
 		if( 0 < db_result( $t_result ) ) {
@@ -395,7 +395,7 @@ function config_set( $p_option, $p_value, $p_user = NO_USER, $p_project = ALL_PR
 			);
 		}
 
-		db_query_bound( $t_set_query, $t_params );
+		db_query( $t_set_query, $t_params );
 	}
 
 	config_set_cache( $p_option, $c_value, $t_type, $p_user, $p_project, $p_access );
@@ -505,7 +505,7 @@ function config_delete( $p_option, $p_user = ALL_USERS, $p_project = ALL_PROJECT
 				WHERE config_id = ' . db_param() . ' AND
 					project_id=' . db_param() . ' AND
 					user_id=' . db_param();
-		db_query_bound( $t_query, array( $p_option, $p_project, $p_user ) );
+		db_query( $t_query, array( $p_option, $p_project, $p_user ) );
 	}
 
 	config_flush_cache( $p_option, $p_user, $p_project );
@@ -525,7 +525,7 @@ function config_delete_for_user( $p_option, $p_user_id ) {
 
 	# Delete the corresponding bugnote texts
 	$t_query = 'DELETE FROM {config} WHERE config_id=' . db_param() . ' AND user_id=' . db_param();
-	db_query_bound( $t_query, array( $p_option, $p_user_id ) );
+	db_query( $t_query, array( $p_option, $p_user_id ) );
 }
 
 /**
@@ -536,7 +536,7 @@ function config_delete_for_user( $p_option, $p_user_id ) {
  */
 function config_delete_project( $p_project = ALL_PROJECTS ) {
 	$t_query = 'DELETE FROM {config} WHERE project_id=' . db_param();
-	db_query_bound( $t_query, array( $p_project ) );
+	db_query( $t_query, array( $p_project ) );
 
 	# flush cache here in case some of the deleted configs are in use.
 	config_flush_cache();

--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -112,7 +112,7 @@ function custom_field_cache_row( $p_field_id, $p_trigger_errors = true ) {
 	}
 
 	$t_query = 'SELECT * FROM {custom_field} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_field_id ) );
+	$t_result = db_query( $t_query, array( $p_field_id ) );
 
 	$t_row = db_fetch_array( $t_result );
 
@@ -152,7 +152,7 @@ function custom_field_cache_array_rows( array $p_cf_id_array ) {
 	}
 
 	$t_query = 'SELECT * FROM {custom_field} WHERE id IN (' . implode( ',', $c_cf_id_array ) . ')';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$g_cache_custom_field[(int)$t_row['id']] = $t_row;
@@ -201,7 +201,7 @@ function custom_field_is_linked( $p_field_id, $p_project_id ) {
 	# figure out if this bug_id/field_id combination exists
 	$t_query = 'SELECT COUNT(*) FROM {custom_field_project}
 				WHERE field_id=' . db_param() . ' AND project_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_field_id, $p_project_id ) );
+	$t_result = db_query( $t_query, array( $p_field_id, $p_project_id ) );
 	$t_count = db_result( $t_result );
 
 	if( $t_count > 0 ) {
@@ -272,7 +272,7 @@ function custom_field_is_name_unique( $p_name, $p_custom_field_id = null ) {
 	if( $p_custom_field_id !== null ) {
 		$t_query .= ' AND (id <> ' . db_param() . ')';
 	}
-	$t_result = db_query_bound( $t_query, ( ($p_custom_field_id !== null) ? array( $p_name, $p_custom_field_id ) : array( $p_name ) ) );
+	$t_result = db_query( $t_query, ( ($p_custom_field_id !== null) ? array( $p_name, $p_custom_field_id ) : array( $p_name ) ) );
 	$t_count = db_result( $t_result );
 
 	if( $t_count > 0 ) {
@@ -397,7 +397,7 @@ function custom_field_create( $p_name ) {
 	$t_query = 'INSERT INTO {custom_field} ( name, possible_values )
 				  VALUES ( ' . db_param() . ',' . db_param() . ')';
 
-	db_query_bound( $t_query, array( $c_name, '' ) );
+	db_query( $t_query, array( $c_name, '' ) );
 
 	return db_insert_id( db_get_table( 'custom_field' ) );
 }
@@ -472,7 +472,7 @@ function custom_field_update( $p_field_id, array $p_def_array ) {
 	if( $t_update !== '' ) {
 		$t_query = 'UPDATE {custom_field} SET ' . rtrim( $t_update, ', ' ) . ' WHERE id = ' . db_param();
 		$t_params[] = $p_field_id;
-		db_query_bound( $t_query, $t_params );
+		db_query( $t_query, $t_params );
 
 		custom_field_clear_cache( $p_field_id );
 
@@ -500,7 +500,7 @@ function custom_field_link( $p_field_id, $p_project_id ) {
 
 	$t_query = 'INSERT INTO {custom_field_project} ( field_id, project_id )
 				  VALUES ( ' . db_param() . ', ' . db_param() . ')';
-	db_query_bound( $t_query, array( $p_field_id, $p_project_id ) );
+	db_query( $t_query, array( $p_field_id, $p_project_id ) );
 
 	return true;
 }
@@ -520,7 +520,7 @@ function custom_field_link( $p_field_id, $p_project_id ) {
 function custom_field_unlink( $p_field_id, $p_project_id ) {
 	$t_query = 'DELETE FROM {custom_field_project}
 				  WHERE field_id = ' . db_param() . ' AND project_id = ' . db_param();
-	db_query_bound( $t_query, array( $p_field_id, $p_project_id ) );
+	db_query( $t_query, array( $p_field_id, $p_project_id ) );
 }
 
 /**
@@ -533,15 +533,15 @@ function custom_field_unlink( $p_field_id, $p_project_id ) {
 function custom_field_destroy( $p_field_id ) {
 	# delete all values
 	$t_query = 'DELETE FROM {custom_field_string} WHERE field_id=' . db_param();
-	db_query_bound( $t_query, array( $p_field_id ) );
+	db_query( $t_query, array( $p_field_id ) );
 
 	# delete all project associations
 	$t_query = 'DELETE FROM {custom_field_project} WHERE field_id=' . db_param();
-	db_query_bound( $t_query, array( $p_field_id ) );
+	db_query( $t_query, array( $p_field_id ) );
 
 	# delete the definition
 	$t_query = 'DELETE FROM {custom_field} WHERE id=' .  db_param();
-	db_query_bound( $t_query, array( $p_field_id ) );
+	db_query( $t_query, array( $p_field_id ) );
 
 	custom_field_clear_cache( $p_field_id );
 }
@@ -558,7 +558,7 @@ function custom_field_destroy( $p_field_id ) {
 function custom_field_unlink_all( $p_project_id ) {
 	# delete all project associations
 	$t_query = 'DELETE FROM {custom_field_project} WHERE project_id=' . db_param();
-	db_query_bound( $t_query, array( $p_project_id ) );
+	db_query( $t_query, array( $p_project_id ) );
 }
 
 /**
@@ -572,7 +572,7 @@ function custom_field_unlink_all( $p_project_id ) {
  */
 function custom_field_delete_all_values( $p_bug_id ) {
 	$t_query = 'DELETE FROM {custom_field_string} WHERE bug_id=' . db_param();
-	db_query_bound( $t_query, array( $p_bug_id ) );
+	db_query( $t_query, array( $p_bug_id ) );
 }
 
 /**
@@ -594,7 +594,7 @@ function custom_field_get_id_from_name( $p_field_name ) {
 	}
 
 	$t_query = 'SELECT id FROM {custom_field} WHERE name=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_field_name ) );
+	$t_result = db_query( $t_query, array( $p_field_name ) );
 
 	$t_row = db_fetch_array( $t_result );
 
@@ -686,7 +686,7 @@ function custom_field_get_linked_ids( $p_project_id = ALL_PROJECTS ) {
 				ORDER BY sequence ASC, name ASC';
 		}
 
-		$t_result = db_query_bound( $t_query, $t_params );
+		$t_result = db_query( $t_query, $t_params );
 		$t_ids = array();
 
 		while( $t_row = db_fetch_array( $t_result ) ) {
@@ -711,7 +711,7 @@ function custom_field_get_ids() {
 
 	if( $g_cache_cf_list === null ) {
 		$t_query = 'SELECT * FROM {custom_field} ORDER BY name ASC';
-		$t_result = db_query_bound( $t_query );
+		$t_result = db_query( $t_query );
 		$t_ids = array();
 
 		while( $t_row = db_fetch_array( $t_result ) ) {
@@ -735,7 +735,7 @@ function custom_field_get_ids() {
  */
 function custom_field_get_project_ids( $p_field_id ) {
 	$t_query = 'SELECT project_id FROM {custom_field_project} WHERE field_id = ' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_field_id ) );
+	$t_result = db_query( $t_query, array( $p_field_id ) );
 
 	$t_ids = array();
 
@@ -817,7 +817,7 @@ function custom_field_get_value( $p_field_id, $p_bug_id ) {
 				  FROM {custom_field_string}
 				  WHERE bug_id=' . db_param() . ' AND
 				  		field_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_bug_id, $p_field_id ) );
+	$t_result = db_query( $t_query, array( $p_bug_id, $p_field_id ) );
 
 	if( $t_value = db_result( $t_result ) ) {
 		return custom_field_database_to_value( $t_value, $t_row['type'] );
@@ -875,7 +875,7 @@ function custom_field_get_all_linked_fields( $p_bug_id ) {
 			WHERE p.project_id = ' . db_param() . '
 			ORDER BY p.sequence ASC, f.name ASC';
 
-		$t_result = db_query_bound( $t_query, array( $p_bug_id, $c_project_id) );
+		$t_result = db_query( $t_query, array( $p_bug_id, $c_project_id) );
 
 		$t_custom_fields = array();
 
@@ -916,7 +916,7 @@ function custom_field_get_sequence( $p_field_id, $p_project_id ) {
 				  FROM {custom_field_project}
 				  WHERE field_id=' . db_param() . ' AND
 						project_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_field_id, $p_project_id ), 1 );
+	$t_result = db_query( $t_query, array( $p_field_id, $p_project_id ), 1 );
 
 	if( 0 == db_num_rows( $t_result ) ) {
 		return false;
@@ -942,7 +942,7 @@ function custom_field_validate( $p_field_id, $p_value ) {
 				  		 access_level_rw, length_min, length_max, default_value
 				  FROM {custom_field}
 				  WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_field_id ) );
+	$t_result = db_query( $t_query, array( $p_field_id ) );
 	$t_row = db_fetch_array( $t_result );
 
 	$t_name = $t_row['name'];
@@ -1083,7 +1083,7 @@ function custom_field_distinct_values( array $p_field_def, $p_project_id = ALL_P
 			WHERE ' . $t_where1 . $t_where2 . '
 			ORDER BY cfst.value';
 
-		$t_result = db_query_bound( $t_query, $t_params );
+		$t_result = db_query( $t_query, $t_params );
 		$t_row_count = db_num_rows( $t_result );
 		if( 0 == $t_row_count ) {
 			return false;
@@ -1176,7 +1176,7 @@ function custom_field_set_value( $p_field_id, $p_bug_id, $p_value, $p_log_insert
 				  FROM {custom_field_string}
 				  WHERE field_id=' . db_param() . ' AND
 				  		bug_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_field_id, $p_bug_id ) );
+	$t_result = db_query( $t_query, array( $p_field_id, $p_bug_id ) );
 
 	if( db_num_rows( $t_result ) > 0 ) {
 		$t_query = 'UPDATE {custom_field_string}
@@ -1188,7 +1188,7 @@ function custom_field_set_value( $p_field_id, $p_bug_id, $p_value, $p_log_insert
 			(int)$p_field_id,
 			(int)$p_bug_id,
 		);
-		db_query_bound( $t_query, $t_params );
+		db_query( $t_query, $t_params );
 
 		$t_row = db_fetch_array( $t_result );
 		history_log_event_direct( $p_bug_id, $t_name, custom_field_database_to_value( $t_row[$t_value_field], $t_type ), $p_value );
@@ -1202,7 +1202,7 @@ function custom_field_set_value( $p_field_id, $p_bug_id, $p_value, $p_log_insert
 			(int)$p_bug_id,
 			custom_field_value_to_database( $p_value, $t_type ),
 		);
-		db_query_bound( $t_query, $t_params );
+		db_query( $t_query, $t_params );
 		# Don't log history events for new bug reports or on other special occasions
 		if( $p_log_insert ) {
 			history_log_event_direct( $p_bug_id, $t_name, '', $p_value );
@@ -1211,7 +1211,7 @@ function custom_field_set_value( $p_field_id, $p_bug_id, $p_value, $p_log_insert
 
 	custom_field_clear_cache( $p_field_id );
 
-	# db_query_bound() errors on failure so:
+	# db_query() errors on failure so:
 	return true;
 }
 
@@ -1229,7 +1229,7 @@ function custom_field_set_sequence( $p_field_id, $p_project_id, $p_sequence ) {
 				  SET sequence=' . db_param() . '
 				  WHERE field_id=' . db_param() . ' AND
 				  		project_id=' . db_param();
-	db_query_bound( $t_query, array( $p_sequence, $p_field_id, $p_project_id ) );
+	db_query( $t_query, array( $p_sequence, $p_field_id, $p_project_id ) );
 
 	custom_field_clear_cache( $p_field_id );
 

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -94,7 +94,7 @@ class MantisDbParam {
 
 	/**
 	 * Pops the previous value of param count from the stack
-	 * This function is called by {@see db_query_bound()} and should not need
+	 * This function is called by {@see db_query()} and should not need
 	 * to be executed directly
 	 * @return void
 	 */
@@ -151,9 +151,9 @@ function db_connect( $p_dsn, $p_hostname = null, $p_username = null, $p_password
 		if( db_is_mysql() ) {
 			# @todo Is there a way to translate any charset name to MySQL format? e.g. remote the dashes?
 			# @todo Is this needed for other databases?
-			db_query_bound( 'SET NAMES UTF8' );
+			db_query( 'SET NAMES UTF8' );
 		} else if( db_is_db2() && $p_db_schema !== null && !is_blank( $p_db_schema ) ) {
-			$t_result2 = db_query_bound( 'set schema ' . $p_db_schema );
+			$t_result2 = db_query( 'set schema ' . $p_db_schema );
 			if( $t_result2 === false ) {
 				db_error();
 				trigger_error( ERROR_DB_CONNECT_FAILED, ERROR );
@@ -309,6 +309,14 @@ function db_check_identifier_size( $p_identifier ) {
 }
 
 /**
+ * function alias for db_query() for legacy support of plugins
+ * @deprecated db_query should be used in preference to this function. This function may be removed in 2.0
+ */
+function db_query_bound() {
+  return call_user_func_array( 'db_query', func_get_args() );
+}
+
+/**
  * execute query, requires connection to be opened
  * An error will be triggered if there is a problem executing the query.
  * This will pop the database parameter stack {@see MantisDbParam} after a successful execution
@@ -321,7 +329,7 @@ function db_check_identifier_size( $p_identifier ) {
  * @param integer $p_offset    Offset query results for paging.
  * @return IteratorAggregate|boolean adodb result set or false if the query failed.
  */
-function db_query_bound( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_offset = -1 ) {
+function db_query( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_offset = -1 ) {
 	global $g_queries_array, $g_db, $g_db_log_queries, $g_db_param;
 
 	$t_db_type = config_get_global( 'db_type' );
@@ -594,13 +602,13 @@ function db_insert_id( $p_table = null, $p_field = 'id' ) {
 			$t_query = 'SELECT currval(\'' . $p_table . '_' . $p_field . '_seq\')';
 		}
 		if( isset( $t_query ) ) {
-			$t_result = db_query_bound( $t_query );
+			$t_result = db_query( $t_query );
 			return db_result( $t_result );
 		}
 	}
 	if( db_is_mssql() ) {
 		$t_query = 'SELECT IDENT_CURRENT(\'' . $p_table . '\')';
-		$t_result = db_query_bound( $t_query );
+		$t_result = db_query( $t_query );
 		return db_result( $t_result );
 	}
 	return $g_db->Insert_ID();
@@ -737,7 +745,7 @@ function db_close() {
  * prepare a string before DB insertion
  * @param string $p_string Unprepared string.
  * @return string prepared database query string
- * @deprecated db_query_bound should be used in preference to this function. This function may be removed in 1.2.0 final
+ * @deprecated db_query should be used in preference to this function. This function may be removed in 1.2.0 final
  */
 function db_prepare_string( $p_string ) {
 	global $g_db;
@@ -783,7 +791,7 @@ function db_prepare_string( $p_string ) {
 /**
  * Prepare a binary string before DB insertion
  * Use of this function is required for some DB types, to properly encode
- * BLOB fields prior to calling db_query_bound()
+ * BLOB fields prior to calling db_query()
  * @param string $p_string Raw binary data.
  * @return string prepared database query string
  */
@@ -817,7 +825,7 @@ function db_prepare_binary_string( $p_string ) {
  * prepare a int for database insertion.
  * @param integer $p_int Integer.
  * @return integer integer
- * @deprecated db_query_bound should be used in preference to this function. This function may be removed in 1.2.0 final
+ * @deprecated db_query should be used in preference to this function. This function may be removed in 1.2.0 final
  * @todo Use/Behaviour of this function should be reviewed before 1.2.0 final
  */
 function db_prepare_int( $p_int ) {
@@ -828,7 +836,7 @@ function db_prepare_int( $p_int ) {
  * prepare a double for database insertion.
  * @param float $p_double Double.
  * @return double double
- * @deprecated db_query_bound should be used in preference to this function. This function may be removed in 1.2.0 final
+ * @deprecated db_query should be used in preference to this function. This function may be removed in 1.2.0 final
  * @todo Use/Behaviour of this function should be reviewed before 1.2.0 final
  */
 function db_prepare_double( $p_double ) {
@@ -839,7 +847,7 @@ function db_prepare_double( $p_double ) {
  * prepare a boolean for database insertion.
  * @param boolean $p_bool Boolean value.
  * @return integer integer representing boolean
- * @deprecated db_query_bound should be used in preference to this function. This function may be removed in 1.2.0 final
+ * @deprecated db_query should be used in preference to this function. This function may be removed in 1.2.0 final
  * @todo Use/Behaviour of this function should be reviewed before 1.2.0 final
  */
 function db_prepare_bool( $p_bool ) {

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -258,7 +258,7 @@ function email_collect_recipients( $p_bug_id, $p_notify_type, array $p_extra_use
 	# add users monitoring the bug
 	if( ON == email_notify_flag( $p_notify_type, 'monitor' ) ) {
 		$t_query = 'SELECT DISTINCT user_id FROM {bug_monitor} WHERE bug_id=' . db_param();
-		$t_result = db_query_bound( $t_query, array( $p_bug_id ) );
+		$t_result = db_query( $t_query, array( $p_bug_id ) );
 
 		while( $t_row = db_fetch_array( $t_result ) ) {
 			$t_user_id = $t_row['user_id'];
@@ -276,7 +276,7 @@ function email_collect_recipients( $p_bug_id, $p_notify_type, array $p_extra_use
 
 	if( ON == email_notify_flag( $p_notify_type, 'bugnotes' ) ) {
 		$t_query = 'SELECT DISTINCT reporter_id FROM {bugnote} WHERE bug_id = ' . db_param();
-		$t_result = db_query_bound( $t_query, array( $p_bug_id ) );
+		$t_result = db_query( $t_query, array( $p_bug_id ) );
 		while( $t_row = db_fetch_array( $t_result ) ) {
 			$t_user_id = $t_row['reporter_id'];
 			$t_recipients[$t_user_id] = true;

--- a/core/email_queue_api.php
+++ b/core/email_queue_api.php
@@ -119,7 +119,7 @@ function email_queue_add( EmailData $p_email_data ) {
 				    ( email, subject, body, submitted, metadata)
 				  VALUES
 				    (' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ')';
-	db_query_bound( $t_query, array( $c_email, $c_subject, $c_body, db_now(), $c_metadata ) );
+	db_query( $t_query, array( $c_email, $c_subject, $c_body, db_now(), $c_metadata ) );
 	$t_id = db_insert_id( db_get_table( 'email' ), 'email_id' );
 
 	log_event( LOG_EMAIL, 'message #' . $t_id . ' queued' );
@@ -165,7 +165,7 @@ function email_queue_row_to_object( $p_row ) {
  */
 function email_queue_get( $p_email_id ) {
 	$t_query = 'SELECT * FROM {email} WHERE email_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_email_id ) );
+	$t_result = db_query( $t_query, array( $p_email_id ) );
 
 	$t_row = db_fetch_array( $t_result );
 
@@ -179,7 +179,7 @@ function email_queue_get( $p_email_id ) {
  */
 function email_queue_delete( $p_email_id ) {
 	$t_query = 'DELETE FROM {email} WHERE email_id=' . db_param();
-	db_query_bound( $t_query, array( $p_email_id ) );
+	db_query( $t_query, array( $p_email_id ) );
 
 	log_event( LOG_EMAIL, 'message #' . $p_email_id . ' deleted from queue' );
 }
@@ -190,7 +190,7 @@ function email_queue_delete( $p_email_id ) {
  */
 function email_queue_get_ids() {
 	$t_query = 'SELECT email_id FROM {email} ORDER BY email_id ASC';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	$t_ids = array();
 	while( ( $t_row = db_fetch_array( $t_result ) ) !== false ) {

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -98,7 +98,7 @@ function file_bug_attachment_count( $p_bug_id ) {
 	# Otherwise build the cache and return the attachment count
 	#   for the given bug (if any).
 	$t_query = 'SELECT bug_id, COUNT(bug_id) AS attachments FROM {bug_file} GROUP BY bug_id';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	$t_file_count = 0;
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -364,7 +364,7 @@ function file_delete_attachments( $p_bug_id ) {
 
 	# Delete files from disk
 	$t_query = 'SELECT diskfile, filename FROM {bug_file} WHERE bug_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_bug_id ) );
+	$t_result = db_query( $t_query, array( $p_bug_id ) );
 
 	$t_file_count = db_num_rows( $t_result );
 	if( 0 == $t_file_count ) {
@@ -382,9 +382,9 @@ function file_delete_attachments( $p_bug_id ) {
 
 	# Delete the corresponding db records
 	$t_query = 'DELETE FROM {bug_file} WHERE bug_id=' . db_param();
-	db_query_bound( $t_query, array( $p_bug_id ) );
+	db_query( $t_query, array( $p_bug_id ) );
 
-	# db_query_bound() errors on failure so:
+	# db_query() errors on failure so:
 	return true;
 }
 
@@ -400,7 +400,7 @@ function file_delete_project_files( $p_project_id ) {
 	if( DISK == $t_method ) {
 		# Delete files from disk
 		$t_query = 'SELECT diskfile, filename FROM {project_file} WHERE project_id=' . db_param();
-		$t_result = db_query_bound( $t_query, array( (int)$p_project_id ) );
+		$t_result = db_query( $t_query, array( (int)$p_project_id ) );
 
 		$t_file_count = db_num_rows( $t_result );
 
@@ -414,7 +414,7 @@ function file_delete_project_files( $p_project_id ) {
 
 	# Delete the corresponding database records
 	$t_query = 'DELETE FROM {project_file} WHERE project_id=' . db_param();
-	db_query_bound( $t_query, array( (int)$p_project_id ) );
+	db_query( $t_query, array( (int)$p_project_id ) );
 }
 
 /**
@@ -443,7 +443,7 @@ function file_get_field( $p_file_id, $p_field_name, $p_table = 'bug' ) {
 	}
 
 	$t_query = 'SELECT ' . $p_field_name . ' FROM ' . $t_bug_file_table . ' WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( (int)$p_file_id ), 1 );
+	$t_result = db_query( $t_query, array( (int)$p_file_id ), 1 );
 
 	return db_result( $t_result );
 }
@@ -482,7 +482,7 @@ function file_delete( $p_file_id, $p_table = 'bug' ) {
 
 	$t_file_table = db_get_table( $p_table . '_file' );
 	$t_query = 'DELETE FROM ' . $t_file_table . ' WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $c_file_id ) );
+	db_query( $t_query, array( $c_file_id ) );
 	return true;
 }
 
@@ -567,7 +567,7 @@ function diskfile_is_name_unique( $p_name, $p_filepath ) {
 			SELECT diskfile FROM {project_file}
 			) f
 		WHERE diskfile=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $c_name ) );
+	$t_result = db_query( $t_query, array( $c_name ) );
 	$t_count = db_result( $t_result );
 
 	return ( $t_count == 0 ) && !file_exists( $c_name );
@@ -591,7 +591,7 @@ function file_is_name_unique( $p_name, $p_bug_id, $p_table = 'bug' ) {
 		$t_param[] = $p_bug_id;
 	}
 
-	$t_result = db_query_bound( $t_query, $t_param );
+	$t_result = db_query( $t_query, $t_param );
 	$t_count = db_result( $t_result );
 
 	return ( $t_count == 0 );
@@ -695,7 +695,7 @@ function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p
 	VALUES
 		( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() .
 		  ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
-	db_query_bound( $t_query, array( $t_id, $p_title, $p_desc, $t_unique_name, $t_file_name, $t_file_path,
+	db_query( $t_query, array( $t_id, $p_title, $p_desc, $t_unique_name, $t_file_name, $t_file_path,
 									 $t_file_size, $p_file['type'], $p_date_added, (int)$p_user_id ) );
 	$t_attachment_id = db_insert_id( $t_file_table );
 
@@ -703,7 +703,7 @@ function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p
 		db_update_blob( $t_file_table, 'content', $c_content, 'diskfile=\'$t_unique_name\'' );
 	} else {
 		$t_query = 'UPDATE ' . $t_file_table . ' SET content=' . db_param() . ' WHERE id = ' . db_param();
-		db_query_bound( $t_query, array( $c_content, $t_attachment_id ) );
+		db_query( $t_query, array( $c_content, $t_attachment_id ) );
 	}
 
 	if( 'bug' == $p_table ) {
@@ -855,7 +855,7 @@ function file_get_content( $p_file_id, $p_type = 'bug' ) {
 		default:
 			return false;
 	}
-	$t_result = db_query_bound( $t_query, array( $p_file_id ) );
+	$t_result = db_query( $t_query, array( $p_file_id ) );
 	$t_row = db_fetch_array( $t_result );
 
 	if( $p_type == 'bug' ) {
@@ -976,7 +976,7 @@ function file_move_bug_attachments( $p_bug_id, $p_project_id_to ) {
 				file_delete_local( $t_disk_file_name_from );
 			}
 			chmod( $t_disk_file_name_to, config_get( 'attachments_file_permissions' ) );
-			db_query_bound( $t_query_disk_attachment_update, array( db_prepare_string( $t_path_to ), $c_bug_id, (int)$t_row['id'] ) );
+			db_query( $t_query_disk_attachment_update, array( db_prepare_string( $t_path_to ), $c_bug_id, (int)$t_row['id'] ) );
 		} else {
 			trigger_error( ERROR_FILE_DUPLICATE, ERROR );
 		}
@@ -995,7 +995,7 @@ function file_move_bug_attachments( $p_bug_id, $p_project_id_to ) {
  */
 function file_copy_attachments( $p_source_bug_id, $p_dest_bug_id ) {
 	$t_query = 'SELECT * FROM {bug_file} WHERE bug_id = ' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_source_bug_id ) );
+	$t_result = db_query( $t_query, array( $p_source_bug_id ) );
 	$t_count = db_num_rows( $t_result );
 
 	$t_project_id = bug_get_field( $p_source_bug_id, 'project_id' );
@@ -1035,7 +1035,7 @@ function file_copy_attachments( $p_source_bug_id, $p_dest_bug_id ) {
 									 ' . db_param() . ',
 									 ' . db_param() . ',
 									 ' . db_param() . ');';
-		db_query_bound( $t_query, array( $p_dest_bug_id, $t_bug_file['title'], $t_bug_file['description'], $t_new_diskfile_name, $t_new_file_name, $t_file_path, $t_bug_file['filesize'], $t_bug_file['file_type'], $t_bug_file['date_added'], $t_bug_file['content'] ) );
+		db_query( $t_query, array( $p_dest_bug_id, $t_bug_file['title'], $t_bug_file['description'], $t_new_diskfile_name, $t_new_file_name, $t_file_path, $t_bug_file['filesize'], $t_bug_file['file_type'], $t_bug_file['date_added'], $t_bug_file['content'] ) );
 	}
 }
 

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1027,7 +1027,7 @@ function filter_get_bug_count( array $p_query_clauses ) {
 		$t_where_string .= implode( $p_query_clauses['operator'], $p_query_clauses['where'] );
 		$t_where_string .= ' ) ';
 	}
-	$t_result = db_query_bound( $t_select_string . ' ' . $t_from_string . ' ' . $t_join_string . ' ' . $t_where_string, $p_query_clauses['where_values'] );
+	$t_result = db_query( $t_select_string . ' ' . $t_from_string . ' ' . $t_join_string . ' ' . $t_where_string, $p_query_clauses['where_values'] );
 	return db_result( $t_result );
 }
 
@@ -2055,7 +2055,7 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 		$t_where_string .= ' ) ';
 	}
 
-	$t_result = db_query_bound( $t_select_string . $t_from_string . $t_join_string . $t_where_string . $t_order_string, $t_query_clauses['where_values'], $p_per_page, $t_offset );
+	$t_result = db_query( $t_select_string . $t_from_string . $t_join_string . $t_where_string . $t_order_string, $t_query_clauses['where_values'], $p_per_page, $t_offset );
 	$t_row_count = db_num_rows( $t_result );
 
 	$t_id_array_lastmod = array();
@@ -2080,7 +2080,7 @@ function filter_cache_result( array $p_rows, array $p_id_array_lastmod ) {
 	$t_query = 'SELECT DISTINCT bug_id,MAX(last_modified) as last_modified, COUNT(last_modified) as count FROM {bugnote} ' . $t_where_string . ' GROUP BY bug_id';
 
 	# perform query
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 	$t_row_count = db_num_rows( $t_result );
 	for( $i = 0;$i < $t_row_count;$i++ ) {
 		$t_row = db_fetch_array( $t_result );
@@ -4432,7 +4432,7 @@ function filter_cache_row( $p_filter_id, $p_trigger_errors = true ) {
 	}
 
 	$t_query = 'SELECT * FROM {filters} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_filter_id ) );
+	$t_result = db_query( $t_query, array( $p_filter_id ) );
 
 	if( 0 == db_num_rows( $t_result ) ) {
 		if( $p_trigger_errors ) {
@@ -4494,7 +4494,7 @@ function filter_db_set_for_current_user( $p_project_id, $p_is_public, $p_name, $
 					WHERE user_id=' . db_param() . '
 					AND project_id=' . db_param() . '
 					AND name=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $t_user_id, $c_project_id, $p_name ) );
+	$t_result = db_query( $t_query, array( $t_user_id, $c_project_id, $p_name ) );
 
 	if( db_num_rows( $t_result ) > 0 ) {
 		$t_row = db_fetch_array( $t_result );
@@ -4503,7 +4503,7 @@ function filter_db_set_for_current_user( $p_project_id, $p_is_public, $p_name, $
 					  SET is_public=' . db_param() . ',
 						filter_string=' . db_param() . '
 					  WHERE id=' . db_param();
-		db_query_bound( $t_query, array( $p_is_public, $p_filter_string, $t_row['id'] ) );
+		db_query( $t_query, array( $p_is_public, $p_filter_string, $t_row['id'] ) );
 
 		return $t_row['id'];
 	} else {
@@ -4511,7 +4511,7 @@ function filter_db_set_for_current_user( $p_project_id, $p_is_public, $p_name, $
 						( user_id, project_id, is_public, name, filter_string )
 					  VALUES
 						( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
-		db_query_bound( $t_query, array( $t_user_id, $c_project_id, $p_is_public, $p_name, $p_filter_string ) );
+		db_query( $t_query, array( $t_user_id, $c_project_id, $p_is_public, $p_name, $p_filter_string ) );
 
 		# Recall the query, we want the filter ID
 		$t_query = 'SELECT id
@@ -4519,7 +4519,7 @@ function filter_db_set_for_current_user( $p_project_id, $p_is_public, $p_name, $
 						WHERE user_id=' . db_param() . '
 						AND project_id=' . db_param() . '
 						AND name=' . db_param();
-		$t_result = db_query_bound( $t_query, array( $t_user_id, $c_project_id, $p_name ) );
+		$t_result = db_query( $t_query, array( $t_user_id, $c_project_id, $p_name ) );
 
 		if( db_num_rows( $t_result ) > 0 ) {
 			$t_row = db_fetch_array( $t_result );
@@ -4555,7 +4555,7 @@ function filter_db_get_filter( $p_filter_id, $p_user_id = null ) {
 	}
 
 	$t_query = 'SELECT * FROM {filters} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $c_filter_id ) );
+	$t_result = db_query( $t_query, array( $c_filter_id ) );
 
 	if( db_num_rows( $t_result ) > 0 ) {
 		$t_row = db_fetch_array( $t_result );
@@ -4601,7 +4601,7 @@ function filter_db_get_project_current( $p_project_id, $p_user_id = null ) {
 				  WHERE user_id=' . db_param() . '
 					AND project_id=' . db_param() . '
 					AND name=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $c_user_id, $c_project_id, '' ) );
+	$t_result = db_query( $t_query, array( $c_user_id, $c_project_id, '' ) );
 
 	if( db_num_rows( $t_result ) > 0 ) {
 		$t_row = db_fetch_array( $t_result );
@@ -4620,7 +4620,7 @@ function filter_db_get_name( $p_filter_id ) {
 	$c_filter_id = (int)$p_filter_id;
 
 	$t_query = 'SELECT * FROM {filters} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $c_filter_id ) );
+	$t_result = db_query( $t_query, array( $c_filter_id ) );
 
 	if( db_num_rows( $t_result ) > 0 ) {
 		$t_row = db_fetch_array( $t_result );
@@ -4657,7 +4657,7 @@ function filter_db_can_delete_filter( $p_filter_id ) {
 				  AND user_id=' . db_param() . '
 				  AND project_id!=' . db_param();
 
-	$t_result = db_query_bound( $t_query, array( $c_filter_id, $t_user_id, -1 ) );
+	$t_result = db_query( $t_query, array( $c_filter_id, $t_user_id, -1 ) );
 
 	if( db_num_rows( $t_result ) > 0 ) {
 		return true;
@@ -4679,7 +4679,7 @@ function filter_db_delete_filter( $p_filter_id ) {
 	}
 
 	$t_query = 'DELETE FROM {filters} WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $c_filter_id ) );
+	db_query( $t_query, array( $c_filter_id ) );
 
 	return true;
 }
@@ -4692,7 +4692,7 @@ function filter_db_delete_current_filters() {
 	$t_all_id = ALL_PROJECTS;
 
 	$t_query = 'DELETE FROM {filters} WHERE project_id<=' . db_param() . ' AND name=' . db_param();
-	db_query_bound( $t_query, array( $t_all_id, '' ) );
+	db_query( $t_query, array( $t_all_id, '' ) );
 }
 
 /**
@@ -4732,7 +4732,7 @@ function filter_db_get_available_queries( $p_project_id = null, $p_user_id = nul
 					AND (is_public = ' . db_param() . '
 						OR user_id = ' . db_param() . ')
 					ORDER BY is_public DESC, name ASC';
-	$t_result = db_query_bound( $t_query, array( $t_project_id, db_prepare_bool( true ), $t_user_id ) );
+	$t_result = db_query( $t_query, array( $t_project_id, db_prepare_bool( true ), $t_user_id ) );
 	$t_query_count = db_num_rows( $t_result );
 
 	for( $i = 0; $i < $t_query_count; $i++ ) {

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -139,7 +139,7 @@ function get_percentage_by_status() {
 		$t_query .= ' AND view_state < ' . VS_PRIVATE;
 	}
 	$t_query .= ' GROUP BY status';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	$t_status_count_array = array();
 

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -88,7 +88,7 @@ function history_log_event_direct( $p_bug_id, $p_field_name, $p_old_value, $p_ne
 						( user_id, bug_id, date_modified, field_name, old_value, new_value, type )
 					VALUES
 						( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
-		db_query_bound( $t_query, array( $p_user_id, $p_bug_id, db_now(), $c_field_name, $c_old_value, $c_new_value, $p_type ) );
+		db_query( $t_query, array( $p_user_id, $p_bug_id, db_now(), $c_field_name, $c_old_value, $c_new_value, $p_type ) );
 	}
 }
 
@@ -123,7 +123,7 @@ function history_log_event_special( $p_bug_id, $p_type, $p_optional = '', $p_opt
 					( user_id, bug_id, date_modified, type, old_value, new_value, field_name )
 				VALUES
 					( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ',' . db_param() . ', ' . db_param() . ')';
-	db_query_bound( $t_query, array( $t_user_id, $p_bug_id, db_now(), $p_type, $c_optional, $c_optional2, '' ) );
+	db_query( $t_query, array( $t_user_id, $p_bug_id, db_now(), $p_type, $c_optional, $c_optional2, '' ) );
 }
 
 /**
@@ -175,7 +175,7 @@ function history_get_raw_events_array( $p_bug_id, $p_user_id = null ) {
 	# for the new bug with the same timestamp...)
 	$t_query = 'SELECT * FROM {bug_history} WHERE bug_id=' . db_param() . '
 				ORDER BY date_modified ' . $t_history_order . ',id';
-	$t_result = db_query_bound( $t_query, array( $p_bug_id ) );
+	$t_result = db_query( $t_query, array( $p_bug_id ) );
 	$t_raw_history = array();
 
 	$t_private_bugnote_visible = access_has_bug_level( config_get( 'private_bugnote_threshold' ), $p_bug_id, $t_user_id );
@@ -578,5 +578,5 @@ function history_localize_item( $p_field_name, $p_type, $p_old_value, $p_new_val
  */
 function history_delete( $p_bug_id ) {
 	$t_query = 'DELETE FROM {bug_history} WHERE bug_id=' . db_param();
-	db_query_bound( $t_query, array( $p_bug_id ) );
+	db_query( $t_query, array( $p_bug_id ) );
 }

--- a/core/install_helper_functions_api.php
+++ b/core/install_helper_functions_api.php
@@ -169,10 +169,10 @@ function install_category_migrate() {
 	$t_log_queries = install_set_log_queries();
 
 	$t_query = 'SELECT project_id, category, user_id FROM {project_category} ORDER BY project_id, category';
-	$t_category_result = db_query_bound( $t_query );
+	$t_category_result = db_query( $t_query );
 
 	$t_query = 'SELECT project_id, category FROM {bug} ORDER BY project_id, category';
-	$t_bug_result = db_query_bound( $t_query );
+	$t_bug_result = db_query( $t_query );
 
 	$t_data = array();
 
@@ -201,7 +201,7 @@ function install_category_migrate() {
 			if( !isset( $t_inserted[$t_lower_name] ) ) {
 				$t_query = 'INSERT INTO {category} ( name, project_id, user_id ) VALUES ( ' .
 					db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
-				db_query_bound( $t_query, array( $t_name, $t_project_id, $t_user_id ) );
+				db_query( $t_query, array( $t_name, $t_project_id, $t_user_id ) );
 				$t_category_id = db_insert_id( db_get_table( 'category' ) );
 				$t_inserted[$t_lower_name] = $t_category_id;
 			} else {
@@ -210,7 +210,7 @@ function install_category_migrate() {
 
 			$t_query = 'UPDATE {bug} SET category_id=' . db_param() . '
 						WHERE project_id=' . db_param() . ' AND category=' . db_param();
-			db_query_bound( $t_query, array( $t_category_id, $t_project_id, $t_name ) );
+			db_query( $t_query, array( $t_category_id, $t_project_id, $t_name ) );
 		}
 	}
 
@@ -265,7 +265,7 @@ function install_date_migrate( array $p_data ) {
 		$t_query = 'SELECT ' . $t_id_column . ', ' . $t_old_column . ' FROM ' . $t_table . ' WHERE ' . $t_new_column_name . ' = 1';
 	}
 
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	if( db_num_rows( $t_result ) > 0 ) {
 		# Build the update query
@@ -312,7 +312,7 @@ function install_date_migrate( array $p_data ) {
 				$t_values = array( $t_new_value, $t_id );
 			}
 
-			db_query_bound( $t_query, $t_values );
+			db_query( $t_query, $t_values );
 		}
 	}
 
@@ -345,7 +345,7 @@ function install_correct_multiselect_custom_fields_db_format() {
 		WHERE (c.type = ' . CUSTOM_FIELD_TYPE_MULTILIST . ' OR c.type = ' . CUSTOM_FIELD_TYPE_CHECKBOX . ")
 			AND v.value != ''
 			AND v.value NOT LIKE '|%|'";
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$c_field_id = (int)$t_row['field_id'];
@@ -355,7 +355,7 @@ function install_correct_multiselect_custom_fields_db_format() {
 			SET value = \'' . $c_value . '\'
 			WHERE field_id = ' . $c_field_id . '
 				AND bug_id = ' . $c_bug_id;
-		db_query_bound( $t_update_query );
+		db_query( $t_update_query );
 	}
 
 	# Remove vertical pipe | prefix and suffix from radio custom field values.
@@ -365,7 +365,7 @@ function install_correct_multiselect_custom_fields_db_format() {
 		WHERE c.type = ' . CUSTOM_FIELD_TYPE_RADIO . "
 			AND v.value != ''
 			AND v.value LIKE '|%|'";
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$c_field_id = (int)$t_row['field_id'];
@@ -375,7 +375,7 @@ function install_correct_multiselect_custom_fields_db_format() {
 			SET value = \'' . $c_value . '\'
 			WHERE field_id = ' . $c_field_id . '
 				AND bug_id = ' . $c_bug_id;
-		db_query_bound( $t_update_query );
+		db_query( $t_update_query );
 	}
 
 	# Re-enable query logging if we disabled it
@@ -432,7 +432,7 @@ function install_stored_filter_migrate() {
 	$t_filter_fields['sticky_issues'] = 'sticky';
 
 	$t_query = 'SELECT * FROM {filters}';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		# Grab Filter Version and data into $t_setting_arr
 		$t_setting_arr = explode( '#', $t_row['filter_string'], 2 );
@@ -444,7 +444,7 @@ function install_stored_filter_migrate() {
 			case 'v3':
 			case 'v4':
 				$t_delete_query = 'DELETE FROM {filters} WHERE id=' . db_param();
-				$t_delete_result = db_query_bound( $t_delete_query, array( $t_row['id'] ) );
+				$t_delete_result = db_query( $t_delete_query, array( $t_row['id'] ) );
 				continue;
 		}
 
@@ -462,7 +462,7 @@ function install_stored_filter_migrate() {
 			}
 		} else {
 			$t_delete_query = 'DELETE FROM {filters} WHERE id=' . db_param();
-			$t_delete_result = db_query_bound( $t_delete_query, array( $t_row['id'] ) );
+			$t_delete_result = db_query( $t_delete_query, array( $t_row['id'] ) );
 			continue;
 		}
 
@@ -501,7 +501,7 @@ function install_stored_filter_migrate() {
 		$t_filter_string = FILTER_VERSION . '#' . $t_filter_serialized;
 
 		$t_update_query = 'UPDATE {filters} SET filter_string=' . db_param() . ' WHERE id=' . db_param();
-		$t_update_result = db_query_bound( $t_update_query, array( $t_filter_string, $t_row['id'] ) );
+		$t_update_result = db_query( $t_update_query, array( $t_filter_string, $t_row['id'] ) );
 	}
 
 	# Re-enable query logging if we disabled it
@@ -538,7 +538,7 @@ function install_update_history_long_custom_fields() {
 
 	# Build list of custom field names longer than 32 chars for reference
 	$t_query = 'SELECT name FROM {custom_field}';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 	while( $t_field = db_fetch_array( $t_result ) ) {
 		if( utf8_strlen( $t_field['name'] ) > 32 ) {
 			$t_custom_fields[utf8_substr( $t_field['name'], 0, 32 )] = $t_field['name'];
@@ -572,7 +572,7 @@ function install_update_history_long_custom_fields() {
 		FROM {bug_history}
 		WHERE type = ' . NORMAL_TYPE . '
 		AND field_name NOT IN ( ' . $t_field_list . ' )';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	# For each entry, update the truncated custom field name with its full name
 	# if a matching custom field exists
@@ -583,7 +583,7 @@ function install_update_history_long_custom_fields() {
 			$t_update_query = 'UPDATE {bug_history}
 				SET field_name = ' . db_param() . '
 				WHERE field_name = ' . db_param();
-			db_query_bound( $t_update_query, array( $t_custom_fields[$t_field['field_name']], $t_field['field_name'] ) );
+			db_query( $t_update_query, array( $t_custom_fields[$t_field['field_name']], $t_field['field_name'] ) );
 		}
 	}
 
@@ -600,7 +600,7 @@ function install_update_history_long_custom_fields() {
 function install_check_project_hierarchy() {
 	$t_query = 'SELECT count(child_id) as count, child_id, parent_id FROM {project_hierarchy} GROUP BY child_id, parent_id';
 
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_count = (int)$t_row['count'];
 		$t_child_id = (int)$t_row['child_id'];
@@ -608,7 +608,7 @@ function install_check_project_hierarchy() {
 
 		if( $t_count > 1 ) {
 			$t_query = 'SELECT inherit_parent, child_id, parent_id FROM {project_hierarchy} WHERE child_id=' . db_param() . ' AND parent_id=' . db_param();
-			$t_result2 = db_query_bound( $t_query, array( $t_child_id, $t_parent_id ) );
+			$t_result2 = db_query( $t_query, array( $t_child_id, $t_parent_id ) );
 
 			# get first result for inherit_parent, discard the rest
 			$t_row2 = db_fetch_array( $t_result2 );
@@ -616,10 +616,10 @@ function install_check_project_hierarchy() {
 			$t_inherit = $t_row2['inherit_parent'];
 
 			$t_query_delete = 'DELETE FROM {project_hierarchy} WHERE child_id=' . db_param() . ' AND parent_id=' . db_param();
-			db_query_bound( $t_query_delete, array( $t_child_id, $t_parent_id ) );
+			db_query( $t_query_delete, array( $t_child_id, $t_parent_id ) );
 
 			$t_query_insert = 'INSERT INTO {project_hierarchy} (child_id, parent_id, inherit_parent) VALUES (' . db_param() . ',' . db_param() . ',' . db_param() . ')';
-			db_query_bound( $t_query_insert, array( $t_child_id, $t_parent_id, $t_inherit ) );
+			db_query( $t_query_insert, array( $t_child_id, $t_parent_id, $t_inherit ) );
 		}
 	}
 
@@ -634,7 +634,7 @@ function install_check_project_hierarchy() {
 function install_check_config_serialization() {
 	$query = 'SELECT * FROM {config} WHERE type=3';
 
-	$t_result = db_query_bound( $query );
+	$t_result = db_query( $query );
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$config_id = $t_row['config_id'];
 		$project_id = (int)$t_row['project_id'];
@@ -649,7 +649,7 @@ function install_check_config_serialization() {
 		$t_json_config = json_encode( $t_config );
 
 		$t_query = 'UPDATE {config} SET value=' .db_param() . ' WHERE config_id=' .db_param() . ' AND project_id=' .db_param() . ' AND user_id=' .db_param();
-		db_query_bound( $t_query, array( $t_json_config, $config_id, $project_id, $user_id ) );
+		db_query( $t_query, array( $t_json_config, $config_id, $project_id, $user_id ) );
 	}
 
 	# flush config here as we've changed the format of the configuration table
@@ -666,7 +666,7 @@ function install_check_config_serialization() {
 function install_check_token_serialization() {
 	$query = 'SELECT * FROM {tokens} WHERE type=1 or type=2 or type=5';
 
-	$t_result = db_query_bound( $query );
+	$t_result = db_query( $query );
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_id = $t_row['id'];
 		$t_value = $t_row['value'];
@@ -679,7 +679,7 @@ function install_check_token_serialization() {
 		$t_json_token = json_encode( $t_token );
 
 		$t_query = 'UPDATE {tokens} SET value=' .db_param() . ' WHERE id=' .db_param();
-		db_query_bound( $t_query, array( $t_json_token, $t_id ) );
+		db_query( $t_query, array( $t_json_token, $t_id ) );
 	}
 
 	# Return 2 because that's what ADOdb/DataDict does when things happen properly

--- a/core/news_api.php
+++ b/core/news_api.php
@@ -80,7 +80,7 @@ function news_create( $p_project_id, $p_poster_id, $p_view_state, $p_announcemen
 				      ' . db_param() . ',
 				      ' . db_param() . '
 					)';
-	db_query_bound( $t_query, array( (int)$p_project_id, (int)$p_poster_id, db_now(), db_now(), (int)$p_view_state, $p_announcement, $p_headline, $p_body ) );
+	db_query( $t_query, array( (int)$p_project_id, (int)$p_poster_id, db_now(), db_now(), (int)$p_view_state, $p_announcement, $p_headline, $p_body ) );
 
 	$t_news_id = db_insert_id( db_get_table( 'news' ) );
 
@@ -95,7 +95,7 @@ function news_create( $p_project_id, $p_poster_id, $p_view_state, $p_announcemen
  */
 function news_delete( $p_news_id ) {
 	$t_query = 'DELETE FROM {news} WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $p_news_id ) );
+	db_query( $t_query, array( $p_news_id ) );
 }
 
 /**
@@ -106,7 +106,7 @@ function news_delete( $p_news_id ) {
  */
 function news_delete_all( $p_project_id ) {
 	$t_query = 'DELETE FROM {news} WHERE project_id=' . db_param();
-	db_query_bound( $t_query, array( (int)$p_project_id ) );
+	db_query( $t_query, array( (int)$p_project_id ) );
 }
 
 /**
@@ -141,7 +141,7 @@ function news_update( $p_news_id, $p_project_id, $p_view_state, $p_announcement,
 					last_modified= ' . db_param() . '
 				  WHERE id=' . db_param();
 
-	db_query_bound( $t_query, array( $p_view_state, $p_announcement, $p_headline, $p_body, $p_project_id, db_now(), $p_news_id ) );
+	db_query( $t_query, array( $p_view_state, $p_announcement, $p_headline, $p_body, $p_project_id, db_now(), $p_news_id ) );
 }
 
 /**
@@ -152,7 +152,7 @@ function news_update( $p_news_id, $p_project_id, $p_view_state, $p_announcement,
  */
 function news_get_row( $p_news_id ) {
 	$t_query = 'SELECT * FROM {news} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_news_id ) );
+	$t_result = db_query( $t_query, array( $p_news_id ) );
 
 	$t_row = db_fetch_array( $t_result );
 
@@ -179,7 +179,7 @@ function news_get_count( $p_project_id, $p_global = true ) {
 		$t_query .= ' OR project_id=' . ALL_PROJECTS;
 	}
 
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	return db_result( $t_result, 0 );
 }
@@ -210,7 +210,7 @@ function news_get_rows( $p_project_id, $p_global = true ) {
 
 	$t_query .= ' ORDER BY date_posted DESC';
 
-	$t_result = db_query_bound( $t_query, array() );
+	$t_result = db_query( $t_query, array() );
 
 	$t_rows = array();
 
@@ -282,7 +282,7 @@ function news_get_limited_rows( $p_offset, $p_project_id = null ) {
 			}
 
 			$t_query .= ' ORDER BY announcement DESC, id DESC';
-			$t_result = db_query_bound( $t_query, $t_params, $t_news_view_limit, $c_offset );
+			$t_result = db_query( $t_query, $t_params, $t_news_view_limit, $c_offset );
 			break;
 		case 1:
 			# BY_DATE - Select the news posts
@@ -301,7 +301,7 @@ function news_get_limited_rows( $p_offset, $p_project_id = null ) {
 				$t_query .= ' AND project_id IN (' . join( $t_projects, ',' ) . ')';
 			}
 			$t_query .= ' ORDER BY announcement DESC, id DESC';
-			$t_result = db_query_bound( $t_query, $t_params, $t_news_view_limit, $c_offset );
+			$t_result = db_query( $t_query, $t_params, $t_news_view_limit, $c_offset );
 			break;
 	}
 

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -623,7 +623,7 @@ function plugin_is_installed( $p_basename ) {
 	}
 
 	$t_query = 'SELECT COUNT(*) FROM {plugin} WHERE basename=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_basename ) );
+	$t_result = db_query( $t_query, array( $p_basename ) );
 	return( 0 < db_result( $t_result ) );
 }
 
@@ -650,7 +650,7 @@ function plugin_install( MantisPlugin $p_plugin ) {
 
 	$t_query = 'INSERT INTO {plugin} ( basename, enabled )
 				VALUES ( ' . db_param() . ', \'1\' )';
-	db_query_bound( $t_query, array( $p_plugin->basename ) );
+	db_query( $t_query, array( $p_plugin->basename ) );
 
 	if( false === ( plugin_config_get( 'schema', false ) ) ) {
 		plugin_config_set( 'schema', -1 );
@@ -764,7 +764,7 @@ function plugin_uninstall( MantisPlugin $p_plugin ) {
 	}
 
 	$t_query = 'DELETE FROM {plugin} WHERE basename=' . db_param();
-	db_query_bound( $t_query, array( $p_plugin->basename ) );
+	db_query( $t_query, array( $p_plugin->basename ) );
 
 	plugin_push_current( $p_plugin->basename );
 
@@ -920,7 +920,7 @@ function plugin_register_installed() {
 
 	# register plugins installed via the interface/database
 	$t_query = 'SELECT basename, priority, protected FROM {plugin} WHERE enabled=' . db_param() . ' ORDER BY priority DESC';
-	$t_result = db_query_bound( $t_query, array( true ) );
+	$t_result = db_query( $t_query, array( true ) );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_basename = $t_row['basename'];

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -413,7 +413,7 @@ function print_news_item_option_list() {
 				WHERE project_id=' . db_param() . '
 				ORDER BY date_posted DESC';
 	}
-	$t_result = db_query_bound( $t_query, ($t_global == true ? array() : array( $t_project_id ) ) );
+	$t_result = db_query( $t_query, ($t_global == true ? array() : array( $t_project_id ) ) );
 	$t_news_count = db_num_rows( $t_result );
 
 	for( $i = 0;$i < $t_news_count;$i++ ) {
@@ -872,7 +872,7 @@ function print_build_option_list( $p_build = '' ) {
 				FROM {bug}
 				WHERE ' . $t_project_where . '
 				ORDER BY build DESC';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 	$t_option_count = db_num_rows( $t_result );
 
 	for( $i = 0;$i < $t_option_count;$i++ ) {
@@ -1082,7 +1082,7 @@ function print_project_user_list_option_list2( $p_user_id ) {
 				WHERE p.enabled = ' . db_param() . ' AND
 					u.user_id IS NULL
 				ORDER BY p.name';
-	$t_result = db_query_bound( $t_query, array( (int)$p_user_id, true ) );
+	$t_result = db_query( $t_query, array( (int)$p_user_id, true ) );
 	$t_category_count = db_num_rows( $t_result );
 	for( $i = 0;$i < $t_category_count;$i++ ) {
 		$t_row = db_fetch_array( $t_result );
@@ -1873,7 +1873,7 @@ function print_bug_attachment_preview_text( array $p_attachment ) {
 			break;
 		case DATABASE:
 			$t_query = 'SELECT * FROM {bug_file} WHERE id=' . db_param();
-			$t_result = db_query_bound( $t_query, array( (int)$p_attachment['id'] ) );
+			$t_result = db_query( $t_query, array( (int)$p_attachment['id'] ) );
 			$t_row = db_fetch_array( $t_result );
 			$t_content = $t_row['content'];
 			break;

--- a/core/profile_api.php
+++ b/core/profile_api.php
@@ -81,7 +81,7 @@ function profile_create( $p_user_id, $p_platform, $p_os, $p_os_build, $p_descrip
 				    ( user_id, platform, os, os_build, description )
 				  VALUES
 				    ( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
-	db_query_bound( $t_query, array( $p_user_id, $p_platform, $p_os, $p_os_build, $p_description ) );
+	db_query( $t_query, array( $p_user_id, $p_platform, $p_os, $p_os_build, $p_description ) );
 
 	return db_insert_id( db_get_table( 'user_profile' ) );
 }
@@ -103,7 +103,7 @@ function profile_delete( $p_user_id, $p_profile_id ) {
 
 	# Delete the profile
 	$t_query = 'DELETE FROM {user_profile} WHERE id=' . db_param() . ' AND user_id=' . db_param();
-	db_query_bound( $t_query, array( $p_profile_id, $p_user_id ) );
+	db_query( $t_query, array( $p_profile_id, $p_user_id ) );
 }
 
 /**
@@ -146,7 +146,7 @@ function profile_update( $p_user_id, $p_profile_id, $p_platform, $p_os, $p_os_bu
 					  os_build=' . db_param() . ',
 					  description=' . db_param() . '
 				  WHERE id=' . db_param() . ' AND user_id=' . db_param();
-	db_query_bound( $t_query, array( $p_platform, $p_os, $p_os_build, $p_description, $p_profile_id, $p_user_id ) );
+	db_query( $t_query, array( $p_platform, $p_os, $p_os_build, $p_description, $p_profile_id, $p_user_id ) );
 }
 
 /**
@@ -157,7 +157,7 @@ function profile_update( $p_user_id, $p_profile_id, $p_platform, $p_os, $p_os_bu
  */
 function profile_get_row( $p_user_id, $p_profile_id ) {
 	$t_query = 'SELECT * FROM {user_profile} WHERE id=' . db_param() . ' AND user_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_profile_id, $p_user_id ) );
+	$t_result = db_query( $t_query, array( $p_profile_id, $p_user_id ) );
 
 	return db_fetch_array( $t_result );
 }
@@ -170,7 +170,7 @@ function profile_get_row( $p_user_id, $p_profile_id ) {
  */
 function profile_get_row_direct( $p_profile_id ) {
 	$t_query = 'SELECT * FROM {user_profile} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_profile_id ) );
+	$t_result = db_query( $t_query, array( $p_profile_id ) );
 
 	return db_fetch_array( $t_result );
 }
@@ -191,7 +191,7 @@ function profile_get_all_rows( $p_user_id, $p_all_users = false ) {
 	}
 
 	$t_query = 'SELECT * FROM {user_profile} WHERE ' . $t_query_where . ' ORDER BY platform, os, os_build';
-	$t_result = db_query_bound( $t_query, $t_param );
+	$t_result = db_query( $t_query, $t_param );
 
 	$t_rows = array();
 
@@ -239,7 +239,7 @@ function profile_get_field_all_for_user( $p_field, $p_user_id = null ) {
 				  FROM {user_profile}
 				  WHERE ( user_id=' . db_param() . ' ) OR ( user_id = 0 )
 				  ORDER BY ' . $c_field;
-	$t_result = db_query_bound( $t_query, array( $c_user_id ) );
+	$t_result = db_query( $t_query, array( $c_user_id ) );
 
 	$t_rows = array();
 
@@ -263,7 +263,7 @@ function profile_get_all_for_project( $p_project_id ) {
 				  WHERE ' . $t_project_where . '
 				  AND up.id = b.profile_id
 				  ORDER BY up.platform, up.os, up.os_build';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	$t_rows = array();
 
@@ -281,7 +281,7 @@ function profile_get_all_for_project( $p_project_id ) {
  */
 function profile_get_default( $p_user_id ) {
 	$t_query = 'SELECT default_profile FROM {user_pref} WHERE user_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_user_id ) );
+	$t_result = db_query( $t_query, array( $p_user_id ) );
 
 	$t_default_profile = (int)db_result( $t_result, 0, 0 );
 

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -75,7 +75,7 @@ function project_table_empty() {
 
 	# Otherwise, check if the projects table contains at least one project.
 	$t_query = 'SELECT * FROM {project}';
-	$t_result = db_query_bound( $t_query, array(), 1 );
+	$t_result = db_query( $t_query, array(), 1 );
 
 	return db_num_rows( $t_result ) == 0;
 }
@@ -103,7 +103,7 @@ function project_cache_row( $p_project_id, $p_trigger_errors = true ) {
 	}
 
 	$t_query = 'SELECT * FROM {project} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_project_id ) );
+	$t_result = db_query( $t_query, array( $p_project_id ) );
 
 	if( 0 == db_num_rows( $t_result ) ) {
 		$g_cache_project_missing[(int)$p_project_id] = true;
@@ -144,7 +144,7 @@ function project_cache_array_rows( array $p_project_id_array ) {
 	}
 
 	$t_query = 'SELECT * FROM {project} WHERE id IN (' . implode( ',', $c_project_id_array ) . ')';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	$t_projects_found = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -168,7 +168,7 @@ function project_cache_all() {
 
 	if( !$g_cache_project_all ) {
 		$t_query = 'SELECT * FROM {project}';
-		$t_result = db_query_bound( $t_query );
+		$t_result = db_query( $t_query );
 		$t_count = db_num_rows( $t_result );
 		for( $i = 0;$i < $t_count;$i++ ) {
 			$t_row = db_fetch_array( $t_result );
@@ -238,7 +238,7 @@ function project_ensure_exists( $p_project_id ) {
  */
 function project_is_name_unique( $p_name ) {
 	$t_query = 'SELECT COUNT(*) FROM {project} WHERE name=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_name ) );
+	$t_result = db_query( $t_query, array( $p_name ) );
 
 	if( 0 == db_result( $t_result ) ) {
 		return true;
@@ -271,7 +271,7 @@ function project_includes_user( $p_project_id, $p_user_id ) {
 	$t_query = 'SELECT COUNT(*) FROM {project_user_list}
 				  WHERE project_id=' . db_param() . ' AND
 						user_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_project_id, $p_user_id ) );
+	$t_result = db_query( $t_query, array( $p_project_id, $p_user_id ) );
 
 	if( 0 == db_result( $t_result ) ) {
 		return false;
@@ -337,7 +337,7 @@ function project_create( $p_name, $p_description, $p_status, $p_view_state = VS_
 				  VALUES
 					( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ')';
 
-	db_query_bound( $t_query, array( $p_name, (int)$p_status, $c_enabled, (int)$p_view_state, $p_file_path, $p_description, $p_inherit_global ) );
+	db_query( $t_query, array( $p_name, (int)$p_status, $c_enabled, (int)$p_view_state, $p_file_path, $p_description, $p_inherit_global ) );
 
 	# return the id of the new project
 	return db_insert_id( db_get_table( 'project' ) );
@@ -387,7 +387,7 @@ function project_delete( $p_project_id ) {
 	# Delete the project entry
 	$t_query = 'DELETE FROM {project} WHERE id=' . db_param();
 
-	db_query_bound( $t_query, array( $p_project_id ) );
+	db_query( $t_query, array( $p_project_id ) );
 
 	config_set_cache( 'enable_email_notification', $t_email_notifications, CONFIG_TYPE_INT );
 
@@ -445,7 +445,7 @@ function project_update( $p_project_id, $p_name, $p_description, $p_status, $p_v
 					description=' . db_param() . ',
 					inherit_global=' . db_param() . '
 				  WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $p_name, (int)$p_status, $c_enabled, (int)$p_view_state, $p_file_path, $p_description, $c_inherit_global, $p_project_id ) );
+	db_query( $t_query, array( $p_name, (int)$p_status, $c_enabled, (int)$p_view_state, $p_file_path, $p_description, $c_inherit_global, $p_project_id ) );
 
 	project_clear_cache( $p_project_id );
 
@@ -480,7 +480,7 @@ function project_copy_custom_fields( $p_destination_id, $p_source_id ) {
  */
 function project_get_id_by_name( $p_project_name ) {
 	$t_query = 'SELECT id FROM {project} WHERE name = ' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_project_name ), 1 );
+	$t_result = db_query( $t_query, array( $p_project_name ), 1 );
 
 	if( db_num_rows( $t_result ) == 0 ) {
 		return 0;
@@ -559,7 +559,7 @@ function project_get_local_user_access_level( $p_project_id, $p_user_id ) {
 	$t_query = 'SELECT access_level
 				  FROM {project_user_list}
 				  WHERE user_id=' . db_param() . ' AND project_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( (int)$p_user_id, $p_project_id ) );
+	$t_result = db_query( $t_query, array( (int)$p_user_id, $p_project_id ) );
 
 	if( db_num_rows( $t_result ) > 0 ) {
 		return (int)db_result( $t_result );
@@ -577,7 +577,7 @@ function project_get_local_user_access_level( $p_project_id, $p_user_id ) {
 function project_get_local_user_rows( $p_project_id ) {
 	$t_query = 'SELECT * FROM {project_user_list} WHERE project_id=' . db_param();
 
-	$t_result = db_query_bound( $t_query, array( (int)$p_project_id ) );
+	$t_result = db_query( $t_query, array( (int)$p_project_id ) );
 
 	$t_user_rows = array();
 	$t_row_count = db_num_rows( $t_result );
@@ -670,7 +670,7 @@ function project_get_all_user_rows( $p_project_id = ALL_PROJECTS, $p_access_leve
 				WHERE enabled = ' . db_param() . '
 					AND access_level ' . $t_global_access_clause;
 
-		$t_result = db_query_bound( $t_query, array( $t_on ) );
+		$t_result = db_query( $t_query, array( $t_on ) );
 		$t_row_count = db_num_rows( $t_result );
 		for( $i = 0;$i < $t_row_count;$i++ ) {
 			$t_row = db_fetch_array( $t_result );
@@ -686,7 +686,7 @@ function project_get_all_user_rows( $p_project_id = ALL_PROJECTS, $p_access_leve
 				AND u.enabled = ' . db_param() . '
 				AND l.project_id = ' . db_param();
 
-		$t_result = db_query_bound( $t_query, array( $t_on, $c_project_id ) );
+		$t_result = db_query( $t_query, array( $t_on, $c_project_id ) );
 		$t_row_count = db_num_rows( $t_result );
 		for( $i = 0; $i < $t_row_count; $i++ ) {
 			$t_row = db_fetch_array( $t_result );
@@ -753,7 +753,7 @@ function project_add_user( $p_project_id, $p_user_id, $p_access_level ) {
 				  VALUES
 				    ( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ')';
 
-	db_query_bound( $t_query, array( (int)$p_project_id, (int)$p_user_id, $t_access_level ) );
+	db_query( $t_query, array( (int)$p_project_id, (int)$p_user_id, $t_access_level ) );
 }
 
 /**
@@ -770,7 +770,7 @@ function project_update_user_access( $p_project_id, $p_user_id, $p_access_level 
 				  WHERE	project_id=' . db_param() . ' AND
 						user_id=' . db_param();
 
-	db_query_bound( $t_query, array( (int)$p_access_level, (int)$p_project_id, (int)$p_user_id ) );
+	db_query( $t_query, array( (int)$p_access_level, (int)$p_project_id, (int)$p_user_id ) );
 }
 
 /**
@@ -799,7 +799,7 @@ function project_remove_user( $p_project_id, $p_user_id ) {
 	$t_query = 'DELETE FROM {project_user_list}
 				  WHERE project_id=' . db_param() . ' AND user_id=' . db_param();
 
-	db_query_bound( $t_query, array( (int)$p_project_id, (int)$p_user_id ) );
+	db_query( $t_query, array( (int)$p_project_id, (int)$p_user_id ) );
 }
 
 /**
@@ -816,9 +816,9 @@ function project_remove_all_users( $p_project_id, $p_access_level_limit = null )
 
 	if( $p_access_level_limit !== null ) {
 		$t_query .= ' AND access_level <= ' . db_param();
-		db_query_bound( $t_query, array( (int)$p_project_id, (int)$p_access_level_limit ) );
+		db_query( $t_query, array( (int)$p_project_id, (int)$p_access_level_limit ) );
 	} else {
-		db_query_bound( $t_query, array( (int)$p_project_id ) );
+		db_query( $t_query, array( (int)$p_project_id ) );
 	}
 }
 

--- a/core/project_hierarchy_api.php
+++ b/core/project_hierarchy_api.php
@@ -52,7 +52,7 @@ function project_hierarchy_add( $p_child_id, $p_parent_id, $p_inherit_parent = t
 						VALUES
 						( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
 
-	db_query_bound( $t_query, array( $p_child_id, $p_parent_id, $p_inherit_parent ) );
+	db_query( $t_query, array( $p_child_id, $p_parent_id, $p_inherit_parent ) );
 }
 
 /**
@@ -67,7 +67,7 @@ function project_hierarchy_update( $p_child_id, $p_parent_id, $p_inherit_parent 
 					SET inherit_parent=' . db_param() . '
 					WHERE child_id=' . db_param() . '
 						AND parent_id=' . db_param();
-	db_query_bound( $t_query, array( $p_inherit_parent, $p_child_id, $p_parent_id ) );
+	db_query( $t_query, array( $p_inherit_parent, $p_child_id, $p_parent_id ) );
 }
 
 /**
@@ -80,7 +80,7 @@ function project_hierarchy_remove( $p_child_id, $p_parent_id ) {
 	$t_query = 'DELETE FROM {project_hierarchy} WHERE child_id = ' . db_param() . '
 						AND parent_id = ' . db_param();
 
-	db_query_bound( $t_query, array( $p_child_id, $p_parent_id ) );
+	db_query( $t_query, array( $p_child_id, $p_parent_id ) );
 }
 
 /**
@@ -92,7 +92,7 @@ function project_hierarchy_remove_all( $p_project_id ) {
 	$t_query = 'DELETE FROM {project_hierarchy} WHERE child_id = ' . db_param() . '
 						  OR parent_id = ' . db_param();
 
-	db_query_bound( $t_query, array( $p_project_id, $p_project_id ) );
+	db_query( $t_query, array( $p_project_id, $p_project_id ) );
 }
 
 /**
@@ -160,7 +160,7 @@ function project_hierarchy_cache( $p_show_disabled = false ) {
 				  WHERE ' . $t_enabled_clause . '
 				  ORDER BY p.name';
 
-	$t_result = db_query_bound( $t_query, ( $p_show_disabled ? array() : array( true ) ) );
+	$t_result = db_query( $t_query, ( $p_show_disabled ? array() : array( true ) ) );
 
 	$g_cache_project_hierarchy = array();
 	$g_cache_project_inheritance = array();

--- a/core/relationship_api.php
+++ b/core/relationship_api.php
@@ -223,7 +223,7 @@ function relationship_add( $p_src_bug_id, $p_dest_bug_id, $p_relationship_type )
 				( source_bug_id, destination_bug_id, relationship_type )
 				VALUES
 				( ' . db_param() . ',' . db_param() . ',' . db_param() . ')';
-	$t_result = db_query_bound( $t_query, array( $c_src_bug_id, $c_dest_bug_id, $c_relationship_type ) );
+	$t_result = db_query( $t_query, array( $c_src_bug_id, $c_dest_bug_id, $c_relationship_type ) );
 	$t_relationship = db_fetch_array( $t_result );
 
 	$t_bug_relationship_data = new BugRelationshipData;
@@ -260,7 +260,7 @@ function relationship_update( $p_relationship_id, $p_src_bug_id, $p_dest_bug_id,
 					destination_bug_id=' . db_param() . ',
 					relationship_type=' . db_param() . '
 				WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $c_src_bug_id, $c_dest_bug_id, $c_relationship_type, (int)$p_relationship_id ) );
+	$t_result = db_query( $t_query, array( $c_src_bug_id, $c_dest_bug_id, $c_relationship_type, (int)$p_relationship_id ) );
 	$t_relationship = db_fetch_array( $t_result );
 
 	$t_bug_relationship_data = new BugRelationshipData;
@@ -279,7 +279,7 @@ function relationship_update( $p_relationship_id, $p_src_bug_id, $p_dest_bug_id,
  */
 function relationship_delete( $p_relationship_id ) {
 	$t_query = 'DELETE FROM {bug_relationship} WHERE id=' . db_param();
-	db_query_bound( $t_query, array( (int)$p_relationship_id ) );
+	db_query( $t_query, array( (int)$p_relationship_id ) );
 }
 
 /**
@@ -291,7 +291,7 @@ function relationship_delete_all( $p_bug_id ) {
 	$t_query = 'DELETE FROM {bug_relationship}
 				WHERE source_bug_id=' . db_param() . ' OR
 				destination_bug_id=' . db_param();
-	db_query_bound( $t_query, array( (int)$p_bug_id, (int)$p_bug_id ) );
+	db_query( $t_query, array( (int)$p_bug_id, (int)$p_bug_id ) );
 }
 
 /**
@@ -321,7 +321,7 @@ function relationship_copy_all( $p_bug_id, $p_new_bug_id ) {
  */
 function relationship_get( $p_relationship_id ) {
 	$t_query = 'SELECT * FROM {bug_relationship} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( (int)$p_relationship_id ) );
+	$t_result = db_query( $t_query, array( (int)$p_relationship_id ) );
 
 	$t_relationship = db_fetch_array( $t_result );
 
@@ -351,7 +351,7 @@ function relationship_get_all_src( $p_src_bug_id ) {
 				INNER JOIN {bug} ON {bug_relationship}.destination_bug_id = {bug}.id
 				WHERE source_bug_id=' . db_param() . '
 				ORDER BY relationship_type, {bug_relationship}.id';
-	$t_result = db_query_bound( $t_query, array( $p_src_bug_id ) );
+	$t_result = db_query( $t_query, array( $p_src_bug_id ) );
 
 	$t_src_project_id = bug_get_field( $p_src_bug_id, 'project_id' );
 
@@ -391,7 +391,7 @@ function relationship_get_all_dest( $p_dest_bug_id ) {
 				INNER JOIN {bug} ON {bug_relationship}.source_bug_id = {bug}.id
 				WHERE destination_bug_id=' . db_param() . '
 				ORDER BY relationship_type, {bug_relationship}.id';
-	$t_result = db_query_bound( $t_query, array( (int)$p_dest_bug_id ) );
+	$t_result = db_query( $t_query, array( (int)$p_dest_bug_id ) );
 
 	$t_dest_project_id = bug_get_field( $p_dest_bug_id, 'project_id' );
 
@@ -452,7 +452,7 @@ function relationship_exists( $p_src_bug_id, $p_dest_bug_id ) {
 				OR
 				(source_bug_id=' . db_param() . '
 				AND destination_bug_id=' . db_param() . ')';
-	$t_result = db_query_bound( $t_query, array( $c_src_bug_id, $c_dest_bug_id, $c_dest_bug_id, $c_src_bug_id ), 1 );
+	$t_result = db_query( $t_query, array( $c_src_bug_id, $c_dest_bug_id, $c_dest_bug_id, $c_src_bug_id ), 1 );
 
 	if( $t_row = db_fetch_array( $t_result ) ) {
 		# return the first id

--- a/core/sponsorship_api.php
+++ b/core/sponsorship_api.php
@@ -117,7 +117,7 @@ function sponsorship_cache_row( $p_sponsorship_id, $p_trigger_errors = true ) {
 	}
 
 	$t_query = 'SELECT * FROM {sponsorship} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $c_sponsorship_id ) );
+	$t_result = db_query( $t_query, array( $c_sponsorship_id ) );
 
 	if( 0 == db_num_rows( $t_result ) ) {
 		$g_cache_sponsorships[$c_sponsorship_id] = false;
@@ -176,7 +176,7 @@ function sponsorship_get_id( $p_bug_id, $p_user_id = null ) {
 	}
 
 	$t_query = 'SELECT id FROM {sponsorship} WHERE bug_id=' . db_param() . ' AND user_id = ' . db_param();
-	$t_result = db_query_bound( $t_query, array( (int)$p_bug_id, $c_user_id ), 1 );
+	$t_result = db_query( $t_query, array( (int)$p_bug_id, $c_user_id ), 1 );
 
 	if( db_num_rows( $t_result ) == 0 ) {
 		return false;
@@ -227,7 +227,7 @@ function sponsorship_get_all_ids( $p_bug_id ) {
 	}
 
 	$t_query = 'SELECT * FROM {sponsorship} WHERE bug_id = ' . db_param();
-	$t_result = db_query_bound( $t_query, array( $c_bug_id ) );
+	$t_result = db_query( $t_query, array( $c_bug_id ) );
 
 	$t_sponsorship_ids = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -330,7 +330,7 @@ function sponsorship_set( SponsorshipData $p_sponsorship ) {
 				  VALUES
 				    (' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ')';
 
-		db_query_bound( $t_query, array( $c_bug_id, $c_user_id, $c_amount, $c_logo, $c_url, $c_now, $c_now ) );
+		db_query( $t_query, array( $c_bug_id, $c_user_id, $c_amount, $c_logo, $c_url, $c_now, $c_now ) );
 
 		$t_sponsorship_id = db_insert_id( db_get_table( 'sponsorship' ) );
 
@@ -355,7 +355,7 @@ function sponsorship_set( SponsorshipData $p_sponsorship ) {
 
 		sponsorship_clear_cache( $c_id );
 
-		db_query_bound( $t_query, array( $c_bug_id, $c_user_id, $c_amount, $c_logo, $c_url, $c_now, $c_id ) );
+		db_query( $t_query, array( $c_bug_id, $c_user_id, $c_amount, $c_logo, $c_url, $c_now, $c_id ) );
 
 		history_log_event_special( $c_bug_id, BUG_UPDATE_SPONSORSHIP, $c_user_id, $c_amount );
 	}
@@ -379,7 +379,7 @@ function sponsorship_set( SponsorshipData $p_sponsorship ) {
  */
 function sponsorship_delete_all( $p_bug_id ) {
 	$t_query = 'DELETE FROM {sponsorship} WHERE bug_id=' . db_param();
-	db_query_bound( $t_query, array( (int)$p_bug_id ) );
+	db_query( $t_query, array( (int)$p_bug_id ) );
 
 	sponsorship_clear_cache( );
 }
@@ -403,7 +403,7 @@ function sponsorship_delete( $p_sponsorship_id ) {
 
 	# Delete the bug entry
 	$t_query = 'DELETE FROM {sponsorship} WHERE id=' . db_param();
-	db_query_bound( $t_query, array( (int)$p_sponsorship_id ) );
+	db_query( $t_query, array( (int)$p_sponsorship_id ) );
 
 	sponsorship_clear_cache( $p_sponsorship_id );
 
@@ -423,7 +423,7 @@ function sponsorship_update_paid( $p_sponsorship_id, $p_paid ) {
 	$t_sponsorship = sponsorship_get( $p_sponsorship_id );
 
 	$t_query = 'UPDATE {sponsorship} SET last_updated=' . db_param() . ', paid=' . db_param() . ' WHERE id=' . db_param();
-	db_query_bound( $t_query, array( db_now(), (int)$p_paid, (int)$p_sponsorship_id ) );
+	db_query( $t_query, array( db_now(), (int)$p_paid, (int)$p_sponsorship_id ) );
 
 	history_log_event_special( $t_sponsorship->bug_id, BUG_PAID_SPONSORSHIP, $t_sponsorship->user_id, $p_paid );
 	sponsorship_clear_cache( $p_sponsorship_id );
@@ -438,7 +438,7 @@ function sponsorship_update_paid( $p_sponsorship_id, $p_paid ) {
  */
 function sponsorship_update_date( $p_sponsorship_id ) {
 	$t_query = 'UPDATE {sponsorship} SET last_updated=' . db_param() . ' WHERE id=' . db_param();
-	db_query_bound( $t_query, array( db_now(), (int)$p_sponsorship_id ) );
+	db_query( $t_query, array( db_now(), (int)$p_sponsorship_id ) );
 
 	sponsorship_clear_cache( $p_sponsorship_id );
 

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -113,7 +113,7 @@ function summary_print_by_enum( $p_enum ) {
 				WHERE ' . $t_project_filter . '
 				GROUP BY ' . $p_enum . ' ' . $t_status_query . '
 				ORDER BY ' . $p_enum . ' ' . $t_status_query;
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	$t_last_value = -1;
 	$t_bugs_open = 0;
@@ -256,7 +256,7 @@ function summary_new_bug_count_by_date( $p_num_days = 1 ) {
 
 	$t_query = 'SELECT COUNT(*) FROM {bug}
 				WHERE ' . db_helper_compare_days( '' . db_now() . '', 'date_submitted', '<= ' . $c_time_length ) . ' AND ' . $t_specific_where;
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 	return db_result( $t_result, 0 );
 }
 
@@ -289,7 +289,7 @@ function summary_resolved_bug_count_by_date( $p_num_days = 1 ) {
 				AND h.new_value >= ' . db_param() . '
 				AND ' . db_helper_compare_days( '' . db_now() . '', 'date_modified', '<= ' . $c_time_length ) . '
 				AND ' . $t_specific_where;
-	$t_result = db_query_bound( $t_query, array( $t_resolved, $t_resolved, $t_resolved ) );
+	$t_result = db_query( $t_query, array( $t_resolved, $t_resolved, $t_resolved ) );
 	return db_result( $t_result, 0 );
 }
 
@@ -356,7 +356,7 @@ function summary_print_by_activity() {
 				AND ' . $t_specific_where . '
 				GROUP BY h.bug_id, b.id, b.summary, b.last_updated, b.view_state
 				ORDER BY count DESC, b.last_updated DESC';
-	$t_result = db_query_bound( $t_query, array( $t_resolved ) );
+	$t_result = db_query( $t_query, array( $t_resolved ) );
 
 	$t_count = 0;
 	$t_private_bug_threshold = config_get( 'private_bug_threshold' );
@@ -409,7 +409,7 @@ function summary_print_by_age() {
 				WHERE status < ' . db_param() . '
 				AND ' . $t_specific_where . '
 				ORDER BY date_submitted ASC, priority DESC';
-	$t_result = db_query_bound( $t_query, array( $t_resolved ) );
+	$t_result = db_query( $t_query, array( $t_resolved ) );
 
 	$t_count = 0;
 	$t_private_bug_threshold = config_get( 'private_bug_threshold' );
@@ -454,7 +454,7 @@ function summary_print_by_developer() {
 				WHERE handler_id>0 AND ' . $t_specific_where . '
 				GROUP BY handler_id, status
 				ORDER BY handler_id, status';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	$t_last_handler = -1;
 	$t_bugs_open = 0;
@@ -554,7 +554,7 @@ function summary_print_by_reporter() {
 				WHERE ' . $t_specific_where . '
 				GROUP BY reporter_id
 				ORDER BY num DESC';
-	$t_result = db_query_bound( $t_query, array(), $t_reporter_summary_limit );
+	$t_result = db_query( $t_query, array(), $t_reporter_summary_limit );
 
 	$t_reporters = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -570,7 +570,7 @@ function summary_print_by_reporter() {
 					AND ' . $t_specific_where . '
 					GROUP BY status
 					ORDER BY status';
-		$t_result2 = db_query_bound( $t_query, array( $v_reporter_id ) );
+		$t_result2 = db_query( $t_query, array( $v_reporter_id ) );
 
 		$t_bugs_open = 0;
 		$t_bugs_resolved = 0;
@@ -636,7 +636,7 @@ function summary_print_by_category() {
 				GROUP BY ' . $t_project_query . ' c.name, b.category_id, b.status
 				ORDER BY ' . $t_project_query . ' c.name';
 
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	$t_last_category_name = -1;
 	$t_last_project = -1;
@@ -749,7 +749,7 @@ function summary_print_by_project( array $p_projects = array(), $p_level = 0, ar
 					FROM {bug}
 					GROUP BY project_id, status';
 
-		$t_result = db_query_bound( $t_query );
+		$t_result = db_query( $t_query );
 		$p_cache = array();
 
 		$t_resolved_val = config_get( 'bug_resolved_status_threshold' );
@@ -830,7 +830,7 @@ function summary_print_developer_resolution( $p_resolution_enum_string ) {
 				WHERE ' . $t_specific_where . '
 				GROUP BY handler_id, resolution
 				ORDER BY handler_id, resolution';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	$t_handler_res_arr = array();
 	$t_arr = db_fetch_array( $t_result );
@@ -936,7 +936,7 @@ function summary_print_reporter_resolution( $p_resolution_enum_string ) {
 				FROM {bug}
 				WHERE ' . $t_specific_where . '
 				GROUP BY reporter_id, resolution';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	$t_reporter_res_arr = array();
 	$t_reporter_bugcount_arr = array();
@@ -1058,7 +1058,7 @@ function summary_print_reporter_effectiveness( $p_severity_enum_string, $p_resol
 				FROM {bug}
 				WHERE ' . $t_specific_where . '
 				GROUP BY reporter_id, resolution, severity';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	$t_reporter_ressev_arr = array();
 	$t_reporter_bugcount_arr = array();

--- a/core/tag_api.php
+++ b/core/tag_api.php
@@ -60,7 +60,7 @@ require_api( 'utility_api.php' );
  */
 function tag_exists( $p_tag_id ) {
 	$t_query = 'SELECT * FROM {tag} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_tag_id ) );
+	$t_result = db_query( $t_query, array( $p_tag_id ) );
 
 	return db_num_rows( $t_result ) > 0;
 }
@@ -87,7 +87,7 @@ function tag_is_unique( $p_name ) {
 	$c_name = trim( $p_name );
 
 	$t_query = 'SELECT id FROM {tag} WHERE ' . db_helper_like( 'name' );
-	$t_result = db_query_bound( $t_query, array( $c_name ) );
+	$t_result = db_query( $t_query, array( $c_name ) );
 
 	if( db_result( $t_result ) ) {
 		return false;
@@ -250,7 +250,7 @@ function tag_get_all( $p_name_filter, $p_count, $p_offset ) {
 
 	$t_query = 'SELECT * FROM {tag} ' . $t_where . ' ORDER BY name';
 
-	return db_query_bound( $t_query, $t_where_params, $p_count, $p_offset );
+	return db_query( $t_query, $t_where_params, $p_count, $p_offset );
 }
 
 /**
@@ -269,7 +269,7 @@ function tag_count( $p_name_filter ) {
 
 	$t_query = 'SELECT count(*) FROM {tag}' . $t_where;
 
-	$t_result = db_query_bound( $t_query, $t_where_params );
+	$t_result = db_query( $t_query, $t_where_params );
 	$t_row = db_fetch_array( $t_result );
 	return (int)db_result( $t_result );
 
@@ -284,7 +284,7 @@ function tag_get( $p_tag_id ) {
 	tag_ensure_exists( $p_tag_id );
 
 	$t_query = 'SELECT * FROM {tag} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_tag_id ) );
+	$t_result = db_query( $t_query, array( $p_tag_id ) );
 
 	$t_row = db_fetch_array( $t_result );
 
@@ -302,7 +302,7 @@ function tag_get( $p_tag_id ) {
  */
 function tag_get_by_name( $p_name ) {
 	$t_query = 'SELECT * FROM {tag} WHERE ' . db_helper_like( 'name' );
-	$t_result = db_query_bound( $t_query, array( $p_name ) );
+	$t_result = db_query( $t_query, array( $p_name ) );
 
 	$t_row = db_fetch_array( $t_result );
 
@@ -358,7 +358,7 @@ function tag_create( $p_name, $p_user_id = null, $p_description = '' ) {
 				VALUES
 				( ' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ')';
 
-	db_query_bound( $t_query, array( $p_user_id, trim( $p_name ), trim( $p_description ), $c_date_created, $c_date_created ) );
+	db_query( $t_query, array( $p_user_id, trim( $p_name ), trim( $p_description ), $c_date_created, $c_date_created ) );
 
 	return db_insert_id( db_get_table( 'tag' ) );
 }
@@ -400,7 +400,7 @@ function tag_update( $p_tag_id, $p_name, $p_user_id, $p_description ) {
 						description=' . db_param() . ',
 						date_updated=' . db_param() . '
 					WHERE id=' . db_param();
-	db_query_bound( $t_query, array( (int)$p_user_id, $p_name, $p_description, $c_date_updated, $p_tag_id ) );
+	db_query( $t_query, array( (int)$p_user_id, $p_name, $p_description, $c_date_updated, $p_tag_id ) );
 
 	if( $t_rename ) {
 		$t_bugs = tag_get_bugs_attached( $p_tag_id );
@@ -429,7 +429,7 @@ function tag_delete( $p_tag_id ) {
 	}
 
 	$t_query = 'DELETE FROM {tag} WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $p_tag_id ) );
+	db_query( $t_query, array( $p_tag_id ) );
 
 	return true;
 }
@@ -450,7 +450,7 @@ function tag_get_candidates_for_bug( $p_bug_id ) {
 			$t_query = 'SELECT t.id FROM {tag} t
 					LEFT JOIN {bug_tag} b ON t.id=b.tag_id
 					WHERE b.bug_id IS NULL OR b.bug_id != ' . db_param();
-			$t_result = db_query_bound( $t_query, $t_params );
+			$t_result = db_query( $t_query, $t_params );
 
 			$t_params = null;
 
@@ -477,7 +477,7 @@ function tag_get_candidates_for_bug( $p_bug_id ) {
 	}
 
 	$t_query .= ' ORDER BY name ASC ';
-	$t_result = db_query_bound( $t_query, $t_params );
+	$t_result = db_query( $t_query, $t_params );
 
 	$t_results_to_return = array();
 
@@ -496,7 +496,7 @@ function tag_get_candidates_for_bug( $p_bug_id ) {
  */
 function tag_bug_is_attached( $p_tag_id, $p_bug_id ) {
 	$t_query = 'SELECT bug_id FROM {bug_tag} WHERE tag_id=' . db_param() . ' AND bug_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_tag_id, $p_bug_id ) );
+	$t_result = db_query( $t_query, array( $p_tag_id, $p_bug_id ) );
 	return( db_result( $t_result ) !== false );
 }
 
@@ -508,7 +508,7 @@ function tag_bug_is_attached( $p_tag_id, $p_bug_id ) {
  */
 function tag_bug_get_row( $p_tag_id, $p_bug_id ) {
 	$t_query = 'SELECT * FROM {bug_tag} WHERE tag_id=' . db_param() . ' AND bug_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_tag_id, $p_bug_id ) );
+	$t_result = db_query( $t_query, array( $p_tag_id, $p_bug_id ) );
 
 	$t_row = db_fetch_array( $t_result );
 	if( !$t_row ) {
@@ -528,7 +528,7 @@ function tag_bug_get_attached( $p_bug_id ) {
 					LEFT JOIN {bug_tag} b
 						on t.id=b.tag_id
 					WHERE b.bug_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_bug_id ) );
+	$t_result = db_query( $t_query, array( $p_bug_id ) );
 
 	$t_rows = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -546,7 +546,7 @@ function tag_bug_get_attached( $p_bug_id ) {
  */
 function tag_get_bugs_attached( $p_tag_id ) {
 	$t_query = 'SELECT bug_id FROM {bug_tag} WHERE tag_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_tag_id ) );
+	$t_result = db_query( $t_query, array( $p_tag_id ) );
 
 	$t_bugs = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -582,7 +582,7 @@ function tag_bug_attach( $p_tag_id, $p_bug_id, $p_user_id = null ) {
 					( tag_id, bug_id, user_id, date_attached )
 					VALUES
 					( ' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ')';
-	db_query_bound( $t_query, array( $p_tag_id, $p_bug_id, $p_user_id, db_now() ) );
+	db_query( $t_query, array( $p_tag_id, $p_bug_id, $p_user_id, db_now() ) );
 
 	$t_tag_name = tag_get_field( $p_tag_id, 'name' );
 	history_log_event_special( $p_bug_id, TAG_ATTACHED, $t_tag_name );
@@ -622,7 +622,7 @@ function tag_bug_detach( $p_tag_id, $p_bug_id, $p_add_history = true, $p_user_id
 	access_ensure_bug_level( $t_detach_level, $p_bug_id, $t_user_id );
 
 	$t_query = 'DELETE FROM {bug_tag} WHERE tag_id=' . db_param() . ' AND bug_id=' . db_param();
-	db_query_bound( $t_query, array( $p_tag_id, $p_bug_id ) );
+	db_query( $t_query, array( $p_tag_id, $p_bug_id ) );
 
 	if( $p_add_history ) {
 		$t_tag_name = tag_get_field( $p_tag_id, 'name' );
@@ -711,7 +711,7 @@ function tag_display_attached( $p_bug_id ) {
  */
 function tag_stats_attached( $p_tag_id ) {
 	$t_query = 'SELECT COUNT(*) FROM {bug_tag} WHERE tag_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_tag_id ) );
+	$t_result = db_query( $t_query, array( $p_tag_id ) );
 
 	return db_result( $t_result );
 }
@@ -742,7 +742,7 @@ function tag_stats_related( $p_tag_id, $p_limit = 5 ) {
 					WHERE tag_id != ' . db_param() . # 1st Param
 						' AND bug_id IN ( ' . $t_subquery . ' ) ';
 
-	$t_result = db_query_bound( $t_query, array( $p_tag_id, $c_user_id, $c_user_id, $p_tag_id ) );
+	$t_result = db_query( $t_query, array( $p_tag_id, $c_user_id, $c_user_id, $p_tag_id ) );
 
 	$t_tag_counts = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {

--- a/core/timeline_api.php
+++ b/core/timeline_api.php
@@ -39,7 +39,7 @@ require_api( 'history_api.php' );
  */
 function timeline_get_affected_issues( $p_start_time, $p_end_time ) {
 	$t_query = 'SELECT DISTINCT(bug_id) from {bug_history} WHERE date_modified >= ' . db_param() . ' AND date_modified < ' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_start_time, $p_end_time ) );
+	$t_result = db_query( $t_query, array( $p_start_time, $p_end_time ) );
 
 	$t_current_project = helper_get_current_project();
 

--- a/core/tokens_api.php
+++ b/core/tokens_api.php
@@ -45,7 +45,7 @@ $g_tokens_purged = false;
  */
 function token_exists( $p_token_id ) {
 	$t_query = 'SELECT id FROM {tokens} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_token_id ), 1 );
+	$t_result = db_query( $t_query, array( $p_token_id ), 1 );
 
 	$t_row = db_fetch_array( $t_result );
 	if( $t_row ) {
@@ -80,7 +80,7 @@ function token_get( $p_type, $p_user_id = null ) {
 	$c_user_id = (int)( $p_user_id == null ? auth_get_current_user_id() : $p_user_id );
 
 	$t_query = 'SELECT * FROM {tokens} WHERE type=' . db_param() . ' AND owner=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $c_type, $c_user_id ) );
+	$t_result = db_query( $t_query, array( $c_type, $c_user_id ) );
 
 	$t_row = db_fetch_array( $t_result );
 	if( $t_row ) {
@@ -135,7 +135,7 @@ function token_touch( $p_token_id, $p_expiry = TOKEN_EXPIRY ) {
 
 	$c_token_expiry = time() + $p_expiry;
 	$t_query = 'UPDATE {tokens} SET expiry=' . db_param() . ' WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $c_token_expiry, $p_token_id ) );
+	db_query( $t_query, array( $c_token_expiry, $p_token_id ) );
 }
 
 /**
@@ -152,7 +152,7 @@ function token_delete( $p_type, $p_user_id = null ) {
 	}
 
 	$t_query = 'DELETE FROM {tokens} WHERE type=' . db_param() . ' AND owner=' . db_param();
-	db_query_bound( $t_query, array( $p_type, $c_user_id ) );
+	db_query( $t_query, array( $p_type, $c_user_id ) );
 }
 
 /**
@@ -168,7 +168,7 @@ function token_delete_by_owner( $p_user_id = null ) {
 	}
 
 	$t_query = 'DELETE FROM {tokens} WHERE owner=' . db_param();
-	db_query_bound( $t_query, array( $c_user_id ) );
+	db_query( $t_query, array( $c_user_id ) );
 }
 
 /**
@@ -193,7 +193,7 @@ function token_create( $p_type, $p_value, $p_expiry = TOKEN_EXPIRY, $p_user_id =
 	$t_query = 'INSERT INTO {tokens}
 					( type, value, timestamp, expiry, owner )
 					VALUES ( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
-	db_query_bound( $t_query, array( $c_type, (string)$p_value, $c_timestamp, $c_expiry, $c_user_id ) );
+	db_query( $t_query, array( $c_type, (string)$p_value, $c_timestamp, $c_expiry, $c_user_id ) );
 	return db_insert_id( db_get_table( 'tokens' ) );
 }
 
@@ -212,7 +212,7 @@ function token_update( $p_token_id, $p_value, $p_expiry = TOKEN_EXPIRY ) {
 	$t_query = 'UPDATE {tokens}
 					SET value=' . db_param() . ', expiry=' . db_param() . '
 					WHERE id=' . db_param();
-	db_query_bound( $t_query, array( (string)$p_value, $c_expiry, $c_token_id ) );
+	db_query( $t_query, array( (string)$p_value, $c_expiry, $c_token_id ) );
 
 	return true;
 }
@@ -224,7 +224,7 @@ function token_update( $p_token_id, $p_value, $p_expiry = TOKEN_EXPIRY ) {
  */
 function token_delete_by_type( $p_token_type ) {
 	$t_query = 'DELETE FROM {tokens} WHERE type=' . db_param();
-	db_query_bound( $t_query, array( $p_token_type ) );
+	db_query( $t_query, array( $p_token_type ) );
 
 	return true;
 }
@@ -240,9 +240,9 @@ function token_purge_expired( $p_token_type = null ) {
 	$t_query = 'DELETE FROM {tokens} WHERE ' . db_param() . ' > expiry';
 	if( !is_null( $p_token_type ) ) {
 		$t_query .= ' AND type=' . db_param();
-		db_query_bound( $t_query, array( db_now(), (int)$p_token_type ) );
+		db_query( $t_query, array( db_now(), (int)$p_token_type ) );
 	} else {
-		db_query_bound( $t_query, array( db_now() ) );
+		db_query( $t_query, array( db_now() ) );
 	}
 
 	$g_tokens_purged = true;

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -79,7 +79,7 @@ function user_cache_row( $p_user_id, $p_trigger_errors = true ) {
 	}
 
 	$t_query = 'SELECT * FROM {user} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_user_id ) );
+	$t_result = db_query( $t_query, array( $p_user_id ) );
 
 	if( 0 == db_num_rows( $t_result ) ) {
 		$g_cache_user[$p_user_id] = false;
@@ -120,7 +120,7 @@ function user_cache_array_rows( array $p_user_id_array ) {
 	}
 
 	$t_query = 'SELECT * FROM {user} WHERE id IN (' . implode( ',', $c_user_id_array ) . ')';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$g_cache_user[(int)$t_row['id']] = $t_row;
@@ -237,7 +237,7 @@ function user_ensure_exists( $p_user_id ) {
  */
 function user_is_name_unique( $p_username ) {
 	$t_query = 'SELECT username FROM {user} WHERE username=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_username ), 1 );
+	$t_result = db_query( $t_query, array( $p_username ), 1 );
 
 	if( db_num_rows( $t_result ) > 0 ) {
 		return false;
@@ -287,7 +287,7 @@ function user_is_realname_unique( $p_username, $p_realname ) {
 
 		# check to see if the realname is unique
 		$t_query = 'SELECT id FROM {user} WHERE realname=' . db_param();
-		$t_result = db_query_bound( $t_query, array( $p_realname ) );
+		$t_result = db_query( $t_query, array( $p_realname ) );
 
 		$t_users = array();
 		while( $t_row = db_fetch_array( $t_result ) ) {
@@ -369,7 +369,7 @@ function user_is_monitoring_bug( $p_user_id, $p_bug_id ) {
 	$t_query = 'SELECT COUNT(*) FROM {bug_monitor}
 				  WHERE user_id=' . db_param() . ' AND bug_id=' . db_param();
 
-	$t_result = db_query_bound( $t_query, array( (int)$p_user_id, (int)$p_bug_id ) );
+	$t_result = db_query( $t_query, array( (int)$p_user_id, (int)$p_bug_id ) );
 
 	if( 0 == db_result( $t_result ) ) {
 		return false;
@@ -460,7 +460,7 @@ function user_is_enabled( $p_user_id ) {
  */
 function user_count_level( $p_level = ANYBODY ) {
 	$t_query = 'SELECT COUNT(id) FROM {user} WHERE access_level>=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_level ) );
+	$t_result = db_query( $t_query, array( $p_level ) );
 
 	# Get the list of connected users
 	$t_users = db_result( $t_result );
@@ -489,7 +489,7 @@ function user_get_logged_in_user_ids( $p_session_duration_in_minutes ) {
 
 	# Execute query
 	$t_query = 'SELECT id FROM {user} WHERE last_visit > ' . db_param();
-	$t_result = db_query_bound( $t_query, array( $t_last_timestamp_threshold ), 1 );
+	$t_result = db_query( $t_query, array( $t_last_timestamp_threshold ), 1 );
 
 	# Get the list of connected users
 	$t_users_connected = array();
@@ -538,7 +538,7 @@ function user_create( $p_username, $p_password, $p_email = '',
 				  VALUES
 				    ( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param()  . ',
 				     ' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ', ' . db_param() . ')';
-	db_query_bound( $t_query, array( $p_username, $p_email, $t_password, db_now(), db_now(), $c_enabled, (int)$p_access_level, 0, $t_cookie_string, $p_realname ) );
+	db_query( $t_query, array( $p_username, $p_email, $t_password, db_now(), db_now(), $c_enabled, (int)$p_access_level, 0, $t_cookie_string, $p_realname ) );
 
 	# Create preferences for the user
 	$t_user_id = db_insert_id( db_get_table( 'user' ) );
@@ -610,7 +610,7 @@ function user_delete_project_specific_access_levels( $p_user_id ) {
 	user_ensure_unprotected( $p_user_id );
 
 	$t_query = 'DELETE FROM {project_user_list} WHERE user_id=' . db_param();
-	db_query_bound( $t_query, array( (int)$p_user_id ) );
+	db_query( $t_query, array( (int)$p_user_id ) );
 
 	user_clear_cache( $p_user_id );
 
@@ -628,7 +628,7 @@ function user_delete_profiles( $p_user_id ) {
 
 	# Remove associated profiles
 	$t_query = 'DELETE FROM {user_profile} WHERE user_id=' . db_param();
-	db_query_bound( $t_query, array( (int)$p_user_id ) );
+	db_query( $t_query, array( (int)$p_user_id ) );
 
 	user_clear_cache( $p_user_id );
 
@@ -660,7 +660,7 @@ function user_delete( $p_user_id ) {
 	if( config_get( 'differentiate_duplicates' ) ) {
 		$c_realname = user_get_field( $p_user_id, 'realname' );
 		$t_query = 'SELECT id FROM {user} WHERE realname=' . db_param();
-		$t_result = db_query_bound( $t_query, array( $c_realname ) );
+		$t_result = db_query( $t_query, array( $c_realname ) );
 
 		$t_users = array();
 		while( $t_row = db_fetch_array( $t_result ) ) {
@@ -682,7 +682,7 @@ function user_delete( $p_user_id ) {
 
 	# Remove account
 	$t_query = 'DELETE FROM {user} WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $c_user_id ) );
+	db_query( $t_query, array( $c_user_id ) );
 
 	return true;
 }
@@ -700,7 +700,7 @@ function user_get_id_by_name( $p_username ) {
 	}
 
 	$t_query = 'SELECT * FROM {user} WHERE username=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_username ) );
+	$t_result = db_query( $t_query, array( $p_username ) );
 
 	$t_row = db_fetch_array( $t_result );
 	if( $t_row ) {
@@ -723,7 +723,7 @@ function user_get_id_by_email( $p_email ) {
 	}
 
 	$t_query = 'SELECT * FROM {user} WHERE email=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_email ) );
+	$t_result = db_query( $t_query, array( $p_email ) );
 
 	$t_row = db_fetch_array( $t_result );
 	if( $t_row ) {
@@ -747,7 +747,7 @@ function user_get_id_by_realname( $p_realname ) {
 	}
 
 	$t_query = 'SELECT * FROM {user} WHERE realname=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_realname ) );
+	$t_result = db_query( $t_query, array( $p_realname ) );
 
 	$t_row = db_fetch_array( $t_result );
 
@@ -982,7 +982,7 @@ function user_get_accessible_projects( $p_user_id, $p_show_disabled = false ) {
 								    AND
 							        u.user_id=' . db_param() . ' )
 							) ORDER BY p.name';
-		$t_result = db_query_bound( $t_query, ( $p_show_disabled ? array( $p_user_id, $t_public, $t_private, $p_user_id ) : array( $p_user_id, true, $t_public, $t_private, $p_user_id ) ) );
+		$t_result = db_query( $t_query, ( $p_show_disabled ? array( $p_user_id, $t_public, $t_private, $p_user_id ) : array( $p_user_id, true, $t_public, $t_private, $p_user_id ) ) );
 
 		$t_projects = array();
 
@@ -1040,7 +1040,7 @@ function user_get_accessible_subprojects( $p_user_id, $p_project_id, $p_show_dis
 					  WHERE ' . $t_enabled_clause . '
 					  	 ph.parent_id IS NOT NULL
 					  ORDER BY p.name';
-		$t_result = db_query_bound( $t_query, ( $p_show_disabled ? array() : array( true ) ) );
+		$t_result = db_query( $t_query, ( $p_show_disabled ? array() : array( true ) ) );
 	} else {
 		$t_query = 'SELECT DISTINCT p.id, p.name, ph.parent_id
 					  FROM {project} p
@@ -1061,7 +1061,7 @@ function user_get_accessible_subprojects( $p_user_id, $p_project_id, $p_show_dis
 			# Insert enabled flag value in 2nd position of parameter array
 			array_splice( $t_param, 1, 0, true );
 		}
-		$t_result = db_query_bound( $t_query, $t_param );
+		$t_result = db_query( $t_query, $t_param );
 	}
 
 	$t_projects = array();
@@ -1157,7 +1157,7 @@ function user_get_assigned_projects( $p_user_id ) {
 				WHERE p.enabled = \'1\' AND
 					u.user_id=' . db_param() . '
 				ORDER BY p.name';
-	$t_result = db_query_bound( $t_query, array( $p_user_id ) );
+	$t_result = db_query( $t_query, array( $p_user_id ) );
 	$t_projects = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_project_id = $t_row['id'];
@@ -1187,7 +1187,7 @@ function user_get_unassigned_by_project_id( $p_project_id = null ) {
 					u.enabled = ' . db_param() . ' AND
 					p.user_id IS NULL
 				ORDER BY u.realname, u.username';
-	$t_result = db_query_bound( $t_query, array( $p_project_id, $t_adm, true ) );
+	$t_result = db_query( $t_query, array( $p_project_id, $t_adm, true ) );
 	$t_display = array();
 	$t_sort = array();
 	$t_users = array();
@@ -1236,7 +1236,7 @@ function user_get_assigned_open_bug_count( $p_user_id, $p_project_id = ALL_PROJE
 				  WHERE ' . $t_where_prj . '
 						status<' . db_param() . ' AND
 						handler_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $t_resolved, $p_user_id ) );
+	$t_result = db_query( $t_query, array( $t_resolved, $p_user_id ) );
 
 	return db_result( $t_result );
 }
@@ -1257,7 +1257,7 @@ function user_get_reported_open_bug_count( $p_user_id, $p_project_id = ALL_PROJE
 				  WHERE ' . $t_where_prj . '
 						  status<' . db_param() . ' AND
 						  reporter_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $t_resolved, $p_user_id ) );
+	$t_result = db_query( $t_query, array( $t_resolved, $p_user_id ) );
 
 	return db_result( $t_result );
 }
@@ -1273,7 +1273,7 @@ function user_get_profile_row( $p_user_id, $p_profile_id ) {
 	$t_query = 'SELECT * FROM {user_profile}
 				  WHERE id=' . db_param() . ' AND
 						user_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_profile_id, $p_user_id ) );
+	$t_result = db_query( $t_query, array( $p_profile_id, $p_user_id ) );
 
 	$t_row = db_fetch_array( $t_result );
 
@@ -1352,7 +1352,7 @@ function user_update_last_visit( $p_user_id ) {
 
 	$t_query = 'UPDATE {user} SET last_visit=' . db_param() . ' WHERE id=' . db_param();
 
-	db_query_bound( $t_query, array( $c_value, $c_user_id ) );
+	db_query( $t_query, array( $c_value, $c_user_id ) );
 
 	user_update_cache( $c_user_id, 'last_visit', $c_value );
 
@@ -1369,7 +1369,7 @@ function user_update_last_visit( $p_user_id ) {
 function user_increment_login_count( $p_user_id ) {
 	$t_query = 'UPDATE {user} SET login_count=login_count+1 WHERE id=' . db_param();
 
-	db_query_bound( $t_query, array( (int)$p_user_id ) );
+	db_query( $t_query, array( (int)$p_user_id ) );
 
 	user_clear_cache( $p_user_id );
 
@@ -1384,7 +1384,7 @@ function user_increment_login_count( $p_user_id ) {
  */
 function user_reset_failed_login_count_to_zero( $p_user_id ) {
 	$t_query = 'UPDATE {user} SET failed_login_count=0 WHERE id=' . db_param();
-	db_query_bound( $t_query, array( (int)$p_user_id ) );
+	db_query( $t_query, array( (int)$p_user_id ) );
 
 	user_clear_cache( $p_user_id );
 
@@ -1399,7 +1399,7 @@ function user_reset_failed_login_count_to_zero( $p_user_id ) {
  */
 function user_increment_failed_login_count( $p_user_id ) {
 	$t_query = 'UPDATE {user} SET failed_login_count=failed_login_count+1 WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $p_user_id ) );
+	db_query( $t_query, array( $p_user_id ) );
 
 	user_clear_cache( $p_user_id );
 
@@ -1414,7 +1414,7 @@ function user_increment_failed_login_count( $p_user_id ) {
  */
 function user_reset_lost_password_in_progress_count_to_zero( $p_user_id ) {
 	$t_query = 'UPDATE {user} SET lost_password_request_count=0 WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $p_user_id ) );
+	db_query( $t_query, array( $p_user_id ) );
 
 	user_clear_cache( $p_user_id );
 
@@ -1431,7 +1431,7 @@ function user_increment_lost_password_in_progress_count( $p_user_id ) {
 	$t_query = 'UPDATE {user}
 				SET lost_password_request_count=lost_password_request_count+1
 				WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $p_user_id ) );
+	db_query( $t_query, array( $p_user_id ) );
 
 	user_clear_cache( $p_user_id );
 
@@ -1468,7 +1468,7 @@ function user_set_fields( $p_user_id, array $p_fields ) {
 	$t_query .= ' WHERE id=' . db_param();
 	array_push( $t_parameters, (int)$p_user_id );
 
-	db_query_bound( $t_query, $t_parameters );
+	db_query( $t_query, $t_parameters );
 
 	user_clear_cache( $p_user_id );
 }
@@ -1519,7 +1519,7 @@ function user_set_password( $p_user_id, $p_password, $p_allow_protected = false 
 	$t_query = 'UPDATE {user}
 				  SET password=' . db_param() . ', cookie_string=' . db_param() . '
 				  WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $c_password, $c_cookie_string, (int)$p_user_id ) );
+	db_query( $t_query, array( $c_password, $c_cookie_string, (int)$p_user_id ) );
 
 	return true;
 }

--- a/core/user_pref_api.php
+++ b/core/user_pref_api.php
@@ -305,7 +305,7 @@ function user_pref_cache_row( $p_user_id, $p_project_id = ALL_PROJECTS, $p_trigg
 	}
 
 	$t_query = 'SELECT * FROM {user_pref} WHERE user_id=' . db_param() . ' AND project_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( (int)$p_user_id, (int)$p_project_id ) );
+	$t_result = db_query( $t_query, array( (int)$p_user_id, (int)$p_project_id ) );
 
 	$t_row = db_fetch_array( $t_result );
 
@@ -351,7 +351,7 @@ function user_pref_cache_array_rows( array $p_user_id_array, $p_project_id = ALL
 
 	$t_query = 'SELECT * FROM {user_pref} WHERE user_id IN (' . implode( ',', $c_user_id_array ) . ') AND project_id=' . db_param();
 
-	$t_result = db_query_bound( $t_query, array( (int)$p_project_id ) );
+	$t_result = db_query( $t_query, array( (int)$p_project_id ) );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		if( !isset( $g_cache_user_pref[(int)$t_row['user_id']] ) ) {
@@ -439,7 +439,7 @@ function user_pref_insert( $p_user_id, $p_project_id, UserPreferences $p_prefs )
 
 	$t_query = 'INSERT INTO {user_pref}
 			  (user_id, project_id, ' . $t_vars_string . ') VALUES ( ' . $t_params_string . ')';
-	db_query_bound( $t_query, $t_values );
+	db_query( $t_query, $t_values );
 
 	return true;
 }
@@ -474,7 +474,7 @@ function user_pref_update( $p_user_id, $p_project_id, UserPreferences $p_prefs )
 
 	$t_query = 'UPDATE {user_pref} SET ' . $t_pairs_string . '
 				  WHERE user_id=' . db_param() . ' AND project_id=' . db_param();
-	db_query_bound( $t_query, $t_values );
+	db_query( $t_query, $t_values );
 
 	user_pref_clear_cache( $p_user_id, $p_project_id );
 }
@@ -492,7 +492,7 @@ function user_pref_delete( $p_user_id, $p_project_id = ALL_PROJECTS ) {
 	$t_query = 'DELETE FROM {user_pref}
 				  WHERE user_id=' . db_param() . ' AND
 				  		project_id=' . db_param();
-	db_query_bound( $t_query, array( $p_user_id, $p_project_id ) );
+	db_query( $t_query, array( $p_user_id, $p_project_id ) );
 
 	user_pref_clear_cache( $p_user_id, $p_project_id );
 }
@@ -511,7 +511,7 @@ function user_pref_delete_all( $p_user_id ) {
 	user_ensure_unprotected( $p_user_id );
 
 	$t_query = 'DELETE FROM {user_pref} WHERE user_id=' . db_param();
-	db_query_bound( $t_query, array( $p_user_id ) );
+	db_query( $t_query, array( $p_user_id ) );
 
 	user_pref_clear_cache( $p_user_id );
 }
@@ -527,7 +527,7 @@ function user_pref_delete_all( $p_user_id ) {
  */
 function user_pref_delete_project( $p_project_id ) {
 	$t_query = 'DELETE FROM {user_pref} WHERE project_id=' . db_param();
-	db_query_bound( $t_query, array( $p_project_id ) );
+	db_query( $t_query, array( $p_project_id ) );
 }
 
 /**

--- a/core/version_api.php
+++ b/core/version_api.php
@@ -137,7 +137,7 @@ function version_cache_row( $p_version_id, $p_trigger_errors = true ) {
 	}
 
 	$t_query = 'SELECT * FROM {project_version} WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $c_version_id ) );
+	$t_result = db_query( $t_query, array( $c_version_id ) );
 
 	$t_row = db_fetch_array( $t_result );
 
@@ -232,7 +232,7 @@ function version_add( $p_project_id, $p_version, $p_released = VERSION_FUTURE, $
 					( project_id, version, date_order, description, released, obsolete )
 				  VALUES
 					(' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
-	db_query_bound( $t_query, array( $c_project_id, $p_version, $c_date_order, $p_description, $c_released, $c_obsolete ) );
+	db_query( $t_query, array( $c_project_id, $p_version, $c_date_order, $p_description, $c_released, $c_obsolete ) );
 
 	$t_version_id = db_insert_id( db_get_table( 'project_version' ) );
 
@@ -270,7 +270,7 @@ function version_update( VersionData $p_version_info ) {
 					date_order=' . db_param() . ',
 					obsolete=' . db_param() . '
 				  WHERE id=' . db_param();
-	db_query_bound( $t_query, array( $c_version_name, $c_description, $c_released, $c_date_order, $c_obsolete, $c_version_id ) );
+	db_query( $t_query, array( $c_version_name, $c_description, $c_released, $c_date_order, $c_obsolete, $c_version_id ) );
 
 	if( $c_version_name != $c_old_version_name ) {
 		$t_project_list = array( $c_project_id );
@@ -281,29 +281,29 @@ function version_update( VersionData $p_version_info ) {
 
 		$t_query = 'UPDATE {bug} SET version=' . db_param() .
 				 ' WHERE ( project_id IN ( ' . $t_project_list . ' ) ) AND ( version=' . db_param() . ')';
-		db_query_bound( $t_query, array( $c_version_name, $c_old_version_name ) );
+		db_query( $t_query, array( $c_version_name, $c_old_version_name ) );
 
 		$t_query = 'UPDATE {bug} SET fixed_in_version=' . db_param() . '
 					  WHERE ( project_id IN ( ' . $t_project_list . ' ) ) AND ( fixed_in_version=' . db_param() . ')';
-		db_query_bound( $t_query, array( $c_version_name, $c_old_version_name ) );
+		db_query( $t_query, array( $c_version_name, $c_old_version_name ) );
 
 		$t_query = 'UPDATE {bug} SET target_version=' . db_param() . '
 					  WHERE ( project_id IN ( ' . $t_project_list . ' ) ) AND ( target_version=' . db_param() . ')';
-		db_query_bound( $t_query, array( $c_version_name, $c_old_version_name ) );
+		db_query( $t_query, array( $c_version_name, $c_old_version_name ) );
 
 		$t_query = 'UPDATE {bug_history}
 			SET old_value='.db_param().'
 			WHERE field_name IN (\'version\',\'fixed_in_version\',\'target_version\')
 				AND old_value='.db_param().'
 				AND bug_id IN (SELECT id FROM {bug} WHERE project_id IN ( ' . $t_project_list . ' ))';
-		db_query_bound( $t_query, array( $c_version_name, $c_old_version_name ) );
+		db_query( $t_query, array( $c_version_name, $c_old_version_name ) );
 
 		$t_query = 'UPDATE {bug_history}
 			SET new_value='.db_param().'
 			WHERE field_name IN (\'version\',\'fixed_in_version\',\'target_version\')
 				AND new_value='.db_param().'
 				AND bug_id IN (SELECT id FROM {bug} WHERE project_id IN ( ' . $t_project_list . ' ))';
-		db_query_bound( $t_query, array( $c_version_name, $c_old_version_name ) );
+		db_query( $t_query, array( $c_version_name, $c_old_version_name ) );
 
 		# @todo We should consider using ids instead of names for foreign keys.  The main advantage of using the names are:
 		#		- for history the version history entries will still be valid even if the version is deleted in the future. --  we can ban deleting referenced versions.
@@ -325,7 +325,7 @@ function version_remove( $p_version_id, $p_new_version = '' ) {
 	$t_project_id = version_get_field( $p_version_id, 'project_id' );
 
 	$t_query = 'DELETE FROM {project_version} WHERE id=' . db_param();
-	db_query_bound( $t_query, array( (int)$p_version_id ) );
+	db_query( $t_query, array( (int)$p_version_id ) );
 
 	$t_project_list = array( $t_project_id );
 	if( config_get( 'subprojects_inherit_versions' ) ) {
@@ -335,15 +335,15 @@ function version_remove( $p_version_id, $p_new_version = '' ) {
 
 	$t_query = 'UPDATE {bug} SET version=' . db_param() . '
 				  WHERE project_id IN ( ' . $t_project_list . ' ) AND version=' . db_param();
-	db_query_bound( $t_query, array( $p_new_version, $t_old_version ) );
+	db_query( $t_query, array( $p_new_version, $t_old_version ) );
 
 	$t_query = 'UPDATE {bug} SET fixed_in_version=' . db_param() . '
 				  WHERE ( project_id IN ( ' . $t_project_list . ' ) ) AND ( fixed_in_version=' . db_param() . ')';
-	db_query_bound( $t_query, array( $p_new_version, $t_old_version ) );
+	db_query( $t_query, array( $p_new_version, $t_old_version ) );
 
 	$t_query = 'UPDATE {bug} SET target_version=' . db_param() . '
 				  WHERE ( project_id IN ( ' . $t_project_list . ' ) ) AND ( target_version=' . db_param() . ')';
-	db_query_bound( $t_query, array( $p_new_version, $t_old_version ) );
+	db_query( $t_query, array( $p_new_version, $t_old_version ) );
 }
 
 /**
@@ -358,11 +358,11 @@ function version_remove_all( $p_project_id ) {
 	$t_query = 'UPDATE {bug}
 				  SET version=\'\', fixed_in_version=\'\', target_version=\'\'
 				  WHERE project_id=' . db_param();
-	db_query_bound( $t_query, array( $c_project_id ) );
+	db_query( $t_query, array( $c_project_id ) );
 
 	# remove the actual versions associated with the project.
 	$t_query = 'DELETE FROM {project_version} WHERE project_id=' . db_param();
-	db_query_bound( $t_query, array( $c_project_id ) );
+	db_query( $t_query, array( $c_project_id ) );
 
 	return true;
 }
@@ -393,7 +393,7 @@ function version_cache_array_rows( array $p_project_id_array ) {
 	$t_query = 'SELECT * FROM {project_version}
 				  WHERE project_id IN (' . implode( ',', $c_project_id_array ) . ')
 				  ORDER BY date_order DESC';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 
 	$t_rows = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -467,7 +467,7 @@ function version_get_all_rows( $p_project_id, $p_released = null, $p_obsolete = 
 
 	$t_query .= ' ORDER BY date_order DESC';
 
-	$t_result = db_query_bound( $t_query, $t_query_params );
+	$t_result = db_query( $t_query, $t_query_params );
 	$t_rows = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$g_cache_versions[(int)$t_row['id']] = $t_row;
@@ -507,7 +507,7 @@ function version_get_all_rows_with_subs( $p_project_id, $p_released = null, $p_o
 	$t_query = 'SELECT * FROM {project_version}
 				  WHERE ' . $t_project_where . ' ' . $t_released_where . ' ' . $t_obsolete_where . '
 				  ORDER BY date_order DESC';
-	$t_result = db_query_bound( $t_query, $t_query_params );
+	$t_result = db_query( $t_query, $t_query_params );
 	$t_rows = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_rows[] = $t_row;
@@ -542,7 +542,7 @@ function version_get_id( $p_version, $p_project_id = null, $p_inherit = null ) {
 
 	$t_query = 'SELECT id FROM {project_version} WHERE ' . $t_project_where . ' AND version=' . db_param();
 
-	$t_result = db_query_bound( $t_query, array( $p_version ) );
+	$t_result = db_query( $t_query, array( $p_version ) );
 
 	if( $t_row = db_result( $t_result ) ) {
 		return $t_row;

--- a/file_download.php
+++ b/file_download.php
@@ -89,7 +89,7 @@ switch( $f_type ) {
 	default:
 		access_denied();
 }
-$t_result = db_query_bound( $t_query, array( $c_file_id ) );
+$t_result = db_query( $t_query, array( $c_file_id ) );
 $t_row = db_fetch_array( $t_result );
 extract( $t_row, EXTR_PREFIX_ALL, 'v' );
 

--- a/lost_pwd.php
+++ b/lost_pwd.php
@@ -73,7 +73,7 @@ email_ensure_valid( $f_email );
 
 # @todo Consider moving this query to user_api.php
 $t_query = 'SELECT id FROM {user} WHERE username = ' . db_param() . ' AND email = ' . db_param() . ' AND enabled=' . db_param();
-$t_result = db_query_bound( $t_query, array( $f_username, $f_email, true ) );
+$t_result = db_query( $t_query, array( $f_username, $f_email, true ) );
 
 if( 0 == db_num_rows( $t_result ) ) {
 	trigger_error( ERROR_LOST_PASSWORD_NOT_MATCHING_DATA, ERROR );

--- a/manage_plugin_update.php
+++ b/manage_plugin_update.php
@@ -49,7 +49,7 @@ auth_reauthenticate();
 access_ensure_global_level( config_get( 'manage_plugin_threshold' ) );
 
 $t_query = 'SELECT basename FROM {plugin}';
-$t_result = db_query_bound( $t_query );
+$t_result = db_query( $t_query );
 
 while( $t_row = db_fetch_array( $t_result ) ) {
 	$t_basename = $t_row['basename'];
@@ -66,7 +66,7 @@ while( $t_row = db_fetch_array( $t_result ) ) {
 	$t_query = 'UPDATE {plugin} SET priority=' . db_param() . ', protected=' . db_param() .
 		' WHERE basename=' . db_param();
 
-	db_query_bound( $t_query, array( $f_priority, $f_protected, $t_basename ) );
+	db_query( $t_query, array( $f_priority, $f_protected, $t_basename ) );
 }
 
 form_security_purge( 'manage_plugin_update' );

--- a/manage_proj_cat_delete.php
+++ b/manage_proj_cat_delete.php
@@ -68,14 +68,14 @@ access_ensure_project_level( config_get( 'manage_project_threshold' ), $t_projec
 # Protect the 'default category for moves' from deletion
 $t_default_cat = 'default_category_for_moves';
 $t_query = 'SELECT count(config_id) FROM {config} WHERE config_id = ' . db_param() . ' AND value = ' . db_param();
-$t_default_cat_count = db_result( db_query_bound( $t_query, array( $t_default_cat, $f_category_id ) ) );
+$t_default_cat_count = db_result( db_query( $t_query, array( $t_default_cat, $f_category_id ) ) );
 if( $t_default_cat_count > 0 || $f_category_id == config_get_global( $t_default_cat ) ) {
 	trigger_error( ERROR_CATEGORY_CANNOT_DELETE_DEFAULT, ERROR );
 }
 
 # Get a bug count
 $t_query = 'SELECT COUNT(id) FROM {bug} WHERE category_id=' . db_param();
-$t_bug_count = db_result( db_query_bound( $t_query, array( $f_category_id ) ) );
+$t_bug_count = db_result( db_query( $t_query, array( $f_category_id ) ) );
 
 # Confirm with the user
 helper_ensure_confirmed( sprintf( lang_get( 'category_delete_sure_msg' ), string_display_line( $t_name ), $t_bug_count ),

--- a/manage_user_page.php
+++ b/manage_user_page.php
@@ -125,7 +125,7 @@ print_manage_menu( 'manage_user_page.php' );
 $t_days_old = 7 * SECONDS_PER_DAY;
 $t_query = 'SELECT COUNT(*) AS new_user_count FROM {user}
 	WHERE '.db_helper_compare_days( (string)db_now(), 'date_created', '<= ' . $t_days_old );
-$t_result = db_query_bound( $t_query );
+$t_result = db_query( $t_query );
 $t_row = db_fetch_array( $t_result );
 $t_new_user_count = $t_row['new_user_count'];
 
@@ -133,7 +133,7 @@ $t_new_user_count = $t_row['new_user_count'];
 
 $t_query = 'SELECT COUNT(*) AS unused_user_count FROM {user}
 	WHERE ( login_count = 0 ) AND ( date_created = last_visit )';
-$t_result = db_query_bound( $t_query );
+$t_result = db_query( $t_query );
 $t_row = db_fetch_array( $t_result );
 $t_unused_user_count = $t_row['unused_user_count'];
 
@@ -207,14 +207,14 @@ if( 1 == $c_show_disabled ) {
 
 if( 0 == $c_hide_inactive ) {
 	$t_query = 'SELECT count(*) as user_count FROM {user} WHERE ' . $t_where . $t_show_disabled_cond;
-	$t_result = db_query_bound( $t_query, $t_where_params );
+	$t_result = db_query( $t_query, $t_where_params );
 	$t_row = db_fetch_array( $t_result );
 	$t_total_user_count = $t_row['user_count'];
 } else {
 	$t_query = 'SELECT count(*) as user_count FROM {user}
 			WHERE ' . $t_where . ' AND ' . db_helper_compare_days( '' . db_now() . '', 'last_visit', '< ' . $t_days_old )
 			. $t_show_disabled_cond;
-	$t_result = db_query_bound( $t_query, $t_where_params );
+	$t_result = db_query( $t_query, $t_where_params );
 	$t_row = db_fetch_array( $t_result );
 	$t_total_user_count = $t_row['user_count'];
 }
@@ -237,12 +237,12 @@ if( $f_page_number < 1 ) {
 
 if( 0 == $c_hide_inactive ) {
 	$t_query = 'SELECT * FROM {user} WHERE ' . $t_where . ' ' . $t_show_disabled_cond . ' ORDER BY ' . $c_sort . ' ' . $c_dir;
-	$t_result = db_query_bound( $t_query, $t_where_params, $p_per_page, $t_offset );
+	$t_result = db_query( $t_query, $t_where_params, $p_per_page, $t_offset );
 } else {
 	$t_query = 'SELECT * FROM {user}
 			WHERE ' . $t_where . ' AND ' . db_helper_compare_days( '' . db_now() . '', 'last_visit', '< ' . $t_days_old ) . '
 			' . $t_show_disabled_cond . ' ORDER BY ' . $c_sort . ' ' . $c_dir;
-	$t_result = db_query_bound( $t_query, $t_where_params, $p_per_page, $t_offset );
+	$t_result = db_query( $t_query, $t_where_params, $p_per_page, $t_offset );
 }
 
 $t_users = array();

--- a/manage_user_prune.php
+++ b/manage_user_prune.php
@@ -59,7 +59,7 @@ $t_days_old = (int)7 * SECONDS_PER_DAY;
 
 $t_query = 'SELECT id, access_level FROM {user}
 		WHERE ( login_count = 0 ) AND ( date_created = last_visit ) AND ' . db_helper_compare_days( 0, 'date_created', '> ' . $t_days_old );
-$t_result = db_query_bound( $t_query, array( db_now() ) );
+$t_result = db_query( $t_query, array( db_now() ) );
 
 if( !$t_result ) {
 	trigger_error( ERROR_GENERIC, ERROR );

--- a/manage_user_update.php
+++ b/manage_user_update.php
@@ -172,7 +172,7 @@ if( $f_protected && $t_old_protected ) {
 	$t_query_params = array( $c_username, $c_email, $c_access_level, $c_enabled, $c_protected, $c_realname, $c_user_id );
 }
 
-$t_result = db_query_bound( $t_query, $t_query_params );
+$t_result = db_query( $t_query, $t_query_params );
 
 if( $f_send_email_notification ) {
 	lang_push( user_pref_get_language( $f_user_id ) );

--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -633,7 +633,7 @@ function create_bug_enum_summary( $p_enum_string, $p_enum ) {
 
 	foreach ( $t_assoc_array as $t_value => $t_label ) {
 		$t_query = 'SELECT COUNT(*) FROM {bug} WHERE ' . $p_enum . '=' . db_param() . ' ' . $t_specific_where;
-		$t_result = db_query_bound( $t_query, array( $t_value ) );
+		$t_result = db_query( $t_query, array( $t_value ) );
 		$t_metrics[$t_label] = db_result( $t_result, 0 );
 	}
 
@@ -664,14 +664,14 @@ function enum_bug_group( $p_enum_string, $p_enum ) {
 		$t_query = 'SELECT COUNT(*) FROM {bug}
 					WHERE ' . $p_enum . '=' . db_param() . ' AND
 						status<' . db_param() . ' ' . $t_specific_where;
-		$t_result2 = db_query_bound( $t_query, array( $t_value, $t_res_val ) );
+		$t_result2 = db_query( $t_query, array( $t_value, $t_res_val ) );
 		$t_metrics['open'][$t_label] = db_result( $t_result2, 0, 0 );
 
 		# Calculates the number of bugs closed and puts the results in a table
 		$t_query = 'SELECT COUNT(*) FROM {bug}
 					WHERE ' . $p_enum . '=' . db_param() . ' AND
 						status>=' . db_param() . ' ' . $t_specific_where;
-		$t_result2 = db_query_bound( $t_query, array( $t_value, $t_clo_val ) );
+		$t_result2 = db_query( $t_query, array( $t_value, $t_clo_val ) );
 		$t_metrics['closed'][$t_label] = db_result( $t_result2, 0, 0 );
 
 		# Calculates the number of bugs resolved and puts the results in a table
@@ -679,7 +679,7 @@ function enum_bug_group( $p_enum_string, $p_enum ) {
 					WHERE ' . $p_enum . '=' . db_param() . ' AND
 						status>=' . db_param() . ' AND
 						status<' . db_param() . ' ' . $t_specific_where;
-		$t_result2 = db_query_bound( $t_query, array(  $t_value, $t_res_val, $t_clo_val ) );
+		$t_result2 = db_query( $t_query, array(  $t_value, $t_res_val, $t_clo_val ) );
 		$t_metrics['resolved'][$t_label] = db_result( $t_result2, 0, 0 );
 	}
 
@@ -699,7 +699,7 @@ function create_developer_summary() {
 	$t_clo_val = config_get( 'bug_closed_status_threshold' );
 
 	$t_query = 'SELECT handler_id, status FROM {bug} WHERE handler_id > 0 ' . $t_specific_where;
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 	$t_total_handled = db_num_rows( $t_result );
 
 	$t_handler_arr = array();
@@ -751,7 +751,7 @@ function create_reporter_summary() {
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
 
 	$t_query = 'SELECT reporter_id FROM {bug} WHERE ' . $t_specific_where;
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 	$t_total_reported = db_num_rows( $t_result );
 
 	$t_reporter_arr = array();
@@ -793,7 +793,7 @@ function create_category_summary() {
 	$t_query = 'SELECT id, name FROM {category}
 				WHERE ' . $t_specific_where . ' OR project_id=' . ALL_PROJECTS . '
 				ORDER BY name';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 	$t_category_count = db_num_rows( $t_result );
 
 	$t_metrics = array();
@@ -802,7 +802,7 @@ function create_category_summary() {
 		$t_cat_name = $t_row['name'];
 		$t_cat_id = $t_row['id'];
 		$t_query = 'SELECT COUNT(*) FROM {bug} WHERE category_id=' . db_param() . ' AND ' . $t_specific_where;
-		$t_result2 = db_query_bound( $t_query, array( $t_cat_id ) );
+		$t_result2 = db_query( $t_query, array( $t_cat_id ) );
 		if( isset($t_metrics[$t_cat_name]) ) {
 			$t_metrics[$t_cat_name] = $t_metrics[$t_cat_name] + db_result( $t_result2, 0, 0 );
 		} else {
@@ -829,7 +829,7 @@ function create_cumulative_bydate() {
 
 	# Get all the submitted dates
 	$t_query = 'SELECT date_submitted FROM {bug} WHERE ' . $t_specific_where . ' ORDER BY date_submitted';
-	$t_result = db_query_bound( $t_query );
+	$t_result = db_query( $t_query );
 	$t_bug_count = db_num_rows( $t_result );
 
 	for( $i = 0; $i < $t_bug_count; $i++ ) {
@@ -857,7 +857,7 @@ function create_cumulative_bydate() {
 								AND {bug_history}.field_name = \'status\' )
 						OR {bug_history}.id is NULL )
 			ORDER BY {bug}.id, date_modified ASC';
-	$t_result = db_query_bound( $t_query, array( $t_res_val, (string)$t_res_val ) );
+	$t_result = db_query( $t_query, array( $t_res_val, (string)$t_res_val ) );
 	$t_bug_count = db_num_rows( $t_result );
 
 	$t_last_id = 0;

--- a/plugins/MantisGraph/pages/bug_graph_bycategory.php
+++ b/plugins/MantisGraph/pages/bug_graph_bycategory.php
@@ -105,7 +105,7 @@ $t_select = 'SELECT bug_id, type, field_name, old_value, new_value, date_modifie
 			'(type=' . NORMAL_TYPE . ' and field_name=\'status\') or type='.NEW_BUG.' ) and '.
 			'date_modified >= ' . db_param() .
 		' order by date_modified DESC';
-$t_result = db_query_bound( $t_select, array( $t_start ) );
+$t_result = db_query( $t_select, array( $t_start ) );
 $t_row = db_fetch_array( $t_result );
 
 for( $t_now = time() - $t_incr; $t_now >= $t_start; $t_now -= $t_incr ) {

--- a/plugins/MantisGraph/pages/bug_graph_bystatus.php
+++ b/plugins/MantisGraph/pages/bug_graph_bystatus.php
@@ -99,7 +99,7 @@ $t_select = 'SELECT bug_id, type, old_value, new_value, date_modified FROM {bug_
 	') and ( (type=' . NORMAL_TYPE . ' and field_name=\'status\')
 		or type=' . NEW_BUG . ' ) and date_modified >= ' . db_param() .
 	' order by date_modified DESC';
-$t_result = db_query_bound( $t_select, array( $t_start ) );
+$t_result = db_query( $t_select, array( $t_start ) );
 $t_row = db_fetch_array( $t_result );
 
 for( $t_now = time() - $t_incr; $t_now >= $t_start; $t_now -= $t_incr ) {

--- a/print_all_bug_options_inc.php
+++ b/print_all_bug_options_inc.php
@@ -107,7 +107,7 @@ function edit_printing_prefs( $p_user_id = null, $p_error_if_protected = true, $
 
 	# Grab the data
 	$t_query = 'SELECT print_pref FROM {user_print_pref} WHERE user_id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $p_user_id ) );
+	$t_result = db_query( $t_query, array( $p_user_id ) );
 
 	## OOPS, No entry in the database yet.	Lets make one
 	if( 0 == db_num_rows( $t_result ) ) {
@@ -123,11 +123,11 @@ function edit_printing_prefs( $p_user_id = null, $p_error_if_protected = true, $
 				(user_id, print_pref)
 				VALUES
 				(' . db_param() . ',' . db_param() . ')';
-		db_query_bound( $t_query, array( $p_user_id, $t_default ) );
+		db_query( $t_query, array( $p_user_id, $t_default ) );
 
 		# Rerun select query
 		$t_query = 'SELECT print_pref FROM {user_print_pref} WHERE user_id=' . db_param();
-		$t_result = db_query_bound( $t_query, array( $p_user_id ) );
+		$t_result = db_query( $t_query, array( $p_user_id ) );
 	}
 
 	# putting the query result into an array with the same size as $t_fields_arr

--- a/print_all_bug_options_reset.php
+++ b/print_all_bug_options_reset.php
@@ -71,7 +71,7 @@ $t_default = implode( '', $t_default_arr );
 # reset to defaults
 $t_query = 'UPDATE {user_print_pref} SET print_pref=' . db_param() . ' WHERE user_id=' . db_param();
 
-$t_result = db_query_bound( $t_query, array( $t_default, $t_user_id ) );
+$t_result = db_query( $t_query, array( $t_default, $t_user_id ) );
 
 form_security_purge( 'print_all_bug_options_reset' );
 

--- a/print_all_bug_options_update.php
+++ b/print_all_bug_options_update.php
@@ -82,7 +82,7 @@ $c_export = implode( '', $t_prefs_arr );
 # update preferences
 $t_query = 'UPDATE {user_print_pref} SET print_pref=' . db_param() . ' WHERE user_id=' . db_param();
 
-$t_result = db_query_bound( $t_query, array( $c_export, $t_user_id ) );
+$t_result = db_query( $t_query, array( $c_export, $t_user_id ) );
 
 form_security_purge( 'print_all_bug_options_update' );
 

--- a/print_bugnote_inc.php
+++ b/print_bugnote_inc.php
@@ -72,7 +72,7 @@ $t_bugnote_order = current_user_get_pref( 'bugnote_order' );
 $t_query = 'SELECT * FROM {bugnote}
 		WHERE bug_id=' . db_param() . ' ' . $t_restriction . '
 		ORDER BY date_submitted ' . $t_bugnote_order;
-$t_result = db_query_bound( $t_query, array( $c_bug_id ) );
+$t_result = db_query( $t_query, array( $c_bug_id ) );
 $t_num_notes = db_num_rows( $t_result );
 ?>
 
@@ -103,7 +103,7 @@ $t_num_notes = db_num_rows( $t_result );
 
 			# grab the bugnote text and id and prefix with v3_
 			$t_query = 'SELECT note, id FROM {bugnote_text} WHERE id=' . db_param();
-			$t_result2 = db_query_bound( $t_query, array( $t_row['bugnote_text_id'] ) );
+			$t_result2 = db_query( $t_query, array( $t_row['bugnote_text_id'] ) );
 			$t_note = db_result( $t_result2, 0, 0 );
 			$t_bugnote_text_id = db_result( $t_result2, 0, 1 );
 

--- a/proj_doc_delete.php
+++ b/proj_doc_delete.php
@@ -63,7 +63,7 @@ $t_project_id = file_get_field( $f_file_id, 'project_id', 'project' );
 access_ensure_project_level( config_get( 'upload_project_file_threshold' ), $t_project_id );
 
 $t_query = 'SELECT title FROM {project_file} WHERE id=' . db_param();
-$t_result = db_query_bound( $t_query, array( $f_file_id ) );
+$t_result = db_query( $t_query, array( $f_file_id ) );
 $t_title = db_result( $t_result );
 
 # Confirm with the user

--- a/proj_doc_edit_page.php
+++ b/proj_doc_edit_page.php
@@ -63,7 +63,7 @@ $t_project_id = file_get_field( $t_file_id, 'project_id', 'project' );
 access_ensure_project_level( config_get( 'upload_project_file_threshold' ), $t_project_id );
 
 $t_query = 'SELECT * FROM {project_file} WHERE id=' . db_param();
-$t_result = db_query_bound( $t_query, array( $t_file_id ) );
+$t_result = db_query( $t_query, array( $t_file_id ) );
 $t_row = db_fetch_array( $t_result );
 extract( $t_row, EXTR_PREFIX_ALL, 'v' );
 

--- a/proj_doc_page.php
+++ b/proj_doc_page.php
@@ -102,7 +102,7 @@ $t_query = 'SELECT pft.id, pft.project_id, pft.filename, pft.filesize, pft.title
 					( ( pult.user_id = ' . db_param() . ' ) AND ( pult.access_level ' . $t_access_clause . ' ) ) OR
 					( ut.access_level >= ' . db_param() . ' ) )
 			ORDER BY pt.name ASC, pft.title ASC';
-$t_result = db_query_bound( $t_query, array( $t_user_id, $t_user_id, $t_pub, $t_user_id, $t_admin ) );
+$t_result = db_query( $t_query, array( $t_user_id, $t_user_id, $t_pub, $t_user_id, $t_admin ) );
 
 html_page_top( lang_get( 'docs_link' ) );
 ?>

--- a/proj_doc_update.php
+++ b/proj_doc_update.php
@@ -118,12 +118,12 @@ if( isset( $f_file['tmp_name'] ) && is_uploaded_file( $f_file['tmp_name'] ) ) {
 		SET title=' . db_param() . ', description=' . db_param() . ', date_added=' . db_param() . ',
 			filename=' . db_param() . ', filesize=' . db_param() . ', file_type=' .db_param() . ', content=' .db_param() . '
 			WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $f_title, $f_description, db_now(), $f_file['name'], $t_file_size, $f_file['type'], $c_content, $f_file_id ) );
+	$t_result = db_query( $t_query, array( $f_title, $f_description, db_now(), $f_file['name'], $t_file_size, $f_file['type'], $c_content, $f_file_id ) );
 } else {
 	$t_query = 'UPDATE {project_file}
 			SET title=' . db_param() . ', description=' . db_param() . '
 			WHERE id=' . db_param();
-	$t_result = db_query_bound( $t_query, array( $f_title, $f_description, $f_file_id ) );
+	$t_result = db_query( $t_query, array( $f_title, $f_description, $f_file_id ) );
 }
 
 if( !$t_result ) {

--- a/roadmap_page.php
+++ b/roadmap_page.php
@@ -223,7 +223,7 @@ foreach( $t_project_ids as $t_project_id ) {
 
 		$t_first_entry = true;
 
-		$t_result = db_query_bound( $t_query, array( $t_project_id, $t_version ) );
+		$t_result = db_query( $t_query, array( $t_project_id, $t_version ) );
 
 		$t_issue_ids = array();
 		$t_issue_parents = array();

--- a/summary_page.php
+++ b/summary_page.php
@@ -73,7 +73,7 @@ $t_query = 'SELECT b.id, b.date_submitted, b.last_updated, MAX(h.date_modified) 
 		WHERE b.status >=' . db_param() . ' AND ' . $t_specific_where . '
 		GROUP BY b.id, b.status, b.date_submitted, b.last_updated
 		ORDER BY b.id ASC';
-$t_result = db_query_bound( $t_query, array( $t_resolved, $t_resolved ) );
+$t_result = db_query( $t_query, array( $t_resolved, $t_resolved ) );
 $t_bug_count = 0;
 
 $t_bug_id       = 0;


### PR DESCRIPTION
We add a function "alias" for db_query_bound so that
existing code will continue to work.

We rename db_query_bound to db_query within mantis core.

Long term, this allows us to shorten db_query_bound() to a more sensible
db_query() call and to remove the function in 2.0 as it gives plugin
authors time to update their code and support both 1.3 and 2.0

1c0c12797f31c307530d8dab8fcb53404ed44870
