### PR TITLE
Load jquery from CDN

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -3410,12 +3410,20 @@ $g_css_include_file = 'default.css';
  */
 $g_css_rtl_include_file = 'rtl.css';
 
-
 /**
  * meta tags
  * @global string $g_meta_include_file
  */
 $g_meta_include_file = '';
+
+/**
+ * A flag that indicates whether to use CDN (content delivery networks) for loading
+ * javascript libraries and their associated CSS.  This improves performance for
+ * loading MantisBT pages.  This can be disabled if it is desired that MantisBT
+ * doesn't reach out outside corporate network.
+ * @global integer $g_cdn_enabled
+ */
+$g_cdn_enabled = OFF;
 
 ################
 # Redirections #

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -590,3 +590,7 @@ define( 'LOG_SOAP', 64 );                           # LOG_WEBSERVICE
 define( 'FTP', 1 );                                 # DISK
 define( 'ERROR_FTP_CONNECT_ERROR', 16 );            # N/A
 
+# JQuery and JQuery UI
+define ( 'JQUERY_VERSION', '1.11.3' );
+define ( 'JQUERY_UI_VERSION', '1.11.4' );
+

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -365,7 +365,13 @@ function require_css( $p_stylesheet_path ) {
 function html_css() {
 	global $g_stylesheets_included;
 	html_css_link( config_get( 'css_include_file' ) );
-	html_css_link( 'jquery-ui-1.11.4.min.css' );
+
+	if ( config_get( 'cdn_enabled' ) == ON ) {
+		echo '<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">' . "\n";
+	} else {
+		html_css_link( 'jquery-ui-1.11.4.min.css' );
+	}
+
 	html_css_link( 'common_config.php' );
 	# Add right-to-left css if needed
 	if( lang_get( 'directionality' ) == 'rtl' ) {
@@ -439,8 +445,15 @@ function html_head_javascript() {
 
 	echo "\t" . '<script type="text/javascript" src="' . helper_mantis_url( 'javascript_config.php' ) . '"></script>' . "\n";
 	echo "\t" . '<script type="text/javascript" src="' . helper_mantis_url( 'javascript_translations.php' ) . '"></script>' . "\n";
-	html_javascript_link( 'jquery-1.11.3.min.js' );
-	html_javascript_link( 'jquery-ui-1.11.4.min.js' );
+
+	if ( config_get( 'cdn_enabled' ) == ON ) {
+		echo "\t" . '<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>' . "\n";
+		echo "\t" . '<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>' . "\n";
+	} else {
+		html_javascript_link( 'jquery-1.11.3.min.js' );
+		html_javascript_link( 'jquery-ui-1.11.4.min.js' );
+	}
+
 	html_javascript_link( 'common.js' );
 	foreach ( $g_scripts_included as $t_script_path ) {
 		html_javascript_link( $t_script_path );

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -367,9 +367,9 @@ function html_css() {
 	html_css_link( config_get( 'css_include_file' ) );
 
 	if ( config_get( 'cdn_enabled' ) == ON ) {
-		echo '<link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">' . "\n";
+		echo '<link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/' . JQUERY_UI_VERSION . '/themes/smoothness/jquery-ui.css">' . "\n";
 	} else {
-		html_css_link( 'jquery-ui-1.11.4.min.css' );
+		html_css_link( 'jquery-ui-' . JQUERY_UI_VERSION . '.min.css' );
 	}
 
 	html_css_link( 'common_config.php' );
@@ -447,11 +447,11 @@ function html_head_javascript() {
 	echo "\t" . '<script type="text/javascript" src="' . helper_mantis_url( 'javascript_translations.php' ) . '"></script>' . "\n";
 
 	if ( config_get( 'cdn_enabled' ) == ON ) {
-		echo "\t" . '<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>' . "\n";
-		echo "\t" . '<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>' . "\n";
+		echo "\t" . '<script src="//ajax.googleapis.com/ajax/libs/jquery/' . JQUERY_VERSION . '/jquery.min.js"></script>' . "\n";
+		echo "\t" . '<script src="//ajax.googleapis.com/ajax/libs/jqueryui/' . JQUERY_UI_VERSION . '/jquery-ui.min.js"></script>' . "\n";
 	} else {
-		html_javascript_link( 'jquery-1.11.3.min.js' );
-		html_javascript_link( 'jquery-ui-1.11.4.min.js' );
+		html_javascript_link( 'jquery-' . JQUERY_VERSION . '.min.js' );
+		html_javascript_link( 'jquery-ui-' . JQUERY_UI_VERSION . '.min.js' );
 	}
 
 	html_javascript_link( 'common.js' );

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -367,7 +367,7 @@ function html_css() {
 	html_css_link( config_get( 'css_include_file' ) );
 
 	if ( config_get( 'cdn_enabled' ) == ON ) {
-		echo '<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">' . "\n";
+		echo '<link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">' . "\n";
 	} else {
 		html_css_link( 'jquery-ui-1.11.4.min.css' );
 	}
@@ -447,8 +447,8 @@ function html_head_javascript() {
 	echo "\t" . '<script type="text/javascript" src="' . helper_mantis_url( 'javascript_translations.php' ) . '"></script>' . "\n";
 
 	if ( config_get( 'cdn_enabled' ) == ON ) {
-		echo "\t" . '<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>' . "\n";
-		echo "\t" . '<script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>' . "\n";
+		echo "\t" . '<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>' . "\n";
+		echo "\t" . '<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>' . "\n";
 	} else {
 		html_javascript_link( 'jquery-1.11.3.min.js' );
 		html_javascript_link( 'jquery-ui-1.11.4.min.js' );

--- a/core/http_api.php
+++ b/core/http_api.php
@@ -167,7 +167,7 @@ function http_security_headers() {
 
 		# White list the CDN urls (if enabled)
 		if ( config_get( 'cdn_enabled' ) == ON ) {
-			$t_cdn_url = 'https://ajax.googleapis.com';
+			$t_cdn_url = '//ajax.googleapis.com';
 			$t_style_src .= " $t_cdn_url";
 			$t_script_src .= " $t_cdn_url";
 		}

--- a/core/http_api.php
+++ b/core/http_api.php
@@ -162,11 +162,24 @@ function http_security_headers() {
 			$t_csp[] = "img-src 'self' $t_avatar_url";
 		}
 
+		$t_style_src = "style-src 'self'";
+		$t_script_src = "script-src 'self'";
+
+		# White list the CDN urls (if enabled)
+		if ( config_get( 'cdn_enabled' ) == ON ) {
+			$t_cdn_url = 'https://ajax.googleapis.com';
+			$t_style_src .= " $t_cdn_url";
+			$t_script_src .= " $t_cdn_url";
+		}
+
 		# Relaxing policy for roadmap page to allow inline styles
 		# This is a workaround to fix the broken progress bars (see #19501)
 		if( 'roadmap_page.php' == basename( $_SERVER['SCRIPT_NAME'] ) ) {
-			$t_csp[] = "style-src 'self' 'unsafe-inline'";
+			$t_style_src .= " 'unsafe-inline'";
 		}
+
+		$t_csp[] = $t_style_src;
+		$t_csp[] = $t_script_src;
 
 		# Set CSP header
 		header( 'Content-Security-Policy: ' . implode('; ', $t_csp) );

--- a/docbook/Admin_Guide/en-US/config/html.xml
+++ b/docbook/Admin_Guide/en-US/config/html.xml
@@ -68,6 +68,17 @@
 			</listitem>
 		</varlistentry>
 		<varlistentry>
+			<term>$g_cdn_enabled</term>
+			<listitem>
+				<para>
+					A flag that indicates whether to use CDN (content delivery networks) for loading
+					javascript libraries and their associated CSS.  This improves performance for
+					loading MantisBT pages.  This can be disabled if it is desired that MantisBT
+					doesn't reach out outside corporate network.  Default OFF.
+				</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
 			<term>$g_main_menu_custom_options</term>
 			<listitem>
 				<para>This option will add custom options to the main menu. It is


### PR DESCRIPTION
This is to improve performance for the following reasons:

- Browser loads more in parallel due to loading from different servers.
- CDN libraries likely to be already cached as it is referenced by other websites / web apps.
- CDN will deliver lower latencies with the possible exception of intranet.

Fixes #19932