### PR TITLE
fix #0020076: auto_set_status_to_assigned

### DIFF
--- a/bug_update.php
+++ b/bug_update.php
@@ -365,6 +365,7 @@ if( $t_bug_note->note &&
 # Handle automatic assignment of issues.
 if( $t_existing_bug->handler_id === NO_USER &&
 	 $t_updated_bug->handler_id !== NO_USER &&
+	 $t_updated_bug->status == $t_existing_bug->status &&
 	 $t_updated_bug->status < config_get( 'bug_assigned_status' ) &&
 	 config_get( 'auto_set_status_to_assigned' ) ) {
 	$t_updated_bug->status = config_get( 'bug_assigned_status' );


### PR DESCRIPTION
only set "bug_assigned_status" if action is an assignment, not a status change
should fix #0020076