### PR TITLE
move signal for EVENT_BUGNOTE_DELETED into core api

### DIFF
--- a/bugnote_delete.php
+++ b/bugnote_delete.php
@@ -82,9 +82,6 @@ helper_ensure_confirmed( lang_get( 'delete_bugnote_sure_msg' ),
 
 bugnote_delete( $f_bugnote_id );
 
-# Event integration
-event_signal( 'EVENT_BUGNOTE_DELETED', array( $t_bug_id, $f_bugnote_id ) );
-
 form_security_purge( 'bugnote_delete' );
 
 print_successful_redirect( string_get_bug_view_url( $t_bug_id ) . '#bugnotes' );

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -285,6 +285,9 @@ function bugnote_delete( $p_bugnote_id ) {
 	# log deletion of bug
 	history_log_event_special( $t_bug_id, BUGNOTE_DELETED, bugnote_format_id( $p_bugnote_id ) );
 
+	# Event integration
+	event_signal( 'EVENT_BUGNOTE_DELETED', array( $t_bug_id, $p_bugnote_id ) );
+
 	return true;
 }
 


### PR DESCRIPTION
This ensure that the bugnote event is triggered whenever
a bugnote is deleted, including from SOAP api calls
