### PR TITLE
Show time tracking on print issue page

### DIFF
--- a/bugnote_view_inc.php
+++ b/bugnote_view_inc.php
@@ -73,6 +73,7 @@ access_cache_matrix_project( helper_get_current_project() );
 # get the bugnote data
 $t_bugnote_order = current_user_get_pref( 'bugnote_order' );
 $t_bugnotes = bugnote_get_all_visible_bugnotes( $f_bug_id, $t_bugnote_order, 0, $t_user_id );
+$t_show_time_tracking = access_has_bug_level( config_get( 'time_tracking_view_threshold' ), $f_bug_id );
 
 #precache users
 $t_bugnote_users = array();
@@ -132,9 +133,8 @@ $t_num_notes = count( $t_bugnotes );
 
 		$t_bugnote_id_formatted = bugnote_format_id( $t_bugnote->id );
 
-		if( 0 != $t_bugnote->time_tracking ) {
+		if( $t_bugnote->time_tracking != 0 ) {
 			$t_time_tracking_hhmm = db_minutes_to_hhmm( $t_bugnote->time_tracking );
-			$t_bugnote->note_type = TIME_TRACKING;   # for older entries that didn't set the type @@@PLR FIXME
 			$t_total_time += $t_bugnote->time_tracking;
 		} else {
 			$t_time_tracking_hhmm = '';
@@ -240,7 +240,7 @@ $t_num_notes = count( $t_bugnotes );
 		<?php
 			switch( $t_bugnote->note_type ) {
 				case REMINDER:
-					echo '<em>';
+					echo '<strong>';
 
 					# List of recipients; remove surrounding delimiters
 					$t_recipients = trim( $t_bugnote->note_attr, '|' );
@@ -262,11 +262,11 @@ $t_num_notes = count( $t_bugnotes );
 							. ( $t_truncated ? ' (' . lang_get( 'reminder_list_truncated' ) . ')' : '' );
 					}
 
-					echo '</em><br /><br />';
+					echo '</strong><br /><br />';
 					break;
 
 				case TIME_TRACKING:
-					if( access_has_bug_level( config_get( 'time_tracking_view_threshold' ), $f_bug_id ) ) {
+					if( $t_show_time_tracking ) {
 						echo '<div class="time-tracked">', lang_get( 'time_tracking_time_spent' ) . ' ' . $t_time_tracking_hhmm, '</div>';
 					}
 					break;
@@ -288,7 +288,7 @@ $t_num_notes = count( $t_bugnotes );
 </table>
 <?php
 
-if( $t_total_time > 0 && access_has_bug_level( config_get( 'time_tracking_view_threshold' ), $f_bug_id ) ) {
+if( $t_total_time > 0 && $t_show_time_tracking ) {
 	echo '<p class="time-tracking-total">', sprintf( lang_get( 'total_time_for_issue' ), '<span class="time-tracked">' . db_minutes_to_hhmm( $t_total_time ) . '</span>' ), '</p>';
 }
 	collapse_closed( 'bugnotes' );

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -396,7 +396,6 @@ function bugnote_get_all_visible_bugnotes( $p_bug_id, $p_user_bugnote_order, $p_
 	$t_user_access_level = user_get_access_level( $t_user_id, $t_project_id );
 
 	$t_all_bugnotes = bugnote_get_all_bugnotes( $p_bug_id );
-	$t_private_bugnote_threshold = config_get( 'private_bugnote_threshold' );
 
 	$t_private_bugnote_visible = access_compare_level( $t_user_access_level, config_get( 'private_bugnote_threshold' ) );
 	$t_time_tracking_visible = access_compare_level( $t_user_access_level, config_get( 'time_tracking_view_threshold' ) );
@@ -477,6 +476,11 @@ function bugnote_get_all_bugnotes( $p_bug_id ) {
 			$t_bugnote->note_type = $t_row['note_type'];
 			$t_bugnote->note_attr = $t_row['note_attr'];
 			$t_bugnote->time_tracking = $t_row['time_tracking'];
+
+			# Handle old bugnotes before setting type to time tracking
+			if ( $t_bugnote->time_tracking != 0 ) {
+				$t_bugnote->note_type = TIME_TRACKING;
+			}
 
 			$t_bugnotes[] = $t_bugnote;
 			$g_cache_bugnote[(int)$t_bugnote->id] = $t_bugnote;

--- a/print_bugnote_inc.php
+++ b/print_bugnote_inc.php
@@ -68,19 +68,15 @@ if( !access_has_bug_level( config_get( 'private_bugnote_threshold' ), $f_bug_id 
 
 # get the bugnote data
 $t_bugnote_order = current_user_get_pref( 'bugnote_order' );
-
-$t_query = 'SELECT * FROM {bugnote}
-		WHERE bug_id=' . db_param() . ' ' . $t_restriction . '
-		ORDER BY date_submitted ' . $t_bugnote_order;
-$t_result = db_query( $t_query, array( $c_bug_id ) );
-$t_num_notes = db_num_rows( $t_result );
+$t_bugnotes = bugnote_get_all_visible_bugnotes( $f_bug_id, $t_bugnote_order, 0, $t_user_id );
+$t_show_time_tracking = access_has_bug_level( config_get( 'time_tracking_view_threshold' ), $f_bug_id );
+$t_total_time = 0;
 ?>
 
 <br />
 <table class="width100" cellspacing="1">
 	<?php
-		# no bugnotes
-		if( 0 == $t_num_notes ) {
+		if( 0 == count( $t_bugnotes ) ) {
 	?>
 	<tr>
 		<td class="print" colspan="2">
@@ -94,20 +90,18 @@ $t_num_notes = db_num_rows( $t_result );
 		</td>
 	</tr>
 	<?php
-		for( $i=0; $i < $t_num_notes; $i++ ) {
-			# prefix all bugnote data with v3_
-			$t_row = db_fetch_array( $t_result );
+		foreach( $t_bugnotes as $t_row ) {
+			$t_date_submitted = date( config_get( 'normal_date_format' ), $t_row->date_submitted );
+			$t_last_modified = date( config_get( 'normal_date_format' ), $t_row->last_modified );
 
-			$t_date_submitted = date( config_get( 'normal_date_format' ), $t_row['date_submitted'] );
-			$t_last_modified = date( config_get( 'normal_date_format' ), $t_row['last_modified'] );
+			$t_note = string_display_links( $t_row->note );
 
-			# grab the bugnote text and id and prefix with v3_
-			$t_query = 'SELECT note, id FROM {bugnote_text} WHERE id=' . db_param();
-			$t_result2 = db_query( $t_query, array( $t_row['bugnote_text_id'] ) );
-			$t_note = db_result( $t_result2, 0, 0 );
-			$t_bugnote_text_id = db_result( $t_result2, 0, 1 );
-
-			$t_note = string_display_links( $t_note );
+			if( $t_row->note_type == TIME_TRACKING ) {
+				$t_time = db_minutes_to_hhmm( $t_row->time_tracking );
+				$t_total_time += $t_row->time_tracking;
+			} else {
+				$t_time = '';
+			}
 	?>
 	<tr>
 		<td class="print-spacer" colspan="2">
@@ -119,13 +113,13 @@ $t_num_notes = db_num_rows( $t_result );
 			<table class="hide" cellspacing="1">
 				<tr>
 					<td class="print">
-						(<?php echo bugnote_format_id( $t_row['id'] ) ?>)
+						(<?php echo bugnote_format_id( $t_row->id ) ?>)
 					</td>
 				</tr>
 				<tr>
 					<td class="print">
 						<?php
-						print_user( $t_row['reporter_id'] );
+						print_user( $t_row->reporter_id );
 						?>&#160;&#160;&#160;
 					</td>
 				</tr>
@@ -144,17 +138,26 @@ $t_num_notes = db_num_rows( $t_result );
 			<tr>
 				<td class="print">
 					<?php
-						switch( $t_row['note_type'] ) {
+						switch( $t_row->note_type ) {
 							case REMINDER:
-								echo '<div class="italic">' . lang_get( 'reminder_sent_to' ) . ': ';
-								$t_note_attr = utf8_substr( $t_row['note_attr'], 1, utf8_strlen( $t_row['note_attr'] ) - 2 );
+								echo '<p><strong>' . lang_get( 'reminder_sent_to' ) . ': ';
+								$t_note_attr = utf8_substr( $t_row->note_attr, 1, utf8_strlen( $t_row->note_attr ) - 2 );
 								$t_to = array();
 								foreach ( explode( '|', $t_note_attr ) as $t_recipient ) {
 									$t_to[] = string_display_line( user_get_name( $t_recipient ) );
 								}
-								echo implode( ', ', $t_to ) . '</div><br />';
+								echo implode( ', ', $t_to ) . '</strong></p>';
+								echo $t_note;
+								break;
+							case TIME_TRACKING:
+								if( $t_show_time_tracking ) {
+									echo '<p><strong>', lang_get( 'time_tracking_time_spent' ) . ' ' . $t_time, '</strong></p>';
+								}
+								echo $t_note;
+								break;
 							default:
 								echo $t_note;
+								break;
 						}
 					?>
 				</td>
@@ -167,3 +170,7 @@ $t_num_notes = db_num_rows( $t_result );
 		} # end else
 	?>
 </table>
+<?php
+if( $t_total_time > 0 && $t_show_time_tracking ) {
+	echo '<p align="right">', sprintf( lang_get( 'total_time_for_issue' ), '<strong>' . db_minutes_to_hhmm( $t_total_time ) . '</strong>' ), '</p>';
+}


### PR DESCRIPTION
This change includes the following fixes:
- Use bugnote API in print issue page.
- Add time tracking information in print issue page.
- Use bold for both reminders and time tracking, rather than one bold and one italics.
- Remove fixup of bugnote type to TIME_TRACKING in API rather than in calling code.

Fixes #17410
