### PR TITLE
Master 1.2.x - Create version on the fly during bug status change

### DIFF
--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -274,6 +274,34 @@ if ( ( $f_new_status >= $t_resolved ) ) {
 		<select name="fixed_in_version">
 			<?php print_version_option_list( $t_bug->fixed_in_version, $t_bug->project_id, VERSION_ALL ) ?>
 		</select>
+    <?php if( access_has_project_level( config_get( 'manage_project_threshold' ), $t_bug->project_id, $t_current_user_id ) ){ ?>
+      <div id="create_fixed_in_version">
+        <label>
+          <?php echo lang_get( 'create_fixed_in_version' ); ?>
+          <input type="text" name="create_fixed_in_version" maxlength="10" />
+        </label>
+        <label>
+          <?php echo lang_get( 'released' ); ?>
+          <input type="checkbox" name="create_fixed_in_version_released" />
+        </label>
+        <script>
+          var createFixedInVersionToggle = function(){
+            document.querySelector('select[name=fixed_in_version]').onchange = function(){
+              document.getElementById('create_fixed_in_version').style.display = (this.value == '' ? 'block' : 'none');
+            }
+            document.getElementById('create_fixed_in_version').style.display
+              = (document.querySelector('select[name=fixed_in_version]').value == '' ? 'block' : 'none');
+          }
+          (window.addEventListener
+            ? window.addEventListener('load', createFixedInVersionToggle, false)
+            : (window.attachEvent
+              ? window.attachEvent('onload', createFixedInVersionToggle)
+              : createFixedInVersionToggle()
+              )
+            );
+        </script>
+      </div>
+    <?php } ?>
 	</td>
 </tr>
 <?php

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -533,6 +533,7 @@ $s_feedback_bug_button = 'Request Feedback';
 $s_acknowledged_bug_button = 'Acknowledge Issue';
 $s_confirmed_bug_button = 'Confirm Issue';
 $s_assigned_bug_button = 'Assign Issue';
+$s_create_fixed_in_version = 'Create Version';
 
 # bug_close.php
 $s_bug_close_msg = 'Issue has been closed...';


### PR DESCRIPTION
This is a simple feature that allows for a new version to be defined when a bug resolution is being applied.  A new `Create Version` input field is shown to permitted users that will trigger the creation of a new project version, and apply the version to the bug along with the status change.