### PR TITLE
Collapse filter box by default

### DIFF
--- a/core/collapse_api.php
+++ b/core/collapse_api.php
@@ -204,6 +204,7 @@ function collapse_cache_token() {
 		$t_data = json_decode( $t_token, true );
 	} else {
 		$t_data = array();
+		$t_data['filter'] = false;
 	}
 
 	$g_collapse_cache_token = $t_data;


### PR DESCRIPTION
The filter box takes a large vertical space and it is expanded by default.
This change makes it collapsed by default.

Fixes #17830
