### PR TITLE
Don't let crawlers go to edit page

### DIFF
--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -161,6 +161,9 @@ if( $t_show_due_date ) {
 	require_css( 'calendar-blue.css' );
 }
 
+# Don't index edit pages
+html_robots_noindex_nofollow();
+
 html_page_top( bug_format_summary( $f_bug_id, SUMMARY_CAPTION ) );
 
 print_recently_visited();

--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -1046,19 +1046,8 @@ function print_column_plugin( $p_column_object, BugData $p_bug, $p_columns_targe
  * @access public
  */
 function print_column_edit( BugData $p_bug, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
-	global $t_icon_path;
-
 	echo '<td class="column-edit">';
-
-	if( !bug_is_readonly( $p_bug->id ) && access_has_bug_level( config_get( 'update_bug_threshold' ), $p_bug->id ) ) {
-		echo '<a href="' . string_get_bug_update_url( $p_bug->id ) . '">';
-		echo '<img width="16" height="16" src="' . $t_icon_path . 'update.png';
-		echo '" alt="' . lang_get( 'update_bug_button' ) . '"';
-		echo ' title="' . lang_get( 'update_bug_button' ) . '" /></a>';
-	} else {
-		echo '&#160;';
-	}
-
+	print_bug_edit_button( $p_bug->id );
 	echo '</td>';
 }
 

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -142,6 +142,16 @@ function html_robots_noindex() {
 }
 
 /**
+ * This method must be called before the html_page_top* methods.  It marks the page as not
+ * for indexing and informs the crawler not to follow links within it.
+ * @return void
+ */
+function html_robots_noindex_nofollow() {
+	global $g_robots_meta;
+	$g_robots_meta = 'noindex,nofollow';
+}
+
+/**
  * Prints the link that allows auto-detection of the associated feed.
  * @return void
  */

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1960,3 +1960,24 @@ function print_max_filesize( $p_size, $p_divider = 1000, $p_unit = 'kb' ) {
 		. get_filesize_info( $p_size / $p_divider, lang_get( $p_unit ) );
 	echo '</span>';
 }
+
+/**
+ * Prints the bug edit button based on access checks.
+ *
+ * @param integer $p_bug_id  The bug id.
+ * @return void
+ */
+function print_bug_edit_button( $p_bug_id ) {
+	if( !bug_is_readonly( $p_bug_id ) && access_has_bug_level( config_get( 'update_bug_threshold' ), $p_bug_id ) ) {
+		global $t_icon_path;
+
+		$t_update_bug_button_text = lang_get( 'update_bug_button' );
+
+		# Make this a hyperlink in CSS to avoid crawlers traversing links to update issue pages.
+		echo '<img class="click-url" width="16" height="16" src="' . $t_icon_path . 'update.png"';
+		echo ' alt="' . $t_update_bug_button_text . '"';
+		echo ' url="' . string_get_bug_update_url( $p_bug_id ) . '"';
+		echo ' title="' . $t_update_bug_button_text . '" />';
+	}
+}
+

--- a/css/default.css
+++ b/css/default.css
@@ -794,3 +794,6 @@ div.timeline p { margin-left: 3px; }
 /* bug_view_inc bug action buttons */
 .details-footer      { padding: 3px 10px 2px 0; }
 .details-buttons     { float: left;  width: auto; }
+
+.click-url { cursor: pointer; }
+

--- a/javascript/common.js
+++ b/javascript/common.js
@@ -247,6 +247,10 @@ $(document).ready( function() {
 		}
 		$(this).val(0);
 	});
+
+	$('.click-url').bind("click", function() {
+		window.location = $(this).attr("url");
+	});
 });
 
 function setBugLabel() {
@@ -361,3 +365,4 @@ function toggleDisplay(idTag)
 {
 	setDisplay( idTag, (document.getElementById(idTag).style.display == 'none')?1:0 );
 }
+

--- a/my_view_inc.php
+++ b/my_view_inc.php
@@ -351,9 +351,7 @@ for( $i = 0;$i < $t_count; $i++ ) {
 
 			echo '<br />';
 
-			if( !bug_is_readonly( $t_bug->id ) && access_has_bug_level( $t_update_bug_threshold, $t_bug->id ) ) {
-				echo '<a class="edit" href="' . string_get_bug_update_url( $t_bug->id ) . '"><img src="' . $t_icon_path . 'update.png' . '" alt="' . lang_get( 'update_bug_button' ) . '" /></a>';
-			}
+			print_bug_edit_button( $t_bug->id );
 
 			if( ON == config_get( 'show_priority_text' ) ) {
 				print_formatted_priority_string( $t_bug );


### PR DESCRIPTION
Use javascript to hyperlink issue edit button to avoid crawlers following
such links reducing load on server.

Move access check and rendering logic for edit issue button to print_api.

Fixes #17960
