### PR TITLE
CSS: Hide collapsed sections for js disabled presentation

### DIFF
--- a/core/collapse_api.php
+++ b/core/collapse_api.php
@@ -110,7 +110,7 @@ function collapse_closed( $p_name, $p_section = '' ) {
 	ob_start();
 
 	$t_div_id = $t_block . '_closed';
-	echo "\n<div id=\"", $t_div_id, '"', ( $t_display ? ' class="collapse-open"' : ' class="collapse-closed"' ), '>';
+	echo "\n<div id=\"", $t_div_id, '" class="collapse-section-closed ', ( $t_display ? 'collapse-open' : 'collapse-closed' ), '">';
 }
 
 /**

--- a/css/default.css
+++ b/css/default.css
@@ -804,3 +804,8 @@ div.timeline * div.action { padding-top: 3px; }
 /* bug_view_inc bug action buttons */
 .details-footer      { padding: 3px 10px 2px 0; }
 .details-buttons     { float: left;  width: auto; }
+
+/* Hide collapsed sections for javascript disabled presentation  */
+.collapse-closed {
+	display: none;
+}

--- a/css/default.css
+++ b/css/default.css
@@ -806,6 +806,6 @@ div.timeline * div.action { padding-top: 3px; }
 .details-buttons     { float: left;  width: auto; }
 
 /* Hide collapsed sections for javascript disabled presentation  */
-.collapse-closed {
+.collapse-section-closed {
 	display: none;
 }


### PR DESCRIPTION
as stated in #0019508
Disabling JavaScript in 1.3.x leads to various side effects, e.g. duplicated sections where collapse functionality is used.

This css modification solves the duplication of sections when javascript is disabled.