### PR TITLE
add plugin_event_exists()

### DIFF
--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -1070,3 +1070,15 @@ function plugin_init( $p_basename ) {
 		return false;
 	}
 }
+
+/**
+ * Check that the event is defined in this mantis version.
+ *
+ * @global array $g_event_cache
+ * @param string $p_event_name
+ * @return boolean true if event exists
+ */
+function plugin_event_exists($p_event_name) {
+   global $g_event_cache;
+   return array_key_exists($p_event_name, $g_event_cache);
+}


### PR DESCRIPTION
to be compatible with multiple mantis releases,
plugins need to check if an event exist or not.

avoid message:
APPLICATION WARNING #2400: Event « EVENT_MANAGE_PROJECT_DELETE » is not defined.
