### PR TITLE
Improve button styling

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -22,8 +22,8 @@ a > img				{ border: none; }
 form				{ display: inline; }
 
 input				{}
-input.button			{}
-input.button-small		{ font-size: 1em; }
+input.button			{ border-radius: 5px; cursor: pointer; padding: 2px 10px; background-color: #ffffff }
+input.button-small		{ border-radius: 5px; cursor: pointer; padding: 2px 3px; margin:0 1px; background-color: #ffffff }
 
 textarea			{}
 select				{}


### PR DESCRIPTION
The buttons across mantis seems washed out with misaligned text. This change sharpens the button and makes them standout and easy to find. It affects all buttons in the product so I suggest trying it out on your dev box as part of the review:

Before:
![screen shot 2014-11-08 at 9 23 44 pm](https://cloud.githubusercontent.com/assets/1354889/4966569/1a2db40c-67d2-11e4-9f43-fcfbcf173798.png)

![screen shot 2014-11-08 at 9 25 09 pm](https://cloud.githubusercontent.com/assets/1354889/4966570/23bb5696-67d2-11e4-8abb-f1a7d07c4311.png)

After:
![screen shot 2014-11-08 at 9 24 36 pm](https://cloud.githubusercontent.com/assets/1354889/4966571/2ca59fa0-67d2-11e4-997f-e543b3af9777.png)

![screen shot 2014-11-08 at 9 25 20 pm](https://cloud.githubusercontent.com/assets/1354889/4966572/307b0bec-67d2-11e4-8d1b-d65251d1e42e.png)

Fixes #17820
