### PR TITLE
Hide news permissions when disabled

### DIFF
--- a/adm_permissions_report.php
+++ b/adm_permissions_report.php
@@ -109,10 +109,12 @@ function get_section_end() {
 }
 
 # News
-echo get_section_begin_apr( lang_get( 'news' ) );
-echo get_capability_row( lang_get( 'view_private_news' ), config_get( 'private_news_threshold' ) );
-echo get_capability_row( lang_get( 'manage_news' ), config_get( 'manage_news_threshold' ) );
-echo get_section_end();
+if( config_get( 'news_enabled' ) == ON ) {
+	echo get_section_begin_apr( lang_get( 'news' ) );
+	echo get_capability_row( lang_get( 'view_private_news' ), config_get( 'private_news_threshold' ) );
+	echo get_capability_row( lang_get( 'manage_news' ), config_get( 'manage_news_threshold' ) );
+	echo get_section_end();
+}
 
 # Attachments
 if( config_get( 'allow_file_upload' ) == ON ) {


### PR DESCRIPTION
The news related permissions should be hidden when the feature is disabled.
