### PR TITLE
Added optional version_unknown display in changelog.

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -989,6 +989,12 @@
 	$g_show_changelog_dates = ON;
 
 	/**
+	 * Show resolved items with no version
+	 * @global int $g_show_changelog_noversion
+	 */
+	$g_show_changelog_noversion = OFF;
+
+	/**
 	 * Show release dates on roadmap
 	 * @global int $g_show_roadmap_dates
 	 */

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1364,6 +1364,10 @@ $s_sponsorship_process_url = '';
 $s_changelog = 'Change Log';
 $s_changelog_empty = 'No Change Log information available';
 
+# Version Unknown
+$s_version_unknown_label = 'Version Unknown';
+$s_version_unknown_description = 'Issues that have not been associated with a version.';
+
 # Roadmap
 $s_roadmap = 'Roadmap';
 $s_resolved_progress = '%1$d of %2$d issue(s) resolved. Progress (%3$d%%).';


### PR DESCRIPTION
Added a toggle to show items in the changelog that have not been associated with a version.

````
$g_show_changelog_noversion = ON | OFF;
````

Added language definitions for the label and description shown for unknown version items.

````
$s_version_unknown_label = 'Version Unknown';
$s_version_unknown_description = 'Issues that have not been associated with a version.';
````