### PR TITLE
Remove display of "current" time:

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -517,7 +517,6 @@ function html_top_banner() {
 function html_login_info() {
 	$t_username = current_user_get_field( 'username' );
 	$t_access_level = get_enum_element( 'access_levels', current_user_get_access_level() );
-	$t_now = date( config_get( 'complete_date_format' ) );
 	$t_realname = current_user_get_field( 'realname' );
 
 	# Login information
@@ -596,9 +595,6 @@ function html_login_info() {
 			}
 		}
 	}
-
-	# Current time
-	echo '<div id="current-time">' . $t_now . '</div>';
 }
 
 /**


### PR DESCRIPTION
a) There are some plugins that make use of AJAX queries to display updated
data. In this case 'current' time is misleading

b) Whilst it was probably useful to display this in ~2000 when the internet
was slower, the clock on the PC is probably a more accurate time source now
