### PR TITLE
Use report_bug_threshold instead of REPORTER for access control

### DIFF
--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -288,7 +288,7 @@ if( $t_show_reporter ) {
 		# Do not allow the bug's reporter to edit the Reporter field
 		# when limit_reporters is ON
 		if( ON == config_get( 'limit_reporters' )
-		&&  !access_has_project_level( REPORTER + 1, $t_bug->project_id )
+		&&  !access_has_project_level( config_get( 'report_bug_threshold', null, null, $t_bug->project_id ) + 1, $t_bug->project_id )
 		) {
 			echo string_attribute( user_get_name( $t_bug->reporter_id ) );
 		} else {

--- a/changelog_page.php
+++ b/changelog_page.php
@@ -186,7 +186,7 @@ foreach( $t_project_ids as $t_project_id ) {
 	$t_can_view_private = access_has_project_level( config_get( 'private_bug_threshold' ), $t_project_id );
 
 	$t_limit_reporters = config_get( 'limit_reporters' );
-	$t_user_access_level_is_reporter = ( REPORTER == access_get_project_level( $t_project_id ) );
+	$t_user_access_level_is_reporter = ( config_get( 'report_bug_threshold', null, null, $t_project_id ) == access_get_project_level( $t_project_id ) );
 
 	$t_resolved = config_get( 'bug_resolved_status_threshold' );
 

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1208,7 +1208,7 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 
 		foreach( $t_project_ids as $t_pid ) {
 			# limit reporters to visible projects
-			if( ( ON === $t_limit_reporters ) && ( !access_has_project_level( REPORTER + 1, $t_pid, $t_user_id ) ) ) {
+			if( ( ON === $t_limit_reporters ) && ( !access_has_project_level( config_get( 'report_bug_threshold', null, $t_user_id, $t_pid ) + 1, $t_pid, $t_user_id ) ) ) {
 				array_push( $t_limited_projects, '({bug}.project_id=' . $t_pid . ' AND ({bug}.reporter_id=' . $t_user_id . ') )' );
 			} else {
 				$t_access_required_to_view_private_bugs = config_get( 'private_bug_threshold', null, null, $t_pid );
@@ -3517,7 +3517,7 @@ function print_filter_reporter_id() {
 	# @@@ thraxisp - access_has_project_level checks greater than or equal to,
 	#   this assumed that there aren't any holes above REPORTER where the limit would apply
 	#
-	if( ( ON === config_get( 'limit_reporters' ) ) && ( !access_has_project_level( REPORTER + 1 ) ) ) {
+	if( ( ON === config_get( 'limit_reporters' ) ) && ( !access_has_project_level( config_get( 'report_bug_threshold' ) + 1 ) ) ) {
 		$t_id = auth_get_current_user_id();
 		$t_username = user_get_field( $t_id, 'username' );
 		$t_realname = user_get_field( $t_id, 'realname' );

--- a/roadmap_page.php
+++ b/roadmap_page.php
@@ -185,7 +185,7 @@ foreach( $t_project_ids as $t_project_id ) {
 	$t_can_view_private = access_has_project_level( config_get( 'private_bug_threshold' ), $t_project_id );
 
 	$t_limit_reporters = config_get( 'limit_reporters' );
-	$t_user_access_level_is_reporter = ( REPORTER == access_get_project_level( $t_project_id ) );
+	$t_user_access_level_is_reporter = ( config_get( 'report_bug_threshold', null, null, $t_project_id ) == access_get_project_level( $t_project_id ) );
 
 	$t_resolved = config_get( 'bug_resolved_status_threshold' );
 


### PR DESCRIPTION
Following @dregads comment on https://github.com/mantisbt/mantisbt/pull/351

This moves use of REPORTER to config_get() calls
