### PR TITLE
parameter 'redirect_url' support

### DIFF
--- a/bug_relationship_delete.php
+++ b/bug_relationship_delete.php
@@ -125,8 +125,8 @@ if( bug_exists( $t_dest_bug_id ) ) {
 form_security_purge( 'bug_relationship_delete' );
 
 $f_redirect_url = gpc_get_string( 'redirect_url', '' );
-if( '' != $f_redirect_url ) {
-   print_header_redirect( $f_redirect_url );
+if( !is_blank( $f_redirect_url ) ) {
+	print_header_redirect( $f_redirect_url );
 } else {
-print_header_redirect_view( $f_bug_id );
+	print_header_redirect_view( $f_bug_id );
 }

--- a/bug_relationship_delete.php
+++ b/bug_relationship_delete.php
@@ -124,4 +124,9 @@ if( bug_exists( $t_dest_bug_id ) ) {
 
 form_security_purge( 'bug_relationship_delete' );
 
+$f_redirect_url = gpc_get_string( 'redirect_url', '' );
+if( '' != $f_redirect_url ) {
+   print_header_redirect( $f_redirect_url );
+} else {
 print_header_redirect_view( $f_bug_id );
+}


### PR DESCRIPTION
Support parameter 'redirect_url' to divert to an alternate page after
deleting a relationship. Needed for plug-ins that manage and view
relationships. (e.g. RelationshipColumnView)