### PR TITLE
fixing  manage_config_workflow_set.php

### DIFF
--- a/manage_config_workflow_set.php
+++ b/manage_config_workflow_set.php
@@ -90,8 +90,9 @@ foreach( $t_valid_thresholds as $t_threshold ) {
 	if( $t_access >= $t_access_current ) {
 		$f_value = gpc_get( 'threshold_' . $t_threshold );
 		$t_value_current = config_get( $t_threshold );
+                $t_value_parent = config_get_parent( $t_project, 'threshold_' . $t_threshold );
 		$f_access = gpc_get( 'access_' . $t_threshold );
-		if( $f_value == $t_value_current && $f_access == $t_access_current ) {
+		if( $f_value == $t_value_parent && $f_access == $t_access_current ) {
 			# If new value is equal to parent and access has not changed
 			config_delete( $t_threshold, ALL_USERS, $t_project );
 		} else if( $f_value != $t_value_current || $f_access != $t_access_current ) {
@@ -165,10 +166,10 @@ if( config_get_access( 'status_enum_workflow' ) <= $t_access ) {
 }
 
 # process the access level changes
-if( config_get_access( 'status_enum_workflow' ) <= $t_access ) {
+if( config_get_access( 'set_status_threshold' ) <= $t_access ) {
 	# get changes to access level to change these values
 	$f_access = gpc_get( 'status_access' );
-	$t_access_current = config_get_access( 'status_enum_workflow' );
+	$t_access_current = config_get_access( 'set_status_threshold' );
 
 	# Build access level reference arrays (parent level and current config)
 	$t_set_parent = config_get_parent( $t_project, 'set_status_threshold' );
@@ -196,7 +197,7 @@ if( config_get_access( 'status_enum_workflow' ) <= $t_access ) {
 	foreach( $t_enum_status as $t_status_id => $t_status_label ) {
 		$f_level = gpc_get_int( 'access_change_' . $t_status_id );
 		if( config_get( 'bug_submit_status' ) == $t_status_id ) {
-			if( $f_level != config_get( 'report_bug_threshold' ) ) {
+                        if( $f_level != $t_set_parent[$t_status_id] ) {
 				config_set( 'report_bug_threshold', (int)$f_level, ALL_USERS, $t_project, $f_access );
 			} else {
 				config_delete( 'report_bug_threshold', ALL_USERS, $t_project );


### PR DESCRIPTION
some corrections to "manage_config_workflow_set.php"
problem: when deleting configuration options if detected as same as parent level settings. but some of that logic was wrong, not correctly comparing against proper parent values, causing valid configurations to disappear (and reset to default)
related: #0019970