### PR TITLE
Don't process history entries outside date range

### DIFF
--- a/core/classes/IssueAssignedTimelineEvent.class.php
+++ b/core/classes/IssueAssignedTimelineEvent.class.php
@@ -45,18 +45,6 @@ class IssueAssignedTimelineEvent extends TimelineEvent {
 	}
 
 	/**
-	 * Whether to skip this event after access checks
-	 * @return boolean
-	 */
-	function skip() {
-		if( !access_has_bug_level( config_get( 'view_handler_threshold' ), $this->issue_id ) ) {
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
 	 * Returns html string to display
 	 * @return string
 	 */

--- a/core/classes/IssueNoteCreatedTimelineEvent.class.php
+++ b/core/classes/IssueNoteCreatedTimelineEvent.class.php
@@ -45,23 +45,6 @@ class IssueNoteCreatedTimelineEvent extends TimelineEvent {
 	}
 
 	/**
-	 * Whether to skip this event after access checks
-	 * @return boolean
-	 */
-	public function skip() {
-		if( !bugnote_exists( $this->issue_note_id ) ) {
-			return true;
-		}
-
-		$t_bug = bug_get( $this->issue_id, true );
-		if( !access_has_bugnote_level( config_get( 'view_bug_threshold', null, null, $t_bug->project_id ), $this->issue_note_id ) ) {
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
 	 * Returns html string to display
 	 * @return string
 	 */

--- a/core/classes/TimelineEvent.class.php
+++ b/core/classes/TimelineEvent.class.php
@@ -44,15 +44,6 @@ class TimelineEvent {
 	}
 
 	/**
-	 * Whether to skip this timeline event.
-	 * This normally implements access checks for the event.
-	 * @return boolean
-	 */
-	public function skip() {
-		return false;
-	}
-
-	/**
 	 * Comparision function for ordering of timeline events.
 	 * We compare first by timestamp, then by the tie_breaker field.
 	 * @param TimelineEvent $p_other An instance of TimelineEvent to compare against.

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -162,9 +162,11 @@ function history_get_events_array( $p_bug_id, $p_user_id = null ) {
  * 'field','type','old_value','new_value'
  * @param integer $p_bug_id  A valid bug identifier.
  * @param integer $p_user_id A valid user identifier.
+ * @param integer $p_start_time The start time to filter by, or null for all.
+ * @param integer $p_end_time   The end time to filter by, or null for all.
  * @return array
  */
-function history_get_raw_events_array( $p_bug_id, $p_user_id = null ) {
+function history_get_raw_events_array( $p_bug_id, $p_user_id = null, $p_start_time = null, $p_end_time = null ) {
 	$t_history_order = config_get( 'history_order' );
 
 	$t_user_id = (( null === $p_user_id ) ? auth_get_current_user_id() : $p_user_id );
@@ -193,6 +195,14 @@ function history_get_raw_events_array( $p_bug_id, $p_user_id = null ) {
 	$j = 0;
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		extract( $t_row, EXTR_PREFIX_ALL, 'v' );
+
+		if ( $p_start_time !== null && $v_date_modified < $p_start_time ) {
+			continue;
+		}
+
+		if ( $p_end_time !== null && $v_date_modified > $p_end_time ) {
+			continue;
+		}
 
 		if( $v_type == NORMAL_TYPE ) {
 			if( !in_array( $v_field_name, $t_standard_fields ) ) {

--- a/core/timeline_api.php
+++ b/core/timeline_api.php
@@ -78,7 +78,7 @@ function timeline_events( $p_start_time, $p_end_time ) {
 	$t_timeline_events = array();
 
 	foreach ( $t_issue_ids as $t_issue_id ) {
-		$t_history_events_array = history_get_raw_events_array( $t_issue_id );
+		$t_history_events_array = history_get_raw_events_array( $t_issue_id, null, $p_start_time, $p_end_time );
 		$t_history_events_array = array_reverse( $t_history_events_array );
 
 		foreach ( $t_history_events_array as $t_history_event ) {
@@ -159,30 +159,6 @@ function timeline_sort_events( array $p_events ) {
 	}
 
 	return $p_events;
-}
-
-/**
- * Truncate an array of events.
- * @param array   $p_events    Array of events to truncate.
- * @param integer $p_max_count Maximum number of entries to return.
- * @return array
- */
-function timeline_filter_events( array $p_events, $p_max_count ) {
-	$t_events = array();
-
-	foreach ( $p_events as $t_event ) {
-		if( $t_event->skip() ) {
-			continue;
-		}
-
-		$t_events[] = $t_event;
-
-		if( $p_max_count > 0 && count( $t_events ) >= $p_max_count ) {
-			break;
-		}
-	}
-
-	return $t_events;
 }
 
 /**

--- a/core/timeline_inc.php
+++ b/core/timeline_inc.php
@@ -43,7 +43,10 @@ if( $t_next_days != $f_days ) {
 
 echo '<div class="date-range">' . date( $t_short_date_format, $t_start_time ) . ' .. ' . date( $t_short_date_format, $t_end_time ) . $t_prev_link . $t_next_link . '</div>';
 $t_events = timeline_sort_events( $t_events );
-$t_events = timeline_filter_events( $t_events, $f_all == 0 ? 50 : 0 );
+
+if ( $f_all == 0 ) {
+	$t_events = array_slice( $t_events, 0, 50 );
+}
 
 if( count( $t_events ) > 0 ) {
 	timeline_print_events( $t_events );


### PR DESCRIPTION
The following queries cut the number of queries in half for a busy week:

- Remove skip() method from events class since history api does the filtering.
- When processing history events for an issue, only process ones within desired
time range.

Before:
- Total queries executed: 1232
- Unique queries executed: 1231
- Total query execution time: 0.7097 seconds

After:
- Total queries executed: 574
- Unique queries executed: 573
- Total query execution time: 0.2581 seconds

Issue #17966