### PR TITLE
Add the ability to log information about modification made by plugins

### DIFF
--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -201,6 +201,7 @@ define( 'TAG_DETACHED', 26 );
 define( 'TAG_RENAMED', 27 );
 define( 'BUG_REVISION_DROPPED', 28 );
 define( 'BUGNOTE_REVISION_DROPPED', 29 );
+define( 'DATA_IMPORTED', 30 );
 define( 'PLUGIN_HISTORY', 100 );
 
 # bug revisions

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -457,6 +457,9 @@ function history_localize_item( $p_field_name, $p_type, $p_old_value, $p_new_val
 				case NEW_BUG:
 					$t_note = lang_get( 'new_bug' );
 					break;
+				case DATA_IMPORTED:
+					$t_note = lang_get( 'data_imported' );
+					$t_change = $p_old_value.' : '.$p_new_value;
 				case BUGNOTE_ADDED:
 					$t_note = lang_get( 'bugnote_added' ) . ': ' . $p_old_value;
 					break;

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -171,6 +171,7 @@ $s_steps_to_reproduce_updated = 'Steps to Reproduce Updated';
 $s_file_added = 'File Added';
 $s_file_deleted = 'File Deleted';
 $s_bug_deleted = 'Issue Deleted';
+$s_data_imported = 'Data Imported';
 
 $s_make_private = 'Make Private';
 $s_make_public = 'Make Public';

--- a/lang/strings_french.txt
+++ b/lang/strings_french.txt
@@ -151,6 +151,7 @@ $s_steps_to_reproduce_updated = 'Étapes pour reproduire mises à jour';
 $s_file_added = 'Fichier ajouté';
 $s_file_deleted = 'Fichier supprimé';
 $s_bug_deleted = 'Bogue supprimé';
+$s_data_imported = 'Données Importées';
 $s_make_private = 'Rendre privé';
 $s_make_public = 'Rendre public';
 $s_create_new_project_link = 'Créer un nouveau projet';


### PR DESCRIPTION
Linked to bug #17907: add the ability to indicate in the issue history that modification had been made by a plugin
