### PR TITLE
Fix #17747: Timezone errors during install

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -25,6 +25,7 @@
 
 error_reporting( E_ALL );
 @set_time_limit( 0 );
+date_default_timezone_set( 'UTC' );
 
 # Load the MantisDB core in maintenance mode. This mode will assume that
 # config/config_inc.php hasn't been specified. Thus the database will not be opened

--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -98,6 +98,9 @@ function require_mantis_core() {
 # Set error reporting to the level to which Zend Framework code must comply.
 error_reporting( E_ALL | E_STRICT );
 
+# Set default timezone to avoid errors
+date_default_timezone_set( 'UTC' );
+
 # Determine the root, library, and tests directories of the framework
 # distribution.
 $g_mantisRoot = dirname( dirname( __FILE__ ) );


### PR DESCRIPTION
Set timezone to UTC in install.php and for unit tests
to fix php errors complaining that it is unsafe to use
date functions without an explicitly set timezone.
