### PR TITLE
history api can pass null to not null field via log_event_special.

### DIFF
--- a/core/history_api.php
+++ b/core/history_api.php
@@ -117,14 +117,18 @@ function history_log_event( $p_bug_id, $p_field_name, $p_old_value ) {
 function history_log_event_special( $p_bug_id, $p_type, $p_old_value = '', $p_new_value = '' ) {
 	$t_user_id = auth_get_current_user_id();
 
-	$c_old_value = (is_null( $p_old_value ) ? '' : $p_old_value );
-	$c_new_value = (is_null( $p_new_value ) ? '' : $p_new_value );
+	if( is_null( $p_old_value ) ) {
+		$p_old_value = '';
+	}
+	if( is_null( $p_new_value ) ) {
+		$p_new_value = '';
+	}
 
 	$t_query = 'INSERT INTO {bug_history}
 					( user_id, bug_id, date_modified, type, old_value, new_value, field_name )
 				VALUES
 					( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ',' . db_param() . ', ' . db_param() . ')';
-	db_query( $t_query, array( $t_user_id, $p_bug_id, db_now(), $p_type, $c_old_value, $c_new_value, '' ) );
+	db_query( $t_query, array( $t_user_id, $p_bug_id, db_now(), $p_type, $p_old_value, $p_new_value, '' ) );
 }
 
 /**


### PR DESCRIPTION
Additionally, we pass in '' to bug_unmonitor to unmonitor all users
on a bug [used by bug_delete]
