### PR TITLE
Fire EVENT_LAYOUT_BODY_END directly before </body>

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -757,8 +757,6 @@ function html_footer() {
 function html_body_end() {
 	global $g_scripts_included;
 
-	event_signal( 'EVENT_LAYOUT_BODY_END' );
-
 	echo "\t" . '<script type="text/javascript" src="' . helper_mantis_url( 'javascript_config.php' ) . '"></script>' . "\n";
 	echo "\t" . '<script type="text/javascript" src="' . helper_mantis_url( 'javascript_translations.php' ) . '"></script>' . "\n";
 
@@ -776,6 +774,8 @@ function html_body_end() {
 	}
 
 	echo '</div>', "\n";
+
+	event_signal( 'EVENT_LAYOUT_BODY_END' );
 
 	echo '</body>', "\n";
 }


### PR DESCRIPTION
Fixes #20084: EVENT_LAYOUT_BODY_END should fire after loading JS libraries 