### PR TITLE
Switching projects should maintain current page

### DIFF
--- a/set_project.php
+++ b/set_project.php
@@ -84,7 +84,7 @@ if( !is_blank( $c_ref ) ) {
 
 	# Check that referrer matches our address after squashing case (case insensitive compare)
 	$t_path = rtrim( config_get( 'path' ), '/' );
-	if( preg_match( '@^(' . $t_path . ')/(?:/*([^\?#]*))(.*)?\$@', $_SERVER['HTTP_REFERER'], $t_matches ) ) {
+	if( preg_match( '@^(' . $t_path . ')/(?:/*([^\?#]*))(.*)?$@', $_SERVER['HTTP_REFERER'], $t_matches ) ) {
 		$t_referrer_page = $t_matches[2];
 		$t_param = $t_matches[3];
 


### PR DESCRIPTION
When possible maintain the current page as user switches project.
A bug was introduced in 1.3.x that made switching projects always
redirects to default home page.

Fixes #19351