### PR TITLE
Fix #0016933: Deleting relationship should set target bug's last updated

### DIFF
--- a/bug_relationship_delete.php
+++ b/bug_relationship_delete.php
@@ -98,8 +98,9 @@ $t_rel_type = $t_bug_relationship_data->type;
 # delete relationship from the DB
 relationship_delete( $f_rel_id );
 
-# update bug last updated (just for the src bug)
+# update bug last updated
 bug_update_date( $f_bug_id );
+bug_update_date( $t_dest_bug_id );
 
 # set the rel_type for both bug and dest_bug based on $t_rel_type and on who is the dest bug
 if( $f_bug_id == $t_bug_relationship_data->src_bug_id ) {

--- a/bug_update.php
+++ b/bug_update.php
@@ -380,6 +380,10 @@ if( $t_bug_note->note || helper_duration_to_minutes( $t_bug_note->time_tracking 
 # Add a duplicate relationship if requested.
 if( $t_updated_bug->duplicate_id !== 0 ) {
 	relationship_add( $f_bug_id, $t_updated_bug->duplicate_id, BUG_DUPLICATE );
+
+	# update last updated timestamp for duplicate bug
+	bug_update_date( $t_updated_bug->duplicate_id );
+
 	history_log_event_special( $f_bug_id, BUG_ADD_RELATIONSHIP, BUG_DUPLICATE, $t_updated_bug->duplicate_id );
 	history_log_event_special( $t_updated_bug->duplicate_id, BUG_ADD_RELATIONSHIP, BUG_HAS_DUPLICATE, $f_bug_id );
 	if( user_exists( $t_existing_bug->reporter_id ) ) {

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1743,6 +1743,9 @@ function bug_resolve( $p_bug_id, $p_resolution, $p_fixed_in_version = '', $p_bug
 			# Add the new relationship
 			relationship_add( $p_bug_id, $p_duplicate_id, BUG_DUPLICATE );
 
+			# update last updated timestamp for duplicate bug
+			bug_update_date( $p_duplicate_id );
+
 			# Add log line to the history (both bugs)
 			history_log_event_special( $p_bug_id, BUG_ADD_RELATIONSHIP, BUG_DUPLICATE, $p_duplicate_id );
 			history_log_event_special( $p_duplicate_id, BUG_ADD_RELATIONSHIP, BUG_HAS_DUPLICATE, $p_bug_id );


### PR DESCRIPTION
1) bug_relationship_delete changed to remove comment about updating date
for just the source bug
2) bug_relationship_delete changed to add bug_update_date for dest bug.

Note: step 2 above matches the behaviour already within the SOAP api,
which updates both bug timestamps (as per 16933  and related 12628)

3) add bug_update_date to duplicate bug id in bug_update

Marking a bug as duplicate did not update bug update timestamp of both bugs

We've previously argued that adding/removing a relationship should trigger
a timestamp update

4) add bug_update_date to similar logic as 3 in bug_api.php

Note: Related Reference issues for this in bugtracker are:

0016933: Deleting relationship should set target bug's last updated
0012628: Update last change date for both bugs when updating a relationship
0014417: Adding duplicate relationship should not set "modified" date of parent issue
0007453: Difference between last_updated in bug_table and date_modified in date_modified
0008911: adding relationship does only change field "last changed" of one issue
