### PR TITLE
config_flush_cache() now clears $g_cache_config_eval too

### DIFF
--- a/core/config_api.php
+++ b/core/config_api.php
@@ -557,9 +557,11 @@ function config_flush_cache( $p_option = '', $p_user = ALL_USERS, $p_project = A
 	if( '' !== $p_option ) {
 		unset( $GLOBALS['g_cache_config'][$p_option][$p_user][$p_project] );
 		unset( $GLOBALS['g_cache_config_access'][$p_option][$p_user][$p_project] );
+		unset( $GLOBALS['g_cache_config_eval'][$p_option] );
 	} else {
 		unset( $GLOBALS['g_cache_config'] );
 		unset( $GLOBALS['g_cache_config_access'] );
+		unset( $GLOBALS['g_cache_config_eval'] );
 		$g_cache_filled = false;
 	}
 }


### PR DESCRIPTION
The config api uses several cache variables. Currently the config_flush_cache() function only clears $g_cache_config and $g_cache_config_access.

It should also clear $g_cache_config_eval.

https://www.mantisbt.org/bugs/view.php?id=19881