### PR TITLE
Changing columns for single projects

### DIFF
--- a/manage_columns_inc.php
+++ b/manage_columns_inc.php
@@ -119,16 +119,23 @@ $t_excel = implode( ', ', $t_columns );
 			<?php
 			if( $t_account_page ) {
 				if( $t_project_id == ALL_PROJECTS ) { ?>
-					<span class="submit-button"><input <?php echo helper_get_tab_index() ?> type="submit" class="button" name="update_columns_as_my_default" value="<?php echo lang_get( 'update_columns_as_my_default' ) ?>" /></span><?php
+					<span class="submit-button"><input <?php echo helper_get_tab_index() ?> type="submit" class="button" value="<?php echo lang_get( 'update_columns_as_my_default' ) ?>" /></span><?php
 				} else { ?>
-					<span class="submit-button"><input <?php echo helper_get_tab_index() ?> type="submit" class="button" name="update_columns_for_current_project" value="<?php echo lang_get( 'update_columns_for_current_project' ) ?>" /></span><?php
-
+					<span class="submit-button"><input <?php echo helper_get_tab_index() ?> type="submit" class="button" value="<?php echo lang_get( 'update_columns_for_current_project' ) ?>" /></span><?php
+				}
 			}
-		}
 
-		if( $t_manage_page && current_user_is_administrator() ) { ?>
-			<span class="submit-button"><input <?php echo helper_get_tab_index() ?> type="submit" class="button" name="update_columns_as_global_default" value="<?php echo lang_get( 'update_columns_as_global_default' ) ?>" /></span><?php
-		} ?>
+			# All Projects: only if admin can setup global default columns.
+			# Specific Project: can set columns for that.  Switch to All Projects to set for all projects.
+			if( $t_manage_page ) { ?>
+				<div class="submit-button"><?php
+				if( $t_project_id != ALL_PROJECTS ) { ?>
+					<input <?php echo helper_get_tab_index() ?> type="submit" class="button" value="<?php echo lang_get( 'update_columns_for_current_project' ) ?>" /><?php
+				} else if( current_user_is_administrator() ) { ?>
+					<input <?php echo helper_get_tab_index() ?> type="submit" class="button" value="<?php echo lang_get( 'update_columns_as_global_default' ) ?>" /><?php
+				} ?>
+				</div><?php
+			} ?>
 		</fieldset>
 	</form>
 </div>

--- a/manage_config_columns_set.php
+++ b/manage_config_columns_set.php
@@ -53,42 +53,40 @@ require_api( 'project_api.php' );
 
 form_security_validate( 'manage_config_columns_set' );
 
-# @@@ access_ensure_project_level( config_get( 'manage_project_threshold' ) );
-
 $f_project_id = gpc_get_int( 'project_id' );
 $f_view_issues_columns = gpc_get_string( 'view_issues_columns' );
 $f_print_issues_columns = gpc_get_string( 'print_issues_columns' );
 $f_csv_columns = gpc_get_string( 'csv_columns' );
 $f_excel_columns = gpc_get_string( 'excel_columns' );
-$f_update_columns_for_current_project = gpc_get_bool( 'update_columns_for_current_project' );
-$f_update_columns_as_my_default = gpc_get_bool( 'update_columns_as_my_default' );
-$f_update_columns_as_global_default = gpc_get_bool( 'update_columns_as_global_default' );
 $f_form_page = gpc_get_string( 'form_page' );
 
-# only admins can set global defaults.for ALL_PROJECT
-if( $f_update_columns_as_global_default && $f_project_id == ALL_PROJECTS && !current_user_is_administrator() ) {
-	access_denied();
+if( $f_project_id != ALL_PROJECTS ) {
+	project_ensure_exists( $f_project_id );
 }
 
-# only MANAGERS can set global defaults.for a project
-if( $f_update_columns_as_global_default && $f_project_id != ALL_PROJECTS ) {
-	access_ensure_project_level( MANAGER, $f_project_id );
-}
+$g_project_override = $f_project_id;
+$t_project_id = $f_project_id;
 
-# user should only be able to set columns for a project that is accessible.
-if( $f_update_columns_for_current_project && $f_project_id != ALL_PROJECTS ) {
-	access_ensure_project_level( config_get( 'view_bug_threshold', null, null, $f_project_id ), $f_project_id );
-}
+$t_account_page = $f_form_page === 'account';
 
-if( $f_update_columns_as_my_default || $f_update_columns_as_global_default ) {
-	$t_project_id = ALL_PROJECTS;
+if( $f_project_id == ALL_PROJECTS ) {
+	if( !$t_account_page ) {
+		# From manage page, only admins can set global defaults for ALL_PROJECT
+		if( !current_user_is_administrator() ) {
+			access_denied();
+		}
+	}
 } else {
-	$t_project_id = $f_project_id;
-	project_ensure_exists( $t_project_id );
+	if( $t_account_page ) {
+		access_ensure_project_level( config_get( 'view_bug_threshold' ), $f_project_id );
+	} else {
+		access_ensure_project_level( config_get( 'manage_project_threshold' ), $f_project_id );
+	}
 }
 
-# Calculate the user id to set the configuration for.
-if( $f_update_columns_as_my_default || $f_update_columns_for_current_project ) {
+# For Account Column Customization, use current user.
+# For Manage Column Customization, use no user.
+if( $t_account_page ) {
 	$t_user_id = auth_get_current_user_id();
 } else {
 	$t_user_id = NO_USER;
@@ -123,7 +121,7 @@ if( json_encode( config_get( 'excel_columns', '', $t_user_id, $t_project_id ) ) 
 
 form_security_purge( 'manage_config_columns_set' );
 
-$t_redirect_url = $f_form_page === 'account' ? 'account_manage_columns_page.php' : 'manage_config_columns_page.php';
+$t_redirect_url = $t_account_page ? 'account_manage_columns_page.php' : 'manage_config_columns_page.php';
 html_page_top( null, $t_redirect_url );
 
 html_operation_successful( $t_redirect_url );


### PR DESCRIPTION
- Simply manage columns access checks/form paramters
- Set user id to NO USER when in Manage - Manage Columns and Logged in User when in My Account - Manage Columns.
- Allow user to set columns for all / current project based on active project.

Fixes #13699

This replaces PR #214
