### PR TITLE
Fix "Delete project specific settings" for email notifications

### DIFF
--- a/manage_config_revert.php
+++ b/manage_config_revert.php
@@ -78,7 +78,7 @@ if( '' != $f_revert ) {
 		lang_get( 'delete_config_button' ) );
 
 	foreach ( $t_revert_vars as $t_revert ) {
-		config_delete( $t_revert, null, $f_project_id );
+		config_delete( $t_revert, ALL_USERS, $f_project_id );
 	}
 }
 


### PR DESCRIPTION
When deleting project specific settings, the manage_config_revert action page was deleting configs for Current User / Current Project scope instead of All Users / Current Project.

Fixes #17660
