### PR TITLE
avoid html output for errors in ajax call

### DIFF
--- a/javascript/common.js
+++ b/javascript/common.js
@@ -80,6 +80,9 @@ $(document).ready( function() {
 			context: $('#' + targetID),
 			success: function(html) {
 				$(this).html(html);
+			},
+			error: function(obj,status,error) {
+				$(this).html('<span class="error-msg">' + status + ': ' + error + '</span>');
 			}
 		});
 	});

--- a/return_dynamic_filters.php
+++ b/return_dynamic_filters.php
@@ -154,7 +154,9 @@ if( function_exists( $t_function_name ) ) {
 
 	if( !$t_found ) {
 		# error - no function to populate the target (e.g., print_filter_foo)
-		# return err "400 Bad Request"
+		# return err "400 Bad Request", and log event
+		error_parameters( $f_filter_target );
+		log_event( LOG_AJAX, error_string(ERROR_FILTER_NOT_FOUND) );
 		header( ' ', true, 400);
 		exit;
 	}

--- a/return_dynamic_filters.php
+++ b/return_dynamic_filters.php
@@ -49,7 +49,11 @@ require_api( 'filter_constants_inc.php' );
 require_api( 'gpc_api.php' );
 require_api( 'helper_api.php' );
 
-auth_ensure_user_authenticated();
+#if user is not authenticated, return err "401 Unauthorized"
+if( !auth_is_user_authenticated() ){
+	header( ' ', true, 401 );
+	exit;
+}
 
 compress_enable();
 
@@ -150,7 +154,8 @@ if( function_exists( $t_function_name ) ) {
 
 	if( !$t_found ) {
 		# error - no function to populate the target (e.g., print_filter_foo)
-		error_parameters( $f_filter_target );
-		trigger_error( ERROR_FILTER_NOT_FOUND, ERROR );
+		# return err "400 Bad Request"
+		header( ' ', true, 400);
+		exit;
 	}
 }

--- a/return_dynamic_filters.php
+++ b/return_dynamic_filters.php
@@ -50,7 +50,7 @@ require_api( 'gpc_api.php' );
 require_api( 'helper_api.php' );
 
 #if user is not authenticated, return err "401 Unauthorized"
-if( !auth_is_user_authenticated() ){
+if( !auth_is_user_authenticated() ) {
 	header( ' ', true, 401 );
 	exit;
 }
@@ -156,8 +156,8 @@ if( function_exists( $t_function_name ) ) {
 		# error - no function to populate the target (e.g., print_filter_foo)
 		# return err "400 Bad Request", and log event
 		error_parameters( $f_filter_target );
-		log_event( LOG_AJAX, error_string(ERROR_FILTER_NOT_FOUND) );
-		header( ' ', true, 400);
+		log_event( LOG_AJAX, error_string( ERROR_FILTER_NOT_FOUND ) );
+		header( ' ', true, 400 );
 		exit;
 	}
 }


### PR DESCRIPTION
fixes [#0013048](https://www.mantisbt.org/bugs/view.php?id=13048)
Filter inputs are populated by ajax call to return_dynamic_filters.php
If there is an error in remote script, it should fail the request
instead of outputting an error page
A failed request is handled by the ajax call.