### PR TITLE
Support disabling per project upload path

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -1695,6 +1695,12 @@ $g_document_files_prefix = 'doc';
 $g_absolute_path_default_upload_folder = '';
 
 /**
+ * Allow per project upload path if the attachments are saved to DISK
+ * and the project has a path set.  Otherwise, use $g_absolute_path_default_upload_folder.
+ */
+$g_allow_per_project_upload_path = ON;
+
+/**
  * Enable support for sending files to users via a more efficient X-Sendfile
  * method. HTTP server software supporting this technique includes Lighttpd,
  * Cherokee, Apache with mod_xsendfile and nginx. You may need to set the
@@ -4165,6 +4171,7 @@ $g_global_settings = array(
 	'class_path','library_path', 'language_path', 'absolute_path_default_upload_folder',
 	'ldap_simulation_file_path', 'plugin_path', 'bottom_include_page', 'top_include_page',
 	'default_home_page', 'logout_redirect_page', 'manual_url', 'logo_url', 'wiki_engine_url',
+	'allow_per_project_upload_path',
 );
 
 # Temporary variables should not remain defined in global scope

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -226,7 +226,7 @@ function file_normalize_attachment_path( $p_diskfile, $p_project_id ) {
 
 	$t_expected_file_path = '';
 
-	if( $p_project_id != ALL_PROJECTS ) {
+	if( $p_project_id != ALL_PROJECTS && config_get( 'allow_per_project_upload_path' ) == ON ) {
 		$t_path = project_get_field( $p_project_id, 'file_path' );
 		if( !is_blank( $t_path ) ) {
 			$t_diskfile = file_path_combine( $t_path, $t_basename );
@@ -650,12 +650,11 @@ function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p
 		$p_date_added = db_now();
 	}
 
-	if( $t_project_id == ALL_PROJECTS ) {
-		$t_file_path = config_get( 'absolute_path_default_upload_folder' );
-	} else {
-		$t_file_path = project_get_field( $t_project_id, 'file_path' );
-		if( is_blank( $t_file_path ) ) {
-			$t_file_path = config_get( 'absolute_path_default_upload_folder' );
+	$t_file_path = config_get( 'absolute_path_default_upload_folder' );
+	if( $t_project_id != ALL_PROJECTS && config_get( 'allow_per_project_upload_path' ) == ON ) {
+		$t_project_file_path = project_get_field( $t_project_id, 'file_path' );
+		if ( !is_blank( $t_project_file_path ) ) {
+			$t_file_path = $t_project_file_path;
 		}
 	}
 

--- a/docbook/Admin_Guide/en-US/Configuration.xml
+++ b/docbook/Admin_Guide/en-US/Configuration.xml
@@ -1664,6 +1664,15 @@ $g_resolution_multipliers = array( UNABLE_TO_DUPLICATE =&gt; 2,
                 </listitem>
             </varlistentry>
             <varlistentry>
+                <term>$g_allow_per_project_upload_path</term>
+                <listitem>
+                    <para>Determines whether each project can have its own upload file path in case
+                    of storing attachments on DISK.  When set to ON, the per project upload path is
+                    honored, otherwise, it is ignored.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
                 <term>$g_fileinfo_magic_db_file</term>
                 <listitem>
                     <para>Specify the filename of the magic database file.

--- a/manage_proj_create_page.php
+++ b/manage_proj_create_page.php
@@ -121,7 +121,7 @@ if( project_table_empty() ) {
 			<?php
 
 			$g_project_override = ALL_PROJECTS;
-			if( file_is_uploading_enabled() && DATABASE !== config_get( 'file_upload_method' ) ) {
+			if( file_is_uploading_enabled() && DATABASE !== config_get( 'file_upload_method' ) && config_get( 'allow_per_project_upload_path' ) == ON ) {
 				$t_file_path = '';
 				# Don't reveal the absolute path to non-administrators for security reasons
 				if( current_user_is_administrator() ) {

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -131,7 +131,7 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 			</div>
 			<?php
 			$g_project_override = $f_project_id;
-			if( file_is_uploading_enabled() && DATABASE !== config_get( 'file_upload_method' ) ) {
+			if( file_is_uploading_enabled() && DATABASE !== config_get( 'file_upload_method' ) && config_get( 'allow_per_project_upload_path' ) == ON ) {
 				$t_file_path = $t_row['file_path'];
 				# Don't reveal the absolute path to non-administrators for security reasons
 				if( is_blank( $t_file_path ) && current_user_is_administrator() ) {


### PR DESCRIPTION
Often there is a single attachments folder for all folders. In such case,
it would be useful to disable the upload path field showing up for each project.
This allows the administrator to set one path to be used for all projects.

Fixes #17826
