### PR TITLE
[discuss] SOAP API: add method for searching within issues

### DIFF
--- a/api/soap/mantisconnect.wsdl
+++ b/api/soap/mantisconnect.wsdl
@@ -268,12 +268,12 @@
  </xsd:complexType>
  <xsd:complexType name="FilterSearchData">
   <xsd:all>
-   <xsd:element name="project_id" type="tns:IntegerArray" minOccurs="1"/>
+   <xsd:element name="project_id" type="tns:IntegerArray" minOccurs="0"/>
    <xsd:element name="search" type="xsd:string" minOccurs="0"/>
    <xsd:element name="category" type="tns:StringArray" minOccurs="0"/>
    <xsd:element name="severity_id" type="tns:IntegerArray" minOccurs="0"/>
    <xsd:element name="status_id" type="tns:IntegerArray" minOccurs="0"/>
-   <xsd:element name="priority_id" type="tns:StringArray" minOccurs="0"/>
+   <xsd:element name="priority_id" type="tns:IntegerArray" minOccurs="0"/>
    <xsd:element name="reporter_id" type="tns:IntegerArray" minOccurs="0"/>
    <xsd:element name="handler_id" type="tns:IntegerArray" minOccurs="0"/>
    <xsd:element name="note_user_id" type="tns:IntegerArray" minOccurs="0"/>
@@ -299,8 +299,6 @@
    <xsd:element name="tag_string" type="tns:StringArray" minOccurs="0"/>
    <xsd:element name="tag_select" type="tns:IntegerArray" minOccurs="0"/>
    <xsd:element name="custom_fields" type="tns:FilterCustomFieldArray" minOccurs="0"/>
-   <xsd:element name="page_number" type="xsd:integer" minOccurs="1"/>
-   <xsd:element name="issues_per_page" type="xsd:integer" minOccurs="1"/>
   </xsd:all>
  </xsd:complexType>
  <xsd:complexType name="FilterDataArray">
@@ -334,9 +332,8 @@
  </xsd:complexType>
  <xsd:complexType name="FilterCustomField">
   <xsd:all>
-   <xsd:element name="name" type="xsd:string" minOccurs="0"/>
-   <xsd:element name="id" type="xsd:integer" minOccurs="0"/>
-   <xsd:element name="value" type="tns:StringArray" minOccurs="0"/>
+   <xsd:element name="field" type="tns:ObjectRef" minOccurs="0"/>
+   <xsd:element name="value" type="tns:StringArray" minOccurs="1"/>
   </xsd:all>
  </xsd:complexType>
  <xsd:complexType name="FilterCustomFieldArray">
@@ -808,13 +805,17 @@
 <message name="mc_filter_search_issue_headersRequest">
   <part name="username" type="xsd:string" />
   <part name="password" type="xsd:string" />
-  <part name="filter" type="tns:FilterSearchData" /></message>
+  <part name="filter" type="tns:FilterSearchData" />
+  <part name="page_number" type="xsd:integer" />
+  <part name="per_page" type="xsd:integer" /></message>
 <message name="mc_filter_search_issue_headersResponse">
   <part name="return" type="tns:IssueHeaderDataArray" /></message>
 <message name="mc_filter_search_issuesRequest">
   <part name="username" type="xsd:string" />
   <part name="password" type="xsd:string" />
-  <part name="filter" type="tns:FilterSearchData" /></message>
+  <part name="filter" type="tns:FilterSearchData" />
+  <part name="page_number" type="xsd:integer" />
+  <part name="per_page" type="xsd:integer" /></message>
 <message name="mc_filter_search_issuesResponse">
   <part name="return" type="tns:IssueDataArray" /></message>
 <message name="mc_config_get_stringRequest">

--- a/api/soap/mantisconnect.wsdl
+++ b/api/soap/mantisconnect.wsdl
@@ -510,6 +510,18 @@
   <part name="issue_id" type="xsd:integer" /></message>
 <message name="mc_issue_getResponse">
   <part name="return" type="tns:IssueData" /></message>
+<message name="mc_issues_getRequest">
+  <part name="username" type="xsd:string" />
+  <part name="password" type="xsd:string" />
+  <part name="issue_ids" type="tns:IntegerArray" /></message>
+<message name="mc_issues_getResponse">
+  <part name="return" type="tns:IssueDataArray" /></message>
+<message name="mc_issues_get_headerRequest">
+  <part name="username" type="xsd:string" />
+  <part name="password" type="xsd:string" />
+  <part name="issue_ids" type="tns:IntegerArray" /></message>
+<message name="mc_issues_get_headerResponse">
+  <part name="return" type="tns:IssueHeaderDataArray" /></message>
 <message name="mc_issue_get_historyRequest">
   <part name="username" type="xsd:string" />
   <part name="password" type="xsd:string" />
@@ -818,6 +830,14 @@
   <part name="per_page" type="xsd:integer" /></message>
 <message name="mc_filter_search_issuesResponse">
   <part name="return" type="tns:IssueDataArray" /></message>
+<message name="mc_filter_search_issue_idsRequest">
+  <part name="username" type="xsd:string" />
+  <part name="password" type="xsd:string" />
+  <part name="filter" type="tns:FilterSearchData" />
+  <part name="page_number" type="xsd:integer" />
+  <part name="per_page" type="xsd:integer" /></message>
+<message name="mc_filter_search_issue_idsResponse">
+  <part name="return" type="tns:IntegerArray" /></message>
 <message name="mc_config_get_stringRequest">
   <part name="username" type="xsd:string" />
   <part name="password" type="xsd:string" />
@@ -949,6 +969,16 @@
     <documentation>Get the issue with the specified id.</documentation>
     <input message="tns:mc_issue_getRequest"/>
     <output message="tns:mc_issue_getResponse"/>
+  </operation>
+  <operation name="mc_issues_get">
+    <documentation>Get all issues matching the ids.</documentation>
+    <input message="tns:mc_issues_getRequest"/>
+    <output message="tns:mc_issues_getResponse"/>
+  </operation>
+  <operation name="mc_issues_get_header">
+    <documentation>Get all issues header matching the ids.</documentation>
+    <input message="tns:mc_issues_get_headerRequest"/>
+    <output message="tns:mc_issues_get_headerResponse"/>
   </operation>
   <operation name="mc_issue_get_history">
     <documentation>Get the history of the issue with the specified id.</documentation>
@@ -1175,6 +1205,11 @@
     <input message="tns:mc_filter_search_issuesRequest"/>
     <output message="tns:mc_filter_search_issuesResponse"/>
   </operation>
+  <operation name="mc_filter_search_issue_ids">
+    <documentation>Get the issue ids that match the custom filter and paging details.</documentation>
+    <input message="tns:mc_filter_search_issue_idsRequest"/>
+    <output message="tns:mc_filter_search_issue_idsResponse"/>
+  </operation>
   <operation name="mc_config_get_string">
     <documentation>Get the value for the specified configuration variable.</documentation>
     <input message="tns:mc_config_get_stringRequest"/>
@@ -1295,6 +1330,16 @@
   </operation>
   <operation name="mc_issue_get">
     <soap:operation soapAction="http://www.mantisbt.org/bugs/api/soap/mantisconnect.php/mc_issue_get" style="rpc"/>
+    <input><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></input>
+    <output><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></output>
+  </operation>
+  <operation name="mc_issues_get">
+    <soap:operation soapAction="http://www.mantisbt.org/bugs/api/soap/mantisconnect.php/mc_issues_get" style="rpc"/>
+    <input><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></input>
+    <output><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></output>
+  </operation>
+  <operation name="mc_issues_get_header">
+    <soap:operation soapAction="http://www.mantisbt.org/bugs/api/soap/mantisconnect.php/mc_issues_get_header" style="rpc"/>
     <input><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></input>
     <output><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></output>
   </operation>
@@ -1520,6 +1565,11 @@
   </operation>
   <operation name="mc_filter_search_issues">
     <soap:operation soapAction="http://www.mantisbt.org/bugs/api/soap/mantisconnect.php/mc_filter_search_issues" style="rpc"/>
+    <input><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></input>
+    <output><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></output>
+  </operation>
+  <operation name="mc_filter_search_issue_ids">
+    <soap:operation soapAction="http://www.mantisbt.org/bugs/api/soap/mantisconnect.php/mc_filter_search_issue_ids" style="rpc"/>
     <input><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></input>
     <output><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></output>
   </operation>

--- a/api/soap/mantisconnect.wsdl
+++ b/api/soap/mantisconnect.wsdl
@@ -5,6 +5,13 @@
 <xsd:schema targetNamespace="http://futureware.biz/mantisconnect">
  <xsd:import namespace="http://schemas.xmlsoap.org/soap/encoding/"/>
  <xsd:import namespace="http://schemas.xmlsoap.org/wsdl/"/>
+ <xsd:complexType name="IntegerArray">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="xsd:integer[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
+ </xsd:complexType>
  <xsd:complexType name="StringArray">
   <xsd:complexContent>
    <xsd:restriction base="SOAP-ENC:Array">
@@ -259,6 +266,43 @@
    <xsd:element name="url" type="xsd:string" minOccurs="0"/>
   </xsd:all>
  </xsd:complexType>
+ <xsd:complexType name="FilterSearchData">
+  <xsd:all>
+   <xsd:element name="project_id" type="tns:IntegerArray" minOccurs="1"/>
+   <xsd:element name="search" type="xsd:string" minOccurs="0"/>
+   <xsd:element name="category" type="tns:StringArray" minOccurs="0"/>
+   <xsd:element name="severity_id" type="tns:IntegerArray" minOccurs="0"/>
+   <xsd:element name="status_id" type="tns:IntegerArray" minOccurs="0"/>
+   <xsd:element name="priority_id" type="tns:StringArray" minOccurs="0"/>
+   <xsd:element name="reporter_id" type="tns:IntegerArray" minOccurs="0"/>
+   <xsd:element name="handler_id" type="tns:IntegerArray" minOccurs="0"/>
+   <xsd:element name="note_user_id" type="tns:IntegerArray" minOccurs="0"/>
+   <xsd:element name="resolution_id" type="tns:IntegerArray" minOccurs="0"/>
+   <xsd:element name="product_version" type="tns:StringArray" minOccurs="0"/>
+   <xsd:element name="user_monitor_id" type="tns:IntegerArray" minOccurs="0"/>
+   <xsd:element name="hide_status_id" type="tns:IntegerArray" minOccurs="0"/>
+   <xsd:element name="sort" type="xsd:string" minOccurs="0"/>
+   <xsd:element name="sort_direction" type="xsd:string" minOccurs="0"/>
+   <xsd:element name="sticky" type="xsd:boolean" minOccurs="0"/>
+   <xsd:element name="view_state_id" type="tns:IntegerArray" minOccurs="0"/>
+   <xsd:element name="fixed_in_version" type="tns:StringArray" minOccurs="0"/>
+   <xsd:element name="target_version" type="tns:StringArray" minOccurs="0"/>
+   <xsd:element name="platform" type="tns:StringArray" minOccurs="0"/>
+   <xsd:element name="os" type="tns:StringArray" minOccurs="0"/>
+   <xsd:element name="os_build" type="tns:StringArray" minOccurs="0"/>
+   <xsd:element name="start_day" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="start_month" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="start_year" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="end_day" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="end_month" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="end_year" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="tag_string" type="tns:StringArray" minOccurs="0"/>
+   <xsd:element name="tag_select" type="tns:IntegerArray" minOccurs="0"/>
+   <xsd:element name="custom_fields" type="tns:FilterCustomFieldArray" minOccurs="0"/>
+   <xsd:element name="page_number" type="xsd:integer" minOccurs="1"/>
+   <xsd:element name="issues_per_page" type="xsd:integer" minOccurs="1"/>
+  </xsd:all>
+ </xsd:complexType>
  <xsd:complexType name="FilterDataArray">
   <xsd:complexContent>
    <xsd:restriction base="SOAP-ENC:Array">
@@ -287,6 +331,20 @@
    <xsd:element name="require_resolved" type="xsd:boolean" minOccurs="0"/>
    <xsd:element name="require_closed" type="xsd:boolean" minOccurs="0"/>
   </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="FilterCustomField">
+  <xsd:all>
+   <xsd:element name="name" type="xsd:string" minOccurs="0"/>
+   <xsd:element name="id" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="value" type="tns:StringArray" minOccurs="0"/>
+  </xsd:all>
+ </xsd:complexType>
+ <xsd:complexType name="FilterCustomFieldArray">
+  <xsd:complexContent>
+   <xsd:restriction base="SOAP-ENC:Array">
+    <xsd:attribute ref="SOAP-ENC:arrayType" wsdl:arrayType="tns:FilterCustomField[]"/>
+   </xsd:restriction>
+  </xsd:complexContent>
  </xsd:complexType>
  <xsd:complexType name="CustomFieldDefinitionDataArray">
   <xsd:complexContent>
@@ -747,6 +805,18 @@
   <part name="per_page" type="xsd:integer" /></message>
 <message name="mc_filter_get_issue_headersResponse">
   <part name="return" type="tns:IssueHeaderDataArray" /></message>
+<message name="mc_filter_search_issue_headersRequest">
+  <part name="username" type="xsd:string" />
+  <part name="password" type="xsd:string" />
+  <part name="filter" type="tns:FilterSearchData" /></message>
+<message name="mc_filter_search_issue_headersResponse">
+  <part name="return" type="tns:IssueHeaderDataArray" /></message>
+<message name="mc_filter_search_issuesRequest">
+  <part name="username" type="xsd:string" />
+  <part name="password" type="xsd:string" />
+  <part name="filter" type="tns:FilterSearchData" /></message>
+<message name="mc_filter_search_issuesResponse">
+  <part name="return" type="tns:IssueDataArray" /></message>
 <message name="mc_config_get_stringRequest">
   <part name="username" type="xsd:string" />
   <part name="password" type="xsd:string" />
@@ -1094,6 +1164,16 @@
     <input message="tns:mc_filter_get_issue_headersRequest"/>
     <output message="tns:mc_filter_get_issue_headersResponse"/>
   </operation>
+  <operation name="mc_filter_search_issue_headers">
+    <documentation>Get the issue headers that match the custom filter and paging details.</documentation>
+    <input message="tns:mc_filter_search_issue_headersRequest"/>
+    <output message="tns:mc_filter_search_issue_headersResponse"/>
+  </operation>
+  <operation name="mc_filter_search_issues">
+    <documentation>Get the issues that match the custom filter and paging details.</documentation>
+    <input message="tns:mc_filter_search_issuesRequest"/>
+    <output message="tns:mc_filter_search_issuesResponse"/>
+  </operation>
   <operation name="mc_config_get_string">
     <documentation>Get the value for the specified configuration variable.</documentation>
     <input message="tns:mc_config_get_stringRequest"/>
@@ -1429,6 +1509,16 @@
   </operation>
   <operation name="mc_filter_get_issue_headers">
     <soap:operation soapAction="http://www.mantisbt.org/bugs/api/soap/mantisconnect.php/mc_filter_get_issue_headers" style="rpc"/>
+    <input><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></input>
+    <output><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></output>
+  </operation>
+  <operation name="mc_filter_search_issue_headers">
+    <soap:operation soapAction="http://www.mantisbt.org/bugs/api/soap/mantisconnect.php/mc_filter_search_issue_headers" style="rpc"/>
+    <input><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></input>
+    <output><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></output>
+  </operation>
+  <operation name="mc_filter_search_issues">
+    <soap:operation soapAction="http://www.mantisbt.org/bugs/api/soap/mantisconnect.php/mc_filter_search_issues" style="rpc"/>
     <input><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></input>
     <output><soap:body use="encoded" namespace="http://futureware.biz/mantisconnect" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></output>
   </operation>

--- a/api/soap/mantisconnect.wsdl
+++ b/api/soap/mantisconnect.wsdl
@@ -332,7 +332,7 @@
  </xsd:complexType>
  <xsd:complexType name="FilterCustomField">
   <xsd:all>
-   <xsd:element name="field" type="tns:ObjectRef" minOccurs="0"/>
+   <xsd:element name="field" type="tns:ObjectRef" minOccurs="1"/>
    <xsd:element name="value" type="tns:StringArray" minOccurs="1"/>
   </xsd:all>
  </xsd:complexType>

--- a/api/soap/mc_filter_api.php
+++ b/api/soap/mc_filter_api.php
@@ -42,7 +42,7 @@ $g_soap_api_to_filter_names = array (
     'handler_id' => FILTER_PROPERTY_HANDLER_ID,
     'note_user_id' => FILTER_PROPERTY_NOTE_USER_ID,
     'resolution_id' => FILTER_PROPERTY_RESOLUTION,
-    'version' => FILTER_PROPERTY_VERSION,
+    'product_version' => FILTER_PROPERTY_VERSION,
 
     'user_monitor_id' => FILTER_PROPERTY_MONITOR_USER_ID,
     'hide_status_id' => FILTER_PROPERTY_HIDE_STATUS,

--- a/api/soap/mc_filter_api.php
+++ b/api/soap/mc_filter_api.php
@@ -31,8 +31,8 @@
 
 require_api( 'filter_constants_inc.php' );
 
-// doesn't contain 'custom_fields'
-$_SOAP_API_TO_FILTER_API_NAMES = array (
+// doesn't contain 'custom_fields' and project_id
+$g_soap_api_to_filter_names = array (
     'search' => FILTER_PROPERTY_SEARCH,
     'category' => FILTER_PROPERTY_CATEGORY_ID,
     'severity_id' => FILTER_PROPERTY_SEVERITY,
@@ -40,7 +40,6 @@ $_SOAP_API_TO_FILTER_API_NAMES = array (
     'priority_id' => FILTER_PROPERTY_PRIORITY,
     'reporter_id' => FILTER_PROPERTY_REPORTER_ID,
     'handler_id' => FILTER_PROPERTY_HANDLER_ID,
-    'project_id' => FILTER_PROPERTY_PROJECT_ID,
     'note_user_id' => FILTER_PROPERTY_NOTE_USER_ID,
     'resolution_id' => FILTER_PROPERTY_RESOLUTION,
     'version' => FILTER_PROPERTY_VERSION,
@@ -110,11 +109,6 @@ function mc_filter_get( $p_username, $p_password, $p_project_id ) {
  * @return array that represents an IssueDataArray structure
  */
 function mc_filter_get_issues( $p_username, $p_password, $p_project_id, $p_filter_id, $p_page_number, $p_per_page ) {
-	$t_user_id = mci_check_login( $p_username, $p_password );
-	if( $t_user_id === false ) {
-		return mci_soap_fault_login_failed();
-	}
-	$t_lang = mci_get_user_lang( $t_user_id );
 
 	if( !mci_has_readonly_access( $t_user_id, $p_project_id ) ) {
 		return mci_soap_fault_access_denied( $t_user_id );
@@ -193,42 +187,55 @@ function mc_filter_get_issue_headers( $p_username, $p_password, $p_project_id, $
 }
 
 /**
- * Get all issue headers matching the custom filter.
+ * Get all issue rows matching the custom filter.
  *
- * @param string                $p_username         The name of the user trying to access the filters.
- * @param string                $p_password         The password of the user.
+ * @param integer               $p_user_id          The user id.
  * @param FilterSearchData      $p_filter_search    The custom filter.
- * @return array that represents an IssueHeaderDataArray structure
+ * @param integer               $p_page_number      Start with the given page number (zero-based).
+ * @param integer               $p_per_page         Number of issues to display per page.
+ * @return array of issue rows
  */
-function mc_filter_search_issue_headers( $p_username, $p_password, $p_filter_search ) {
+function mci_filter_search_get_rows( $p_user_id, $p_filter_search, $p_page_number, $p_per_page) {
 
-    global $_SOAP_API_TO_FILTER_API_NAMES;
-
-    $t_user_id = mci_check_login( $p_username, $p_password );
-
-    if( $t_user_id === false ) {
-        return mci_soap_fault_login_failed();
-    }
+    global $g_soap_api_to_filter_names;
 
     // object to array
     if( is_object($p_filter_search) ) {
         $p_filter_search = get_object_vars($p_filter_search);
     }
 
-    $t_project_id = $p_filter_search['project_id'];
+    $t_project_id = array();
+    if( isset( $p_filter_search['project_id'] ) ) {
+        // check access right to all projects
+        foreach( $p_filter_search['project_id'] as $t_id ) {
+            if( mci_has_readonly_access( $p_user_id, $t_id ) ) {
+                $t_project_id[] = $t_id;
+            }
+            else {
+                error_log( 'User: ' . $p_user_id . ' has not access right to project: ' . $t_id . '.' );
+            }
+        }
+        // user has not access right to any project
+        if( count($t_project_id) < 1 ) {
+            return mci_soap_fault_access_denied( $p_user_id );
+        }
+    }
+    else {
+        if( !mci_has_readonly_access( $p_user_id, ALL_PROJECTS ) ) {
+            return mci_soap_fault_access_denied( $p_user_id );
+        }
 
-    if( !mci_has_readonly_access( $t_user_id, $t_project_id  ) ) {
-        return mci_soap_fault_access_denied( $t_user_id );
+        $t_project_id = array( ALL_PROJECTS );
     }
 
     $t_filter = array( '_view_type' => 'advanced' );
+    $t_filter['project_id'] = $t_project_id;
 
     // default fields
-    foreach( $_SOAP_API_TO_FILTER_API_NAMES as $t_soap_name => $t_filter_name ) {
-        if ( isset ( $p_filter_search[$t_soap_name]) ) {
+    foreach( $g_soap_api_to_filter_names as $t_soap_name => $t_filter_name ) {
+        if( isset ( $p_filter_search[$t_soap_name]) ) {
 
             $t_value = $p_filter_search[$t_soap_name];
-            error_log('Simple extraction, value is ' . print_r($t_value, true) . ' .' );
             $t_filter[$t_filter_name] = $t_value;
         }
     }
@@ -242,16 +249,20 @@ function mc_filter_search_issue_headers( $p_username, $p_password, $p_filter_sea
                 $t_custom_field = get_object_vars($t_custom_field);
             }
 
+            $t_field = $t_custom_field['field'];
+            if( is_object($t_field) ) {
+                $t_field = get_object_vars($t_field);
+            }
+
             // if is set custom_field's id, use it primary
-            if ( isset($t_custom_field['id']) ) {
-                $t_custom_field_id = $t_custom_field['id'];
+            if( isset($t_field['id']) ) {
+                $t_custom_field_id = $t_field['id'];
             }
             else {
-                $t_custom_field_id = custom_field_get_id_from_name( $t_custom_field['name'] );
+                $t_custom_field_id = custom_field_get_id_from_name( $t_field['name'] );
             }
 
             $t_value = $t_custom_field['value'];
-            error_log('custom field id ' . $t_custom_field_id . print_r($t_value, true) . ' .' );
             $t_filter['custom_fields'][$t_custom_field_id] =  $t_value;
         }
     }
@@ -259,12 +270,33 @@ function mc_filter_search_issue_headers( $p_username, $p_password, $p_filter_sea
     $t_filter = filter_ensure_valid_filter( $t_filter );
 
     $t_result = array();
-    $t_page_number = 0;
-    $t_per_page = $p_filter_search['issues_per_page'];
+    $t_page_number = $p_page_number < 1 ? 1 : $p_page_number;
     $t_page_count = 0;
     $t_bug_count = 0;
-    $t_rows = filter_get_bug_rows( $t_page_number, $t_per_page, $t_page_count, $t_bug_count, $t_filter );
+    return filter_get_bug_rows( $t_page_number, $p_per_page, $t_page_count, $t_bug_count, $t_filter );
+}
 
+/**
+ * Get all issue headers matching the custom filter.
+ *
+ * @param string                $p_username         The name of the user trying to access the filters.
+ * @param string                $p_password         The password of the user.
+ * @param FilterSearchData      $p_filter_search    The custom filter.
+ * @param integer               $p_page_number      Start with the given page number (zero-based).
+ * @param integer               $p_per_page         Number of issues to display per page.
+ * @return array that represents an IssueHeaderDataArray structure
+ */
+function mc_filter_search_issue_headers( $p_username, $p_password, $p_filter_search, $p_page_number, $p_per_page) {
+
+    $t_user_id = mci_check_login( $p_username, $p_password );
+
+    if( $t_user_id === false ) {
+        return mci_soap_fault_login_failed();
+    }
+
+    $t_rows = mci_filter_search_get_rows( $t_user_id, $p_filter_search, $p_page_number, $p_per_page);
+
+    $t_result = array();
     foreach( $t_rows as $t_issue_data ) {
         $t_result[] = mci_issue_data_as_header_array( $t_issue_data );
     }
@@ -278,11 +310,11 @@ function mc_filter_search_issue_headers( $p_username, $p_password, $p_filter_sea
  * @param string                $p_username         The name of the user trying to access the filters.
  * @param string                $p_password         The password of the user.
  * @param FilterSearchData      $p_filter_search    The custom filter.
+ * @param integer               $p_page_number Start with the given page number (zero-based).
+ * @param integer               $p_per_page    Number of issues to display per page.
  * @return array that represents an IssueDataArray structure
  */
-function mc_filter_search_issues( $p_username, $p_password, $p_filter_search ) {
-
-    global $_SOAP_API_TO_FILTER_API_NAMES;
+function mc_filter_search_issues( $p_username, $p_password, $p_filter_search, $p_page_number, $p_per_page ) {
 
     $t_user_id = mci_check_login( $p_username, $p_password );
 
@@ -290,66 +322,15 @@ function mc_filter_search_issues( $p_username, $p_password, $p_filter_search ) {
         return mci_soap_fault_login_failed();
     }
 
+    $t_rows = mci_filter_search_get_rows( $t_user_id, $p_filter_search, $p_page_number, $p_per_page);
+
     $t_lang = mci_get_user_lang( $t_user_id );
 
-    // object to array
-    if( is_object($p_filter_search) ) {
-        $p_filter_search = get_object_vars($p_filter_search);
-    }
-
-    $t_project_id = $p_filter_search['project_id'];
-
-    if( !mci_has_readonly_access( $t_user_id, $t_project_id  ) ) {
-        return mci_soap_fault_access_denied( $t_user_id );
-    }
-
-    $t_filter = array( '_view_type' => 'advanced' );
-
-    // default fields
-    foreach( $_SOAP_API_TO_FILTER_API_NAMES as $t_soap_name => $t_filter_name ) {
-        if ( isset ( $p_filter_search[$t_soap_name]) ) {
-
-            $t_value = $p_filter_search[$t_soap_name];
-            error_log('Simple extraction, value is ' . print_r($t_value, true) . ' .' );
-            $t_filter[$t_filter_name] = $t_value;
-        }
-    }
-
-    // custom fields
-    if( isset ( $p_filter_search['custom_fields']) ) {
-        foreach(  $p_filter_search['custom_fields'] as $t_custom_field ) {
-
-            // object to array
-            if( is_object($t_custom_field) ) {
-                $t_custom_field = get_object_vars($t_custom_field);
-            }
-
-            // if is set custom_field's id, use it primary
-            if ( isset($t_custom_field['id']) ) {
-                $t_custom_field_id = $t_custom_field['id'];
-            }
-            else {
-                $t_custom_field_id = custom_field_get_id_from_name( $t_custom_field['name'] );
-            }
-
-            $t_value = $t_custom_field['value'];
-            error_log('custom field id ' . $t_custom_field_id . print_r($t_value, true) . ' .' );
-            $t_filter['custom_fields'][$t_custom_field_id] =  $t_value;
-        }
-    }
-
-    $t_filter = filter_ensure_valid_filter( $t_filter );
-
     $t_result = array();
-    $t_page_number = 0;
-    $t_per_page = $p_filter_search['issues_per_page'];
-    $t_page_count = 0;
-    $t_bug_count = 0;
-    $t_rows = filter_get_bug_rows( $t_page_number, $t_per_page, $t_page_count, $t_bug_count, $t_filter );
-
     foreach( $t_rows as $t_issue_data ) {
         $t_result[] = mci_issue_data_as_array( $t_issue_data, $t_user_id, $t_lang );
     }
 
     return $t_result;
 }
+

--- a/api/soap/mc_filter_api.php
+++ b/api/soap/mc_filter_api.php
@@ -23,6 +23,50 @@
  * @link http://www.mantisbt.org
  */
 
+# Path to MantisBT is assumed to be the grand parent directory.  If this is not
+# the case, then this variable should be set to the MantisBT path.
+# This can not be a configuration option, then MantisConnect configuration
+# needs MantisBT to be included first to make use of the constants and possibly
+# configuration defined in MantisBT.
+
+require_api( 'filter_constants_inc.php' );
+
+// doesn't contain 'custom_fields'
+$_SOAP_API_TO_FILTER_API_NAMES = array (
+    'search' => FILTER_PROPERTY_SEARCH,
+    'category' => FILTER_PROPERTY_CATEGORY_ID,
+    'severity_id' => FILTER_PROPERTY_SEVERITY,
+    'status_id' => FILTER_PROPERTY_STATUS,
+    'priority_id' => FILTER_PROPERTY_PRIORITY,
+    'reporter_id' => FILTER_PROPERTY_REPORTER_ID,
+    'handler_id' => FILTER_PROPERTY_HANDLER_ID,
+    'project_id' => FILTER_PROPERTY_PROJECT_ID,
+    'note_user_id' => FILTER_PROPERTY_NOTE_USER_ID,
+    'resolution_id' => FILTER_PROPERTY_RESOLUTION,
+    'version' => FILTER_PROPERTY_VERSION,
+
+    'user_monitor_id' => FILTER_PROPERTY_MONITOR_USER_ID,
+    'hide_status_id' => FILTER_PROPERTY_HIDE_STATUS,
+    'sort' => FILTER_PROPERTY_SORT_FIELD_NAME,
+    'sort_direction' => FILTER_PROPERTY_SORT_DIRECTION,
+    'sticky' => FILTER_PROPERTY_STICKY,
+    'view_state' => FILTER_PROPERTY_VIEW_STATE,
+    'fixed_in_version' => FILTER_PROPERTY_FIXED_IN_VERSION,
+    'target_version' => FILTER_PROPERTY_TARGET_VERSION,
+    'platform' => FILTER_PROPERTY_PLATFORM,
+    'os' => FILTER_PROPERTY_OS,
+    'os_build' => FILTER_PROPERTY_OS_BUILD,
+    'start_day' => FILTER_PROPERTY_START_DAY,
+    'start_month' => FILTER_PROPERTY_START_MONTH,
+    'start_year' => FILTER_PROPERTY_START_YEAR,
+    'end_day' => FILTER_PROPERTY_END_DAY,
+    'end_month' => FILTER_PROPERTY_END_MONTH,
+    'end_year' => FILTER_PROPERTY_END_YEAR,
+    'tag_string' => FILTER_PROPERTY_TAG_STRING,
+    'tag_select' => FILTER_PROPERTY_TAG_SELECT,
+);
+
+
 /**
  * Get all user defined issue filters for the given project.
  *
@@ -146,4 +190,166 @@ function mc_filter_get_issue_headers( $p_username, $p_password, $p_project_id, $
 	}
 
 	return $t_result;
+}
+
+/**
+ * Get all issue headers matching the custom filter.
+ *
+ * @param string                $p_username         The name of the user trying to access the filters.
+ * @param string                $p_password         The password of the user.
+ * @param FilterSearchData      $p_filter_search    The custom filter.
+ * @return array that represents an IssueHeaderDataArray structure
+ */
+function mc_filter_search_issue_headers( $p_username, $p_password, $p_filter_search ) {
+
+    global $_SOAP_API_TO_FILTER_API_NAMES;
+
+    $t_user_id = mci_check_login( $p_username, $p_password );
+
+    if( $t_user_id === false ) {
+        return mci_soap_fault_login_failed();
+    }
+
+    // object to array
+    if( is_object($p_filter_search) ) {
+        $p_filter_search = get_object_vars($p_filter_search);
+    }
+
+    $t_project_id = $p_filter_search['project_id'];
+
+    if( !mci_has_readonly_access( $t_user_id, $t_project_id  ) ) {
+        return mci_soap_fault_access_denied( $t_user_id );
+    }
+
+    $t_filter = array( '_view_type' => 'advanced' );
+
+    // default fields
+    foreach( $_SOAP_API_TO_FILTER_API_NAMES as $t_soap_name => $t_filter_name ) {
+        if ( isset ( $p_filter_search[$t_soap_name]) ) {
+
+            $t_value = $p_filter_search[$t_soap_name];
+            error_log('Simple extraction, value is ' . print_r($t_value, true) . ' .' );
+            $t_filter[$t_filter_name] = $t_value;
+        }
+    }
+
+    // custom fields
+    if( isset ( $p_filter_search['custom_fields']) ) {
+        foreach(  $p_filter_search['custom_fields'] as $t_custom_field ) {
+
+            // object to array
+            if( is_object($t_custom_field) ) {
+                $t_custom_field = get_object_vars($t_custom_field);
+            }
+
+            // if is set custom_field's id, use it primary
+            if ( isset($t_custom_field['id']) ) {
+                $t_custom_field_id = $t_custom_field['id'];
+            }
+            else {
+                $t_custom_field_id = custom_field_get_id_from_name( $t_custom_field['name'] );
+            }
+
+            $t_value = $t_custom_field['value'];
+            error_log('custom field id ' . $t_custom_field_id . print_r($t_value, true) . ' .' );
+            $t_filter['custom_fields'][$t_custom_field_id] =  $t_value;
+        }
+    }
+
+    $t_filter = filter_ensure_valid_filter( $t_filter );
+
+    $t_result = array();
+    $t_page_number = 0;
+    $t_per_page = $p_filter_search['issues_per_page'];
+    $t_page_count = 0;
+    $t_bug_count = 0;
+    $t_rows = filter_get_bug_rows( $t_page_number, $t_per_page, $t_page_count, $t_bug_count, $t_filter );
+
+    foreach( $t_rows as $t_issue_data ) {
+        $t_result[] = mci_issue_data_as_header_array( $t_issue_data );
+    }
+
+    return $t_result;
+}
+
+/**
+ * Get all issues matching the custom filter.
+ *
+ * @param string                $p_username         The name of the user trying to access the filters.
+ * @param string                $p_password         The password of the user.
+ * @param FilterSearchData      $p_filter_search    The custom filter.
+ * @return array that represents an IssueDataArray structure
+ */
+function mc_filter_search_issues( $p_username, $p_password, $p_filter_search ) {
+
+    global $_SOAP_API_TO_FILTER_API_NAMES;
+
+    $t_user_id = mci_check_login( $p_username, $p_password );
+
+    if( $t_user_id === false ) {
+        return mci_soap_fault_login_failed();
+    }
+
+    $t_lang = mci_get_user_lang( $t_user_id );
+
+    // object to array
+    if( is_object($p_filter_search) ) {
+        $p_filter_search = get_object_vars($p_filter_search);
+    }
+
+    $t_project_id = $p_filter_search['project_id'];
+
+    if( !mci_has_readonly_access( $t_user_id, $t_project_id  ) ) {
+        return mci_soap_fault_access_denied( $t_user_id );
+    }
+
+    $t_filter = array( '_view_type' => 'advanced' );
+
+    // default fields
+    foreach( $_SOAP_API_TO_FILTER_API_NAMES as $t_soap_name => $t_filter_name ) {
+        if ( isset ( $p_filter_search[$t_soap_name]) ) {
+
+            $t_value = $p_filter_search[$t_soap_name];
+            error_log('Simple extraction, value is ' . print_r($t_value, true) . ' .' );
+            $t_filter[$t_filter_name] = $t_value;
+        }
+    }
+
+    // custom fields
+    if( isset ( $p_filter_search['custom_fields']) ) {
+        foreach(  $p_filter_search['custom_fields'] as $t_custom_field ) {
+
+            // object to array
+            if( is_object($t_custom_field) ) {
+                $t_custom_field = get_object_vars($t_custom_field);
+            }
+
+            // if is set custom_field's id, use it primary
+            if ( isset($t_custom_field['id']) ) {
+                $t_custom_field_id = $t_custom_field['id'];
+            }
+            else {
+                $t_custom_field_id = custom_field_get_id_from_name( $t_custom_field['name'] );
+            }
+
+            $t_value = $t_custom_field['value'];
+            error_log('custom field id ' . $t_custom_field_id . print_r($t_value, true) . ' .' );
+            $t_filter['custom_fields'][$t_custom_field_id] =  $t_value;
+        }
+    }
+
+    $t_filter = filter_ensure_valid_filter( $t_filter );
+
+    $t_result = array();
+    $t_page_number = 0;
+    $t_per_page = $p_filter_search['issues_per_page'];
+    $t_page_count = 0;
+    $t_bug_count = 0;
+    $t_rows = filter_get_bug_rows( $t_page_number, $t_per_page, $t_page_count, $t_bug_count, $t_filter );
+
+    foreach( $t_rows as $t_issue_data ) {
+        $t_result[] = mci_issue_data_as_array( $t_issue_data, $t_user_id, $t_lang );
+    }
+
+    return $t_result;
 }

--- a/api/soap/mc_filter_api.php
+++ b/api/soap/mc_filter_api.php
@@ -109,6 +109,11 @@ function mc_filter_get( $p_username, $p_password, $p_project_id ) {
  * @return array that represents an IssueDataArray structure
  */
 function mc_filter_get_issues( $p_username, $p_password, $p_project_id, $p_filter_id, $p_page_number, $p_per_page ) {
+    $t_user_id = mci_check_login( $p_username, $p_password );
+    if( $t_user_id === false ) {
+        return mci_soap_fault_login_failed();
+    }
+    $t_lang = mci_get_user_lang( $t_user_id );
 
 	if( !mci_has_readonly_access( $t_user_id, $p_project_id ) ) {
 		return mci_soap_fault_access_denied( $t_user_id );
@@ -334,3 +339,30 @@ function mc_filter_search_issues( $p_username, $p_password, $p_filter_search, $p
     return $t_result;
 }
 
+/**
+ * Get all issue ids matching the custom filter.
+ *
+ * @param string                $p_username         The name of the user trying to access the filters.
+ * @param string                $p_password         The password of the user.
+ * @param FilterSearchData      $p_filter_search    The custom filter.
+ * @param integer               $p_page_number Start with the given page number (zero-based).
+ * @param integer               $p_per_page    Number of issues to display per page.
+ * @return array that represents an IntegerArray structure
+ */
+function mc_filter_search_issue_ids( $p_username, $p_password, $p_filter_search, $p_page_number, $p_per_page ) {
+
+    $t_user_id = mci_check_login( $p_username, $p_password );
+
+    if( $t_user_id === false ) {
+        return mci_soap_fault_login_failed();
+    }
+
+    $t_rows = mci_filter_search_get_rows( $t_user_id, $p_filter_search, $p_page_number, $p_per_page);
+
+    $t_result = array();
+    foreach( $t_rows as $t_issue_data ) {
+        $t_result[] = $t_issue_data->id;
+    }
+
+    return $t_result;
+}

--- a/tests/soap/FilterTest.php
+++ b/tests/soap/FilterTest.php
@@ -565,4 +565,83 @@ class FilterTest extends SoapBase {
 			0,
 			self::ISSUES_TO_RETRIEVE );
 	}
+
+
+    /**
+     * Test the custom filter search by all possible parameters
+     * methods: mc_filter_search_issue_headers, mc_filter_search_issue_ids and mc_filter_search_issues
+     * @return void
+     */
+    public function testCustomFilterSearchAllPossibleParameters() {
+
+        $t_issue_to_add = $this->getIssueToAdd( 'FilterTest.testCustomFilterSearchAllPossibleParameters' );
+        $t_issue_to_add['severity'] = array( 'id' => BLOCK );
+        $t_issue_to_add['status'] = array( 'id' => 50 );
+        $t_issue_to_add['priority'] = array( 'id' => NORMAL );
+        $t_issue_to_add['reporter'] = array( 'id' => 1 );
+        $t_issue_to_add['handler'] = array( 'id' => 1 );
+        $t_issue_to_add['resolution'] = array( 'id' => FIXED );
+        $t_issue_to_add['sticky'] = true;
+        $t_issue_to_add['view_state'] = array( 'id' => VS_PUBLIC );
+        $t_issue_to_add['fixed_in_version'] = 'test_69';
+        $t_issue_to_add['target_version'] = 'test_70';
+        $t_issue_to_add['platform'] = 'test_plaform';
+        $t_issue_to_add['os'] = 'test_os';
+        $t_issue_to_add['os_build'] = 'test_6';
+
+
+        $t_issue_id = $this->client->mc_issue_add( $this->userName, $this->password, $t_issue_to_add );
+
+        $this->deleteAfterRun( $t_issue_id );
+
+        $t_filter = array( 'project_id' => array( 0 ),
+                           'category' => array( $this->getCategory() ),
+                           'severity_id' => array( BLOCK ),
+                           'status_id' => array( 50 ),
+                           'priority_id' => array( NORMAL ),
+                           'reporter_id' => array( 1 ),
+                           'handler_id' => array( 1 ),
+                           'resolution_id' => array( FIXED ),
+
+                           'hide_status_id' => array( -2 ),
+                           'sort' => 'last_updated',
+                           'sort_direction' => 'DESC',
+                           'sticky' => true,
+                           'view_state' => array( VS_PUBLIC ),
+                           'fixed_in_version' => array( 'test_69' ),
+                           'target_version' => array( 'test_70' ),
+                           'platform' => array( 'test_plaform' ),
+                           'os' => array( 'test_os' ),
+                           'os_build' => array( 'test_6' )
+                );
+
+        $t_search_result_headers = $this->client->mc_filter_search_issue_headers( $this->userName, $this->password, $t_filter, 1, -1 );
+        $t_search_result_ids = $this->client->mc_filter_search_issue_ids( $this->userName, $this->password, $t_filter, 1, -1 );
+        $t_search_result_issues = $this->client->mc_filter_search_issues( $this->userName, $this->password, $t_filter, 1, -1 );
+
+        $this->assertEquals( 1, count( $t_search_result_headers ));
+        $this->assertEquals( VS_PUBLIC, $t_search_result_headers[0]->view_state );
+        $this->assertEquals( $this->getCategory(), $t_search_result_headers[0]->category );
+        $this->assertEquals( 0, $t_search_result_headers[0]->notes_count );
+        $this->assertEquals( 0, $t_search_result_headers[0]->attachments_count );
+        $this->assertEquals( BLOCK, $t_search_result_headers[0]->severity );
+
+        $this->assertEquals( 1, count( $t_search_result_ids ));
+
+        $this->assertEquals( 1, count( $t_search_result_issues ));
+        $this->assertEquals( VS_PUBLIC, $t_search_result_issues[0]->view_state->id);
+        $this->assertEquals( $this->getCategory(), $t_search_result_issues[0]->category );
+        $this->assertEquals( BLOCK, $t_search_result_issues[0]->severity->id );
+
+        // filter doesn't match any issue
+        $t_filter['severity_id'] = array( FEATURE );
+
+        $t_search_result_headers = $this->client->mc_filter_search_issue_headers( $this->userName, $this->password, $t_filter, 1, -1 );
+        $t_search_result_ids = $this->client->mc_filter_search_issue_ids( $this->userName, $this->password, $t_filter, 1, -1 );
+        $t_search_result_issues = $this->client->mc_filter_search_issues( $this->userName, $this->password, $t_filter, 1, -1 );
+
+        $this->assertEquals( 0, count( $t_search_result_headers ) );
+        $this->assertEquals( 0, count( $t_search_result_ids ) );
+        $this->assertEquals( 0, count( $t_search_result_issues ) );
+    }
 }

--- a/tests/soap/IssueAddTest.php
+++ b/tests/soap/IssueAddTest.php
@@ -495,4 +495,41 @@ class IssueAddTest extends SoapBase {
 		$this->assertEquals( $t_issue_to_add['summary'], $t_issue->summary, 'summary is not correct' );
 		$this->assertEquals( $t_issue_to_add['description'], $t_issue->description, 'description is not correct' );
 	}
+
+    /**
+     * A test case that tests the following:
+     * 1. mc_issues_get()
+     * 3. mc_issues_get_header()
+     * @return void
+     */
+    public function testIssuesGet() {
+
+        $t_issue_to_add = $this->getIssueToAdd( 'FilterTest.testIssuesGet' );
+        $t_issue_to_add_2 = $this->getIssueToAdd( 'FilterTest.testIssuesGet2' );
+
+        $t_issue_id = $this->client->mc_issue_add( $this->userName, $this->password, $t_issue_to_add );
+        $t_issue_id_2 = $this->client->mc_issue_add( $this->userName, $this->password, $t_issue_to_add_2 );
+
+        $this->deleteAfterRun( $t_issue_id );
+        $this->deleteAfterRun( $t_issue_id_2 );
+
+        $t_search_result_issues = $this->client->mc_issues_get( $this->userName, $this->password, array( $t_issue_id, $t_issue_id_2 ) );
+        $t_search_result_headers = $this->client->mc_issues_get_header( $this->userName, $this->password, array( $t_issue_id, $t_issue_id_2 ) );
+
+        $this->assertEquals( 2, count( $t_search_result_headers ));
+        $this->assertContains( 'testIssuesGet', $t_search_result_headers[0]->summary );
+        $this->assertContains( 'testIssuesGet2', $t_search_result_headers[1]->summary );
+
+        $this->assertEquals( VS_PUBLIC, $t_search_result_headers[0]->view_state );
+        $this->assertEquals( 0, $t_search_result_headers[0]->notes_count );
+        $this->assertEquals( 0, $t_search_result_headers[0]->attachments_count );
+        $this->assertEquals( 10, $t_search_result_headers[0]->status );
+
+        $this->assertEquals( 2, count( $t_search_result_issues ));
+        $this->assertContains( 'testIssuesGet', $t_search_result_issues[0]->summary );
+        $this->assertContains( 'testIssuesGet2', $t_search_result_issues[1]->summary );
+
+        $this->assertEquals( VS_PUBLIC, $t_search_result_issues[0]->view_state->id);
+        $this->assertEquals( 10, $t_search_result_issues[0]->status->id );
+    }
 }


### PR DESCRIPTION
Add method 'mc_search_issues' to SOAP API. Filter is in JSON format.
It is also possible to filter by custom fields.

The example of filter with 'os' == "CentOS" and custom field 'abrt_hash' == "hash_content":

{"abrt_hash":"hash_content", "os":"CenstOS"}

Signed-off-by: Matej Habrnal <mhabrnal@redhat.com>