### PR TITLE
Master 1.2.x - Changelog obsolete toggle

### DIFF
--- a/changelog_page.php
+++ b/changelog_page.php
@@ -154,7 +154,7 @@ foreach( $t_project_ids as $t_project_id ) {
 	$t_relation_table = db_get_table( 'mantis_bug_relationship_table' );
 
 	# grab version info for later use
-	$t_version_rows = version_get_all_rows( $t_project_id, /* released */ null, /* obsolete */ false );
+	$t_version_rows = version_get_all_rows( $t_project_id, /* released */ null, /* obsolete */ (config_get( 'show_changelog_obsolete' ) === ON ? null : false) );
 
 	# cache category info, but ignore the results for now
 	category_get_all_rows( $t_project_id );

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -989,6 +989,12 @@
 	$g_show_changelog_dates = ON;
 
 	/**
+	 * Show obsolete versions in the changelog list
+	 * @global int $g_changelog_show_obsolete
+	 */
+	$g_show_changelog_obsolete = OFF;
+
+	/**
 	 * Show release dates on roadmap
 	 * @global int $g_show_roadmap_dates
 	 */


### PR DESCRIPTION
Added a new configuration value for toggling obsolete version visibility in the changelog.

$g_show_changelog_obsolete = ON | OFF;
