### PR TITLE
Replace remaining uses of deprecated db_num_rows() function

### DIFF
--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -517,10 +517,10 @@ function mci_filter_db_get_available_queries( $p_project_id = null, $p_user_id =
 						OR user_id = ' . db_param() . ')
 					ORDER BY is_public DESC, name ASC';
 	$t_result = db_query( $t_query, array( $t_project_id, db_prepare_bool( true ), $t_user_id ) );
-	$t_query_count = db_num_rows( $t_result );
+	$t_queries = array();
 
-	for( $i = 0;$i < $t_query_count;$i++ ) {
-		$t_row = db_fetch_array( $t_result );
+	while ( $t_row = db_fetch_array( $t_result ) ) {
+		$t_row = $t_queries;
 
 		$t_filter_detail = explode( '#', $t_row['filter_string'], 2 );
 		if( !isset($t_filter_detail[1]) ) {

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -567,23 +567,21 @@ function mc_issue_get_id_from_summary( $p_username, $p_password, $p_summary ) {
 
 	$t_result = db_query( $t_query, array( $p_summary ), 1 );
 
-	if( db_num_rows( $t_result ) == 0 ) {
-		return 0;
-	} else {
-		while( ( $t_row = db_fetch_array( $t_result ) ) !== false ) {
-			$t_issue_id = (int)$t_row['id'];
-			$t_project_id = bug_get_field( $t_issue_id, 'project_id' );
-			$g_project_override = $t_project_id;
+	$t_issues = array();
+	while ( $t_issue = db_fetch_array( $t_result ) ) {
+		$t_issue_id = (int)$t_issue['id'];
+		$t_project_id = bug_get_field( $t_issue_id, 'project_id' );
 
-			if( mci_has_readonly_access( $t_user_id, $t_project_id ) &&
-				access_has_bug_level( VIEWER, $t_issue_id, $t_user_id ) ) {
-				return $t_issue_id;
-			}
+		$g_project_override = $t_project_id;
+
+		if( mci_has_readonly_access( $t_user_id, $t_project_id ) &&
+			access_has_bug_level( VIEWER, $t_issue_id, $t_user_id ) ) {
+			return $t_issue_id;
 		}
-
-		# no issue found that belongs to a project that the user has read access to.
-		return 0;
 	}
+
+	# no issue found that belongs to a project that the user has read access to.
+	return 0;
 }
 
 /**

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -735,12 +735,9 @@ function mc_project_get_attachments( $p_username, $p_password, $p_project_id ) {
 		ORDER BY pt.name ASC, pft.title ASC';
 
 	$t_result = db_query( $t_query, array( $t_user_id, $t_user_id, $t_pub, $t_user_id, $t_admin ) );
-	$t_num_files = db_num_rows( $t_result );
 
 	$t_attachments = array();
-	for( $i = 0; $i < $t_num_files; $i++ ) {
-		$t_row = db_fetch_array( $t_result );
-
+	while ( $t_row = db_fetch_array( $t_result ) ) {
 		$t_attachment = array();
 		$t_attachment['id'] = $t_row['id'];
 		$t_attachment['filename'] = $t_row['filename'];

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -362,20 +362,15 @@ function file_get_visible_attachments( $p_bug_id ) {
 function file_delete_attachments( $p_bug_id ) {
 	$t_method = config_get( 'file_upload_method' );
 
-	# Delete files from disk
-	$t_query = 'SELECT diskfile, filename FROM {bug_file} WHERE bug_id=' . db_param();
-	$t_result = db_query( $t_query, array( $p_bug_id ) );
-
-	$t_file_count = db_num_rows( $t_result );
-	if( 0 == $t_file_count ) {
-		return true;
-	}
-
 	if( DISK == $t_method ) {
-		for( $i = 0; $i < $t_file_count; $i++ ) {
-			$t_row = db_fetch_array( $t_result );
+		# Delete files from disk
+		$t_query = 'SELECT diskfile, filename FROM {bug_file} WHERE bug_id=' . db_param();
+		$t_result = db_query( $t_query, array( $p_bug_id ) );
 
-			$t_local_diskfile = file_normalize_attachment_path( $t_row['diskfile'], bug_get_field( $p_bug_id, 'project_id' ) );
+		$t_project_id = bug_get_field( $p_bug_id, 'project_id' );
+
+		while( $t_row = db_fetch_array( $t_result ) ) {
+			$t_local_diskfile = file_normalize_attachment_path( $t_row['diskfile'], $t_project_id );
 			file_delete_local( $t_local_diskfile );
 		}
 	}
@@ -402,11 +397,7 @@ function file_delete_project_files( $p_project_id ) {
 		$t_query = 'SELECT diskfile, filename FROM {project_file} WHERE project_id=' . db_param();
 		$t_result = db_query( $t_query, array( (int)$p_project_id ) );
 
-		$t_file_count = db_num_rows( $t_result );
-
-		for( $i = 0;$i < $t_file_count;$i++ ) {
-			$t_row = db_fetch_array( $t_result );
-
+		while( $t_row = db_fetch_array( $t_result ) ) {
 			$t_local_diskfile = file_normalize_attachment_path( $t_row['diskfile'], $p_project_id );
 			file_delete_local( $t_local_diskfile );
 		}

--- a/manage_user_prune.php
+++ b/manage_user_prune.php
@@ -65,18 +65,21 @@ if( !$t_result ) {
 	trigger_error( ERROR_GENERIC, ERROR );
 }
 
-$t_count = db_num_rows( $t_result );
+$t_users = array();
+while ( $t_row = db_fetch_array( $t_result ) ) {
+	$t_users[] = $t_row;
+}
+$t_user_count = count( $t_users );
 
-if( $t_count > 0 ) {
-	helper_ensure_confirmed( lang_get( 'confirm_account_pruning' ),
-							 lang_get( 'prune_accounts_button' ) );
+if ( $t_user_count > 0 )
+	helper_ensure_confirmed( lang_get( 'confirm_account_pruning' ), lang_get( 'prune_accounts_button' ) );
 }
 
-for( $i=0; $i < $t_count; $i++ ) {
-	$t_row = db_fetch_array( $t_result );
+for( $i = 0; $i < $t_user_count; $i++ ) {
+	$t_user = $t_users[$i];
 	# Don't prune accounts with a higher global access level than the current user
-	if( access_has_global_level( $t_row['access_level'] ) ) {
-		user_delete( $t_row['id'] );
+	if( access_has_global_level( $t_user['access_level'] ) ) {
+		user_delete( $t_user['id'] );
 	}
 }
 

--- a/print_bugnote_inc.php
+++ b/print_bugnote_inc.php
@@ -73,7 +73,12 @@ $t_query = 'SELECT * FROM {bugnote}
 		WHERE bug_id=' . db_param() . ' ' . $t_restriction . '
 		ORDER BY date_submitted ' . $t_bugnote_order;
 $t_result = db_query( $t_query, array( $c_bug_id ) );
-$t_num_notes = db_num_rows( $t_result );
+
+$t_notes = array();
+while ( $t_row = db_fetch_array( $t_result ) ) {
+	$t_notes[] = $t_row;
+}
+$t_num_notes = count( $t_notes );
 ?>
 
 <br />
@@ -95,8 +100,7 @@ $t_num_notes = db_num_rows( $t_result );
 	</tr>
 	<?php
 		for( $i=0; $i < $t_num_notes; $i++ ) {
-			# prefix all bugnote data with v3_
-			$t_row = db_fetch_array( $t_result );
+			$t_row = $t_notes[$i];
 
 			$t_date_submitted = date( config_get( 'normal_date_format' ), $t_row['date_submitted'] );
 			$t_last_modified = date( config_get( 'normal_date_format' ), $t_row['last_modified'] );


### PR DESCRIPTION
The db_num_rows() function is deprecated as some databases do not know how
many rows are being returned until all rows have been requested from the
server. We therefore have to perform the row count ourselves - when
necessary.

In many cases it may make more sense to perform a SELECT(*) query to
retrieve counts. This is less costly than returning data that we're not
going to use. This is something to consider in the future as the core is
upgraded to use more modern/robust database queries.
