### PR TITLE
Tidy require_api/require_lib

### DIFF
--- a/core.php
+++ b/core.php
@@ -106,13 +106,11 @@ function require_api( $p_api_name ) {
 	static $s_api_included;
 	global $g_core_path;
 	if( !isset( $s_api_included[$p_api_name] ) ) {
-		$t_existing_globals = get_defined_vars();
 		require_once( $g_core_path . $p_api_name );
-		$t_new_globals = array_diff_key( get_defined_vars(), $GLOBALS, array( 't_existing_globals' => 0, 't_new_globals' => 0 ) );
+		$t_new_globals = array_diff_key( get_defined_vars(), $GLOBALS, array( 't_new_globals' => 0 ) );
 		foreach ( $t_new_globals as $t_global_name => $t_global_value ) {
-			global $$t_global_name;
+			$GLOBALS[$t_global_name] = $t_global_value;
 		}
-		extract( $t_new_globals );
 		$s_api_included[$p_api_name] = 1;
 	}
 }
@@ -127,8 +125,6 @@ function require_lib( $p_library_name ) {
 	static $s_libraries_included;
 	global $g_library_path;
 	if( !isset( $s_libraries_included[$p_library_name] ) ) {
-		$t_existing_globals = get_defined_vars();
-
 		$t_library_file_path = $g_library_path . $p_library_name;
 		if( !file_exists( $t_library_file_path ) ) {
 			echo 'External library \'' . $t_library_file_path . '\' not found.';
@@ -136,11 +132,10 @@ function require_lib( $p_library_name ) {
 		}
 
 		require_once( $t_library_file_path );
-		$t_new_globals = array_diff_key( get_defined_vars(), $GLOBALS, array( 't_existing_globals' => 0, 't_new_globals' => 0 ) );
+		$t_new_globals = array_diff_key( get_defined_vars(), $GLOBALS, array( 't_new_globals' => 0 ) );
 		foreach ( $t_new_globals as $t_global_name => $t_global_value ) {
-			global $$t_global_name;
+			$GLOBALS[$t_global_name] = $t_global_value;
 		}
-		extract( $t_new_globals );
 		$s_libraries_included[$p_library_name] = 1;
 	}
 }


### PR DESCRIPTION
1) $t_existing_globals is never used
2) avoid using extract()
3) fix Mantis build on phpng (which currently doesn't define the globals)
