### PR TITLE
Float the details view action buttons toward the left

### DIFF
--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -327,7 +327,7 @@ echo '</thead>';
 
 if( $t_bottom_buttons_enabled ) {
 	echo '<tfoot>';
-	echo '<tr class="bottom-buttons"><td colspan="6">';
+	echo '<tr class="details-footer"><td colspan="6">';
 	html_buttons_view_bug_page( $t_bug_id );
 	echo '</td></tr>';
 	echo '</tfoot>';

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1786,29 +1786,29 @@ function html_buttons_view_bug_page( $p_bug_id ) {
 
 	$t_bug = bug_get( $p_bug_id );
 
-	echo '<table><tr class="vcenter">';
+	echo '<table><tr class="details-buttons">';
 	if( !$t_readonly ) {
 		# UPDATE button
-		echo '<td class="center">';
+		echo '<td>';
 		html_button_bug_update( $p_bug_id );
 		echo '</td>';
 
 		# ASSIGN button
-		echo '<td class="center">';
+		echo '<td>';
 		html_button_bug_assign_to( $t_bug );
 		echo '</td>';
 	}
 
 	# Change status button/dropdown
 	if( !$t_readonly ) {
-		echo '<td class="center">';
+		echo '<td>';
 		html_button_bug_change_status( $t_bug );
 		echo '</td>';
 	}
 
 	# MONITOR/UNMONITOR button
 	if( !current_user_is_anonymous() ) {
-		echo '<td class="center">';
+		echo '<td>';
 		if( user_is_monitoring_bug( auth_get_current_user_id(), $p_bug_id ) ) {
 			html_button_bug_unmonitor( $p_bug_id );
 		} else {
@@ -1819,7 +1819,7 @@ function html_buttons_view_bug_page( $p_bug_id ) {
 
 	# STICK/UNSTICK button
 	if( access_has_bug_level( $t_sticky, $p_bug_id ) ) {
-		echo '<td class="center">';
+		echo '<td>';
 		if( !bug_get_field( $p_bug_id, 'sticky' ) ) {
 			html_button_bug_stick( $p_bug_id );
 		} else {
@@ -1830,28 +1830,28 @@ function html_buttons_view_bug_page( $p_bug_id ) {
 
 	# CLONE button
 	if( !$t_readonly ) {
-		echo '<td class="center">';
+		echo '<td>';
 		html_button_bug_create_child( $p_bug_id );
 		echo '</td>';
 	}
 
 	# REOPEN button
-	echo '<td class="center">';
+	echo '<td>';
 	html_button_bug_reopen( $t_bug );
 	echo '</td>';
 
 	# CLOSE button
-	echo '<td class="center">';
+	echo '<td>';
 	html_button_bug_close( $t_bug );
 	echo '</td>';
 
 	# MOVE button
-	echo '<td class="center">';
+	echo '<td>';
 	html_button_bug_move( $p_bug_id );
 	echo '</td>';
 
 	# DELETE button
-	echo '<td class="center">';
+	echo '<td>';
 	html_button_bug_delete( $p_bug_id );
 	echo '</td>';
 

--- a/css/default.css
+++ b/css/default.css
@@ -779,3 +779,7 @@ div.timeline p { margin-left: 3px; }
 /* manage_config_* colors */
 .color-global		{ background-color: LightBlue; }
 .color-project		{ background-color: LightGreen; }
+
+/* bug_view_inc bug action buttons */
+.details-footer      { padding: 3px 10px 2px 0; }
+.details-buttons     { float: left;  width: auto; }


### PR DESCRIPTION
Adjust the buttons in the view issue details page to float toward the left:

Fixes: 17819

Before:

![screen shot 2014-10-31 at 10 22 11 pm](https://cloud.githubusercontent.com/assets/1354889/4870892/e29b8e0c-618b-11e4-8284-8b441d053dde.png)

After:

![screen shot 2014-10-31 at 10 55 02 pm](https://cloud.githubusercontent.com/assets/1354889/4870893/eb6ed958-618b-11e4-93e3-85a6655314f3.png)
