### PR TITLE
Bump min php to 5.3.3 - this matches version phpunit supports

### DIFF
--- a/core/php_api.php
+++ b/core/php_api.php
@@ -30,7 +30,7 @@
 /**
  * Constant for our minimum required PHP version
  */
-define( 'PHP_MIN_VERSION', '5.3.2' );
+define( 'PHP_MIN_VERSION', '5.3.3' );
 
 /**
  * Determine if PHP is running in CLI or CGI mode and return the mode.

--- a/docbook/Admin_Guide/en-US/Installation.xml
+++ b/docbook/Admin_Guide/en-US/Installation.xml
@@ -310,7 +310,7 @@
 							<row>
 								<entry>PHP</entry>
 								<entry>PHP</entry>
-								<entry>5.3.2</entry>
+								<entry>5.3.3</entry>
 								<entry>5.3.x or above</entry>
 								<entry>See above for PHP extensions</entry>
 							</row>

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Requirements
 ------------
 
  * MySQL 4.1.1+, PostgreSQL 8+, or other supported database
- * PHP 5.3.2+
+ * PHP 5.3.3+
  * a webserver (e.g. Apache or IIS)
 
 Installation


### PR DESCRIPTION
As an aside, 14th August 2014 marked last security release of php 5.3, so
people should be migrating from it anyway ;)
