### PR TITLE
use selective bug cache for attachment count

### DIFF
--- a/core/file_api.php
+++ b/core/file_api.php
@@ -178,7 +178,7 @@ function file_bug_attachment_count( $p_bug_id ) {
 
 	# First check if we have a cache miss, if so try to load
 	if( !isset( $g_cache_file_count[$p_bug_id] ) ) {
-		file_bug_attachment_count_cache( array( $p_bug_id ) );
+		file_bug_attachment_count_cache( array( (int)$p_bug_id ) );
 	}
 
 	# If bug is valid, it should be in cache now.

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2099,6 +2099,7 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 
 /**
  *  Cache the filter results with bugnote stats for later use
+ *  also fills bug attachment count cache
  * @param array $p_rows             Results of the filter query.
  * @param array $p_id_array_lastmod Array of bug ids.
  * @return array
@@ -2116,13 +2117,17 @@ function filter_cache_result( array $p_rows, array $p_id_array_lastmod ) {
 	}
 
 	$t_rows = array();
+	$t_bug_ids = array();
 	foreach( $p_rows as $t_row ) {
+		$t_bug_ids[] = $t_row['id'];
 		if( !isset( $t_stats[$t_row['id']] ) ) {
 			$t_rows[] = bug_row_to_object( bug_cache_database_result( $t_row ) );
 		} else {
 			$t_rows[] = bug_row_to_object( bug_cache_database_result( $t_row, $t_stats[$t_row['id']] ) );
 		}
 	}
+	#cache the attachment count for bug list
+	file_bug_attachment_count_cache( $t_bug_ids );
 	return $t_rows;
 }
 

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2119,7 +2119,7 @@ function filter_cache_result( array $p_rows, array $p_id_array_lastmod ) {
 	$t_rows = array();
 	$t_bug_ids = array();
 	foreach( $p_rows as $t_row ) {
-		$t_bug_ids[] = $t_row['id'];
+		$t_bug_ids[] = (int)$t_row['id'];
 		if( !isset( $t_stats[$t_row['id']] ) ) {
 			$t_rows[] = bug_row_to_object( bug_cache_database_result( $t_row ) );
 		} else {


### PR DESCRIPTION
use selective bug cache for attachment count instead of cache data for all bugs in db
fetch data only for bugs included in filter result set
fixes #0020138

The problem identified in bug #0020138, is that caching the attachment count query data for all bugs in database. This is unnecessary, and can penalize in db time, processing time and memory usage.

Modification uses the filter bug list and caches all of its values, only for that set. Usually all bugs accessed are those from the filter result, so subsequent calls to file_bug_attachment_count will hit the cache successfully. In other case, a single query will be issued.

Typical scenario will perform one query in view_all_bug_page, and several queries in my_view_page (one for each filter box). Hopefully the queries and its processing are more lightweight that original approach.
