### PR TITLE
Possibility to write a violation report for CSP

### DIFF
--- a/core/http_api.php
+++ b/core/http_api.php
@@ -169,6 +169,26 @@ function http_security_headers() {
 
 		header( 'Content-Security-Policy: ' . $t_default_src . $t_frame_ancestors . $t_img_src . $t_report_uri);
 
+		# Header: CSP-Report-Only
+		if( config_get_global( 'csp_develop' ) ) {
+			$t_default_src = "default-src 'none'"; // nothing at all
+			$t_frame_ancestors = "; frame-ancestors 'none'";
+
+			if( config_get_global( 'show_avatar' ) ) {
+				if( http_is_protocol_https() ) {
+					$t_avatar_img_allow = " https://secure.gravatar.com";
+				} else {
+					$t_avatar_img_allow = " http://www.gravatar.com";
+				}
+			}
+			$t_img_src = "; img-src 'self'" . $t_avatar_img_allow; // allow our images and gravatars
+			$t_script_src = "; script-src 'self'"; // allow our script
+			$t_style_src = "; style-src 'self'"; // allow our css
+
+			$t_report_uri = '; report-uri ./csp/csp_report_only.php'; // Note: This does not work from admin- or any other folder
+			header( 'Content-Security-Policy-Report-Only: ' . $t_default_src . $t_frame_ancestors . $t_img_src . $t_script_src . $t_style_src . $t_report_uri);
+		}
+
 		# Header: STS
 		if( http_is_protocol_https() ) {
 			header( 'Strict-Transport-Security: max-age=7776000' );

--- a/core/http_api.php
+++ b/core/http_api.php
@@ -144,16 +144,32 @@ function http_content_headers() {
  */
 function http_security_headers() {
 	if( !headers_sent() ) {
+		# Header: X-Frame-Options
 		header( 'X-Frame-Options: DENY' );
+
+		# Header: CSP
+		$t_default_src = "default-src 'self'";
+		$t_frame_ancestors = "; frame-ancestors 'none'";
+
 		$t_avatar_img_allow = '';
 		if( config_get_global( 'show_avatar' ) ) {
 			if( http_is_protocol_https() ) {
-				$t_avatar_img_allow = "; img-src 'self' https://secure.gravatar.com:443";
+				$t_avatar_img_allow = " https://secure.gravatar.com:443";
 			} else {
-				$t_avatar_img_allow = "; img-src 'self' http://www.gravatar.com:80";
+				$t_avatar_img_allow = " http://www.gravatar.com:80";
 			}
 		}
-		header( 'Content-Security-Policy: default-src \'self\';' . $t_avatar_img_allow . '; frame-ancestors \'none\'' );
+		$t_img_src = "; img-src 'self'" . $t_avatar_img_allow;
+
+		#
+		$t_report_uri = '';
+		if( config_get_global( 'report_csp_violation' ) ) {
+			$t_report_uri = '; report-uri ./csp/csp_report.php'; // Note: This does not work from admin- or any other folder
+		}
+
+		header( 'Content-Security-Policy: ' . $t_default_src . $t_frame_ancestors . $t_img_src . $t_report_uri);
+
+		# Header: STS
 		if( http_is_protocol_https() ) {
 			header( 'Strict-Transport-Security: max-age=7776000' );
 		}

--- a/csp/csp_report.php
+++ b/csp/csp_report.php
@@ -1,0 +1,24 @@
+<?php
+
+$filename = './logs/csp_report.log';
+$logprefix = date('y-m-d') . ' - CSP Violation:' . PHP_EOL;
+
+// Send `204 No Content` status code
+http_response_code(204);
+
+// Get the raw POST data
+$data = file_get_contents('php://input');
+// Only continue if it’s valid JSON that is not just `null`, `0`, `false` or an
+// empty string, i.e. if it could be a CSP violation report.
+if ($data = json_decode($data)) {
+  // Prettify the JSON-formatted data
+  $data = json_encode(
+    $data,
+    #JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+    JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT
+  );
+}
+
+file_put_contents( $filename, $logprefix . $data . PHP_EOL, FILE_APPEND | LOCK_EX );
+
+?>

--- a/csp/csp_report_only.php
+++ b/csp/csp_report_only.php
@@ -1,0 +1,24 @@
+<?php
+
+$filename = './logs/csp_report_only.log';
+$logprefix = date('y-m-d') . ' - CSP Potential:' . PHP_EOL;
+
+// Send `204 No Content` status code
+http_response_code(204);
+
+// Get the raw POST data
+$data = file_get_contents('php://input');
+// Only continue if it’s valid JSON that is not just `null`, `0`, `false` or an
+// empty string, i.e. if it could be a CSP violation report.
+if ($data = json_decode($data)) {
+  // Prettify the JSON-formatted data
+  $data = json_encode(
+    $data,
+    #JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+    JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT
+  );
+}
+
+file_put_contents( $filename, $logprefix . $data . PHP_EOL, FILE_APPEND | LOCK_EX );
+
+?>


### PR DESCRIPTION

Try to find reason of BugID [0017491](https://www.mantisbt.org/bugs/view.php?id=17491).
First added some source-comments (sorry for that not being a single commit).
Second splitted the construction of this csp-header to simplyfie future changes (again sorry).
Third added an option to enable/disable an report-uri-directiv to the csp-header.
Finally added <mantishome>\csp\csp_report.php which do log any violations.

To get such a report set $g_report_csp_violation = ON and start using mantis.
As far as an violation appears, the corresponding logfile will be extended - and this way we'll get noticed which csp-directive results in blocking those gravatars.

Note: Also added csp_report_only.php which is for a future csp-read-only -header.

I wasn't sure where to put csp_report*.php and their logs, that's why simply created new subfolder. I'm sure you would relocate that...