### PR TITLE
Fix AJAX for 'Match type' and 'Highlight changed'

### DIFF
--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -3389,7 +3389,13 @@ function filter_draw_selection_area2( $p_page_number, $p_for_screen = true, $p_e
 
 		<!-- Match Type -->
 		<tr class="row-1">
-			<td class="small-caption category2"><a href="<?php echo $t_filters_url . FILTER_PROPERTY_MATCH_TYPE;?>" id="match_type_filter"><?php echo lang_get( 'filter_match_type' )?>:</a></td>
+			<td class="small-caption category2">
+				<a id="match_type_filter"
+					href="<?php echo $t_filters_url . FILTER_PROPERTY_MATCH_TYPE;?>"
+					<?php echo $t_dynamic_filter_expander_class; ?>>
+					<?php echo lang_get( 'filter_match_type' )?>:
+				</a>
+			</td>
 			<td class="small-caption" id="match_type_filter_target">
 			<?php
 				switch( $t_filter[FILTER_PROPERTY_MATCH_TYPE] ) {
@@ -3408,7 +3414,7 @@ function filter_draw_selection_area2( $p_page_number, $p_for_screen = true, $p_e
 			<td class="small-caption category2">
 				<a id="highlight_changed_filter"
 					href="<?php echo $t_filters_url . FILTER_PROPERTY_HIGHLIGHT_CHANGED; ?>"
-					<?php #echo $t_dynamic_filter_expander_class; ?>>
+					<?php echo $t_dynamic_filter_expander_class; ?>>
 					<?php echo lang_get( 'changed_label' )?>
 				</a>
 			</td>

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1188,6 +1188,7 @@ $s_recently_visited = 'Recently Visited';
 $s_priority_abbreviation = 'P';
 $s_note_user_id_label = 'Note By:';
 $s_filter_match_type = 'Match Type';
+$s_filter_match_type_label = 'Match Type:';
 $s_filter_match_all = 'All Conditions';
 $s_filter_match_any = 'Any Condition';
 


### PR DESCRIPTION
Add missing 'dynamic-filter-expander' class to the HTML anchor tags to enable the AJAX.

https://www.mantisbt.org/bugs/view.php?id=20080

Also fixes a minor inconsistency in language strings:
- the identifier was missing the standard `_label` suffix), and 
- the trailing `:` was hardcoded in the page instead of being part of the language string
