### PR TITLE
0006939 count only visible notes

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -729,6 +729,10 @@ function bug_cache_database_result( array $p_bug_database_result, array $p_stats
 	global $g_cache_bug;
 
 	if( !is_array( $p_bug_database_result ) || isset( $g_cache_bug[(int)$p_bug_database_result['id']] ) ) {
+		if( null !== $p_stats ) {
+			#force store the bugnote statistics
+			return bug_add_to_cache( $p_bug_database_result, $p_stats );
+		}
 		return $g_cache_bug[(int)$p_bug_database_result['id']];
 	}
 

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1484,12 +1484,22 @@ function bug_get_bugnote_stats_array( array $p_bugs_id, $p_user_id = null ) {
 	$t_array_chunks = array_chunk( $t_unique_array, 1000 );
 
 	foreach( $t_array_chunks as $t_id_array ) {
-		$t_where_string = ' WHERE n.bug_id in (' . implode( ', ', $t_id_array ) . ')';
+		# Build sql IN list
+		$t_count = count( $t_id_array );
+		$t_query_items = '';
+		for( $ix = 0; $ix < $t_count; ++$ix ) {
+			if( $ix !== 0 ) {
+				$t_query_items .= ',';
+			}
+			$t_query_items .= db_param();
+		}
+		# Build main query
 		$t_query = 'SELECT n.id, n.bug_id, n.reporter_id, n.view_state, n.last_modified, n.date_submitted, b.project_id'
-			. ' FROM {bugnote} n JOIN {bug} b ON (n.bug_id = b.id) ' . $t_where_string
+			. ' FROM {bugnote} n JOIN {bug} b ON (n.bug_id = b.id) '
+			. ' WHERE n.bug_id in (' . $t_query_items . ')'
 			. ' ORDER BY b.project_id, n.bug_id, n.last_modified';
 		# perform query
-		$t_result = db_query( $t_query );
+		$t_result = db_query( $t_query, $t_id_array );
 		$t_query_row = db_fetch_array( $t_result );
 		$t_counter = 0;
 		#We need to check for each bugnote if it has permissions to view in respective project.

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -817,9 +817,7 @@ function bug_add_to_cache( array $p_bug_row, array $p_stats = null ) {
 
 	$g_cache_bug[(int)$p_bug_row['id']] = $p_bug_row;
 
-	if( !is_null( $p_stats ) ) {
-		$g_cache_bug[(int)$p_bug_row['id']]['_stats'] = $p_stats;
-	}
+	$g_cache_bug[(int)$p_bug_row['id']]['_stats'] = $p_stats;
 
 	return $g_cache_bug[(int)$p_bug_row['id']];
 }
@@ -1498,34 +1496,37 @@ function bug_get_bugnote_stats_array( array $p_bugs_id, $p_user_id = null ) {
 			$t_query_items .= db_param();
 		}
 		# Build main query
-		$t_query = 'SELECT n.id, n.bug_id, n.reporter_id, n.view_state, n.last_modified, n.date_submitted, b.project_id'
-			. ' FROM {bugnote} n JOIN {bug} b ON (n.bug_id = b.id) '
-			. ' WHERE n.bug_id in (' . $t_query_items . ')'
-			. ' ORDER BY b.project_id, n.bug_id, n.last_modified';
+		$t_query = 'SELECT b.project_id, b.id as bug_id, n.id, n.reporter_id, n.view_state, n.last_modified, n.date_submitted'
+			. ' FROM {bug} b LEFT OUTER JOIN {bugnote} n ON (n.bug_id = b.id) '
+			. ' WHERE b.id in (' . $t_query_items . ')'
+			. ' ORDER BY b.project_id, b.id, n.last_modified';
 		# perform query
 		$t_result = db_query( $t_query, $t_id_array );
 		$t_query_row = db_fetch_array( $t_result );
 		$t_counter = 0;
-		#We need to check for each bugnote if it has permissions to view in respective project.
-		#bugnotes are grouped by project_id and bug_id to save calls to config_get
+		# We need to check for each bugnote if it has permissions to view in respective project.
+		# bugnotes are grouped by project_id and bug_id to save calls to config_get
 		if( $t_query_row ) {
 			do {
+				if( $t_query_row['id'] === null ) {
+					$t_stats[$t_query_row['bug_id']] = null;
+					continue;
+				}
 				if( 0 == $t_counter || $t_current_project_id !== $t_query_row['project_id'] ) {
-					#evaluating a new project from the rowset
+					# evaluating a new project from the rowset
 					$t_current_project_id = $t_query_row['project_id'];
 					$t_user_access_level = access_get_project_level( $t_query_row['project_id'], $t_user_id );
 					$t_private_bugnote_visible = access_compare_level( $t_user_access_level, config_get( 'private_bugnote_threshold', null, $t_user_id, $t_query_row['project_id'] ) );
 				}
 				if( 0 == $t_counter || $t_current_bug_id !== $t_query_row['bug_id'] ) {
-					#evaluating a new bug from the rowset
+					# evaluating a new bug from the rowset
 					$t_current_bug_id = $t_query_row['bug_id'];
-					$t_bug_visible = access_has_bug_level( config_get( 'view_bug_threshold', null, $t_user_id, $t_query_row['project_id'] ), $t_query_row['bug_id'], $t_user_id );
 					$t_note_count = 0;
 					$t_last_submit_date= 0;
 				}
-				$t_note_visible = $t_private_bugnote_visible || $t_query_row[reporter_id] == $t_user_id || ( VS_PUBLIC == $t_query_row[view_state] );
-				if( $t_note_visible && $t_bug_visible ) {
-					#only count the bugnote if user has access
+				$t_note_visible = $t_private_bugnote_visible || $t_query_row['reporter_id'] == $t_user_id || ( VS_PUBLIC == $t_query_row['view_state'] );
+				if( $t_note_visible ) {
+					# only count the bugnote if user has access
 					$t_stats[$t_query_row['bug_id']]['bug_id'] = $t_query_row['bug_id'];
 					$t_stats[$t_query_row['bug_id']]['last_modified'] = $t_query_row['last_modified'];
 					$t_stats[$t_query_row['bug_id']]['count'] = ++$t_note_count;

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1461,6 +1461,70 @@ function bug_get_newest_bugnote_timestamp( $p_bug_id ) {
 }
 
 /**
+ * For a list of bug ids, return array of bugnote stats:
+ * the timestamp for the most recent time at which a bugnote
+ * associated with the bug was modified and the total bugnote
+ * count in one db query.
+ * @param array $p_bugs_id Array of Integer representing bug identifiers.
+ * @param integer|null $p_user_id User for checking access levels. null defaults to current user
+ * @return array objects consisting of bugnote stats
+ * @access public
+ * @uses database_api.php
+ */
+function bug_get_bugnote_stats_multi( array $p_bugs_id, $p_user_id = null ) {
+	$t_id_array = array_unique( $p_bugs_id );
+	if ( null === $p_user_id ) {
+		$t_user_id = auth_get_current_user_id();
+	}
+	else {
+		$t_user_id = $p_user_id;
+	}
+	$t_where_string = ' WHERE n.bug_id in (' . implode( ', ', $t_id_array ) . ')';
+	$t_query = 'SELECT n.id, n.bug_id, n.reporter_id, n.view_state, n.last_modified, n.date_submitted, b.project_id'
+		. ' FROM {bugnote} n JOIN {bug} b ON (n.bug_id = b.id) ' . $t_where_string
+		. ' ORDER BY b.project_id, n.bug_id, n.last_modified';
+	# perform query
+	$t_result = db_query( $t_query );
+	$t_query_row = db_fetch_array( $t_result );
+	$t_counter = 0;
+	$t_stats = array();
+	#We need to check for each bugnote if it has permissions to view in respective project.
+	#bugnotes are grouped by project_id and bug_id to save calls to config_get
+	if( $t_query_row ) {
+		do {
+			if( 0 == $t_counter || $t_current_project_id !== $t_query_row['project_id'] ) {
+				#evaluating a new project from the rowset
+				$t_current_project_id = $t_query_row['project_id'];
+				$t_user_access_level = access_get_project_level( $t_query_row['project_id'], $t_user_id );
+				$t_private_bugnote_visible = access_compare_level( $t_user_access_level, config_get( 'private_bugnote_threshold', null, $t_user_id, $t_query_row['project_id'] ) );
+			}
+			if( 0 == $t_counter || $t_current_bug_id !== $t_query_row['bug_id'] ) {
+				#evaluating a new bug from the rowset
+				$t_current_bug_id = $t_query_row['bug_id'];
+				$t_bug_visible = access_has_bug_level( config_get( 'view_bug_threshold', null, $t_user_id, $t_query_row['project_id'] ), $t_query_row['bug_id'], $t_user_id );
+				$t_note_count = 0;
+				$t_last_submit_date= 0;
+			}
+			$t_note_visible = $t_private_bugnote_visible || $t_query_row[reporter_id] == $t_user_id || ( VS_PUBLIC == $t_query_row[view_state] );
+			if( $t_note_visible && $t_bug_visible ) {
+				#only count the bugnote if user has access
+				$t_stats[$t_query_row['bug_id']]['bug_id'] = $t_query_row['bug_id'];
+				$t_stats[$t_query_row['bug_id']]['last_modified'] = $t_query_row['last_modified'];
+				$t_stats[$t_query_row['bug_id']]['count'] = ++$t_note_count;
+				$t_stats[$t_query_row['bug_id']]['last_modified_bugnote'] = $t_query_row['id'];
+				if( $t_query_row['date_submitted'] > $t_last_submit_date ) {
+					$t_last_submit_date = $t_query_row['date_submitted'];
+					$t_stats[$t_query_row['bug_id']]['last_submitted_bugnote'] = $t_query_row['id'];
+				}
+			}
+			$t_counter++;
+		}
+		while ( $t_query_row = db_fetch_array( $t_result ) );
+	}
+	return $t_stats;
+}
+
+/**
  * return the timestamp for the most recent time at which a bugnote
  * associated with the bug was modified and the total bugnote
  * count in one db query
@@ -1476,24 +1540,10 @@ function bug_get_bugnote_stats( $p_bug_id ) {
 	if( array_key_exists( '_stats', $g_cache_bug[$c_bug_id] ) ) {
 		return $g_cache_bug[$c_bug_id]['_stats'];
 	}
-
-	# @todo - optimise - max(), count()
-	$t_query = 'SELECT last_modified FROM {bugnote} WHERE bug_id=' . db_param() . ' ORDER BY last_modified ASC';
-	$t_result = db_query( $t_query, array( $c_bug_id ) );
-
-	$t_bugnote_count = 0;
-	while( $t_row = db_fetch_array( $t_result ) ) {
-		$t_bugnote_count++;
+	else {
+		$t_stats = bug_get_bugnote_stats_multi( array($p_bug_id) );
+		return $t_stats[$p_bug_id];
 	}
-
-	if( $t_bugnote_count === 0 ) {
-		return false;
-	}
-
-	$t_stats['last_modified'] = $t_row['last_modified'];
-	$t_stats['count'] = $t_bugnote_count;
-
-	return $t_stats;
 }
 
 /**

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2104,17 +2104,7 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
  * @return array
  */
 function filter_cache_result( array $p_rows, array $p_id_array_lastmod ) {
-	$t_id_array_lastmod = array_unique( $p_id_array_lastmod );
-	$t_where_string = ' WHERE {bugnote}.bug_id in (' . implode( ', ', $t_id_array_lastmod ) . ')';
-	$t_query = 'SELECT DISTINCT bug_id,MAX(last_modified) as last_modified, COUNT(last_modified) as count FROM {bugnote} ' . $t_where_string . ' GROUP BY bug_id';
-
-	# perform query
-	$t_result = db_query( $t_query );
-	$t_row_count = db_num_rows( $t_result );
-	while ( $t_row = db_fetch_array( $t_result ) ) {
-		$t_stats[$t_row['bug_id']] = $t_row;
-	}
-
+	$t_stats = bug_get_bugnote_stats_multi( $p_id_array_lastmod );
 	$t_rows = array();
 	foreach( $p_rows as $t_row ) {
 		if( !isset( $t_stats[$t_row['id']] ) ) {

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2104,7 +2104,7 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
  * @return array
  */
 function filter_cache_result( array $p_rows, array $p_id_array_lastmod ) {
-	$t_stats = bug_get_bugnote_stats_multi( $p_id_array_lastmod );
+	$t_stats = bug_get_bugnote_stats_array( $p_id_array_lastmod );
 	$t_rows = array();
 	foreach( $p_rows as $t_row ) {
 		if( !isset( $t_stats[$t_row['id']] ) ) {

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2107,7 +2107,7 @@ function filter_cache_result( array $p_rows, array $p_id_array_lastmod ) {
 	$t_stats = bug_get_bugnote_stats_array( $p_id_array_lastmod );
 	$t_rows = array();
 	foreach( $p_rows as $t_row ) {
-		if( !isset( $t_stats[$t_row['id']] ) ) {
+		if( !array_key_exists( $t_row['id'], $t_stats ) ) {
 			$t_rows[] = bug_row_to_object( bug_cache_database_result( $t_row ) );
 		} else {
 			$t_rows[] = bug_row_to_object( bug_cache_database_result( $t_row, $t_stats[$t_row['id']] ) );


### PR DESCRIPTION
This is another take on #0006939: Number of Private notes visible for reporters
It was also discussed in PR: https://github.com/mantisbt/mantisbt/pull/43
This PR accounts for each project, (since view bug page may list bugs from different projects, each with different access levels to private notes)
Instead of using count, max in sql query, there's need to traverse actual bugnote list, but it still done in only one query, and trying to get minimum api_calls in the loop.

* This modification has revealed bug #0020121 which should be fixed to improve performance on bug cache.

* This modification consolidates sql query which was duplicated (differently) in two apis, creating a new function to be called from both places.

* I have expanded statistics with new values:
last_modified_bugnote
last_submitted_bugnote
which can prove useful to future features (eg: #0020122)

