### PR TITLE
EVENT_MANAGE_VERSION_CREATE should be triggered when a version is create...

### DIFF
--- a/core/version_api.php
+++ b/core/version_api.php
@@ -236,6 +236,8 @@ function version_add( $p_project_id, $p_version, $p_released = VERSION_FUTURE, $
 
 	$t_version_id = db_insert_id( db_get_table( 'project_version' ) );
 
+	event_signal( 'EVENT_MANAGE_VERSION_CREATE', array( $t_version_id ) );
+
 	return $t_version_id;
 }
 

--- a/manage_proj_ver_add.php
+++ b/manage_proj_ver_add.php
@@ -81,7 +81,6 @@ foreach ( $t_versions as $t_version ) {
 	$t_version = trim( $t_version );
 	if( version_is_unique( $t_version, $f_project_id ) ) {
 		$t_version_id = version_add( $f_project_id, $t_version );
-		event_signal( 'EVENT_MANAGE_VERSION_CREATE', array( $t_version_id ) );
 	} else if( 1 == $t_version_count ) {
 		# We only error out on duplicates when a single value was
 		#  given.  If multiple values were given, we just add the

--- a/manage_proj_ver_copy.php
+++ b/manage_proj_ver_copy.php
@@ -77,7 +77,6 @@ $t_rows = version_get_all_rows( $t_src_project_id );
 foreach ( $t_rows as $t_row ) {
 	if( version_is_unique( $t_row['version'], $t_dst_project_id ) ) {
 		$t_version_id = version_add( $t_dst_project_id, $t_row['version'], $t_row['released'], $t_row['description'], $t_row['date_order'] );
-		event_signal( 'EVENT_MANAGE_VERSION_CREATE', array( $t_version_id ) );
 	}
 }
 


### PR DESCRIPTION
...d

Move event_signal into core api - this means the event will get fired
automatically if any plugin etc uses creates a new project version.

As per docs, "This event is triggered for each version created."
