### PR TITLE
Fix broken issue update page due to custom field

### DIFF
--- a/bug_update.php
+++ b/bug_update.php
@@ -297,7 +297,7 @@ foreach ( $t_related_custom_field_ids as $t_cf_id ) {
 		trigger_error( ERROR_ACCESS_DENIED, ERROR );
 	}
 
-	$t_new_custom_field_value = gpc_get_custom_field( 'custom_field_' . $t_cf_id, $t_cf_def['type'], null );
+	$t_new_custom_field_value = gpc_get_custom_field( 'custom_field_' . $t_cf_id, $t_cf_def['type'], '' );
 	$t_old_custom_field_value = custom_field_get_value( $t_cf_id, $f_bug_id );
 
 	# Validate the value of the field against current validation rules.


### PR DESCRIPTION
In some corner cases, the customer hits invalid query which is trying to set
the custom field string to null. This is caused in the following case:

- Custom field is visible on update page.
- Custom field is not required.
- Custom field is of type list.
- Custom field doesn't have any value selected.

In this case, the new custom field value evaluated to default value provided by
bug_update.php page which is null. The fix is to change it to ''.

Fixes #20196