### PR TITLE
Generate valid CSS/class name for custom status with spaces

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1431,12 +1431,9 @@ function html_status_legend( $p_display_position, $p_restrict_by_filter = false 
 		$t_status_enum_string = config_get( 'status_enum_string' );
 		foreach( $t_status_array as $t_status => $t_name ) {
 			$t_val = isset( $t_status_names[$t_status] ) ? $t_status_names[$t_status] : $t_status_array[$t_status];
-			$t_status_css = html_get_css_identifier(
-				MantisEnum::getLabel( $t_status_enum_string, $t_status ),
-				'color'
-			);
 
-			echo '<td class="small-caption ' . $t_status_css . '">' . $t_val . '</td>';
+			echo '<td class="small-caption ' . html_get_status_css_class( $t_status ) . '">'
+				. $t_val . '</td>';
 		}
 
 		echo '</tr>';
@@ -1474,10 +1471,11 @@ function html_status_percentage_legend() {
 			$t_percent = ( isset( $t_status_percents[$t_status] ) ?  $t_status_percents[$t_status] : 0 );
 
 			if( $t_percent > 0 ) {
-				$t_status_css = html_get_css_identifier(
-					MantisEnum::getLabel( $t_status_enum_string, $t_status )
-				);
-				echo '<td class="small-caption-center ' . $t_status_css . '-color ' . $t_status_css . '-percentage">' . $t_percent . '%</td>';
+				$t_class = html_get_status_css_class( $t_status );
+				echo '<td class="small-caption-center '
+					. $t_class . ' '
+					. str_replace( 'color', 'percentage', $t_class ) . '">'
+					. $t_percent . '%</td>';
 			}
 		}
 
@@ -1911,28 +1909,10 @@ function html_buttons_view_bug_page( $p_bug_id ) {
  * Build CSS including project or even user-specific colors ?
  */
 function html_get_status_css_class( $p_status, $p_user = null, $p_project = null ) {
-	$t_identifier = MantisEnum::getLabel(
-		config_get( 'status_enum_string', null, $p_user, $p_project ),
-		$p_status
-	);
-	return html_get_css_identifier( $t_identifier, 'color' );
-}
-
-/**
- * Get a CSS-friendly identifier for the given string
- * Replace all invalid characters by a dash, remove multiple consecutive dashes
- * and append the given suffix.
- * This is useful e.g. for dynamic css class names used for status colors.
- * @param string $p_string Identifier to convert
- * @param string $p_string Suffix to append at end of string
- * @return string
- */
-function html_get_css_identifier( $p_string, $p_suffix = null ) {
-	$t_string = string_attribute( strtolower ( $p_string ) );
-	$t_string = preg_replace( '/[^a-z0-9_-]/', '-', $t_string );
-	if( $p_suffix ) {
-		$t_string .= '-' . $p_suffix;
+	$t_status_enum = config_get( 'status_enum_string', null, $p_user, $p_project );
+	if( MantisEnum::hasValue( $t_status_enum, $p_status ) ) {
+		return 'status-' . $p_status . '-color';
+	} else {
+		return '';
 	}
-	$t_string = preg_replace( '/-+/', '-', trim( $t_string, '-' ) );
-	return $t_string;
 }

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1431,9 +1431,12 @@ function html_status_legend( $p_display_position, $p_restrict_by_filter = false 
 		$t_status_enum_string = config_get( 'status_enum_string' );
 		foreach( $t_status_array as $t_status => $t_name ) {
 			$t_val = isset( $t_status_names[$t_status] ) ? $t_status_names[$t_status] : $t_status_array[$t_status];
-			$t_status_label = MantisEnum::getLabel( $t_status_enum_string, $t_status );
+			$t_status_css = html_get_css_identifier(
+				MantisEnum::getLabel( $t_status_enum_string, $t_status ),
+				'color'
+			);
 
-			echo '<td class="small-caption ' . $t_status_label . '-color">' . $t_val . '</td>';
+			echo '<td class="small-caption ' . $t_status_css . '">' . $t_val . '</td>';
 		}
 
 		echo '</tr>';
@@ -1471,8 +1474,10 @@ function html_status_percentage_legend() {
 			$t_percent = ( isset( $t_status_percents[$t_status] ) ?  $t_status_percents[$t_status] : 0 );
 
 			if( $t_percent > 0 ) {
-				$t_status_label = MantisEnum::getLabel( $t_status_enum_string, $t_status );
-				echo '<td class="small-caption-center ' . $t_status_label . '-color ' . $t_status_label . '-percentage">' . $t_percent . '%</td>';
+				$t_status_css = html_get_css_identifier(
+					MantisEnum::getLabel( $t_status_enum_string, $t_status )
+				);
+				echo '<td class="small-caption-center ' . $t_status_css . '-color ' . $t_status_css . '-percentage">' . $t_percent . '%</td>';
 			}
 		}
 
@@ -1906,5 +1911,28 @@ function html_buttons_view_bug_page( $p_bug_id ) {
  * Build CSS including project or even user-specific colors ?
  */
 function html_get_status_css_class( $p_status, $p_user = null, $p_project = null ) {
-	return string_attribute( MantisEnum::getLabel( config_get( 'status_enum_string', null, $p_user, $p_project ), $p_status ) . '-color' );
+	$t_identifier = MantisEnum::getLabel(
+		config_get( 'status_enum_string', null, $p_user, $p_project ),
+		$p_status
+	);
+	return html_get_css_identifier( $t_identifier, 'color' );
+}
+
+/**
+ * Get a CSS-friendly identifier for the given string
+ * Replace all invalid characters by a dash, remove multiple consecutive dashes
+ * and append the given suffix.
+ * This is useful e.g. for dynamic css class names used for status colors.
+ * @param string $p_string Identifier to convert
+ * @param string $p_string Suffix to append at end of string
+ * @return string
+ */
+function html_get_css_identifier( $p_string, $p_suffix = null ) {
+	$t_string = string_attribute( strtolower ( $p_string ) );
+	$t_string = preg_replace( '/[^a-z0-9_-]/', '-', $t_string );
+	if( $p_suffix ) {
+		$t_string .= '-' . $p_suffix;
+	}
+	$t_string = preg_replace( '/-+/', '-', trim( $t_string, '-' ) );
+	return $t_string;
 }

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1430,9 +1430,12 @@ function html_status_legend( $p_display_position, $p_restrict_by_filter = false 
 		# draw the status bar
 		$t_status_enum_string = config_get( 'status_enum_string' );
 		foreach( $t_status_array as $t_status => $t_name ) {
-			$t_val = isset( $t_status_names[$t_status] ) ? $t_status_names[$t_status] : $t_status_array[$t_status];
+			$t_val = isset( $t_status_names[$t_status] )
+				? $t_status_names[$t_status]
+				: $t_status_array[$t_status];
 
-			echo '<td class="small-caption ' . html_get_status_css_class( $t_status ) . '">'
+			echo '<td class="small-caption '
+				. html_get_status_css_class( $t_status ) . '">'
 				. $t_val . '</td>';
 		}
 

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1434,7 +1434,7 @@ function html_status_legend( $p_display_position, $p_restrict_by_filter = false 
 				? $t_status_names[$t_status]
 				: $t_status_array[$t_status];
 
-			echo '<td class="small-caption '
+			echo '<td class="small-caption status-legend-width '
 				. html_get_status_css_class( $t_status ) . '">'
 				. $t_val . '</td>';
 		}

--- a/css/status_config.php
+++ b/css/status_config.php
@@ -77,9 +77,11 @@ $t_status_percents = auth_is_user_authenticated() ? get_percentage_by_status() :
 
 foreach( $t_statuses AS $t_id=>$t_label ) {
 	if( array_key_exists( $t_label, $t_colors ) ) {
-		echo ".$t_label-color { background-color: {$t_colors[$t_label]}; width: $t_color_width%; }\n";
+		echo '.' . html_get_css_identifier( $t_label, 'color' )
+			. " { background-color: {$t_colors[$t_label]}; width: $t_color_width%; }\n";
 	}
 	if( array_key_exists( $t_id, $t_status_percents ) ) {
-		echo ".$t_label-percentage { width: {$t_status_percents[$t_id]}%; }\n";
+		echo '.' . html_get_css_identifier( $t_label, 'percentage' )
+			. " { width: {$t_status_percents[$t_id]}%; }\n";
 	}
 }

--- a/css/status_config.php
+++ b/css/status_config.php
@@ -77,12 +77,16 @@ foreach( $t_statuses as $t_id => $t_label ) {
 	$t_css_class = html_get_status_css_class( $t_id );
 
 	# Status color class
-	echo '.' . $t_css_class
-		. " { background-color: {$t_colors[$t_label]}; }\n";
+	if( array_key_exists( $t_label, $t_colors ) ) {
+		echo '.' . $t_css_class
+			. " { background-color: {$t_colors[$t_label]}; }\n";
+	}
 
 	# Status percentage width class
-	echo '.' . str_replace( 'color', 'percentage', $t_css_class )
-		. " { width: {$t_status_percents[$t_id]}%; }\n";
+	if( array_key_exists( $t_id, $t_status_percents ) ) {
+		echo '.' . str_replace( 'color', 'percentage', $t_css_class )
+			. " { width: {$t_status_percents[$t_id]}%; }\n";
+	}
 }
 
 # Status legend width class

--- a/css/status_config.php
+++ b/css/status_config.php
@@ -75,13 +75,14 @@ $t_color_count = count( $t_colors );
 $t_color_width = ( $t_color_count > 0 ? ( round( 100/$t_color_count ) ) : 0 );
 $t_status_percents = auth_is_user_authenticated() ? get_percentage_by_status() : array();
 
-foreach( $t_statuses AS $t_id=>$t_label ) {
-	if( array_key_exists( $t_label, $t_colors ) ) {
-		echo '.' . html_get_css_identifier( $t_label, 'color' )
-			. " { background-color: {$t_colors[$t_label]}; width: $t_color_width%; }\n";
-	}
-	if( array_key_exists( $t_id, $t_status_percents ) ) {
-		echo '.' . html_get_css_identifier( $t_label, 'percentage' )
-			. " { width: {$t_status_percents[$t_id]}%; }\n";
-	}
+foreach( $t_statuses as $t_id => $t_label ) {
+	$t_css_class = html_get_status_css_class( $t_id );
+
+	# Status color class
+	echo '.' . $t_css_class
+		. " { background-color: {$t_colors[$t_label]}; width: $t_color_width%; }\n";
+
+	# Status percentage width class
+	echo '.' . str_replace( 'color', 'percentage', $t_css_class )
+		. " { width: {$t_status_percents[$t_id]}%; }\n";
 }

--- a/css/status_config.php
+++ b/css/status_config.php
@@ -71,8 +71,6 @@ switch( $t_referer_page ) {
 $t_status_string = config_get( 'status_enum_string' );
 $t_statuses = MantisEnum::getAssocArrayIndexedByValues( $t_status_string );
 $t_colors = config_get( 'status_colors' );
-$t_color_count = count( $t_colors );
-$t_color_width = ( $t_color_count > 0 ? ( round( 100/$t_color_count ) ) : 0 );
 $t_status_percents = auth_is_user_authenticated() ? get_percentage_by_status() : array();
 
 foreach( $t_statuses as $t_id => $t_label ) {
@@ -80,9 +78,14 @@ foreach( $t_statuses as $t_id => $t_label ) {
 
 	# Status color class
 	echo '.' . $t_css_class
-		. " { background-color: {$t_colors[$t_label]}; width: $t_color_width%; }\n";
+		. " { background-color: {$t_colors[$t_label]}; }\n";
 
 	# Status percentage width class
 	echo '.' . str_replace( 'color', 'percentage', $t_css_class )
 		. " { width: {$t_status_percents[$t_id]}%; }\n";
 }
+
+# Status legend width class
+$t_color_count = count( $t_colors );
+$t_color_width = ( $t_color_count > 0 ? ( round( 100/$t_color_count ) ) : 0 );
+echo ".status-legend-width { width: $t_color_width%; }\n";


### PR DESCRIPTION
Prior to this, for a custom status 'in progress', Mantis would generate
the following invalid code:

- HTML (class name): class="small-caption in progress-color"
- Dynamic CSS (status_config.php): .in progress-color { ... }

We now rely on a new API function html_get_css_identifier() to generate
a valid CSS class name by replacing invalid characters with '-'.

Fixes [#20068](https://www.mantisbt.org/bugs/view.php?id=20068)