### PR TITLE
Revert 738272f and reimplement hide graph link

### DIFF
--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -87,10 +87,8 @@ class MantisGraphPlugin extends MantisPlugin  {
 		$t_hooks = array(
 			'EVENT_MENU_SUMMARY' => 'summary_menu',
 			'EVENT_SUBMENU_SUMMARY' => 'summary_submenu',
+			'EVENT_MENU_FILTER' => 'graph_filter_menu'
 		);
-		if( access_has_project_level( config_get( 'view_summary_threshold' ) ) ) {
-			$t_hooks['EVENT_MENU_FILTER'] = 'graph_filter_menu';
-		}
 		return $t_hooks;
 	}
 
@@ -107,7 +105,11 @@ class MantisGraphPlugin extends MantisPlugin  {
 	 * @return array
 	 */
 	function graph_filter_menu() {
-		return array( '<a href="' . plugin_page( 'bug_graph_page.php' ) . '">' . plugin_lang_get( 'graph_bug_page_link' ) . '</a>', );
+		if( access_has_project_level( config_get( 'view_summary_threshold' ) ) ) {
+			return array( '<a href="' . plugin_page( 'bug_graph_page.php' ) . '">' . plugin_lang_get( 'graph_bug_page_link' ) . '</a>', );
+		} else {
+			return '';
+		}
 	}
 
 	/**


### PR DESCRIPTION
commit 738272f to hide Mantisgraph link introduces
regression: failing at login when anonymous login is
disabled.
Here that change is reverted and the access level check
is now placed in the callback function, instead of the
hook initialization

#0020217