### PR TITLE
Fix captcha validation

### DIFF
--- a/core/session_api.php
+++ b/core/session_api.php
@@ -171,6 +171,7 @@ class MantisPHPSession extends MantisSession {
 		}
 
 		unset( $_SESSION[ $this->key ] );
+		session_write_close();
 	}
 }
 

--- a/signup.php
+++ b/signup.php
@@ -37,6 +37,9 @@
 	$f_email = email_append_domain( trim( $f_email ) );
 	$f_captcha = utf8_strtolower( trim( $f_captcha ) );
 
+	# Retrieve captcha key now, as session might get cleared by logout
+	$t_form_key = session_get_int( CAPTCHA_KEY, null );
+
 	# force logout on the current user if already authenticated
 	if( auth_is_user_authenticated() ) {
 		auth_logout();
@@ -50,8 +53,6 @@
 
 	if( ON == config_get( 'signup_use_captcha' ) && get_gd_version() > 0 	&&
 				helper_call_custom_function( 'auth_can_change_password', array() ) ) {
-		$t_form_key = session_get( CAPTCHA_KEY );
-
 		# captcha image requires GD library and related option to ON
 		$t_key = utf8_strtolower( utf8_substr( md5( config_get( 'password_confirm_hash_magic_string' ) . $t_form_key ), 1, 5) );
 


### PR DESCRIPTION
Following 7bb78e4581ff1092c811ea96582fe602624cdcdd, it was no longer
possible to validate the captcha, because the PHP session is destroyed
as part of the logout performed in signup.php.

We now retrieve the captcha key from the session before logging out, and
recreate the session variable after that.

Fixes [#17993](https://www.mantisbt.org/bugs/view.php?id=17993)