### PR TITLE
Early version - remove _text_tables

### DIFF
--- a/admin/schema.php
+++ b/admin/schema.php
@@ -743,5 +743,15 @@ $g_upgrade[196] = array( 'AlterColumnSQL', array( db_get_table( 'user' ), "usern
 $g_upgrade[197] = array( 'AlterColumnSQL', array( db_get_table( 'user' ), "realname C(255) $t_notnull DEFAULT \" '' \"" ) );
 $g_upgrade[198] = array( 'AlterColumnSQL', array( db_get_table( 'user' ), "password C(64) $t_notnull DEFAULT \" '' \"" ) );
 $g_upgrade[199] = array( 'AlterColumnSQL', array( db_get_table( 'user' ), "email C(255) $t_notnull DEFAULT \" '' \"" ) );
+$g_upgrade[200] = array( 'AddColumnSQL', array( db_get_table( 'bug' ), "description XL NOTNULL" ) );
+$g_upgrade[201] = array( 'AddColumnSQL', array( db_get_table( 'bug' ), "steps_to_reproduce XL NOTNULL" ) );
+$g_upgrade[202] = array( 'AddColumnSQL', array( db_get_table( 'bug' ), "additional_information XL NOTNULL" ) );
+$g_upgrade[203] = array( 'UpdateFunction', "migrate_bug_text", array() );
+$g_upgrade[204] = array( 'DropTableSQL', array( db_get_table( 'bug_text' ) ) );
+$g_upgrade[205] = array( 'DropColumnSQL', array( db_get_table( 'bug' ), "bug_text_id" ) );
+$g_upgrade[206] = array( 'AddColumnSQL', array( db_get_table( 'bugnote' ), "note XL NOTNULL" ) );
+$g_upgrade[207] = array( 'UpdateFunction', "migrate_bugnote_text", array() );
+$g_upgrade[208] = array( 'DropTableSQL', array( db_get_table( 'bugnote_text' ) ) );
+$g_upgrade[209] = array( 'DropColumnSQL', array( db_get_table( 'bugnote' ), "bugnote_text_id" ) );
 
 # Release marker: 1.3.0

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1970,10 +1970,10 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 
 			$c_search = '%' . $t_search_term . '%';
 			$t_textsearch_where_clause .= '( ' . db_helper_like( '{bug}.summary' ) .
-				' OR ' . db_helper_like( '{bug_text}.description' ) .
-				' OR ' . db_helper_like( '{bug_text}.steps_to_reproduce' ) .
-				' OR ' . db_helper_like( '{bug_text}.additional_information' ) .
-				' OR ' . db_helper_like( '{bugnote_text}.note' );
+				' OR ' . db_helper_like( '{bug}.description' ) .
+				' OR ' . db_helper_like( '{bug}.steps_to_reproduce' ) .
+				' OR ' . db_helper_like( '{bug}.additional_information' ) .
+				' OR ' . db_helper_like( '{bugnote}.note' );
 
 			$t_where_params[] = $c_search;
 			$t_where_params[] = $c_search;
@@ -2005,10 +2005,8 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 
 		# add text query elements to arrays
 		if( !$t_first ) {
-			$t_join_clauses[] = 'JOIN {bug_text} ON {bug}.bug_text_id = {bug_text}.id';
 			$t_join_clauses[] = 'LEFT JOIN {bugnote} ON {bug}.id = {bugnote}.bug_id';
 			# Outer join required otherwise we don't retrieve issues without notes
-			$t_join_clauses[] = 'LEFT JOIN {bugnote_text} ON {bugnote}.bugnote_text_id = {bugnote_text}.id';
 			$t_where_clauses[] = $t_textsearch_where_clause;
 		}
 	}

--- a/plugins/XmlImportExport/pages/export.php
+++ b/plugins/XmlImportExport/pages/export.php
@@ -74,7 +74,6 @@ $t_writer->writeAttribute( 'format', '1' );
 # Ignored fields, these will be skipped
 $t_ignore = array(
 	'_stats',
-	'bug_text_id',
 );
 
 # properties that we want to export are 'protected'
@@ -241,7 +240,6 @@ foreach( $t_result as $t_row ) {
 
 	# Save memory by clearing cache
 	# bug_clear_cache();
-	# bug_text_clear_cache();
 }
 
 $t_writer->endElement(); # mantis

--- a/print_all_bug_page_word.php
+++ b/print_all_bug_page_word.php
@@ -161,7 +161,6 @@ for( $j=0; $j < $t_row_count; $j++ ) {
 
 	if( $j % 50 == 0 ) {
 		# to save ram as report will list data once, clear cache after 50 bugs
-		bug_text_clear_cache();
 		bug_clear_cache();
 		bugnote_clear_cache();
 	}

--- a/print_bugnote_inc.php
+++ b/print_bugnote_inc.php
@@ -101,13 +101,7 @@ $t_num_notes = db_num_rows( $t_result );
 			$t_date_submitted = date( config_get( 'normal_date_format' ), $t_row['date_submitted'] );
 			$t_last_modified = date( config_get( 'normal_date_format' ), $t_row['last_modified'] );
 
-			# grab the bugnote text and id and prefix with v3_
-			$t_query = 'SELECT note, id FROM {bugnote_text} WHERE id=' . db_param();
-			$t_result2 = db_query_bound( $t_query, array( $t_row['bugnote_text_id'] ) );
-			$t_note = db_result( $t_result2, 0, 0 );
-			$t_bugnote_text_id = db_result( $t_result2, 0, 1 );
-
-			$t_note = string_display_links( $t_note );
+			$t_note = string_display_links( $t_row['note'] );
 	?>
 	<tr>
 		<td class="print-spacer" colspan="2">


### PR DESCRIPTION
This is an early version of some code that i'm currently benchmarking (with both myisam and innodb)

We've had users complain before about ID's not matching between bug_table and bug_text_table. there's a bug on tracker for this somewhere. bugzilla/eventum etc store the bug description inline.

I've not yet rebased to latest master.
