### PR TITLE
Bug19258: Fix custom date field in filter

### DIFF
--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -4289,21 +4289,12 @@ function print_filter_custom_field_date( $p_field_num, $p_field_id ) {
 			$t_end = $t_end_time;
 			break;
 		case CUSTOM_FIELD_DATE_ONORBEFORE:
-			$t_start_disable = false;
-			$t_start = $t_end_time;
-			break;
 		case CUSTOM_FIELD_DATE_BEFORE:
 			$t_start_disable = false;
 			$t_start = $t_end_time;
 			break;
 		case CUSTOM_FIELD_DATE_ON:
-			$t_start_disable = false;
-			$t_start = $t_start_time;
-			break;
 		case CUSTOM_FIELD_DATE_AFTER:
-			$t_start_disable = false;
-			$t_start = $t_start_time;
-			break;
 		case CUSTOM_FIELD_DATE_ONORAFTER:
 			$t_start_disable = false;
 			$t_start = $t_start_time;

--- a/javascript/common.js
+++ b/javascript/common.js
@@ -222,7 +222,7 @@ $(document).ready( function() {
 	});
 
 	/* Handle custom field of date type */
-	$(document).on('change', 'select[name*=custom_field_]', function() {
+	$(document).on('change', 'select[name^=custom_field_][name$=_control]', function() {
 		var table = $(this).closest('table');
 		switch(this.value) {
 			case '2': // between

--- a/javascript/common.js
+++ b/javascript/common.js
@@ -221,6 +221,45 @@ $(document).ready( function() {
 		}
 	});
 
+    /* Handle custom field of date type */
+    $(document).on('change', 'select[name*=custom_field_]', function() {
+        var table = $(this).closest('table');
+        switch(this.value) {
+            case '2': // between
+                $(table).find("select[name*=_start_year]").prop('disabled', false);
+                $(table).find("select[name*=_start_month]").prop('disabled', false);
+                $(table).find("select[name*=_start_day]").prop('disabled', false);
+                $(table).find("select[name*=_end_year]").prop('disabled', false);
+                $(table).find("select[name*=_end_month]").prop('disabled', false);
+                $(table).find("select[name*=_end_day]").prop('disabled', false);
+                break;
+
+            case '3': // on or before
+            case '4': // before
+            case '5': // on
+            case '6': // after
+            case '7': // on or after
+                $(table).find("select[name*=_start_year]").prop('disabled', false);
+                $(table).find("select[name*=_start_month]").prop('disabled', false);
+                $(table).find("select[name*=_start_day]").prop('disabled', false);
+                $(table).find("select[name*=_end_year]").prop('disabled', 'disabled');
+                $(table).find("select[name*=_end_month]").prop('disabled', 'disabled');
+                $(table).find("select[name*=_end_day]").prop('disabled', 'disabled');
+                break;
+
+            case '0': // any
+            case '1': // none
+            default:
+                $(table).find("select[name*=_start_year]").prop('disabled', 'disabled');
+                $(table).find("select[name*=_start_month]").prop('disabled', 'disabled');
+                $(table).find("select[name*=_start_day]").prop('disabled', 'disabled');
+                $(table).find("select[name*=_end_year]").prop('disabled', 'disabled');
+                $(table).find("select[name*=_end_month]").prop('disabled', 'disabled');
+                $(table).find("select[name*=_end_day]").prop('disabled', 'disabled');
+            break;
+        }
+    });
+
 	/* For Period.php bundled with the core MantisGraph plugin */
 	$('#dates > input[type=image].datetime').hide();
 	$('#period_menu > select#interval').change(function() {

--- a/javascript/common.js
+++ b/javascript/common.js
@@ -221,44 +221,44 @@ $(document).ready( function() {
 		}
 	});
 
-    /* Handle custom field of date type */
-    $(document).on('change', 'select[name*=custom_field_]', function() {
-        var table = $(this).closest('table');
-        switch(this.value) {
-            case '2': // between
-                $(table).find("select[name*=_start_year]").prop('disabled', false);
-                $(table).find("select[name*=_start_month]").prop('disabled', false);
-                $(table).find("select[name*=_start_day]").prop('disabled', false);
-                $(table).find("select[name*=_end_year]").prop('disabled', false);
-                $(table).find("select[name*=_end_month]").prop('disabled', false);
-                $(table).find("select[name*=_end_day]").prop('disabled', false);
-                break;
+	/* Handle custom field of date type */
+	$(document).on('change', 'select[name*=custom_field_]', function() {
+		var table = $(this).closest('table');
+		switch(this.value) {
+			case '2': // between
+				$(table).find("select[name*=_start_year]").prop('disabled', false);
+				$(table).find("select[name*=_start_month]").prop('disabled', false);
+				$(table).find("select[name*=_start_day]").prop('disabled', false);
+				$(table).find("select[name*=_end_year]").prop('disabled', false);
+				$(table).find("select[name*=_end_month]").prop('disabled', false);
+				$(table).find("select[name*=_end_day]").prop('disabled', false);
+				break;
 
-            case '3': // on or before
-            case '4': // before
-            case '5': // on
-            case '6': // after
-            case '7': // on or after
-                $(table).find("select[name*=_start_year]").prop('disabled', false);
-                $(table).find("select[name*=_start_month]").prop('disabled', false);
-                $(table).find("select[name*=_start_day]").prop('disabled', false);
-                $(table).find("select[name*=_end_year]").prop('disabled', true);
-                $(table).find("select[name*=_end_month]").prop('disabled', true);
-                $(table).find("select[name*=_end_day]").prop('disabled', true);
-                break;
+			case '3': // on or before
+			case '4': // before
+			case '5': // on
+			case '6': // after
+			case '7': // on or after
+				$(table).find("select[name*=_start_year]").prop('disabled', false);
+				$(table).find("select[name*=_start_month]").prop('disabled', false);
+				$(table).find("select[name*=_start_day]").prop('disabled', false);
+				$(table).find("select[name*=_end_year]").prop('disabled', true);
+				$(table).find("select[name*=_end_month]").prop('disabled', true);
+				$(table).find("select[name*=_end_day]").prop('disabled', true);
+				break;
 
-            case '0': // any
-            case '1': // none
-            default:
-                $(table).find("select[name*=_start_year]").prop('disabled', true);
-                $(table).find("select[name*=_start_month]").prop('disabled', true);
-                $(table).find("select[name*=_start_day]").prop('disabled', true);
-                $(table).find("select[name*=_end_year]").prop('disabled', true);
-                $(table).find("select[name*=_end_month]").prop('disabled', true);
-                $(table).find("select[name*=_end_day]").prop('disabled', true);
-            break;
-        }
-    });
+			case '0': // any
+			case '1': // none
+			default:
+				$(table).find("select[name*=_start_year]").prop('disabled', true);
+				$(table).find("select[name*=_start_month]").prop('disabled', true);
+				$(table).find("select[name*=_start_day]").prop('disabled', true);
+				$(table).find("select[name*=_end_year]").prop('disabled', true);
+				$(table).find("select[name*=_end_month]").prop('disabled', true);
+				$(table).find("select[name*=_end_day]").prop('disabled', true);
+			break;
+		}
+	});
 
 	/* For Period.php bundled with the core MantisGraph plugin */
 	$('#dates > input[type=image].datetime').hide();

--- a/javascript/common.js
+++ b/javascript/common.js
@@ -242,20 +242,20 @@ $(document).ready( function() {
                 $(table).find("select[name*=_start_year]").prop('disabled', false);
                 $(table).find("select[name*=_start_month]").prop('disabled', false);
                 $(table).find("select[name*=_start_day]").prop('disabled', false);
-                $(table).find("select[name*=_end_year]").prop('disabled', 'disabled');
-                $(table).find("select[name*=_end_month]").prop('disabled', 'disabled');
-                $(table).find("select[name*=_end_day]").prop('disabled', 'disabled');
+                $(table).find("select[name*=_end_year]").prop('disabled', true);
+                $(table).find("select[name*=_end_month]").prop('disabled', true);
+                $(table).find("select[name*=_end_day]").prop('disabled', true);
                 break;
 
             case '0': // any
             case '1': // none
             default:
-                $(table).find("select[name*=_start_year]").prop('disabled', 'disabled');
-                $(table).find("select[name*=_start_month]").prop('disabled', 'disabled');
-                $(table).find("select[name*=_start_day]").prop('disabled', 'disabled');
-                $(table).find("select[name*=_end_year]").prop('disabled', 'disabled');
-                $(table).find("select[name*=_end_month]").prop('disabled', 'disabled');
-                $(table).find("select[name*=_end_day]").prop('disabled', 'disabled');
+                $(table).find("select[name*=_start_year]").prop('disabled', true);
+                $(table).find("select[name*=_start_month]").prop('disabled', true);
+                $(table).find("select[name*=_start_day]").prop('disabled', true);
+                $(table).find("select[name*=_end_year]").prop('disabled', true);
+                $(table).find("select[name*=_end_month]").prop('disabled', true);
+                $(table).find("select[name*=_end_day]").prop('disabled', true);
             break;
         }
     });

--- a/javascript/common.js
+++ b/javascript/common.js
@@ -256,7 +256,7 @@ $(document).ready( function() {
 				$(table).find("select[name*=_end_year]").prop('disabled', true);
 				$(table).find("select[name*=_end_month]").prop('disabled', true);
 				$(table).find("select[name*=_end_day]").prop('disabled', true);
-			break;
+				break;
 		}
 	});
 


### PR DESCRIPTION
It appears that this was never fully implemented. This fix enables the correct date field based on user selection of comparison operator in the select menu above (see snapshots)

Fixes #19258: Custom fields of type date are disabled in filter

![screen shot 2015-01-24 at 10 44 05 am](https://cloud.githubusercontent.com/assets/1354889/5888510/0605abd6-a3b6-11e4-8bcf-01487629b8aa.png)
![screen shot 2015-01-24 at 10 44 16 am](https://cloud.githubusercontent.com/assets/1354889/5888511/07af546e-a3b6-11e4-8489-d9bb88450679.png)
![screen shot 2015-01-24 at 10 44 26 am](https://cloud.githubusercontent.com/assets/1354889/5888512/0c4a6c3e-a3b6-11e4-8116-af82a4493e95.png)
