### PR TITLE
Clarify separator that can be used to separate possible values

### DIFF
--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -740,7 +740,7 @@ $s_last_visit_label = 'Last Visit:';
 $s_edit_user_link = 'Edit User';
 
 # manage_custom_field_edit_page.php
-$s_separate_lists_by = '(Separate lists by "%1$s")';
+$s_separate_list_items_by = '(separate list items by "%1$s")';
 
 # manage_config_email_page
 $s_config_all_projects = 'Note: These configurations affect all projects, unless overridden at the project level.';

--- a/manage_custom_field_edit_page.php
+++ b/manage_custom_field_edit_page.php
@@ -89,7 +89,7 @@ $t_definition = custom_field_get_definition( $f_field_id );
 			<div class="field-container">
 				<label for="custom-field-possible-values"><span><?php echo lang_get( 'custom_field_possible_values' ) ?></span></label>
 				<span class="input"><input type="text" id="custom-field-possible-values" name="possible_values" size="100" value="<?php echo string_attribute( $t_definition['possible_values'] ) ?>" />
-					<?php echo sprintf( lang_get( 'separate_lists_by' ), '|' ) ?>
+					<?php echo sprintf( lang_get( 'separate_list_items_by' ), '|' ) ?>
 				</span>
 				<span class="label-style"></span>
 			</div>


### PR DESCRIPTION
1. Show the separator to use to separate custom field possible values given that '|' is hard to guess.
2. Increase the width of the possible values field for readability of its content.

Fixes #17825
