### PR TITLE
Make Assign work with required custom fields

### DIFF
--- a/bug_update.php
+++ b/bug_update.php
@@ -65,6 +65,7 @@ form_security_validate( 'bug_update' );
 
 $f_bug_id = gpc_get_int( 'bug_id' );
 $t_existing_bug = bug_get( $f_bug_id, true );
+$f_update_type = gpc_get_string( 'action_type', BUG_UPDATE_TYPE_NORMAL );
 
 if( helper_get_current_project() !== $t_existing_bug->project_id ) {
 	$g_project_override = $t_existing_bug->project_id;
@@ -262,7 +263,7 @@ foreach ( $t_related_custom_field_ids as $t_cf_id ) {
 	$t_cf_def = custom_field_get_definition( $t_cf_id );
 
 	if( !gpc_isset_custom_field( $t_cf_id, $t_cf_def['type'] ) ) {
-		if( $t_cf_def[$t_cf_require_check] ) {
+		if( $t_cf_def[$t_cf_require_check] && $f_update_type == BUG_UPDATE_TYPE_NORMAL ) {
 			# A value for the custom field was expected however
 			# no value was given by the user.
 			error_parameters( lang_get_defaulted( custom_field_get_field( $t_cf_id, 'name' ) ) );

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -219,6 +219,10 @@ define( 'BUG_DEPENDANT', 2 );
 define( 'BUG_BLOCKS', 3 );
 define( 'BUG_HAS_DUPLICATE', 4 );
 
+# bug update types
+define( 'BUG_UPDATE_TYPE_NORMAL', 'update' );
+define( 'BUG_UPDATE_TYPE_ASSIGN', 'assign' );
+
 # error messages
 define( 'ERROR_GENERIC', 0 );
 define( 'ERROR_SQL', 1 );

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1612,6 +1612,7 @@ function html_button_bug_assign_to( BugData $p_bug ) {
 	echo '<form method="post" action="bug_update.php">';
 	echo form_security_field( 'bug_update' );
 	echo '<input type="hidden" name="last_updated" value="' . $p_bug->last_updated . '" />';
+	echo '<input type="hidden" name="action_type" value="' . BUG_UPDATE_TYPE_ASSIGN . '" />';
 
 	$t_button_text = lang_get( 'bug_assign_to_button' );
 	echo '<input type="submit" class="button" value="' . $t_button_text . '" />';


### PR DESCRIPTION
This bug was introduced in 1.3.x where users are not able to assign issues within projects that have required custom fields on update. This failure happens even independent of whether the fields are populated or not.  The fix is to enabling the Assign-To action to work independent of custom fields values.  This this is an assign-to action rather than a full update.

Fixes #19265