### PR TITLE
Actions for edit/clone configuration options

### DIFF
--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -217,6 +217,7 @@ $t_edit_project_id      = gpc_get_int( 'project_id', $t_filter_project_value == 
 $t_edit_option          = gpc_get_string( 'config_option', $t_filter_config_value == META_FILTER_NONE ? '' : $t_filter_config_value );
 $t_edit_type            = gpc_get_string( 'type', CONFIG_TYPE_DEFAULT );
 $t_edit_value           = gpc_get_string( 'value', '' );
+$t_edit_action          = gpc_get_string( 'action', 'action_create' );
 
 # Apply filters
 
@@ -412,6 +413,21 @@ while( $t_row = db_fetch_array( $t_result ) ) {
 					'config_option' => $v_config_id,
 					'type'          => $v_type,
 					'value'         => $v_value,
+					'action'        => 'action_edit',
+				),
+				OFF );
+
+			# Clone button
+			print_button(
+				'#config_set_form',
+				lang_get( 'create_child_bug_button' ),
+				array(
+					'user_id'       => $v_user_id,
+					'project_id'    => $v_project_id,
+					'config_option' => $v_config_id,
+					'type'          => $v_type,
+					'value'         => $v_value,
+					'action'        => 'action_clone',
 				),
 				OFF );
 
@@ -457,7 +473,7 @@ if( $t_read_write_access ) {
 
 		<!-- Title -->
 		<legend><span>
-			<?php echo lang_get( 'set_configuration_option' ) ?>
+			<?php echo lang_get( 'set_configuration_option_' . $t_edit_action ) ?>
 		</span></legend>
 
 		<!-- Username -->
@@ -471,6 +487,7 @@ if( $t_read_write_access ) {
 					</option>
 					<?php print_user_option_list( $t_edit_user_id ) ?>
 				</select>
+				<input type="hidden" name="original_user_id" value="<?php echo $t_edit_user_id; ?>" />
 			</span>
 			<span class="label-style"></span>
 		</div>
@@ -486,6 +503,7 @@ if( $t_read_write_access ) {
 						</option>
 						<?php print_project_option_list( $t_edit_project_id, false ) ?>
 					</select>
+					<input type="hidden" name="original_project_id" value="<?php echo $t_edit_project_id; ?>" />
 				</span>
 				<span class="label-style"></span>
 			</div>
@@ -497,6 +515,7 @@ if( $t_read_write_access ) {
 					<input type="text" name="config_option"
 						value="<?php echo string_attribute( $t_edit_option ); ?>"
 						size="64" maxlength="64" />
+					<input type="hidden" name="original_config_option" value="<?php echo $t_edit_option; ?>" />
 				</span>
 				<span class="label-style"></span>
 			</div>
@@ -524,7 +543,10 @@ if( $t_read_write_access ) {
 			</div>
 
 			<!-- Submit button -->
-			<span class="submit-button"><input type="submit" name="config_set" class="button" value="<?php echo lang_get( 'set_configuration_option' ) ?>" /></span>
+			<span class="submit-button">
+				<input type="hidden" name="action" value="<?php echo $t_edit_action; ?>" />
+				<input type="submit" name="config_set" class="button" value="<?php echo lang_get( 'set_configuration_option_' . $t_edit_action ) ?>" />
+			</span>
 		</fieldset>
 	</form>
 </div>

--- a/adm_config_set.php
+++ b/adm_config_set.php
@@ -54,7 +54,7 @@ $f_type = gpc_get_string( 'type' );
 $f_value = gpc_get_string( 'value' );
 $f_original_user_id = gpc_get_int( 'original_user_id' );
 $f_original_project_id = gpc_get_int( 'original_project_id' );
-$f_original_edit_option = gpc_get_string( 'original_config_option' );
+$f_original_config_option = gpc_get_string( 'original_config_option' );
 $f_edit_action = gpc_get_string( 'action' );
 
 
@@ -124,9 +124,12 @@ switch( $t_type ) {
 }
 
 if( 'action_edit' === $f_edit_action ){
-	# EDIT action doesnt keep original key values if different.
-	# if key values were not modified, can delete before re-creation
-	config_delete( $f_original_edit_option, $f_original_user_id, $f_original_project_id );
+	# EDIT action doesn't keep original if key values are different.
+	if ( $f_original_config_option !== $f_config_option
+			|| $f_original_user_id !== $f_user_id
+			|| $f_original_project_id !== $f_project_id ){
+		config_delete( $f_original_config_option, $f_original_user_id, $f_original_project_id );
+		}
 }
 
 config_set( $f_config_option, $t_value, $f_user_id, $f_project_id );

--- a/adm_config_set.php
+++ b/adm_config_set.php
@@ -52,6 +52,11 @@ $f_project_id = gpc_get_int( 'project_id' );
 $f_config_option = trim( gpc_get_string( 'config_option' ) );
 $f_type = gpc_get_string( 'type' );
 $f_value = gpc_get_string( 'value' );
+$f_original_user_id = gpc_get_int( 'original_user_id' );
+$f_original_project_id = gpc_get_int( 'original_project_id' );
+$f_original_edit_option = gpc_get_string( 'original_config_option' );
+$f_edit_action = gpc_get_string( 'action' );
+
 
 if( is_blank( $f_config_option ) ) {
 	error_parameters( 'config_option' );
@@ -116,6 +121,12 @@ switch( $t_type ) {
 	default:
 		$t_value = process_complex_value( $f_value );
 		break;
+}
+
+if( 'action_edit' === $f_edit_action ){
+	# EDIT action doesnt keep original key values if different.
+	# if key values were not modified, can delete before re-creation
+	config_delete( $f_original_edit_option, $f_original_user_id, $f_original_project_id );
 }
 
 config_set( $f_config_option, $t_value, $f_user_id, $f_project_id );

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -837,6 +837,9 @@ $s_all_users = 'All Users';
 $s_set_configuration_option = 'Set Configuration Option';
 $s_delete_config_sure_msg = 'Are you sure you wish to delete this configuration option?';
 $s_configuration_corrupted = 'The configuration in the database is corrupted.';
+$s_set_configuration_option_action_create = 'Create Configuration Option';
+$s_set_configuration_option_action_edit = 'Edit Configuration Option';
+$s_set_configuration_option_action_clone = 'Clone Configuration Option';
 
 # manage_plugin_page.php
 $s_plugin = 'Plugin';


### PR DESCRIPTION
~~In adm_config_report, adds new button and rename current for editing options~~
- ~~action "Create Configuration Option" is the previous behaviour (create new
  option and keep old)~~
- ~~action "Move Configuration Option" creates new option and deletes old one
  (or keep if doesn't change key values)~~

In adm_config_report, show buttons for different editing actions:
- Action "Clone" creates new option and keeps old, overwritting if one
  already exists with those key values.
  exists
- Action "Edit" updates current configuration option, or moves the
  option if key values are changed, overwritting if one already exists

Fixes #0020058


