### PR TITLE
Revert email_* calls to not use generic API

### DIFF
--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -830,7 +830,7 @@ function mc_issue_add( $p_username, $p_password, stdClass $p_issue ) {
 		mci_tag_set_for_issue( $t_issue_id, $p_issue['tags'], $t_user_id );
 	}
 
-	email_new_bug( $t_issue_id );
+	email_bug_added( $t_issue_id );
 
 	if( $t_bug_data->status != config_get( 'bug_submit_status' ) ) {
 		history_log_event( $t_issue_id, 'status', config_get( 'bug_submit_status' ) );

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -830,7 +830,7 @@ function mc_issue_add( $p_username, $p_password, stdClass $p_issue ) {
 		mci_tag_set_for_issue( $t_issue_id, $p_issue['tags'], $t_user_id );
 	}
 
-	email_generic( $t_issue_id, 'new', 'email_notification_title_for_action_bug_submitted' );
+	email_new_bug( $t_issue_id );
 
 	if( $t_bug_data->status != config_get( 'bug_submit_status' ) ) {
 		history_log_event( $t_issue_id, 'status', config_get( 'bug_submit_status' ) );

--- a/bug_actiongroup.php
+++ b/bug_actiongroup.php
@@ -197,7 +197,7 @@ foreach( $f_bug_arr as $t_bug_id ) {
 				$f_priority = gpc_get_int( 'priority' );
 				# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
 				bug_set_field( $t_bug_id, 'priority', $f_priority );
-				email_generic( $t_bug_id, 'updated', 'email_notification_title_for_action_bug_updated' );
+				email_bug_updated( $t_bug_id );
 				helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 			} else {
 				$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_access' );
@@ -215,7 +215,7 @@ foreach( $f_bug_arr as $t_bug_id ) {
 						bugnote_add( $t_bug_id, $f_bug_notetext, null, $f_bug_noteprivate );
 						# No need to call email_generic(), bugnote_add() does it
 					} else {
-						email_generic( $t_bug_id, 'updated', 'email_notification_title_for_action_bug_updated' );
+						email_bug_updated( $t_bug_id );
 					}
 
 					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
@@ -232,7 +232,7 @@ foreach( $f_bug_arr as $t_bug_id ) {
 				if( category_exists( $f_category_id ) ) {
 					# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
 					bug_set_field( $t_bug_id, 'category_id', $f_category_id );
-					email_generic( $t_bug_id, 'updated', 'email_notification_title_for_action_bug_updated' );
+					email_bug_updated( $t_bug_id );
 					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 				} else {
 					$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_category' );
@@ -247,7 +247,7 @@ foreach( $f_bug_arr as $t_bug_id ) {
 				if( $f_product_version === '' || version_get_id( $f_product_version, $t_bug->project_id ) !== false ) {
 					/** @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) ); */
 					bug_set_field( $t_bug_id, 'version', $f_product_version );
-					email_generic( $t_bug_id, 'updated', 'email_notification_title_for_action_bug_updated' );
+					email_bug_updated( $t_bug_id );
 					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 				} else {
 					$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_version' );
@@ -262,7 +262,7 @@ foreach( $f_bug_arr as $t_bug_id ) {
 				if( $f_fixed_in_version === '' || version_get_id( $f_fixed_in_version, $t_bug->project_id ) !== false ) {
 					# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
 					bug_set_field( $t_bug_id, 'fixed_in_version', $f_fixed_in_version );
-					email_generic( $t_bug_id, 'updated', 'email_notification_title_for_action_bug_updated' );
+					email_bug_updated( $t_bug_id );
 					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 					} else {
 						$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_version' );
@@ -277,7 +277,7 @@ foreach( $f_bug_arr as $t_bug_id ) {
 				if( $f_target_version === '' || version_get_id( $f_target_version, $t_bug->project_id ) !== false ) {
 					# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
 					bug_set_field( $t_bug_id, 'target_version', $f_target_version );
-					email_generic( $t_bug_id, 'updated', 'email_notification_title_for_action_bug_updated' );
+					email_bug_updated( $t_bug_id );
 					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 				} else {
 					$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_version' );
@@ -291,7 +291,7 @@ foreach( $f_bug_arr as $t_bug_id ) {
 				$f_view_status = gpc_get_int( 'view_status' );
 				# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
 				bug_set_field( $t_bug_id, 'view_state', $f_view_status );
-				email_generic( $t_bug_id, 'updated', 'email_notification_title_for_action_bug_updated' );
+				email_bug_updated( $t_bug_id );
 				helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 			} else {
 				$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_access' );
@@ -318,7 +318,7 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			$t_custom_field_value = gpc_get_custom_field( $t_form_var, $t_custom_field_def['type'], null );
 			custom_field_set_value( $f_custom_field_id, $t_bug_id, $t_custom_field_value );
 			bug_update_date( $t_bug_id );
-			email_generic( $t_bug_id, 'updated', 'email_notification_title_for_action_bug_updated' );
+			email_bug_updated( $t_bug_id );
 			helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 			break;
 		default:

--- a/bug_report.php
+++ b/bug_report.php
@@ -283,7 +283,7 @@ helper_call_custom_function( 'issue_create_notify', array( $t_bug_id ) );
 # Allow plugins to post-process bug data with the new bug ID
 event_signal( 'EVENT_REPORT_BUG', array( $t_bug_data, $t_bug_id ) );
 
-email_generic( $t_bug_id, 'new', 'email_notification_title_for_action_bug_submitted' );
+email_new_bug( $t_bug_id );
 
 # log status and resolution changes if they differ from the default
 if( $t_bug_data->status != config_get( 'bug_submit_status' ) ) {

--- a/bug_report.php
+++ b/bug_report.php
@@ -283,7 +283,7 @@ helper_call_custom_function( 'issue_create_notify', array( $t_bug_id ) );
 # Allow plugins to post-process bug data with the new bug ID
 event_signal( 'EVENT_REPORT_BUG', array( $t_bug_data, $t_bug_id ) );
 
-email_new_bug( $t_bug_id );
+email_bug_added( $t_bug_id );
 
 # log status and resolution changes if they differ from the default
 if( $t_bug_data->status != config_get( 'bug_submit_status' ) ) {

--- a/bug_update.php
+++ b/bug_update.php
@@ -417,16 +417,16 @@ helper_call_custom_function( 'issue_update_notify', array( $f_bug_id ) );
 
 # Send a notification of changes via email.
 if( $t_resolve_issue ) {
-	email_generic( $f_bug_id, 'resolved', 'The following issue has been RESOLVED.' );
+	email_resolved( $f_bug_id );
 	email_relationship_child_resolved( $f_bug_id );
 } else if( $t_close_issue ) {
-	email_generic( $f_bug_id, 'closed', 'The following issue has been CLOSED' );
+	email_close( $f_bug_id );
 	email_relationship_child_closed( $f_bug_id );
 } else if( $t_reopen_issue ) {
-	email_generic( $f_bug_id, 'reopened', 'email_notification_title_for_action_bug_reopened' );
+	email_reopen( $f_bug_id );
 } else if( $t_existing_bug->handler_id === NO_USER &&
-			$t_updated_bug->handler_id !== NO_USER ) {
-	email_generic( $f_bug_id, 'owner', 'email_notification_title_for_action_bug_assigned' );
+           $t_updated_bug->handler_id !== NO_USER ) {
+	email_assign( $f_bug_id );
 } else if( $t_existing_bug->status !== $t_updated_bug->status ) {
 	$t_new_status_label = MantisEnum::getLabel( config_get( 'status_enum_string' ), $t_updated_bug->status );
 	$t_new_status_label = str_replace( ' ', '_', $t_new_status_label );

--- a/bug_update.php
+++ b/bug_update.php
@@ -430,7 +430,7 @@ if( $t_resolve_issue ) {
 } else if( $t_existing_bug->status !== $t_updated_bug->status ) {
 	$t_new_status_label = MantisEnum::getLabel( config_get( 'status_enum_string' ), $t_updated_bug->status );
 	$t_new_status_label = str_replace( ' ', '_', $t_new_status_label );
-	email_generic( $f_bug_id, $t_new_status_label, 'email_notification_title_for_status_bug_' . $t_new_status_label );
+	email_status_change( $f_bug_id, $t_new_status_label );
 } else {
 	email_bug_updated( $f_bug_id );
 }

--- a/bug_update.php
+++ b/bug_update.php
@@ -423,7 +423,7 @@ if( $t_resolve_issue ) {
 	email_close( $f_bug_id );
 	email_relationship_child_closed( $f_bug_id );
 } else if( $t_reopen_issue ) {
-	email_reopen( $f_bug_id );
+	email_bug_reopened( $f_bug_id );
 } else if( $t_existing_bug->handler_id === NO_USER &&
            $t_updated_bug->handler_id !== NO_USER ) {
 	email_assign( $f_bug_id );

--- a/bug_update.php
+++ b/bug_update.php
@@ -426,7 +426,7 @@ if( $t_resolve_issue ) {
 	email_bug_reopened( $f_bug_id );
 } else if( $t_existing_bug->handler_id === NO_USER &&
            $t_updated_bug->handler_id !== NO_USER ) {
-	email_assign( $f_bug_id );
+	email_bug_assigned( $f_bug_id );
 } else if( $t_existing_bug->status !== $t_updated_bug->status ) {
 	$t_new_status_label = MantisEnum::getLabel( config_get( 'status_enum_string' ), $t_updated_bug->status );
 	$t_new_status_label = str_replace( ' ', '_', $t_new_status_label );

--- a/bug_update.php
+++ b/bug_update.php
@@ -432,7 +432,7 @@ if( $t_resolve_issue ) {
 	$t_new_status_label = str_replace( ' ', '_', $t_new_status_label );
 	email_generic( $f_bug_id, $t_new_status_label, 'email_notification_title_for_status_bug_' . $t_new_status_label );
 } else {
-	email_generic( $f_bug_id, 'updated', 'email_notification_title_for_action_bug_updated' );
+	email_bug_updated( $f_bug_id );
 }
 
 form_security_purge( 'bug_update' );

--- a/bug_update.php
+++ b/bug_update.php
@@ -430,7 +430,7 @@ if( $t_resolve_issue ) {
 } else if( $t_existing_bug->status !== $t_updated_bug->status ) {
 	$t_new_status_label = MantisEnum::getLabel( config_get( 'status_enum_string' ), $t_updated_bug->status );
 	$t_new_status_label = str_replace( ' ', '_', $t_new_status_label );
-	email_status_change( $f_bug_id, $t_new_status_label );
+	email_bug_status_changed( $f_bug_id, $t_new_status_label );
 } else {
 	email_bug_updated( $f_bug_id );
 }

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -695,7 +695,7 @@ class BugData {
 		if( false == $p_bypass_mail ) {
 			# bug assigned
 			if( $t_old_data->handler_id != $this->handler_id ) {
-				email_assign( $c_bug_id );
+				email_bug_assigned( $c_bug_id );
 				return true;
 			}
 
@@ -1669,7 +1669,7 @@ function bug_assign( $p_bug_id, $p_user_id, $p_bugnote_text = '', $p_bugnote_pri
 		bug_clear_cache( $p_bug_id );
 
 		# send assigned to email
-		email_assign( $p_bug_id );
+		email_bug_assigned( $p_bug_id );
 	}
 
 	return true;

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1256,7 +1256,7 @@ function bug_delete( $p_bug_id ) {
 	# log deletion of bug
 	history_log_event_special( $p_bug_id, BUG_DELETED, bug_format_id( $p_bug_id ) );
 
-	email_generic( $p_bug_id, 'deleted', 'email_notification_title_for_action_bug_deleted' );
+	email_bug_deleted( $p_bug_id );
 
 	# call post-deletion custom function.  We call this here to allow the custom function to access the details of the bug before
 	# they are deleted from the database given it's id.  The other option would be to move this to the end of the function and
@@ -1670,7 +1670,7 @@ function bug_assign( $p_bug_id, $p_user_id, $p_bugnote_text = '', $p_bugnote_pri
 		bug_clear_cache( $p_bug_id );
 
 		# send assigned to email
-		email_generic( $p_bug_id, 'owner', 'email_notification_title_for_action_bug_assigned' );
+		email_assign( $p_bug_id );
 	}
 
 	return true;
@@ -1695,7 +1695,7 @@ function bug_close( $p_bug_id, $p_bugnote_text = '', $p_bugnote_private = false,
 
 	bug_set_field( $p_bug_id, 'status', config_get( 'bug_closed_status_threshold' ) );
 
-	email_generic( $p_bug_id, 'closed', 'The following issue has been CLOSED' );
+	email_close( $p_bug_id );
 	email_relationship_child_closed( $p_bug_id );
 
 	return true;
@@ -1781,7 +1781,7 @@ function bug_resolve( $p_bug_id, $p_resolution, $p_fixed_in_version = '', $p_bug
 		bug_set_field( $p_bug_id, 'handler_id', $p_handler_id );
 	}
 
-	email_generic( $p_bug_id, 'resolved', 'The following issue has been RESOLVED.' );
+	email_resolved( $p_bug_id );
 	email_relationship_child_resolved( $p_bug_id );
 
 	return true;
@@ -1811,7 +1811,7 @@ function bug_reopen( $p_bug_id, $p_bugnote_text = '', $p_time_tracking = '0:00',
 	bug_set_field( $p_bug_id, 'status', config_get( 'bug_reopen_status' ) );
 	bug_set_field( $p_bug_id, 'resolution', config_get( 'bug_reopen_resolution' ) );
 
-	email_generic( $p_bug_id, 'reopened', 'email_notification_title_for_action_bug_reopened' );
+	email_reopen( $p_bug_id );
 
 	return true;
 }

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -695,7 +695,7 @@ class BugData {
 		if( false == $p_bypass_mail ) {
 			# bug assigned
 			if( $t_old_data->handler_id != $this->handler_id ) {
-				email_generic( $c_bug_id, 'owner', 'email_notification_title_for_action_bug_assigned' );
+				email_assign( $c_bug_id );
 				return true;
 			}
 

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -703,7 +703,7 @@ class BugData {
 			if( $t_old_data->status != $this->status ) {
 				$t_status = MantisEnum::getLabel( config_get( 'status_enum_string' ), $this->status );
 				$t_status = str_replace( ' ', '_', $t_status );
-				email_status_change( $c_bug_id, $t_status );
+				email_bug_status_changed( $c_bug_id, $t_status );
 				return true;
 			}
 

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1810,7 +1810,7 @@ function bug_reopen( $p_bug_id, $p_bugnote_text = '', $p_time_tracking = '0:00',
 	bug_set_field( $p_bug_id, 'status', config_get( 'bug_reopen_status' ) );
 	bug_set_field( $p_bug_id, 'resolution', config_get( 'bug_reopen_resolution' ) );
 
-	email_reopen( $p_bug_id );
+	email_bug_reopened( $p_bug_id );
 
 	return true;
 }

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -708,8 +708,7 @@ class BugData {
 			}
 
 			# @todo handle priority change if it requires special handling
-			# generic update notification
-			email_generic( $c_bug_id, 'updated', 'email_notification_title_for_action_bug_updated' );
+			email_bug_updated( $c_bug_id );
 		}
 
 		return true;

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -703,7 +703,7 @@ class BugData {
 			if( $t_old_data->status != $this->status ) {
 				$t_status = MantisEnum::getLabel( config_get( 'status_enum_string' ), $this->status );
 				$t_status = str_replace( ' ', '_', $t_status );
-				email_generic( $c_bug_id, $t_status, 'email_notification_title_for_status_bug_' . $t_status );
+				email_status_change( $c_bug_id, $t_status );
 				return true;
 			}
 

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -262,7 +262,7 @@ function bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking = '0:00', $p_
 
 	# only send email if the text is not blank, otherwise, it is just recording of time without a comment.
 	if( true == $p_send_email && !is_blank( $t_bugnote_text ) ) {
-		email_generic( $p_bug_id, 'bugnote', 'email_notification_title_for_action_bugnote_submitted' );
+		email_bugnote_add( $p_bug_id );
 	}
 
 	return $t_bugnote_id;

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -839,6 +839,15 @@ function email_assign( $p_bug_id ) {
 }
 
 /**
+ * Send notifications when bug status is changed.
+ * @param int $p_bug_id The bug id
+ * @param string $p_new_status_label The new status label.
+ */
+function email_status_change( $p_bug_id, $p_new_status_label ) {
+	email_generic( $p_bug_id, $p_new_status_label, 'email_notification_title_for_status_bug_' . $p_new_status_label );
+}
+
+/**
  * send notices when a bug is DELETED
  * @param int $p_bug_id
  * @return null

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -825,7 +825,7 @@ function email_resolved( $p_bug_id ) {
  * @param int $p_bug_id
  * @return null
  */
-function email_reopen( $p_bug_id ) {
+function email_bug_reopened( $p_bug_id ) {
 	email_generic( $p_bug_id, 'reopened', 'email_notification_title_for_action_bug_reopened' );
 }
 

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -781,7 +781,7 @@ function email_sponsorship_deleted( $p_bug_id ) {
  * @param int $p_bug_id
  * @return null
  */
-function email_new_bug( $p_bug_id ) {
+function email_bug_added( $p_bug_id ) {
 	email_generic( $p_bug_id, 'new', 'email_notification_title_for_action_bug_submitted' );
 }
 

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -786,6 +786,14 @@ function email_new_bug( $p_bug_id ) {
 }
 
 /**
+ * Send notifications for bug update.
+ * @param int $p_bug_id  The bug id.
+ */
+function email_bug_updated( $p_bug_id ) {
+	email_generic( $p_bug_id, 'updated', 'email_notification_title_for_action_bug_updated' );
+}
+
+/**
  * send notices when a new bugnote
  * @param int $p_bug_id
  * @return null

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -750,6 +750,96 @@ function email_relationship_child_resolved_closed( $p_bug_id, $p_message_id ) {
 }
 
 /**
+ * send notices when a bug is sponsored
+ * @param int $p_bug_id
+ * @return null
+ */
+function email_sponsorship_added( $p_bug_id ) {
+	email_generic( $p_bug_id, 'sponsor', 'email_notification_title_for_action_sponsorship_added' );
+}
+
+/**
+ * send notices when a sponsorship is modified
+ * @param int $p_bug_id
+ * @return null
+ */
+function email_sponsorship_updated( $p_bug_id ) {
+	email_generic( $p_bug_id, 'sponsor', 'email_notification_title_for_action_sponsorship_updated' );
+}
+
+/**
+ * send notices when a sponsorship is deleted
+ * @param int $p_bug_id
+ * @return null
+ */
+function email_sponsorship_deleted( $p_bug_id ) {
+	email_generic( $p_bug_id, 'sponsor', 'email_notification_title_for_action_sponsorship_deleted' );
+}
+
+/**
+ * send notices when a new bug is added
+ * @param int $p_bug_id
+ * @return null
+ */
+function email_new_bug( $p_bug_id ) {
+	email_generic( $p_bug_id, 'new', 'email_notification_title_for_action_bug_submitted' );
+}
+
+/**
+ * send notices when a new bugnote
+ * @param int $p_bug_id
+ * @return null
+ */
+function email_bugnote_add( $p_bug_id ) {
+	email_generic( $p_bug_id, 'bugnote', 'email_notification_title_for_action_bugnote_submitted' );
+}
+
+/**
+ * send notices when a bug is RESOLVED
+ * @param int $p_bug_id
+ * @return null
+ */
+function email_resolved( $p_bug_id ) {
+	email_generic( $p_bug_id, 'resolved', 'email_notification_title_for_status_bug_resolved' );
+}
+
+/**
+ * send notices when a bug is CLOSED
+ * @param int $p_bug_id
+ * @return null
+ */
+ function email_close( $p_bug_id ) {
+	email_generic( $p_bug_id, 'closed', 'email_notification_title_for_status_bug_closed' );
+}
+
+/**
+ * send notices when a bug is REOPENED
+ * @param int $p_bug_id
+ * @return null
+ */
+function email_reopen( $p_bug_id ) {
+	email_generic( $p_bug_id, 'reopened', 'email_notification_title_for_action_bug_reopened' );
+}
+
+/**
+ * send notices when a bug is ASSIGNED
+ * @param int $p_bug_id
+ * @return null
+ */
+function email_assign( $p_bug_id ) {
+	email_generic( $p_bug_id, 'owner', 'email_notification_title_for_action_bug_assigned' );
+}
+
+/**
+ * send notices when a bug is DELETED
+ * @param int $p_bug_id
+ * @return null
+ */
+function email_bug_deleted( $p_bug_id ) {
+	email_generic( $p_bug_id, 'deleted', 'email_notification_title_for_action_bug_deleted' );
+}
+
+/**
  * Store email in queue for sending
  *
  * @param string  $p_recipient Email recipient address.

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -843,7 +843,7 @@ function email_bug_assigned( $p_bug_id ) {
  * @param int $p_bug_id The bug id
  * @param string $p_new_status_label The new status label.
  */
-function email_status_change( $p_bug_id, $p_new_status_label ) {
+function email_bug_status_changed( $p_bug_id, $p_new_status_label ) {
 	email_generic( $p_bug_id, $p_new_status_label, 'email_notification_title_for_status_bug_' . $p_new_status_label );
 }
 

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -834,7 +834,7 @@ function email_bug_reopened( $p_bug_id ) {
  * @param int $p_bug_id
  * @return null
  */
-function email_assign( $p_bug_id ) {
+function email_bug_assigned( $p_bug_id ) {
 	email_generic( $p_bug_id, 'owner', 'email_notification_title_for_action_bug_assigned' );
 }
 

--- a/core/sponsorship_api.php
+++ b/core/sponsorship_api.php
@@ -365,9 +365,9 @@ function sponsorship_set( SponsorshipData $p_sponsorship ) {
 	bug_monitor( $c_bug_id, $c_user_id );
 
 	if( $c_id == 0 ) {
-		email_generic( $c_bug_id, 'sponsor', 'email_notification_title_for_action_sponsorship_added' );
+		email_sponsorship_added( $c_bug_id );
 	} else {
-		email_generic( $c_bug_id, 'sponsor', 'email_notification_title_for_action_sponsorship_updated' );
+		email_sponsorship_updated( $c_bug_id );
 	}
 
 	return $t_sponsorship_id;
@@ -411,7 +411,7 @@ function sponsorship_delete( $p_sponsorship_id ) {
 	history_log_event_special( $t_sponsorship->bug_id, BUG_DELETE_SPONSORSHIP, $t_sponsorship->user_id, $t_sponsorship->amount );
 	sponsorship_update_bug( $t_sponsorship->bug_id );
 
-	email_generic( $t_sponsorship->bug_id, 'sponsor', 'A sponsorship of the following issue was withdrawn.' );
+	email_sponsorship_deleted( $t_sponsorship->bug_id );
 }
 
 /**


### PR DESCRIPTION
It is undesirable to use this approach for the following:
- Having each caller having to know the right language string + call type.
- Having a properly named APIs provides better intelli-sense experience.
- It is easier to add event spent logic or extra parameters compared to switch statements in generic API.
- More inline with the approach of having different email formats based on the change event, rather than a single format which dumps the whole issue, rather than focus on the actual change.

Fixes #19984

This reverts commit 03c5a5d18cfef07dec45a1025072981f24a5f07c.

Conflicts:
- bug_update.php
- core/bugnote_api.php
- library/disposable
- library/ezc/Base
- library/ezc/Graph
- library/securimage