### PR TITLE
Remove reference to mantisbt-announce

### DIFF
--- a/docbook/Admin_Guide/en-US/About.xml
+++ b/docbook/Admin_Guide/en-US/About.xml
@@ -211,14 +211,11 @@
         <itemizedlist>
             <listitem>
                 <para>
-                    The <ulink url="mailto:mantisbt-announce@lists.sourceforge.net">
-                        mantisbt-announce mailing list</ulink>
-                    is a very low traffic
-                    list that is used for major announcements,  typically
-                    about new releases.  All MantisBT users are
-                    encouraged to subscribe to this mailing list.  The
-                    average traffic should be no more than one to two posts
-                    per month.
+                    We send release announcements and important updates to users registered
+                    on our <ulink url="http://www.mantisbt.org/bugs">official bugtracker</ulink>.
+                    To get onto our mailing list, users will have to signup there and verify
+                    their email address. This same account can also be used to report, monitor,
+                    and comment on issues relating to MantisBT.
                 </para>
             </listitem>
             <listitem>


### PR DESCRIPTION
Remove reference to mantisbt-announce and mention that announcements will be sent to
users registered on our official bugtracker.

Will backport to 1.2.x after this PR is closed.

Fixes #19378