### PR TITLE
accept objects for event EVENT_FILTER_COLUMNS

### DIFF
--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -179,12 +179,16 @@ function columns_get_plugin_columns() {
 		foreach( $t_all_plugin_columns as $t_plugin => $t_plugin_columns ) {
 			foreach( $t_plugin_columns as $t_callback => $t_plugin_column_array ) {
 				if( is_array( $t_plugin_column_array ) ) {
-					foreach( $t_plugin_column_array as $t_column_class ) {
-						if( class_exists( $t_column_class ) && is_subclass_of( $t_column_class, 'MantisColumn' ) ) {
-							$t_column_object = new $t_column_class();
-							$t_column_name = utf8_strtolower( $t_plugin . '_' . $t_column_object->column );
-							$s_column_array[$t_column_name] = $t_column_object;
+					foreach( $t_plugin_column_array as $t_column_item ) {
+						if( is_object( $t_column_item ) && $t_column_item instanceof MantisColumn ) {
+							$t_column_object = $t_column_item;
+						} elseif( class_exists( $t_column_item ) && is_subclass_of( $t_column_item, 'MantisColumn' ) ) {
+							$t_column_object = new $t_column_item();
+						} else {
+							continue;
 						}
+						$t_column_name = utf8_strtolower( $t_plugin . '_' . $t_column_object->column );
+						$s_column_array[$t_column_name] = $t_column_object;
 					}
 				}
 			}

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -106,12 +106,16 @@ function filter_get_plugin_filters() {
 		foreach( $t_all_plugin_filters as $t_plugin => $t_plugin_filters ) {
 			foreach( $t_plugin_filters as $t_callback => $t_plugin_filter_array ) {
 				if( is_array( $t_plugin_filter_array ) ) {
-					foreach( $t_plugin_filter_array as $t_filter_class ) {
-						if( class_exists( $t_filter_class ) && is_subclass_of( $t_filter_class, 'MantisFilter' ) ) {
-							$t_filter_object = new $t_filter_class();
-							$t_field_name = $t_plugin . '_' . $t_filter_object->field;
-							$s_field_array[$t_field_name] = $t_filter_object;
+					foreach( $t_plugin_filter_array as $t_filter_item ) {
+						if( is_object( $t_filter_item ) && $t_filter_item instanceof MantisFilter ) {
+							$t_filter_object = $t_filter_item;
+						} elseif( class_exists( $t_filter_item ) && is_subclass_of( $t_filter_item, 'MantisFilter' ) ) {
+							$t_filter_object = new $t_filter_item();
+						} else {
+							continue;
 						}
+						$t_filter_name = utf8_strtolower( $t_plugin . '_' . $t_filter_object->field );
+						$s_field_array[$t_filter_name] = $t_filter_object;
 					}
 				}
 			}

--- a/docbook/Developers_Guide/en-US/Events_Reference_Filter.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference_Filter.xml
@@ -16,14 +16,16 @@
 				<para>
 					This event allows a plugin to register custom filter objects (based
 					on the <classname>MantisFilter</classname> class) that will allow the user
-					to search for issues based on custom criteria or datasets.  The plugin
-					must ensure that the filter class has been defined before returning
+					to search for issues based on custom criteria or datasets. The plugin
+					can return either a class name (which will be instantiated at runtime)
+					or an already instantiated object.
+					The plugin must ensure that the filter class has been defined before returning
 					the class name for this event.
 				</para>
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>&lt;Array&gt;: Array of class names for custom filters</para></listitem>
+					<listitem><para>&lt;Array&gt;: Array of class names or objects for custom filters</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -35,14 +37,16 @@
 				<para>
 					This event allows a plugin to register custom column objects (based
 					on the <classname>MantisColumn</classname> class) that will allow the
-					user to view data for issues based on custom datasets.  The plugin
-					must ensure that the column class has been defined before returning
+					user to view data for issues based on custom datasets. The plugin
+					can return either a class name (which will be instantiated at runtime)
+					or an already instantiated object.
+					The plugin must ensure that the column class has been defined before returning
 					the class name for this event.
 				</para>
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>&lt;Array&gt;: Array of class names for custom columns</para></listitem>
+					<listitem><para>&lt;Array&gt;: Array of class names or objects for custom columns</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>


### PR DESCRIPTION
As explained in [#0020140](https://www.mantisbt.org/bugs/view.php?id=20140)
Modify EVENT_FILTER_COLUMNS event processing, to allow plugin to pass objects, not only classes
Maintains compatibility with previous functionality
