### PR TITLE
Fix install page when database is not created yet

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -182,7 +182,8 @@ if( $t_config_exists && $t_install_state <= 1 ) {
 	$f_timezone               = config_get( 'default_timezone', '' );
 
 	# Set default prefix/suffix form variables ($f_db_table_XXX)
-	foreach( $t_prefix_defaults['other'] as $t_key => $t_value ) {
+	$t_prefix_type = 'other';
+	foreach( $t_prefix_defaults[$t_prefix_type] as $t_key => $t_value ) {
 		${'f_' . $t_key} = $t_value;
 	}
 } else {


### PR DESCRIPTION
This issue results in a broken install page when attempting fresh install of mantisbt with these two conditions:

- config_inc.php exists
- Database is not created yet

Fixes #17805