### PR TITLE
0020107 config report filter options

### DIFF
--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -156,7 +156,7 @@ function print_option_list_from_array( array $p_array, $p_filter_value ) {
 function check_config_value( $p_config ) {
 	if(    $p_config != META_FILTER_NONE
 	   && !is_blank( $p_config )
-	   && is_null( @config_get_global( $p_config ) )
+	   && is_null( @config_get( $p_config ) )
 	) {
 		return META_FILTER_NONE;
 	}

--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -449,6 +449,7 @@ if( $t_read_write_access ) {
 
 <!-- Config Set Form -->
 
+<?php if( config_can_delete( $t_edit_option ) ){ ?>
 <div id="config-edit-div" class="form-container">
 <form id="config_set_form" method="post" action="adm_config_set.php">
 	<fieldset>
@@ -527,6 +528,7 @@ if( $t_read_write_access ) {
 		</fieldset>
 	</form>
 </div>
+<?php } # end if config_can_delete ?>
 
 <?php
 } # end user can change config

--- a/adm_config_set.php
+++ b/adm_config_set.php
@@ -66,7 +66,7 @@ if( $f_project_id != ALL_PROJECTS ) {
 
 # make sure that configuration option specified is a valid one.
 $t_not_found_value = '***CONFIG OPTION NOT FOUND***';
-if( config_get_global( $f_config_option, $t_not_found_value ) === $t_not_found_value ) {
+if( config_get( $f_config_option, $t_not_found_value ) === $t_not_found_value ) {
 	error_parameters( $f_config_option );
 	trigger_error( ERROR_CONFIG_OPT_NOT_FOUND, ERROR );
 }

--- a/adm_config_set.php
+++ b/adm_config_set.php
@@ -77,6 +77,13 @@ if( !config_can_set_in_database( $f_config_option ) ) {
 	trigger_error( ERROR_CONFIG_OPT_CANT_BE_SET_IN_DB, ERROR );
 }
 
+if( !config_can_delete( $f_config_option ) ) {
+	error_parameters( $f_config_option );
+	# @TODO define an error code for values that cant be set in DB, nor config_inc
+	trigger_error( ERROR_CONFIG_OPT_CANT_BE_SET_IN_DB, ERROR );
+}
+
+
 # For 'default', behavior is based on the global variable's type
 if( $f_type == CONFIG_TYPE_DEFAULT ) {
 	$t_config_global_value = config_get_global( $f_config_option );


### PR DESCRIPTION
In configuration report (adm_config_report.php)
when selecting a specific configuration option, some options are not showing the filtered list and resets to the "any" state.
Fixes #0020107

after modifications, found that some values like "database version" were editable, which is also fixed here.



