### PR TITLE
Always perform database version check on login page

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -811,12 +811,6 @@ $g_fallback_language = 'english';
 $g_window_title = 'MantisBT';
 
 /**
- * Check for admin directory, database upgrades, etc.
- * @global int $g_admin_checks
- */
-$g_admin_checks = ON;
-
-/**
  * Favicon image
  * @global string $g_favicon_image
  */

--- a/login_page.php
+++ b/login_page.php
@@ -202,74 +202,72 @@ if( $f_error || $f_cookie_error ) {
 # Do some checks to warn administrators of possible security holes.
 #
 
-if( config_get_global( 'admin_checks' ) == ON ) {
-	$t_warnings = array();
+$t_warnings = array();
 
-	# Generate a warning if default user administrator/root is valid.
-	$t_admin_user_id = user_get_id_by_name( 'administrator' );
-	if( $t_admin_user_id !== false ) {
-		if( user_is_enabled( $t_admin_user_id ) && auth_does_password_match( $t_admin_user_id, 'root' ) ) {
-			$t_warnings[] = lang_get( 'warning_default_administrator_account_present' );
-		}
+# Generate a warning if default user administrator/root is valid.
+$t_admin_user_id = user_get_id_by_name( 'administrator' );
+if( $t_admin_user_id !== false ) {
+	if( user_is_enabled( $t_admin_user_id ) && auth_does_password_match( $t_admin_user_id, 'root' ) ) {
+		$t_warnings[] = lang_get( 'warning_default_administrator_account_present' );
 	}
+}
 
-	/**
-	 * Display Warnings for enabled debugging / developer settings
-	 * @param string $p_type    Message Type.
-	 * @param string $p_setting Setting.
-	 * @param string $p_value   Value.
-	 * @return string
-	 */
-	function debug_setting_message ( $p_type, $p_setting, $p_value ) {
-		return sprintf( lang_get( 'warning_change_setting' ), $p_setting, $p_value )
-			. sprintf( lang_get( 'word_separator' ) )
-			. sprintf( lang_get( "warning_${p_type}_hazard" ) );
-	}
+/**
+ * Display Warnings for enabled debugging / developer settings
+ * @param string $p_type    Message Type.
+ * @param string $p_setting Setting.
+ * @param string $p_value   Value.
+ * @return string
+ */
+function debug_setting_message ( $p_type, $p_setting, $p_value ) {
+	return sprintf( lang_get( 'warning_change_setting' ), $p_setting, $p_value )
+		. sprintf( lang_get( 'word_separator' ) )
+		. sprintf( lang_get( "warning_${p_type}_hazard" ) );
+}
 
-	$t_config = 'show_detailed_errors';
-	if( config_get( $t_config ) != OFF ) {
-		$t_warnings[] = debug_setting_message( 'security', $t_config, 'OFF' );
-	}
-	$t_config = 'display_errors';
-	$t_errors = config_get_global( $t_config );
-	if( $t_errors[E_USER_ERROR] != DISPLAY_ERROR_HALT ) {
-		$t_warnings[] = debug_setting_message(
-			'integrity',
-			$t_config . '[E_USER_ERROR]',
-			DISPLAY_ERROR_HALT );
-	}
+$t_config = 'show_detailed_errors';
+if( config_get( $t_config ) != OFF ) {
+	$t_warnings[] = debug_setting_message( 'security', $t_config, 'OFF' );
+}
+$t_config = 'display_errors';
+$t_errors = config_get_global( $t_config );
+if( $t_errors[E_USER_ERROR] != DISPLAY_ERROR_HALT ) {
+	$t_warnings[] = debug_setting_message(
+		'integrity',
+		$t_config . '[E_USER_ERROR]',
+		DISPLAY_ERROR_HALT );
+}
 
-	# since admin directory and db_upgrade lists are available check for missing db upgrades
-	# if db version is 0, we do not have a valid database.
-	$t_db_version = config_get( 'database_version', 0 );
-	if( $t_db_version == 0 ) {
-		$t_warnings[] = lang_get( 'error_database_no_schema_version' );
-	}
+# since admin directory and db_upgrade lists are available check for missing db upgrades
+# if db version is 0, we do not have a valid database.
+$t_db_version = config_get( 'database_version', 0 );
+if( $t_db_version == 0 ) {
+	$t_warnings[] = lang_get( 'error_database_no_schema_version' );
+}
 
-	# Check for db upgrade for versions > 1.0.0 using new installer and schema
-	# Note: install_helper_functions_api.php required for db_null_date() function definition
-	require_api( 'install_helper_functions_api.php' );
-	require_once( 'admin' . DIRECTORY_SEPARATOR . 'schema.php' );
-	$t_upgrades_reqd = count( $g_upgrade ) - 1;
+# Check for db upgrade for versions > 1.0.0 using new installer and schema
+# Note: install_helper_functions_api.php required for db_null_date() function definition
+require_api( 'install_helper_functions_api.php' );
+require_once( 'admin' . DIRECTORY_SEPARATOR . 'schema.php' );
+$t_upgrades_reqd = count( $g_upgrade ) - 1;
 
-	if( ( 0 < $t_db_version ) &&
-			( $t_db_version != $t_upgrades_reqd ) ) {
+if( ( 0 < $t_db_version ) &&
+		( $t_db_version != $t_upgrades_reqd ) ) {
 
-		if( $t_db_version < $t_upgrades_reqd ) {
-			$t_warnings[] = lang_get( 'error_database_version_out_of_date_2' );
-		} else {
-			$t_warnings[] = lang_get( 'error_code_version_out_of_date' );
-		}
+	if( $t_db_version < $t_upgrades_reqd ) {
+		$t_warnings[] = lang_get( 'error_database_version_out_of_date_2' );
+	} else {
+		$t_warnings[] = lang_get( 'error_code_version_out_of_date' );
 	}
-	if( count( $t_warnings ) > 0 ) {
-		echo '<div class="important-msg">';
-		echo '<ul>';
-		foreach( $t_warnings as $t_warning ) {
-			echo '<li>' . $t_warning . '</li>';
-		}
-		echo '</ul>';
-		echo '</div>';
+}
+if( count( $t_warnings ) > 0 ) {
+	echo '<div class="important-msg">';
+	echo '<ul>';
+	foreach( $t_warnings as $t_warning ) {
+		echo '<li>' . $t_warning . '</li>';
 	}
-} # if 'admin_checks'
+	echo '</ul>';
+	echo '</div>';
+}
 
 html_page_bottom1a( __FILE__ );


### PR DESCRIPTION
This ensures that we can inform users or even block users from logging in
if the database version does not match the code version.

We should stop non-admin users from logging in if the database and
code version do not match, to stop any possible corruption issues from
occuring.
