### PR TITLE
Integrate Auth-Plugins using Events

### DIFF
--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -134,6 +134,7 @@ define( 'MD5', 3 );
 define( 'LDAP', 4 );
 define( 'BASIC_AUTH', 5 );
 define( 'HTTP_AUTH', 6 );
+define( 'AUTH_PLUGIN', 7 );
 
 # file upload methods
 define( 'DISK', 1 );

--- a/core/events_inc.php
+++ b/core/events_inc.php
@@ -118,4 +118,9 @@ event_declare_many( array(
 
 	# Logging (tracing) events
 	'EVENT_LOG' => EVENT_TYPE_EXECUTE,
+
+    # Auth Plugin
+    'EVENT_AUTH_GET_PASSWORD_MAX_SIZE' => EVENT_TYPE_FIRST,
+    'EVENT_AUTH_DOES_PASSWORD_MATCH' => EVENT_TYPE_FIRST,
+    'EVENT_AUTH_AUTHENTIFICATE_BY_USERNAME' => EVENT_TYPE_FIRST,
 ) );


### PR DESCRIPTION
Sometimes there is the need to authentificate Mantis against another backend than the existing ones. For this reason I implemented the possibility to add an Auth-Plugin like this one:
https://github.com/etlam/mantisbt-submit-auth

To get it working only the $g_login_method has to be changed to AUTH_PLUGIN in config_inc.php.
$g_login_method = AUTH_PLUGIN;
