### PR TITLE
Simplify timezone configuration within Mantis

### DIFF
--- a/account_prefs_update.php
+++ b/account_prefs_update.php
@@ -112,14 +112,12 @@ if( ( config_get( 'min_refresh_delay' ) > $t_prefs->refresh_delay )&&
 	$t_prefs->refresh_delay = config_get( 'min_refresh_delay' );
 }
 
-if( function_exists( 'timezone_identifiers_list' ) ) {
-	$t_timezone = gpc_get_string( 'timezone' );
-	if( in_array( $t_timezone, timezone_identifiers_list() ) ) {
-		if( $t_timezone == config_get_global( 'default_timezone' ) ) {
-			$t_prefs->timezone = '';
-		} else {
-			$t_prefs->timezone = $t_timezone;
-		}
+$t_timezone = gpc_get_string( 'timezone' );
+if( in_array( $t_timezone, timezone_identifiers_list() ) ) {
+	if( $t_timezone == config_get_global( 'default_timezone' ) ) {
+		$t_prefs->timezone = '';
+	} else {
+		$t_prefs->timezone = $t_timezone;
 	}
 }
 

--- a/admin/check/check_i18n_inc.php
+++ b/admin/check/check_i18n_inc.php
@@ -47,13 +47,11 @@ if( $t_config_default_timezone ) {
 		)
 	);
 } else {
-	$t_php_default_timezone = ini_get( 'date.timezone' );
 	check_print_test_row(
-		'Default timezone has been specified in config_inc.php (default_timezone option) or php.ini (date.timezone directive)',
-		in_array( $t_php_default_timezone, timezone_identifiers_list() ),
+		'Default timezone has not been specified in config_inc.php (default_timezone option)',
+		false,
 		array(
-			true => 'Default timezone (specified by the date.timezone directive in php.ini) is: ' . htmlentities( $t_php_default_timezone ),
-			false => 'Invalid timezone \'' . htmlentities( $t_php_default_timezone ) . '\' specified for the date.timezone php.ini directive.'
+			false => 'Default timezone should be specified in config_inc.php.'
 		)
 	);
 }

--- a/admin/schema.php
+++ b/admin/schema.php
@@ -50,7 +50,11 @@ if( !function_exists( 'db_null_date' ) ) {
 function installer_db_now() {
 	global $g_db;
 
-	return $g_db->BindTimeStamp( time() );
+	$t_timezone = @date_default_timezone_get();
+	date_default_timezone_set( 'UTC' );
+	$t_time = $g_db->BindTimeStamp( time() );
+	@date_default_timezone_set(@date_default_timezone_get());
+	return $t_time;
 }
 
 # Special handling for Oracle (oci8):

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -1134,10 +1134,13 @@ $g_calendar_date_format = 'Y-m-d H:i';
 /**
  * Default timezone to use in MantisBT
  *
- * If this config is left blank, it will be initialized by calling function
- * {@link http://php.net/date-default-timezone-get date_default_timezone_get()}
- * to determine the default timezone.
- * Note that this function's behavior was modified in PHP 5.4.0.
+ * This configuration value is set during the initial mantis installation.
+ * The value of this config should be set to any of the PHP supported timezones.
+ *
+ * Correct configuration of this variable (after initial installation)
+ * can be confirmed by running the administration checks.
+ *
+ * Individual users can customise their own timezones under user preferences.
  *
  * @link http://php.net/timezones List of Supported Timezones
  * @global string $g_default_timezone

--- a/core.php
+++ b/core.php
@@ -252,20 +252,10 @@ if( !isset( $g_login_anonymous ) ) {
 }
 
 # Attempt to set the current timezone to the user's desired value
-# Note that PHP 5.1 on RHEL/CentOS doesn't support the timezone functions
-# used here so we just skip this action on RHEL/CentOS platforms.
-if( function_exists( 'timezone_identifiers_list' ) ) {
-	if( in_array( config_get_global( 'default_timezone' ), timezone_identifiers_list() ) ) {
-		# if a default timezone is set in config, set it here, else we use php.ini's value
-		# having a timezone set avoids a php warning
-		date_default_timezone_set( config_get_global( 'default_timezone' ) );
-	} else {
-		# To ensure proper detection of timezone settings issues, we must not
-		# initialize the default timezone when executing admin checks
-		if( basename( $g_short_path ) != 'check' ) {
-			config_set_global( 'default_timezone', date_default_timezone_get(), true );
-		}
-	}
+# To ensure proper detection of timezone settings issues, we must not
+# initialize the default timezone when executing admin checks or during installation
+if( !defined( 'MANTIS_MAINTENANCE_MODE' ) ) {
+	date_default_timezone_set( config_get_global( 'default_timezone' ) );
 
 	require_api( 'authentication_api.php' );
 	if( auth_is_user_authenticated() ) {

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1911,11 +1911,6 @@ function print_bug_attachment_preview_image( array $p_attachment ) {
  * @return void
  */
 function print_timezone_option_list( $p_timezone ) {
-	if( !function_exists( 'timezone_identifiers_list' ) ) {
-		echo "\t" . '<option value="' . $p_timezone . '" selected="selected">' . $p_timezone . '</option>' . "\n";
-		return;
-	}
-
 	$t_identifiers = timezone_identifiers_list( DateTimeZone::ALL );
 
 	foreach ( $t_identifiers as $t_identifier ) {

--- a/scripts/travis_before_script.sh
+++ b/scripts/travis_before_script.sh
@@ -118,6 +118,7 @@ declare -A query=(
 	[db_password]=$DB_PASSWORD
 	[admin_username]=$DB_USER
 	[admin_password]=$DB_PASSWORD
+	[timezone]=UTC
 )
 
 # Build http query string


### PR DESCRIPTION
This is hopefully a simpler fix for Vboctor's #380 

The current timezone initialisation logic in mantis is fairly complex as it deals with historical situations. For example - handling of php 5.1 on redhat disabling functionality of PHP.

Following https://github.com/mantisbt/mantisbt/commit/8213d69110140b3fc2c18ed423fa410bacfdb52a, for a new installation we always set the value of default_timezone, therefore we can simplify the logic and avoid trying to do complicated checks as we expect default_timezone to always be set.

Equally, we can use the value of the MANTIS_MAINTANENCE mode constant to skip the timezone initialisation.

/admin/check has then been adjusted to check that the default_timezone has been set in config_inc.php and is valid. This is now the expected case as new installations MUST set a timezone during installation, and allows the simplification of the existing code. 

Existing Mantis users who have never set a timezone will pick up the requirement to set a timezone (that was added by 8213d69110140b3fc2c18ed423fa410bacfdb52a when doing an upgrade and running the admin checks.

This fixes the phpunit tests when a timezone is not set in php.ini, and maintains consistent behaviour both before and after the php5.4 change to timezone handling.

---

PHP Unit Test results:

PHPUnit 3.7.28 by Sebastian Bergmann.

..................................SS...........................  63 / 139 ( 45%)
.......S.........S.SS.................S......SSSS.............. 126 / 139 ( 90%)
.............

Time: 49.4 seconds, Memory: 26.00Mb

OK, but incomplete or skipped tests!
Tests: 139, Assertions: 511, Skipped: 11.
