### PR TITLE
Temp fix to inability to disable notifications

### DIFF
--- a/core/email_api.php
+++ b/core/email_api.php
@@ -337,12 +337,10 @@ function email_collect_recipients( $p_bug_id, $p_notify_type, array $p_extra_use
 		case 'relation':
 		case 'monitor':
 		case 'priority': # This is never used, but exists in the database!
-			# FIXME: these notification actions are not actually implemented
+			# Issue #19459 these notification actions are not actually implemented
 			# in the database and therefore aren't adjustable on a per-user
 			# basis! The exception is 'monitor' that makes no sense being a
 			# customisable per-user preference.
-			$t_pref_field = false;
-			break;
 		default:
 			# Anything not built-in is probably going to be a status
 			$t_pref_field = 'email_on_status';


### PR DESCRIPTION
The proper fix for this is not trivial involving database schema change, localization, etc.
Until this is done, we will treat uncustomizable notifications the same way as the
default preference where the "email_on_status" preference is used.
The issue will not be marked as resolved until we add the necessary preferences.
However, we should consider a model where adding user preferences doesn't
require a schema change.

Issue #19459