### PR TITLE
Fixes #19642: If log file is not writable, log_event() fails silently

### DIFF
--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -110,12 +110,11 @@ function log_event( $p_level, $p_msg ) {
 	if( function_exists( 'event_signal' ) ) {
 		event_signal( 'EVENT_LOG', array( $t_plugin_event ) );
 	}
-
 	$t_log_destination = config_get_global( 'log_destination' );
-
 	if( is_blank( $t_log_destination ) ) {
 		$t_destination = '';
-	} else {
+	}
+	else {
 		$t_result = explode( ':', $t_log_destination, 2 );
 		$t_destination = $t_result[0];
 		if( isset( $t_result[1] ) ) {
@@ -124,6 +123,14 @@ function log_event( $p_level, $p_msg ) {
 	}
 
 	$t_php_event = $t_now . ' ' . $t_level . ' ' . $t_msg;
+
+	#here is the modification.
+	$perms=fileperms( $t_modifiers);
+	if (!(($perms & 0x0080) && ($perms & 0x0010)) ){
+		error_log( $t_php_event . PHP_EOL, 3, $t_modifiers );
+		$t_destination = 'none';
+	}
+
 
 	switch( $t_destination ) {
 		case 'none':

--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -46,7 +46,7 @@ $g_log_levels = array(
 	LOG_WEBSERVICE => 'WEBSERVICE'
 );
 
-$t_call_once = True;
+$s_check_log_writable = true;
 
 /**
  * Log an event
@@ -111,12 +111,12 @@ function log_event( $p_level, $p_msg ) {
 	$t_plugin_event = '[' . $t_level . '] ' . $t_msg;
 	if( function_exists( 'event_signal' ) ) {
 		event_signal( 'EVENT_LOG', array( $t_plugin_event ) );
+
 	}
 	$t_log_destination = config_get_global( 'log_destination' );
 	if( is_blank( $t_log_destination ) ) {
 		$t_destination = '';
-	}
-	else {
+	} else {
 		$t_result = explode( ':', $t_log_destination, 2 );
 		$t_destination = $t_result[0];
 		if( isset( $t_result[1] ) ) {
@@ -126,18 +126,18 @@ function log_event( $p_level, $p_msg ) {
 
 	$t_php_event = $t_now . ' ' . $t_level . ' ' . $t_msg;
 
-	if( isset( $t_modifiers ) && !( is_writable ( $t_modifiers ) ) && $t_call_once ){
-		trigger_error( "Warning : $t_modifiers is not a writable file", E_USER_WARNING );
-		$t_call_once = false;	
-	}
-
 
 	switch( $t_destination ) {
 		case 'none':
 			break;
 		case 'file':
-			if( isset( $t_modifiers ) && ( is_writable ( $t_modifiers ) ) )
+			if( $s_check_log_writable && isset( $t_modifiers ) && !( is_writable ( $t_modifiers ) ) ){
+				trigger_error( "Warning : $t_modifiers is not a writable file", E_USER_WARNING );
+				$s_check_log_writable = false;	
+			}
+			if( isset( $t_modifiers ) && ( is_writable ( $t_modifiers ) ) ){
 				error_log( $t_php_event . PHP_EOL, 3, $t_modifiers );
+			}
 			break;
 		case 'page':
 			global $g_log_events;

--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -55,7 +55,7 @@ $s_check_log_writable = true;
  * @return void
  */
 function log_event( $p_level, $p_msg ) {
-	global $g_log_levels;
+	global $g_log_levels, ;
 
 	# check to see if logging is enabled
 	$t_sys_log = config_get_global( 'log_level' );
@@ -132,7 +132,7 @@ function log_event( $p_level, $p_msg ) {
 			break;
 		case 'file':
 			if( $s_check_log_writable && isset( $t_modifiers ) && !( is_writable ( $t_modifiers ) ) ){
-				trigger_error( "Warning : $t_modifiers is not a writable file", E_USER_WARNING );
+				trigger_error( sprintf( lang_get('warning_log_not_writable'), $t_modifiers ) );
 				$s_check_log_writable = false;	
 			}
 			if( isset( $t_modifiers ) && ( is_writable ( $t_modifiers ) ) ){

--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -46,7 +46,6 @@ $g_log_levels = array(
 	LOG_WEBSERVICE => 'WEBSERVICE'
 );
 
-$s_check_log_writable = true;
 
 /**
  * Log an event
@@ -55,7 +54,7 @@ $s_check_log_writable = true;
  * @return void
  */
 function log_event( $p_level, $p_msg ) {
-	global $g_log_levels, ;
+	global $g_log_levels;
 
 	# check to see if logging is enabled
 	$t_sys_log = config_get_global( 'log_level' );
@@ -125,18 +124,22 @@ function log_event( $p_level, $p_msg ) {
 	}
 
 	$t_php_event = $t_now . ' ' . $t_level . ' ' . $t_msg;
+	$s_check_log_writable = true;
 
 
 	switch( $t_destination ) {
 		case 'none':
 			break;
 		case 'file':
-			if( $s_check_log_writable && isset( $t_modifiers ) && !( is_writable ( $t_modifiers ) ) ){
-				trigger_error( sprintf( lang_get('warning_log_not_writable'), $t_modifiers ) );
-				$s_check_log_writable = false;	
-			}
-			if( isset( $t_modifiers ) && ( is_writable ( $t_modifiers ) ) ){
-				error_log( $t_php_event . PHP_EOL, 3, $t_modifiers );
+			if( isset( $t_modifiers ) ) {
+				$t_is_writable = ( is_writable( $t_modifiers ) );
+				if( $s_check_log_writable && !$t_is_writable ) {
+					trigger_error( sprintf( lang_get('warning_log_not_writable'), $t_modifiers ) );
+					$s_check_log_writable = false;	
+				}
+				if( $t_is_writable ){
+					error_log( $t_php_event . PHP_EOL, 3, $t_modifiers );
+				}
 			}
 			break;
 		case 'page':

--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -46,6 +46,8 @@ $g_log_levels = array(
 	LOG_WEBSERVICE => 'WEBSERVICE'
 );
 
+$t_call_once = True;
+
 /**
  * Log an event
  * @param integer          $p_level Valid debug log level.
@@ -124,11 +126,9 @@ function log_event( $p_level, $p_msg ) {
 
 	$t_php_event = $t_now . ' ' . $t_level . ' ' . $t_msg;
 
-	#here is the modification.
-	$perms=fileperms( $t_modifiers);
-	if (!(($perms & 0x0080) && ($perms & 0x0010)) ){
-		error_log( $t_php_event . PHP_EOL, 3, $t_modifiers );
-		$t_destination = 'none';
+	if( isset( $t_modifiers ) && !( is_writable ( $t_modifiers ) ) && $t_call_once ){
+		trigger_error( "Warning : $t_modifiers is not a writable file", E_USER_WARNING );
+		$t_call_once = false;	
 	}
 
 
@@ -136,7 +136,8 @@ function log_event( $p_level, $p_msg ) {
 		case 'none':
 			break;
 		case 'file':
-			error_log( $t_php_event . PHP_EOL, 3, $t_modifiers );
+			if( isset( $t_modifiers ) && ( is_writable ( $t_modifiers ) ) )
+				error_log( $t_php_event . PHP_EOL, 3, $t_modifiers );
 			break;
 		case 'page':
 			global $g_log_events;

--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -113,6 +113,7 @@ function log_event( $p_level, $p_msg ) {
 
 	}
 	$t_log_destination = config_get_global( 'log_destination' );
+
 	if( is_blank( $t_log_destination ) ) {
 		$t_destination = '';
 	} else {

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -653,6 +653,7 @@ $s_warning_debug_email = '<strong>Warning:</strong> "<code>debug_email</code>" i
 $s_error_database_no_schema_version = '<strong>Error:</strong> The database structure appears to be out of date (config(databaseversion) is 0) or corrupt. Please check that your database is running - we can not retrieve the database schema version. Config Table did not return a valid database schema version - please ask for support on the mantis-help mailing list if required.';
 $s_error_database_version_out_of_date_2 = '<strong>Warning:</strong> The database structure may be out of date. Please upgrade <a href="admin/install.php">here</a> before logging in.';
 $s_error_code_version_out_of_date = '<strong>Warning:</strong> The database structure is more up-to-date than the code installed. Please upgrade the code.';
+$s_warning_log_not_writable = 'Warning log ( %s ) is not a writable file.';
 
 # login_page.php
 $s_login_page_info = 'Welcome to the Issue Tracker.';

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -653,7 +653,7 @@ $s_warning_debug_email = '<strong>Warning:</strong> "<code>debug_email</code>" i
 $s_error_database_no_schema_version = '<strong>Error:</strong> The database structure appears to be out of date (config(databaseversion) is 0) or corrupt. Please check that your database is running - we can not retrieve the database schema version. Config Table did not return a valid database schema version - please ask for support on the mantis-help mailing list if required.';
 $s_error_database_version_out_of_date_2 = '<strong>Warning:</strong> The database structure may be out of date. Please upgrade <a href="admin/install.php">here</a> before logging in.';
 $s_error_code_version_out_of_date = '<strong>Warning:</strong> The database structure is more up-to-date than the code installed. Please upgrade the code.';
-$s_warning_log_not_writable = 'Warning log ( %s ) is not a writable file.';
+$s_warning_log_not_writable = 'Warning log %s is not a writable file.';
 
 # login_page.php
 $s_login_page_info = 'Welcome to the Issue Tracker.';


### PR DESCRIPTION
Added a warning in log_event() when the log file
is not writable and prevented from calling error_log with
the same not writable file which caused the page to crash.
