### PR TITLE
Allow retrieving multiple/complex configs

### DIFF
--- a/api/soap/mantisconnect.wsdl
+++ b/api/soap/mantisconnect.wsdl
@@ -753,6 +753,14 @@
   <part name="config_var" type="xsd:string" /></message>
 <message name="mc_config_get_stringResponse">
   <part name="return" type="xsd:string" /></message>
+<message name="mc_config_getRequest">
+    <part name="username" type="xsd:string" />
+    <part name="password" type="xsd:string" />
+    <part name="user" type="tns:ObjectRef" />
+    <part name="project" type="tns:ObjectRef" />
+    <part name="configs" type="tns:StringArray" /></message>
+<message name="mc_config_getResponse">
+    <part name="return" type="xsd:string" /></message>
 <message name="mc_issue_checkinRequest">
   <part name="username" type="xsd:string" />
   <part name="password" type="xsd:string" />
@@ -1099,6 +1107,11 @@
     <input message="tns:mc_config_get_stringRequest"/>
     <output message="tns:mc_config_get_stringResponse"/>
   </operation>
+  <operation name="mc_config_get">
+    <documentation>Get the specified configurations for the specified user and project.</documentation>
+    <input message="tns:mc_config_get_stringRequest"/>
+    <output message="tns:mc_config_get_stringResponse"/>
+  </operation>
   <operation name="mc_issue_checkin">
     <documentation>Notifies MantisBT of a check-in for the issue with the specified id.</documentation>
     <input message="tns:mc_issue_checkinRequest"/>
@@ -1436,6 +1449,11 @@
     <soap:operation soapAction="http://www.mantisbt.org/bugs/api/soap/mantisconnect.php/mc_config_get_string" style="rpc"/>
     <input><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></input>
     <output><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></output>
+  </operation>
+  <operation name="mc_config_get">
+    <soap:operation soapAction="http://www.mantisbt.org/bugs/api/soap/mantisconnect.php/mc_config_get" style="rpc"/>
+      <input><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></input>
+      <output><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></output>
   </operation>
   <operation name="mc_issue_checkin">
     <soap:operation soapAction="http://www.mantisbt.org/bugs/api/soap/mantisconnect.php/mc_issue_checkin" style="rpc"/>

--- a/api/soap/mc_config_api.php
+++ b/api/soap/mc_config_api.php
@@ -51,3 +51,57 @@ function mc_config_get_string( $p_username, $p_password, $p_config_var ) {
 	return config_get( $p_config_var );
 }
 
+/**
+ * Gets the specified set of configs for the specified user and project.
+ *
+ * @param string $p_username   Username.
+ * @param string $p_password   Password.
+ * @param string $p_user       The user to get the configs for (ObjectRef) or null for current user.
+ * @param string $p_project    The project to get the configs for (ObjectRef) or null for default project.
+ * @param arrays $p_configs    The array of configs to return.
+ * @return string json encoded string
+ */
+function mc_config_get( $p_username, $p_password, $p_user, $p_project, $p_configs ) {
+	$t_user_id = mci_check_login( $p_username, $p_password );
+	if( $t_user_id === false ) {
+		return mci_soap_fault_login_failed();
+	}
+
+	if( !mci_has_readonly_access( $t_user_id ) ) {
+		return mci_soap_fault_access_denied( $t_user_id );
+	}
+
+	$t_target_user_id = $p_user === null ? $t_user_id : mci_get_user_id( $p_user );
+	if( $t_target_user_id != $t_user_id ) {
+		# We can add a config threshold in the future if needed.
+		if( !access_has_global_level( ADMINISTRATOR, $t_user_id ) ) {
+			return mci_soap_fault_access_denied( $t_user_id );
+		}
+	}
+
+	if( $p_project === null ) {
+		$t_project_id = null;
+	} else {
+		$t_project_id = mci_get_project_id( $p_project );
+
+		if( !access_has_project_level( config_get( 'view_bug_threshold' ), $t_project_id, $t_target_user_id ) ) {
+			$t_project_id = null;
+		}
+	}
+
+	$t_configs = array();
+
+	foreach( $p_configs as $t_config_var ) {
+		if( config_is_private( $t_config_var ) ) {
+			return SoapObjectsFactory::newSoapFault( 'Client', 'Access to \'' . $t_config_var . '\' is denied' );
+		}
+
+		if( !config_is_set( $t_config_var, $t_target_user_id, $t_project_id ) ) {
+			return SoapObjectsFactory::newSoapFault( 'Client', 'Config \'' . $t_config_var . '\' is undefined' );
+		}
+
+		$t_configs[$t_config_var] = config_get( $t_config_var, /* default */ null, $t_target_user_id, $t_project_id );
+	}
+
+	return json_encode( $t_configs );
+}


### PR DESCRIPTION
NOTE: This is a preview of the change.  If we are in agreement, then will test and add test cases.

Add mc_config_get() to enables clients to do the following - compared to mc_config_get_string():
- Retrieve multiple configs in one call.
- Retrieve complex configs.
- Retrieve configs within context of a target user.
- Retrieve configs within context of a project.

This method returns configs in json.  I was opposing serialization, but thinking about it there is no way to do this in a strongly typed way.  Json is a good option due to the good support for decoding into native structures/objects in all languages.
