### PR TITLE
mc_login() should auto-create valid LDAP users

### DIFF
--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -187,6 +187,42 @@ function auth_prepare_password( $p_password ) {
 }
 
 /**
+ * In the case where a user is attempting to authenticate but doesn't exist.
+ * Check if the authentication provider supports auto-creation of users and
+ * whether the password matches.
+ *
+ * @param string  $p_username   A prepared username.
+ * @param string  $p_password   A prepared password.
+ * @return int|boolean user id or false in case of failure.
+ * @access private
+ */
+function auth_auto_create_user( $p_username, $p_password ) {
+	$t_login_method = config_get( 'login_method' );
+
+	if( $t_login_method == BASIC_AUTH ) {
+		$t_auto_create = true;
+	} else if( $t_login_method == LDAP && ldap_authenticate_by_username( $p_username, $p_password ) ) {
+		$t_auto_create = true;
+	} else {
+		$t_auto_create = false;
+	}
+
+	if( $t_auto_create ) {
+		# attempt to create the user
+		$t_cookie_string = user_create( $p_username, md5( $p_password ) );
+		if( $t_cookie_string === false ) {
+			# it didn't work
+			return false;
+		}
+
+		# ok, we created the user, get the row again
+		return user_get_id_by_name( $p_username );
+	}
+
+	return false;
+}
+
+/**
  * Attempt to login the user with the given password
  * If the user fails validation, false is returned
  * If the user passes validation, the cookies are set and
@@ -201,35 +237,9 @@ function auth_prepare_password( $p_password ) {
 function auth_attempt_login( $p_username, $p_password, $p_perm_login = false ) {
 	$t_user_id = user_get_id_by_name( $p_username );
 
-	$t_login_method = config_get( 'login_method' );
-
-	if( false === $t_user_id ) {
-		if( BASIC_AUTH == $t_login_method ) {
-			$t_auto_create = true;
-		} else if( LDAP == $t_login_method && ldap_authenticate_by_username( $p_username, $p_password ) ) {
-			$t_auto_create = true;
-		} else {
-			$t_auto_create = false;
-		}
-
-		if( $t_auto_create ) {
-			# attempt to create the user
-			$t_cookie_string = user_create( $p_username, md5( $p_password ) );
-
-			if( false === $t_cookie_string ) {
-				# it didn't work
-				return false;
-			}
-
-			# ok, we created the user, get the row again
-			$t_user_id = user_get_id_by_name( $p_username );
-
-			if( false === $t_user_id ) {
-				# uh oh, something must be really wrong
-				# @@@ trigger an error here?
-				return false;
-			}
-		} else {
+	if( $t_user_id === false ) {
+		$t_user_id = auth_auto_create_user( $p_username, $p_password );
+		if( $t_user_id === false ) {
 			return false;
 		}
 	}
@@ -310,9 +320,11 @@ function auth_attempt_script_login( $p_username, $p_password = null ) {
 	}
 
 	$t_user_id = user_get_id_by_name( $t_username );
-
-	if( false === $t_user_id ) {
-		return false;
+	if( $t_user_id === false ) {
+		$t_user_id = auth_auto_create_user( $t_username, $p_password );
+		if( $t_user_id === false ) {
+			return false;
+		}
 	}
 
 	$t_user = user_get_row( $t_user_id );


### PR DESCRIPTION
The web login logic auto-creates users in case of BASIC AUTH and LDAP when they don't exist.  However, the SOAP API didn't.

This fix includes:
- When user authenticates using SOAP API, re-use the same auto-creation logic to create the user in case of valid credentials.
- When a user is auto-created, execute post login checks and processing like login count, cookies, tokens, etc.  This fix applies to the web interface code path.

Fixes #15869
