### PR TITLE
Documentation events, code clean-up

### DIFF
--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -203,7 +203,7 @@ if( $t_top_buttons_enabled ) {
 ?>
 			<tbody>
 <?php
-event_signal( 'EVENT_UPDATE_BUG_FORM_TOP', array( $t_bug_id, true ) );
+event_signal( 'EVENT_UPDATE_BUG_FORM_TOP', array( $t_bug_id ) );
 
 if( $t_show_id || $t_show_project || $t_show_category || $t_show_view_state || $t_show_date_submitted | $t_show_last_updated ) {
 	#
@@ -634,7 +634,7 @@ if( $t_show_target_version || $t_show_fixed_in_version ) {
 	echo '</tr>';
 }
 
-event_signal( 'EVENT_UPDATE_BUG_FORM', array( $t_bug_id, true ) );
+event_signal( 'EVENT_UPDATE_BUG_FORM', array( $t_bug_id ) );
 
 # spacer
 echo '<tr class="spacer"><td colspan="6"></td></tr>';

--- a/core/event_api.php
+++ b/core/event_api.php
@@ -270,9 +270,9 @@ function event_type_output( $p_event, array $p_callbacks, $p_params = null ) {
  * final callback's return value will be returned to the event origin.
  * @param string $p_event     Event name.
  * @param array  $p_callbacks Array of callback function/plugin basename key/value pairs.
- * @param string $p_input     Input string.
+ * @param mixed  $p_input     Input data.
  * @param array  $p_params    Parameters.
- * @return string Output string
+ * @return mixed Output data
  * @access public
  */
 function event_type_chain( $p_event, array $p_callbacks, $p_input, $p_params = null ) {

--- a/docbook/Developers_Guide/en-US/Events_Reference.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference.xml
@@ -113,6 +113,10 @@
 					This event receives the logging string as a parameter.
 				</para>
 
+				<itemizedlist>
+					<title>Parameters</title>
+					<listitem><para>&lt;String&gt;: the logging string</para></listitem>
+				</itemizedlist>
 			</blockquote>
 		</blockquote>
 

--- a/docbook/Developers_Guide/en-US/Events_Reference_Manage.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference_Manage.xml
@@ -19,6 +19,12 @@
 				Any output here should be defining appropriate rows and columns for the
 				surrounding &lt;table&gt; elements.
 			</para>
+
+			<itemizedlist>
+				<title>Parameters</title>
+				<listitem><para>&lt;Boolean&gt;: whether user is administrator</para></listitem>
+			</itemizedlist>
+
 		</blockquote>
 	</blockquote>
 

--- a/docbook/Developers_Guide/en-US/Events_Reference_Output.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference_Output.xml
@@ -80,6 +80,7 @@
 				<itemizedlist>
 					<title>Return Value</title>
 					<listitem><para>String: modified input string</para></listitem>
+					<listitem><para>Boolean: multiline input string</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -192,6 +193,11 @@
 					This event gives plugins the opportunity to add new links to the issue
 					menu available to users when viewing issues.
 				</para>
+
+				<itemizedlist>
+					<title>Parameters</title>
+					<listitem><para>&lt;Integer&gt;: bug ID</para></listitem>
+				</itemizedlist>
 
 				<itemizedlist>
 					<title>Return Value</title>
@@ -412,7 +418,13 @@
 			<blockquote>
 				<para>
 					This event allows plugins to output HTML code immediately after the line of an attachment.
+					Recives an attachment, the array returned by the file_get_visible_attachments() function.
 				</para>
+
+				<itemizedlist>
+					<title>Parameters</title>
+					<listitem><para>&lt;Array&gt;: the attachment data</para></listitem>
+				</itemizedlist>
 
 				<itemizedlist>
 					<title>Return Value</title>

--- a/docbook/Developers_Guide/en-US/Events_Reference_Output.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference_Output.xml
@@ -66,7 +66,7 @@
 
 			<blockquote>
 				<para>
-					This is an event to format the subject line of an email before being sent.
+					This is an event to format the subject line of an email before it is sent.
 				</para>
 
 				<itemizedlist>
@@ -438,12 +438,13 @@
 			<blockquote>
 				<para>
 					This event allows plugins to output HTML code immediately after the line of an attachment.
-					Recives an attachment, the array returned by the file_get_visible_attachments() function.
+					Receives the attachement data as a parameter, in the form of an attachment array from within
+					the array returned by the <function>file_get_visible_attachments()</function> function.
 				</para>
 
 				<itemizedlist>
 					<title>Parameters</title>
-					<listitem><para>&lt;Array&gt;: the attachment data</para></listitem>
+					<listitem><para>&lt;Array&gt;: the attachment data as an array (see <filename>core/file_api.php</filename>)</para></listitem>
 				</itemizedlist>
 
 				<itemizedlist>

--- a/docbook/Developers_Guide/en-US/Events_Reference_Output.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference_Output.xml
@@ -61,6 +61,26 @@
 			</blockquote>
 		</blockquote>
 
+		<blockquote id="dev.eventref.output.display.email.subject">
+			<title>EVENT_DISPLAY_EMAIL_BUILD_SUBJECT (Chained)</title>
+
+			<blockquote>
+				<para>
+					This is an event to format the subject line of an email before being sent.
+				</para>
+
+				<itemizedlist>
+					<title>Parameters</title>
+					<listitem><para>String: input string for email subject</para></listitem>
+				</itemizedlist>
+
+				<itemizedlist>
+					<title>Return Value</title>
+					<listitem><para>String: modified subject string</para></listitem>
+				</itemizedlist>
+			</blockquote>
+		</blockquote>
+
 		<blockquote id="dev.eventref.output.display.formatted">
 			<title>EVENT_DISPLAY_FORMATTED (Chained)</title>
 

--- a/docbook/Developers_Guide/en-US/Events_Reference_Output.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference_Output.xml
@@ -27,13 +27,13 @@
 
 				<itemizedlist>
 					<title>Parameters</title>
-					<listitem><para>String: bug ID string to be displayed</para></listitem>
-					<listitem><para>Int: bug ID number</para></listitem>
+					<listitem><para>&lt;String&gt;: bug ID string to be displayed</para></listitem>
+					<listitem><para>&lt;Integer&gt;: bug ID number</para></listitem>
 				</itemizedlist>
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: modified bug ID string</para></listitem>
+					<listitem><para>&lt;String&gt;: modified bug ID string</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -51,12 +51,12 @@
 
 				<itemizedlist>
 					<title>Parameters</title>
-					<listitem><para>String: input string to be displayed</para></listitem>
+					<listitem><para>&lt;String&gt;: input string to be displayed</para></listitem>
 				</itemizedlist>
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: modified input string</para></listitem>
+					<listitem><para>&lt;String&gt;: modified input string</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -71,12 +71,12 @@
 
 				<itemizedlist>
 					<title>Parameters</title>
-					<listitem><para>String: input string for email subject</para></listitem>
+					<listitem><para>&lt;String&gt;: input string for email subject</para></listitem>
 				</itemizedlist>
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: modified subject string</para></listitem>
+					<listitem><para>&lt;String&gt;: modified subject string</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -94,13 +94,13 @@
 
 				<itemizedlist>
 					<title>Parameters</title>
-					<listitem><para>String: input string to be displayed</para></listitem>
+					<listitem><para>&lt;String&gt;: input string to be displayed</para></listitem>
 				</itemizedlist>
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: modified input string</para></listitem>
-					<listitem><para>Boolean: multiline input string</para></listitem>
+					<listitem><para>&lt;String&gt;: modified input string</para></listitem>
+					<listitem><para>&lt;Boolean&gt;: multiline input string</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -117,13 +117,13 @@
 
 				<itemizedlist>
 					<title>Parameters</title>
-					<listitem><para>String: input string to be displayed</para></listitem>
-					<listitem><para>Boolean: multiline input string</para></listitem>
+					<listitem><para>&lt;String&gt;: input string to be displayed</para></listitem>
+					<listitem><para>&lt;Boolean&gt;: multiline input string</para></listitem>
 				</itemizedlist>
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: modified input string</para></listitem>
+					<listitem><para>&lt;String&gt;: modified input string</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -140,13 +140,13 @@
 
 				<itemizedlist>
 					<title>Parameters</title>
-					<listitem><para>String: input string to be displayed</para></listitem>
-					<listitem><para>Boolean: multiline input string</para></listitem>
+					<listitem><para>&lt;String&gt;: input string to be displayed</para></listitem>
+					<listitem><para>&lt;Boolean&gt;: multiline input string</para></listitem>
 				</itemizedlist>
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: modified input string</para></listitem>
+					<listitem><para>&lt;String&gt;: modified input string</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -171,7 +171,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>Array: List of HTML links for the user account menu.</para></listitem>
+					<listitem><para>&lt;Array&gt;: List of HTML links for the user account menu.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -186,7 +186,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>Array: List of HTML links for the documents menu.</para></listitem>
+					<listitem><para>&lt;Array&gt;: List of HTML links for the documents menu.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -201,7 +201,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>Array: List of HTML links for the issue list menu.</para></listitem>
+					<listitem><para>&lt;Array&gt;: List of HTML links for the issue list menu.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -221,7 +221,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>Array: List of HTML links for the documents menu.</para></listitem>
+					<listitem><para>&lt;Array&gt;: List of HTML links for the documents menu.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -239,7 +239,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>Array: List of HTML links for the main menu.</para></listitem>
+					<listitem><para>&lt;Array&gt;: List of HTML links for the main menu.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -257,7 +257,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>Array: List of HTML links for the main menu.</para></listitem>
+					<listitem><para>&lt;Array&gt;: List of HTML links for the main menu.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -274,7 +274,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>Array: List of HTML links for the management menu.</para></listitem>
+					<listitem><para>&lt;Array&gt;: List of HTML links for the management menu.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -291,7 +291,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>Array: List of HTML links for the manage configuration menu.</para></listitem>
+					<listitem><para>&lt;Array&gt;: List of HTML links for the manage configuration menu.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -306,7 +306,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>Array: List of HTML links for the summary menu.</para></listitem>
+					<listitem><para>&lt;Array&gt;: List of HTML links for the summary menu.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -334,7 +334,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: HTML code to output.</para></listitem>
+					<listitem><para>&lt;String&gt;: HTML code to output.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -350,7 +350,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: HTML code to output.</para></listitem>
+					<listitem><para>&lt;String&gt;: HTML code to output.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -365,7 +365,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: HTML code to output.</para></listitem>
+					<listitem><para>&lt;String&gt;: HTML code to output.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -380,7 +380,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: HTML code to output.</para></listitem>
+					<listitem><para>&lt;String&gt;: HTML code to output.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -396,7 +396,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: HTML code to output.</para></listitem>
+					<listitem><para>&lt;String&gt;: HTML code to output.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -412,7 +412,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: HTML code to output.</para></listitem>
+					<listitem><para>&lt;String&gt;: HTML code to output.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -428,7 +428,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: HTML code to output.</para></listitem>
+					<listitem><para>&lt;String&gt;: HTML code to output.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -448,7 +448,7 @@
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>String: HTML code to output.</para></listitem>
+					<listitem><para>&lt;String&gt;: HTML code to output.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>


### PR DESCRIPTION
Fixes documentation and code clean up for plugin events
After my question in #0020183, here is some clean up for the events documentation

Added doc for missing parameters:
EVENT_LOG
EVENT_DISPLAY_FORMATTED 
EVENT_MENU_ISSUE
EVENT_VIEW_BUG_ATTACHMENT
EVENT_MANAGE_OVERVIEW_INFO

Missing documentation for event
EVENT_DISPLAY_EMAIL_BUILD_SUBJECT

Code clean up on usage of events:
EVENT_UPDATE_BUG_FORM
EVENT_UPDATE_BUG_FORM_TOP

Change comments to reflect actual types for function
event_type_chain()

Apply consistent formating to documentation



