### PR TITLE
Fix #17715: Manage Config should trim option name

### DIFF
--- a/adm_config_set.php
+++ b/adm_config_set.php
@@ -49,7 +49,7 @@ form_security_validate( 'adm_config_set' );
 
 $f_user_id = gpc_get_int( 'user_id' );
 $f_project_id = gpc_get_int( 'project_id' );
-$f_config_option = gpc_get_string( 'config_option' );
+$f_config_option = trim( gpc_get_string( 'config_option' ) );
 $f_type = gpc_get_string( 'type' );
 $f_value = gpc_get_string( 'value' );
 


### PR DESCRIPTION
If copying and pasting causes a space at the beginning or end of the config option then the validation that the option is known will fail.  The fix is to trim the option name before validation and setting.
