### PR TITLE
Add config to disable caching of LDAP passwords

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -1946,6 +1946,13 @@ $g_ldap_uid_field = 'uid';
 $g_ldap_realname_field = 'cn';
 
 /**
+ * Keep a local copy of the LDAP password (ON) so we can
+ * authenticate even when LDAP is unavailable.
+ * @global integer $g_ldap_cache_passwords
+ */
+$g_ldap_cache_passwords = ON;
+
+/**
  * Use the realname specified in LDAP (ON) rather than the one stored in the
  * database (OFF).
  * @global integer $g_use_ldap_realname
@@ -4260,7 +4267,7 @@ $g_global_settings = array(
 	'class_path','library_path', 'language_path', 'absolute_path_default_upload_folder',
 	'ldap_simulation_file_path', 'plugin_path', 'bottom_include_page', 'top_include_page',
 	'default_home_page', 'logout_redirect_page', 'manual_url', 'logo_url', 'wiki_engine_url',
-	'cdn_enabled'
+	'cdn_enabled', 'ldap_cache_passwords'
 );
 
 # Temporary variables should not remain defined in global scope

--- a/core/config_api.php
+++ b/core/config_api.php
@@ -719,6 +719,7 @@ function config_is_private( $p_config_var ) {
 		case 'ldap_bind_dn':
 		case 'ldap_bind_passwd':
 		case 'use_ldap_email':
+		case 'ldap_cache_passwords':
 		case 'ldap_protocol_version':
 		case 'login_method':
 		case 'cookie_path':

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -379,7 +379,11 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
 
 		if( false !== $t_user_id ) {
 
-			$t_fields_to_update = array('password' => md5( $p_password ));
+			$t_fields_to_update = array();
+
+			if ( ON == config_get( 'ldap_cache_passwords' ) ) {
+				$t_fields_to_update['password'] = md5( $p_password );
+			}
 
 			if( ON == config_get( 'use_ldap_realname' ) ) {
 				$t_fields_to_update['realname'] = ldap_realname( $t_user_id );

--- a/docbook/Admin_Guide/en-US/config/auth.xml
+++ b/docbook/Admin_Guide/en-US/config/auth.xml
@@ -213,6 +213,20 @@ ldaps://ldap.example.com:3269/
 			</varlistentry>
 
 			<varlistentry>
+				<term>$g_ldap_cache_passwords</term>
+
+				<listitem>
+					<para>Keep a local copy of the LDAP password (ON)
+					so we can authenticate even when LDAP is unavailable.
+					Defaults to
+					<emphasis>ON</emphasis>.</para>
+
+					<para>Note that MantisBT will update the database with
+					the data retrieved from LDAP when ON.</para>
+				</listitem>
+			</varlistentry>
+
+			<varlistentry>
 				<term>$g_use_ldap_realname</term>
 
 				<listitem>


### PR DESCRIPTION
our LDAP passwords are SSHA hashed for a reason. I don't like the idea of having a MD5 hashed version of my password in mantis' database so I introduced `use_ldap_password` to toggle whether mantis should keep a local copy of the LDAP password after logging in.