### PR TITLE
Fix php errors with filters

### DIFF
--- a/core/current_user_api.php
+++ b/core/current_user_api.php
@@ -209,7 +209,7 @@ function current_user_ensure_unprotected() {
  * @param integer $p_project_id Project id. This argument is only used if a 'filter' string is not passed via the web request.
  *                              The default value is null meaning return the current filter for user's current project
                                 if a filter string is not supplied.
- * @return mixed Active issue filter for current user or false if no filter is currently defined.
+ * @return array User filter, if not set, then default filter.
  * @access public
  */
 function current_user_get_bug_filter( $p_project_id = null ) {
@@ -227,7 +227,7 @@ function current_user_get_bug_filter( $p_project_id = null ) {
 		}
 		$t_filter = filter_ensure_valid_filter( $t_filter );
 	} else if( !filter_is_cookie_valid() ) {
-		return false;
+		$t_filter = filter_get_default();
 	} else {
 		$t_user_id = auth_get_current_user_id();
 		$t_filter = user_get_bug_filter( $t_user_id, $p_project_id );

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -80,6 +80,17 @@ require_api( 'user_api.php' );
 require_api( 'utility_api.php' );
 require_api( 'version_api.php' );
 
+$g_filter = null;
+
+/**
+ * Initialize the filter API with the current filter.
+ * @param array $p_filter The filter to set as the current filter.
+ */
+function filter_init( $p_filter ) {
+	global $g_filter;
+	$g_filter = $p_filter;
+}
+
 /**
  * Allow plugins to define a set of class-based filters, and register/load
  * them here to be used by the rest of filter_api.
@@ -546,7 +557,7 @@ function filter_ensure_valid_filter( array $p_filter_arr ) {
 		$p_filter_arr[FILTER_PROPERTY_FILTER_BY_DATE] = gpc_get_bool( FILTER_PROPERTY_FILTER_BY_DATE, false );
 	}
 	if( !isset( $p_filter_arr[FILTER_PROPERTY_VIEW_STATE] ) ) {
-		$p_filter_arr[FILTER_PROPERTY_VIEW_STATE] = gpc_get( FILTER_PROPERTY_VIEW_STATE, '' );
+		$p_filter_arr[FILTER_PROPERTY_VIEW_STATE] = gpc_get( FILTER_PROPERTY_VIEW_STATE, META_FILTER_ANY );
 	} else if( filter_field_is_any( $p_filter_arr[FILTER_PROPERTY_VIEW_STATE] ) ) {
 		$p_filter_arr[FILTER_PROPERTY_VIEW_STATE] = META_FILTER_ANY;
 	}

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1312,7 +1312,7 @@ function user_is_lost_password_request_allowed( $p_user_id ) {
  *
  * @param integer $p_user_id    A valid user identifier.
  * @param integer $p_project_id A valid project identifier.
- * @return array
+ * @return array The user filter, or default filter if not valid.
  */
 function user_get_bug_filter( $p_user_id, $p_project_id = null ) {
 	if( null === $p_project_id ) {
@@ -1326,7 +1326,7 @@ function user_get_bug_filter( $p_user_id, $p_project_id = null ) {
 	$t_cookie_detail = explode( '#', $t_view_all_cookie, 2 );
 
 	if( !isset( $t_cookie_detail[1] ) ) {
-		return false;
+		return filter_get_default();
 	}
 
 	$t_filter = json_decode( $t_cookie_detail[1], true );

--- a/return_dynamic_filters.php
+++ b/return_dynamic_filters.php
@@ -53,12 +53,11 @@ auth_ensure_user_authenticated();
 
 compress_enable();
 
-global $g_filter;
+$t_filter = current_user_get_bug_filter();
+filter_init( $t_filter );
+
 global $g_select_modifier;
-$g_filter = current_user_get_bug_filter();
-if( $g_filter === false ) {
-	$g_filter = filter_get_default();
-}
+
 $t_project_id = helper_get_current_project();
 $t_current_user_access_level = current_user_get_access_level();
 $t_accessible_custom_fields_ids = array();
@@ -128,7 +127,7 @@ function return_dynamic_filters_prepend_headers() {
 }
 
 $f_filter_target = gpc_get_string( 'filter_target' );
-$t_function_name = 'print_filter_' . utf8_substr( $f_filter_target, 0, -7 );
+$t_function_name = 'print_filter_' . utf8_substr( $f_filter_target, 0, -7 ); # -7 for '_filter'
 if( function_exists( $t_function_name ) ) {
 	return_dynamic_filters_prepend_headers();
 	call_user_func( $t_function_name );

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -53,11 +53,8 @@ require_api( 'html_api.php' );
 require_api( 'lang_api.php' );
 require_api( 'print_api.php' );
 
-$g_filter = current_user_get_bug_filter();
-# NOTE: this check might be better placed in current_user_get_bug_filter()
-if( $g_filter === false ) {
-	$g_filter = filter_get_default();
-}
+$t_filter = current_user_get_bug_filter();
+filter_init( $t_filter );
 
 list( $t_sort, ) = explode( ',', $g_filter['sort'] );
 list( $t_dir, ) = explode( ',', $g_filter['dir'] );

--- a/view_filters_page.php
+++ b/view_filters_page.php
@@ -65,7 +65,9 @@ compress_enable();
 
 html_page_top();
 
-$t_filter = filter_get_default();
+$t_filter = current_user_get_bug_filter();
+filter_init( $t_filter );
+
 $t_target_field = rtrim( gpc_get_string( 'target_field', '' ), '[]' );
 if( !isset( $t_filter[$t_target_field] ) ) {
 	$t_target_field = '';
@@ -73,10 +75,6 @@ if( !isset( $t_filter[$t_target_field] ) ) {
 
 # @todo thraxisp - could this be replaced by a call to filter_draw_selection_area2
 
-$t_filter = current_user_get_bug_filter();
-if( $t_filter === false ) {
-	$t_filter = filter_get_default();
-}
 $t_project_id = helper_get_current_project();
 
 $t_current_user_access_level = current_user_get_access_level();


### PR DESCRIPTION
This fixes the php errors that occur when clicking on View State, Match Type, and Highlight Changed.

The change includes:
- When a filter is retrieved for a user, if the user doesn't have a filter or something is wrong with it, return default fitler.
- Move access to $g_filter into the filter_api and introduce filter_init() API.  Default $g_filter in filter_api as well.
- View State initialization should use correct type to avoid type mismatch in check_selected().

Fixes #17654
