### PR TITLE
Don't expand reporters by default in update page

### DIFF
--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -74,6 +74,7 @@ require_api( 'version_api.php' );
 require_css( 'status_config.php' );
 
 $f_bug_id = gpc_get_int( 'bug_id' );
+$f_reporter_edit = gpc_get_bool( 'reporter_edit' );
 
 $t_bug = bug_get( $f_bug_id, true );
 
@@ -288,9 +289,14 @@ if( $t_show_reporter ) {
 		) {
 			echo string_attribute( user_get_name( $t_bug->reporter_id ) );
 		} else {
-			echo '<select ' . helper_get_tab_index() . ' id="reporter_id" name="reporter_id">';
-			print_reporter_option_list( $t_bug->reporter_id, $t_bug->project_id );
-			echo '</select>';
+			if ( $f_reporter_edit ) {
+				echo '<select ' . helper_get_tab_index() . ' id="reporter_id" name="reporter_id">';
+				print_reporter_option_list( $t_bug->reporter_id, $t_bug->project_id );
+				echo '</select>';
+			} else {
+				echo string_attribute( user_get_name( $t_bug->reporter_id ) );
+				echo ' [<a href="#reporter_edit" class="click-url" url="' . string_get_bug_update_url( $f_bug_id ) . '&amp;reporter_edit=true">' . lang_get( 'edit_link' ) . '</a>]';
+			}
 		}
 		echo '</td>';
 	} else {

--- a/javascript/common.js
+++ b/javascript/common.js
@@ -247,6 +247,10 @@ $(document).ready( function() {
 		}
 		$(this).val(0);
 	});
+
+	$('a.click-url').bind("click", function() {
+		$(this).attr("href", $(this).attr("url"));
+	});
 });
 
 function setBugLabel() {


### PR DESCRIPTION
For performance reasons with update issue pages, we should revert
back to 1.2.x behavior where we don't populate the combobox of
reporters by default.  This is in order to reduce database load and
improve performance for instances with large number of reporters.

This change is also designed to make sure that search engine crawlers
don't expand such list and hence avoiding the database load.

In the future, we should use jquery auto-complete or similar control.
We could also possibly add a configuration option or cache a session
variable that determines whether to expand the list by default.  This
can be useful for instances with small number of reporters.

Fixes #17944
