### PR TITLE
Support multi-line default values for memo fields

### DIFF
--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -442,6 +442,11 @@ function custom_field_update( $p_field_id, array $p_def_array ) {
 			case 'possible_values':
 			case 'default_value':
 			case 'valid_regexp':
+				# Possible values doesn't apply to textarea fields
+				if( $p_def_array['type'] == CUSTOM_FIELD_TYPE_TEXTAREA && $t_field == 'possible_values' ) {
+					$t_value = '';
+				}
+
 				$t_update .= $t_field . '=' . db_param() . ', ';
 				$t_params[] = (string)$t_value;
 				break;

--- a/javascript/manage_custom_field_edit_page.js
+++ b/javascript/manage_custom_field_edit_page.js
@@ -1,0 +1,39 @@
+/*
+# Mantis - a php based bugtracking system
+
+# Copyright 2000 - 2002  Kenzaburo Ito - kenito@300baud.org
+# Copyright 2002 MantisBT Team   - mantisbt-dev@lists.sourceforge.net
+
+# Mantis is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Mantis is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Mantis.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Handle switching between textarea custom field type and other types
+$(document).ready(function() {
+  $('#custom-field-type').on('change', function() {
+    if($(this).val() == 10) {  // 10: CUSTOM_FIELD_TYPE_TEXTAREA
+      $('#custom-field-possible-values').closest('.field-container').hide();
+      $('#custom-field-default-value').closest('.input').hide();
+      $('#custom-field-default-value').attr('disabled', 'disabled');
+      $('#custom-field-default-value-textarea').closest('.textarea').show();
+      $('#custom-field-default-value-textarea').removeAttr('disabled');
+    } else {
+      $('#custom-field-possible-values').closest('.field-container').show();
+      $('#custom-field-default-value-textarea').closest('.textarea').hide();
+      $('#custom-field-default-value-textarea').attr('disabled', 'disabled');
+      $('#custom-field-default-value').closest('.input').show();
+      $('#custom-field-default-value').removeAttr('disabled');
+    }
+  });
+  $('#custom-field-type').trigger('change');
+});

--- a/manage_custom_field_edit_page.php
+++ b/manage_custom_field_edit_page.php
@@ -58,6 +58,8 @@ $f_return	= strip_tags( gpc_get_string( 'return', 'manage_custom_field_page.php'
 
 custom_field_ensure_exists( $f_field_id );
 
+require_js( 'manage_custom_field_edit_page.js' );
+
 html_page_top();
 
 print_manage_menu( 'manage_custom_field_edit_page.php' );
@@ -95,7 +97,12 @@ $t_definition = custom_field_get_definition( $f_field_id );
 			</div>
 			<div class="field-container">
 				<label for="custom-field-default-value"><span><?php echo lang_get( 'custom_field_default_value' ) ?></span></label>
-				<span class="input"><input type="text" id="custom-field-default-value" name="default_value" size="32" maxlength="255" value="<?php echo string_attribute( $t_definition['default_value'] ) ?>" /></span>
+				<span class="input">
+					<input type="text" id="custom-field-default-value" name="default_value" size="32" maxlength="255" value="<?php echo string_attribute( $t_definition['default_value'] ) ?>" />
+				</span>
+				<span class="textarea">
+					<textarea disabled="disabled" id="custom-field-default-value-textarea" name="default_value" cols="80" rows="10"><?php echo string_attribute( $t_definition['default_value'] ) ?></textarea>
+				</span>
 				<span class="label-style"></span>
 			</div>
 			<div class="field-container">


### PR DESCRIPTION
- When type is text area enable setting multi-line default.
- When type is text area, don't enable possible values field.

Fixes #19542