### PR TITLE
Add admin check to ensure mbstring is loaded.

### DIFF
--- a/admin/check/check_php_inc.php
+++ b/admin/check/check_php_inc.php
@@ -49,7 +49,8 @@ $t_extensions_required = array(
 	'hash',
 	'pcre',
 	'Reflection',
-	'session'
+	'session',
+	'mbstring'
 );
 
 foreach( $t_extensions_required as $t_extension ) {


### PR DESCRIPTION
This ensures that Mantis is running at optimal performance.
