### PR TITLE
Allow definition of view_bug_threshold

### DIFF
--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -81,7 +81,7 @@ function mc_issue_get( $p_username, $p_password, $p_issue_id ) {
 		return mci_soap_fault_access_denied( $t_user_id );
 	}
 
-	if( !access_has_bug_level( VIEWER, $p_issue_id, $t_user_id ) ) {
+	if( !access_has_bug_level( config_get( 'view_bug_threshold', null, null, $t_project_id ), $p_issue_id, $t_user_id ) ) {
 		return mci_soap_fault_access_denied( $t_user_id );
 	}
 
@@ -166,7 +166,7 @@ function mc_issue_get_history( $p_username, $p_password, $p_issue_id ) {
 	}
 	$g_project_override = $t_project_id;
 
-	if( !access_has_bug_level( VIEWER, $p_issue_id, $t_user_id ) ) {
+	if( !access_has_bug_level( config_get( 'view_bug_threshold', null, null, $t_project_id ), $p_issue_id, $t_user_id ) ) {
 		return mci_soap_fault_access_denied( $t_user_id );
 	}
 
@@ -576,7 +576,7 @@ function mc_issue_get_id_from_summary( $p_username, $p_password, $p_summary ) {
 			$g_project_override = $t_project_id;
 
 			if( mci_has_readonly_access( $t_user_id, $t_project_id ) &&
-				access_has_bug_level( VIEWER, $t_issue_id, $t_user_id ) ) {
+				access_has_bug_level( config_get( 'view_bug_threshold', null, null, $t_project_id ), $t_issue_id, $t_user_id ) ) {
 				return $t_issue_id;
 			}
 		}
@@ -1350,7 +1350,7 @@ function mc_issue_relationship_add( $p_username, $p_password, $p_issue_id, stdCl
 	}
 
 	# user can access to the related bug at least as viewer...
-	if( !access_has_bug_level( VIEWER, $t_dest_issue_id, $t_user_id ) ) {
+	if( !access_has_bug_level( config_get( 'view_bug_threshold', null, null, $t_project_id ), $t_dest_issue_id, $t_user_id ) ) {
 		return mci_soap_fault_access_denied( $t_user_id, 'The issue \'' . $t_dest_issue_id . '\' requires higher access level' );
 	}
 
@@ -1421,7 +1421,7 @@ function mc_issue_relationship_delete( $p_username, $p_password, $p_issue_id, $p
 
 	# user can access to the related bug at least as viewer, if it's exist...
 	if( bug_exists( $t_dest_issue_id ) ) {
-		if( !access_has_bug_level( VIEWER, $t_dest_issue_id, $t_user_id ) ) {
+		if( !access_has_bug_level( config_get( 'view_bug_threshold', null, null, $t_project_id ), $t_dest_issue_id, $t_user_id ) ) {
 			return mci_soap_fault_access_denied( $t_user_id, 'The issue \'' . $t_dest_issue_id . '\' requires higher access level.' );
 		}
 	}

--- a/bug_relationship_add.php
+++ b/bug_relationship_add.php
@@ -77,6 +77,7 @@ foreach( $f_dest_bug_id_array as $f_dest_bug_id ) {
 
 	# the related bug exists...
 	bug_ensure_exists( $f_dest_bug_id );
+	$t_dest_bug = bug_get( $f_dest_bug_id, true );
 
 	# bug is not read-only...
 	if( bug_is_readonly( $f_src_bug_id ) ) {
@@ -85,7 +86,7 @@ foreach( $f_dest_bug_id_array as $f_dest_bug_id ) {
 	}
 
 	# user can access to the related bug at least as viewer...
-	if( !access_has_bug_level( VIEWER, $f_dest_bug_id ) ) {
+	if( !access_has_bug_level( config_get( 'view_bug_threshold', null, null, $t_dest_bug->project_id ), $f_dest_bug_id ) ) {
 		error_parameters( $f_dest_bug_id );
 		trigger_error( ERROR_RELATIONSHIP_ACCESS_LEVEL_TO_DEST_BUG_TOO_LOW, ERROR );
 	}

--- a/bug_relationship_delete.php
+++ b/bug_relationship_delete.php
@@ -82,9 +82,11 @@ if( bug_is_readonly( $f_bug_id ) ) {
 # retrieve the destination bug of the relationship
 $t_dest_bug_id = relationship_get_linked_bug_id( $f_rel_id, $f_bug_id );
 
+$t_dest_bug = bug_get( $t_dest_bug_id, true );
+
 # user can access to the related bug at least as viewer, if it's exist...
 if( bug_exists( $t_dest_bug_id ) ) {
-	if( !access_has_bug_level( VIEWER, $t_dest_bug_id ) ) {
+	if( !access_has_bug_level( config_get( 'view_bug_threshold', null, null, $t_dest_bug->project_id ), $t_dest_bug_id ) ) {
 		error_parameters( $t_dest_bug_id );
 		trigger_error( ERROR_RELATIONSHIP_ACCESS_LEVEL_TO_DEST_BUG_TOO_LOW, ERROR );
 	}

--- a/bug_relationship_graph.php
+++ b/bug_relationship_graph.php
@@ -87,7 +87,7 @@ if( $t_bug->project_id != helper_get_current_project() ) {
 	$g_project_override = $t_bug->project_id;
 }
 
-access_ensure_bug_level( VIEWER, $f_bug_id );
+access_ensure_bug_level( config_get( 'view_bug_threshold' ), $f_bug_id );
 
 compress_enable();
 

--- a/bug_relationship_graph_img.php
+++ b/bug_relationship_graph_img.php
@@ -56,9 +56,9 @@ $f_bug_id		= gpc_get_int( 'bug_id' );
 $f_type			= gpc_get_string( 'graph', 'relation' );
 $f_orientation	= gpc_get_string( 'orientation', config_get( 'relationship_graph_orientation' ) );
 
-access_ensure_bug_level( VIEWER, $f_bug_id );
-
 $t_bug = bug_get( $f_bug_id, true );
+
+access_ensure_bug_level( config_get( 'view_bug_threshold', null, null, $t_bug->project_id ), $f_bug_id );
 
 compress_enable();
 

--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -91,7 +91,7 @@ $t_bug = bug_get( $f_bug_id, true );
 # per-project function calls use the project ID of this bug.
 $g_project_override = $t_bug->project_id;
 
-access_ensure_bug_level( VIEWER, $f_bug_id );
+access_ensure_bug_level( config_get( 'view_bug_threshold' ), $f_bug_id );
 
 $f_history = gpc_get_bool( 'history', config_get( 'history_default_visible' ) );
 

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2516,6 +2516,12 @@ $g_report_bug_threshold = REPORTER;
 $g_update_bug_threshold = UPDATER;
 
 /**
+ * access level needed to view bugs
+ * @global integer $g_view_bug_threshold
+ */
+$g_view_bug_threshold = VIEWER;
+
+/**
  * Access level needed to monitor bugs.
  * Look in the constant_inc.php file if you want to set a different value.
  * @global integer $g_monitor_bug_threshold

--- a/core/classes/IssueNoteCreatedTimelineEvent.class.php
+++ b/core/classes/IssueNoteCreatedTimelineEvent.class.php
@@ -53,7 +53,8 @@ class IssueNoteCreatedTimelineEvent extends TimelineEvent {
 			return true;
 		}
 
-		if( !access_has_bugnote_level( VIEWER, $this->issue_note_id ) ) {
+		$t_bug = bug_get( $this->issue_id, true );
+		if( !access_has_bugnote_level( config_get( 'view_bug_threshold', null, null, $t_bug->project_id ), $this->issue_note_id ) ) {
 			return true;
 		}
 

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -395,8 +395,8 @@ function email_collect_recipients( $p_bug_id, $p_notify_type, array $p_extra_use
 
 		# exclude users who don't have at least viewer access to the bug,
 		# or who can't see bugnotes if the last update included a bugnote
-		if( !access_has_bug_level( VIEWER, $p_bug_id, $t_id )
-		 || $t_bug_date == $t_bugnote_date && !access_has_bugnote_level( VIEWER, $t_bugnote_id, $t_id )
+		if( !access_has_bug_level( config_get( 'view_bug_threshold', null, $t_id, $t_bug->project_id ), $p_bug_id, $t_id )
+		 || $t_bug_date == $t_bugnote_date && !access_has_bugnote_level( config_get( 'view_bug_threshold', null, $t_id, $t_bug->project_id ), $t_bugnote_id, $t_id )
 		) {
 			log_event( LOG_EMAIL_RECIPIENT, 'Issue = #%d, drop @U%d (access level)', $p_bug_id, $t_id );
 			continue;

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1153,7 +1153,7 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 		}
 
 		# filter out inaccessible projects.
-		if( !project_exists( $t_pid ) || !access_has_project_level( VIEWER, $t_pid, $t_user_id ) ) {
+		if( !project_exists( $t_pid ) || !access_has_project_level( config_get( 'view_bug_threshold', null, $t_user_id, $t_pid ), $t_pid, $t_user_id ) ) {
 			log_event( LOG_FILTERING, 'Invalid or inaccessible project: ' . $t_pid );
 			continue;
 		}

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -330,7 +330,7 @@ function helper_get_current_project() {
 			$t_project_id = $t_project_id[count( $t_project_id ) - 1];
 		}
 
-		if( !project_exists( $t_project_id ) || ( 0 == project_get_field( $t_project_id, 'enabled' ) ) || !access_has_project_level( VIEWER, $t_project_id ) ) {
+		if( !project_exists( $t_project_id ) || ( 0 == project_get_field( $t_project_id, 'enabled' ) ) || !access_has_project_level( config_get( 'view_bug_threshold', null, null, $t_project_id ), $t_project_id ) ) {
 			$t_project_id = ALL_PROJECTS;
 		}
 		$g_cache_current_project = (int)$t_project_id;
@@ -370,7 +370,7 @@ function helper_get_current_project_trace() {
 		$t_bottom = $t_project_id[count( $t_project_id ) - 1];
 	}
 
-	if( !project_exists( $t_bottom ) || ( 0 == project_get_field( $t_bottom, 'enabled' ) ) || !access_has_project_level( VIEWER, $t_bottom ) ) {
+	if( !project_exists( $t_bottom ) || ( 0 == project_get_field( $t_bottom, 'enabled' ) ) || !access_has_project_level( config_get( 'view_bug_threshold', null, null, $t_bottom ), $t_bottom ) ) {
 		$t_project_id = array(
 			ALL_PROJECTS,
 		);

--- a/core/relationship_api.php
+++ b/core/relationship_api.php
@@ -597,11 +597,13 @@ function relationship_get_details( $p_bug_id, BugRelationshipData $p_relationshi
 
 	if( $p_bug_id == $p_relationship->src_bug_id ) {
 		# root bug is in the source side, related bug in the destination side
+		$t_related_project_id = $p_relationship->dest_bug_id;
 		$t_related_bug_id = $p_relationship->dest_bug_id;
 		$t_related_project_name = project_get_name( $p_relationship->dest_project_id );
 		$t_relationship_descr = relationship_get_description_src_side( $p_relationship->type );
 	} else {
 		# root bug is in the dest side, related bug in the source side
+		$t_related_project_id = $p_relationship->src_bug_id;
 		$t_related_bug_id = $p_relationship->src_bug_id;
 		$t_related_project_name = project_get_name( $p_relationship->src_project_id );
 		$t_relationship_descr = relationship_get_description_dest_side( $p_relationship->type );
@@ -613,7 +615,7 @@ function relationship_get_details( $p_bug_id, BugRelationshipData $p_relationshi
 	}
 
 	# user can access to the related bug at least as a viewer
-	if( !access_has_bug_level( VIEWER, $t_related_bug_id ) ) {
+	if( !access_has_bug_level( config_get( 'view_bug_threshold', null, null, $t_related_project_id ), $t_related_bug_id ) ) {
 		return '';
 	}
 

--- a/core/relationship_graph_api.php
+++ b/core/relationship_graph_api.php
@@ -108,11 +108,13 @@ function relgraph_generate_rel_graph( $p_bug_id ) {
 			continue;
 		}
 
-		if( !access_has_bug_level( VIEWER, $t_id ) ) {
+		$t_bug = bug_get( $t_id, false );
+
+		if( !access_has_bug_level( config_get( 'view_bug_threshold', null, null, $t_bug->project_id ), $t_id ) ) {
 			continue;
 		}
 
-		$v_bug_list[$t_id] = bug_get( $t_id, false );
+		$v_bug_list[$t_id] = $t_bug;
 
 		$t_relationships = relationship_get_all_src( $t_id );
 		foreach( $t_relationships as $t_relationship ) {
@@ -357,12 +359,14 @@ function relgraph_add_parent( array &$p_bug_list, $p_bug_id ) {
 		return false;
 	}
 
-	if( !access_has_bug_level( VIEWER, $p_bug_id ) ) {
+	$t_bug = bug_get( $p_bug_id, false );
+
+	if( !access_has_bug_level( config_get( 'view_bug_threshold', null, null, $t_bug->project_id ), $p_bug_id ) ) {
 		return false;
 	}
 
 	# Add the issue to the list.
-	$p_bug_list[$p_bug_id] = bug_get( $p_bug_id, false );
+	$p_bug_list[$p_bug_id] = $t_bug;
 	$p_bug_list[$p_bug_id]->is_descendant = false;
 	$p_bug_list[$p_bug_id]->parents = array();
 	$p_bug_list[$p_bug_id]->children = array();
@@ -428,12 +432,14 @@ function relgraph_add_child( array &$p_bug_list, $p_bug_id ) {
 			return false;
 		}
 
-		if( !access_has_bug_level( VIEWER, $p_bug_id ) ) {
+		$t_bug = bug_get( $p_bug_id, false );
+
+		if( !access_has_bug_level( config_get( 'view_bug_threshold', null, null, $t_bug->project_id ), $p_bug_id ) ) {
 			return false;
 		}
 
 		# Add the issue to the list.
-		$p_bug_list[$p_bug_id] = bug_get( $p_bug_id, false );
+		$p_bug_list[$p_bug_id] = $t_bug;
 		$p_bug_list[$p_bug_id]->is_descendant = true;
 		$p_bug_list[$p_bug_id]->parents = array();
 		$p_bug_list[$p_bug_id]->children = array();

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -345,11 +345,13 @@ function string_process_bug_link( $p_string, $p_include_anchor = true, $p_detail
 	if( !isset( $g_string_process_bug_link_callback[$p_include_anchor][$p_detail_info][$p_fqdn] ) ) {
 		if( $p_include_anchor ) {
 			$g_string_process_bug_link_callback[$p_include_anchor][$p_detail_info][$p_fqdn] = create_function( '$p_array', '
-										if( bug_exists( (int)$p_array[2] ) && access_has_bug_level( VIEWER, (int)$p_array[2] ) ) {
-											return $p_array[1] . string_get_bug_view_link( (int)$p_array[2], null, ' . ( $p_detail_info ? 'true' : 'false' ) . ', ' . ( $p_fqdn ? 'true' : 'false' ) . ');
-										} else {
-											return $p_array[0];
+										if( bug_exists( (int)$p_array[2] ) ) {
+											$t_project_id = bug_get_field( (int)$p_array[2], \'project_id\' );
+											if( access_has_bug_level( config_get( \'view_bug_threshold\', null, null, $t_project_id ), (int)$p_array[2] ) ) {
+												return $p_array[1] . string_get_bug_view_link( (int)$p_array[2], null, ' . ( $p_detail_info ? 'true' : 'false' ) . ', ' . ( $p_fqdn ? 'true' : 'false' ) . ');
+											}
 										}
+										return $p_array[0];
 										' );
 		} else {
 			$g_string_process_bug_link_callback[$p_include_anchor][$p_detail_info][$p_fqdn] = create_function( '$p_array', '

--- a/core/timeline_api.php
+++ b/core/timeline_api.php
@@ -56,7 +56,7 @@ function timeline_get_affected_issues( $p_start_time, $p_end_time ) {
 			continue;
 		}
 
-		if( !access_has_bug_level( VIEWER, $t_issue_id ) ) {
+		if( !access_has_bug_level( config_get( 'view_bug_threshold' ), $t_issue_id ) ) {
 			continue;
 		}
 

--- a/issues_rss.php
+++ b/issues_rss.php
@@ -83,7 +83,7 @@ if( $f_username !== null ) {
 
 # Make sure that the current user has access to the selected project (if not ALL PROJECTS).
 if( $f_project_id != ALL_PROJECTS ) {
-	access_ensure_project_level( VIEWER, $f_project_id );
+	access_ensure_project_level( config_get( 'view_bug_threshold', null, null, $f_project_id ), $f_project_id );
 }
 
 if( $f_sort === 'update' ) {

--- a/main_page.php
+++ b/main_page.php
@@ -52,7 +52,7 @@ require_api( 'news_api.php' );
 require_api( 'print_api.php' );
 require_api( 'rss_api.php' );
 
-access_ensure_project_level( VIEWER );
+access_ensure_project_level( config_get( 'view_bug_threshold' ) );
 
 $f_offset = gpc_get_int( 'offset', 0 );
 

--- a/manage_columns_copy.php
+++ b/manage_columns_copy.php
@@ -77,7 +77,7 @@ if( $f_manage_page && $t_dst_project_id != ALL_PROJECTS ) {
 
 # user should only be able to set columns for a project that is accessible.
 if( $t_dst_project_id != ALL_PROJECTS ) {
-	access_ensure_project_level( VIEWER, $t_dst_project_id );
+	access_ensure_project_level( config_get( 'view_bug_threshold', null, null, $t_dst_project_id ), $t_dst_project_id );
 }
 
 # Calculate the user id to set the configuration for.

--- a/manage_config_columns_set.php
+++ b/manage_config_columns_set.php
@@ -77,7 +77,7 @@ if( $f_update_columns_as_global_default && $f_project_id != ALL_PROJECTS ) {
 
 # user should only be able to set columns for a project that is accessible.
 if( $f_update_columns_for_current_project && $f_project_id != ALL_PROJECTS ) {
-	access_ensure_project_level( VIEWER, $f_project_id );
+	access_ensure_project_level( config_get( 'view_bug_threshold', null, null, $f_project_id ), $f_project_id );
 }
 
 if( $f_update_columns_as_my_default || $f_update_columns_as_global_default ) {

--- a/news_list_page.php
+++ b/news_list_page.php
@@ -47,7 +47,7 @@ require_api( 'string_api.php' );
 
 news_ensure_enabled();
 
-access_ensure_project_level( VIEWER );
+access_ensure_project_level( config_get( 'view_bug_threshold' ) );
 
 html_page_top();
 ?>

--- a/news_rss.php
+++ b/news_rss.php
@@ -75,7 +75,7 @@ if( $f_username !== null ) {
 
 # Make sure that the current user has access to the selected project (if not ALL PROJECTS).
 if( $f_project_id != ALL_PROJECTS ) {
-	access_ensure_project_level( VIEWER, $f_project_id );
+	access_ensure_project_level( config_get( 'view_bug_threshold', null, null, $f_project_id ), $f_project_id );
 }
 
 # construct rss file

--- a/news_view_page.php
+++ b/news_view_page.php
@@ -56,7 +56,7 @@ if( $f_news_id !== null ) {
 		access_ensure_project_level(	config_get( 'private_news_threshold' ),
 						$t_project_id );
 	} else {
-		access_ensure_project_level( VIEWER, $t_project_id );
+		access_ensure_project_level( config_get( 'view_bug_threshold', null, null, $t_project_id ), $t_project_id );
 	}
 
 	print_news_string_by_news_id( $f_news_id );

--- a/print_bug_page.php
+++ b/print_bug_page.php
@@ -88,7 +88,7 @@ if( $t_bug->project_id != $t_selected_project ) {
 	$g_project_override = $t_bug->project_id;
 }
 
-access_ensure_bug_level( VIEWER, $f_bug_id );
+access_ensure_bug_level( config_get( 'view_bug_threshold' ), $f_bug_id );
 
 $t_fields = config_get( 'bug_print_page_fields' );
 $t_fields = columns_filter_disabled( $t_fields );


### PR DESCRIPTION
Following up on removing hard coded REPORTER references,
allow users to define a view_bug_threshold to replace hardcoded instances
of VIEWER.

This allows "hiding" projects from a user that would normally
have global developer access by setting the level to administrator only
for instance.
