### PR TITLE
Fix custom field access denied on bug update page

### DIFF
--- a/bug_update.php
+++ b/bug_update.php
@@ -276,12 +276,7 @@ $t_custom_fields_to_set = array();
 foreach ( $t_related_custom_field_ids as $t_cf_id ) {
 	$t_cf_def = custom_field_get_definition( $t_cf_id );
 
-	# if this is not a full update action and custom field is not on the form, then don't
-	# continue with code that checks access level and validates the field.
-	if ( $f_update_type != BUG_UPDATE_TYPE_NORMAL && !custom_field_is_present( $t_cf_id ) ) {
-		continue;
-	}
-
+	# If the custom field is not set and is required, then complain!
 	if( !gpc_isset_custom_field( $t_cf_id, $t_cf_def['type'] ) ) {
 		if( $t_cf_def[$t_cf_require_check] &&
 			$f_update_type == BUG_UPDATE_TYPE_NORMAL &&
@@ -291,6 +286,11 @@ foreach ( $t_related_custom_field_ids as $t_cf_id ) {
 			error_parameters( lang_get_defaulted( custom_field_get_field( $t_cf_id, 'name' ) ) );
 			trigger_error( ERROR_EMPTY_FIELD, ERROR );
 		}
+	}
+
+	# Otherwise, if not present then skip it.
+	if ( !custom_field_is_present( $t_cf_id ) ) {
+		continue;
 	}
 
 	if( !custom_field_has_write_access( $t_cf_id, $f_bug_id ) ) {


### PR DESCRIPTION
The previous fix caused triggering of access_denied due to the addition of the BUG_UPDATE_TYPE_NORMAL.

Issue #20002