### PR TITLE
Filters and print user lists

### DIFF
--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -1056,6 +1056,7 @@ function mc_project_get_issue_headers( $p_username, $p_password, $p_project_id, 
 
 /**
  * Get appropriate users assigned to a project by access level.
+ * @TODO cproensa: Do we need to call user_cache_array_rows() here?
  *
  * @param string  $p_username   The name of the user trying to access the versions.
  * @param string  $p_password   The password of the user.

--- a/core/access_api.php
+++ b/core/access_api.php
@@ -643,3 +643,28 @@ function access_get_status_threshold( $p_status, $p_project_id = ALL_PROJECTS ) 
 		}
 	}
 }
+
+/**
+ * Converts an access level threshold, which can be an integer or an array
+ * of access levels, to an array of access levels.
+ * E.g. threshold >= 40 results in [40,55,80,90], being the numbers those
+ * access levels defined in configuration.
+ * If input is already an array, it's returned as is.
+ * @param integer|array $p_threshold input threshold or array
+ * @return array Array of specific access levels that satisfy the threshold
+ */
+function access_convert_threshold_to_array( $p_threshold ) {
+	if( is_array( $p_threshold ) ){
+		return $p_threshold;
+	}
+	else {
+		$t_values = MantisEnum::getValues( config_get( 'access_levels_enum_string' ) );
+		$t_count = count($t_values);
+		for( $i = 0; $i < $t_count; $i++ ) {
+			if( $t_values[$i] < $p_threshold ) {
+				unset ($t_values[$i]);
+			}
+		}
+		return $t_values;
+	}
+}

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -906,6 +906,35 @@ function db_helper_in_clause( array $p_array ) {
 }
 
 /**
+ * A helper function that generates a formatted IN clause based on an array,
+ * whose elements are arrays, inserting db_param() placeholders.
+ * The array values are assumed to be safe to insert in a query (i.e. already cleaned).
+ * Input array is of form: [[a1,..,an],[b1,..,bn],..]
+ * Inner arrays should all have the same number of elements
+ * Tip: for later merging the params array, flatten a 2 dimensional
+ *		array with: call_user_func_array('array_merge', $array)
+ *		from [[a,b],[c,d]] results in [a,b,c,d]
+ * @param array $p_array The array of values that will be used
+ * @return string returns a formatted sql clause
+ */
+function db_helper_in2_clause( array $p_array ) {
+	$t_result = ' IN (';
+	$idx1 = 0;
+	foreach( $p_array as $t_set ) {
+		if( $idx1++ > 0 ) $t_result .= ',';
+		$t_result .= '(';
+		$idx2 = 0;
+		foreach( $t_set as $t_val ) {
+			if( $idx2++ > 0 ) $t_result .= ',';
+			$t_result .= db_param();
+		}
+		$t_result .= ')';
+	}
+	$t_result .= ')';
+	return $t_result;
+}
+
+/**
  * A helper function that generates a case-sensitive or case-insensitive like phrase based on the current db type.
  * The field name and value are assumed to be safe to insert in a query (i.e. already cleaned).
  * @param string  $p_field_name     The name of the field to filter on.

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -881,6 +881,31 @@ function db_minutes_to_hhmm( $p_min = 0 ) {
 }
 
 /**
+ * A helper function that generates a formatted IN clause based on an array,
+ * inserting db_param() placeholders for the array values
+ * The array values are assumed to be safe to insert in a query (i.e. already cleaned).
+ * If array consist of only one value, an "equals" expression is generated.
+ * For more values, the complete "IN (..)" expression is generated
+ * @param array $p_array The array of values that will be used
+ * @return string returns a formatted sql clause
+ */
+function db_helper_in_clause( array $p_array ) {
+	if( count( $p_array ) === 1 ){
+		return ' = '.db_param() . ' ';
+	}
+	else {
+		$t_result = ' IN (';
+		$idx1 = 0;
+		foreach( $p_array as $t_val ) {
+			if( $idx1++ > 0 ) $t_result .= ',';
+			$t_result .= db_param();
+		}
+		$t_result .= ') ';
+		return $t_result;
+	}
+}
+
+/**
  * A helper function that generates a case-sensitive or case-insensitive like phrase based on the current db type.
  * The field name and value are assumed to be safe to insert in a query (i.e. already cleaned).
  * @param string  $p_field_name     The name of the field to filter on.

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -536,6 +536,7 @@ function email_notify_new_account( $p_username, $p_email ) {
 	$t_threshold_users = project_get_all_user_rows( ALL_PROJECTS, $t_threshold_min );
 	$t_user_ids= array_keys( $t_threshold_users );
 	user_cache_array_rows( $t_user_ids );
+	user_pref_cache_array_rows( $t_user_ids );
 
 	foreach( $t_threshold_users as $t_user ) {
 		lang_push( user_pref_get_language( $t_user['id'] ) );

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -534,6 +534,8 @@ function email_send_confirm_hash_url( $p_user_id, $p_confirm_hash ) {
 function email_notify_new_account( $p_username, $p_email ) {
 	$t_threshold_min = config_get( 'notify_new_user_created_threshold_min' );
 	$t_threshold_users = project_get_all_user_rows( ALL_PROJECTS, $t_threshold_min );
+	$t_user_ids= array_keys( $t_threshold_users );
+	user_cache_array_rows( $t_user_ids );
 
 	foreach( $t_threshold_users as $t_user ) {
 		lang_push( user_pref_get_language( $t_user['id'] ) );

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -3574,7 +3574,7 @@ function print_filter_reporter_id() {
 				check_selected( $g_filter[FILTER_PROPERTY_REPORTER_ID], META_FILTER_MYSELF );
 				echo '>[' . lang_get( 'myself' ) . ']</option>';
 			}
-		print_reporter_option_list( $g_filter[FILTER_PROPERTY_REPORTER_ID] );
+		print_reporter_option_list( $g_filter[FILTER_PROPERTY_REPORTER_ID], filter_get_included_projects() );
 	}?>
 		</select>
 		<?php
@@ -3600,7 +3600,7 @@ function print_filter_user_monitor() {
 	$t_has_project_level = access_has_project_level( $t_threshold );
 
 	if( $t_has_project_level ) {
-		print_reporter_option_list( $g_filter[FILTER_PROPERTY_MONITOR_USER_ID] );
+		print_monitor_user_option_list( $g_filter[FILTER_PROPERTY_MONITOR_USER_ID], filter_get_included_projects() );
 	}
 	?>
 		</select>
@@ -3626,7 +3626,7 @@ function print_filter_handler_id() {
 			echo '>[' . lang_get( 'myself' ) . ']</option>';
 		}
 
-		print_assign_to_option_list( $g_filter[FILTER_PROPERTY_HANDLER_ID] );
+		print_assign_to_option_list( $g_filter[FILTER_PROPERTY_HANDLER_ID], filter_get_included_projects() );
 	}?>
 		</select>
 		<?php
@@ -4046,7 +4046,7 @@ function print_filter_note_user_id() {
 				echo '>[' . lang_get( 'myself' ) . ']</option>';
 			}
 
-			print_note_option_list( $g_filter[FILTER_PROPERTY_NOTE_USER_ID] );
+			print_note_option_list( $g_filter[FILTER_PROPERTY_NOTE_USER_ID], filter_get_included_projects() );
 		}
 	?>
 	</select>

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -4839,3 +4839,21 @@ function filter_create_monitored_by( $p_project_id, $p_user_id ) {
 
 	return filter_ensure_valid_filter( $t_filter );
 }
+
+function filter_get_included_projects() {
+	global $g_filter;
+
+	if( 'simple' == $g_filter['_view_type'] ) {
+		# simple filters search in current project and desdendants
+		return user_get_all_accessible_projects( auth_get_current_user_id(), helper_get_current_project() );
+	} else {
+		# advanced filters search only in specified projects
+		$t_projects = $g_filter[FILTER_PROPERTY_PROJECT_ID];
+		# if there is the meta value "current", replace with actual project id
+		$t_meta_current = array_search( META_FILTER_CURRENT, $t_projects );
+		if( false !== $t_meta_current ) {
+			$t_projects[$t_meta_current] = helper_get_current_project();
+		}
+		return $t_projects;
+	}
+}

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -328,7 +328,8 @@ function print_user_option_list( $p_user_id, $p_project_id = null, $p_access = A
 
 /**
  * This populates the reporter option list with the appropriate users
- *
+ * Parameter for user id(s) will set those values as defaulted in
+ * the select input field.
  * @todo ugly functions  need to be refactored
  * @todo This function really ought to print out all the users, I think.
  *  I just encountered a situation where a project used to be public and

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -354,12 +354,23 @@ function print_user_option_list( $p_user_id, $p_project_id = null, $p_access = A
  *  actually reported the bugs at the time. Maybe we could get all user
  *  who are listed as the reporter in any bug?  It would probably be a
  *  faster query actually.
- * @param integer $p_user_id    A user identifier.
- * @param integer $p_project_id A project identifier.
+ * @param integer|array $p_user_id    A user identifier, or array of users
+ * @param integer|array $p_project_id A project identifier, or array of projects
  * @return void
  */
 function print_reporter_option_list( $p_user_id, $p_project_id = null ) {
-	print_user_option_list( $p_user_id, $p_project_id, config_get( 'report_bug_threshold' ) );
+	print_user_option_list( $p_user_id, $p_project_id, 'report_bug_threshold' );
+}
+
+/**
+ * This populates the reporter option list with the appropriate users
+ * Parameter for user id(s) will set those values as defaulted in
+ * the select input field.
+ * @param integer|array $p_user_id	A user identifier, or array of users
+ * @param integer|array $p_project_id	A project identifier, or array of projects
+ */
+function print_monitor_user_option_list( $p_user_id, $p_project_id = null ) {
+	print_user_option_list( $p_user_id, $p_project_id, 'monitor_bug_threshold' );
 }
 
 /**
@@ -535,30 +546,20 @@ function print_news_string_by_news_id( $p_news_id ) {
  * Print User option list for assigned to field
  * @param integer|string $p_user_id    A user identifier.
  * @param integer        $p_project_id A project identifier.
- * @param integer        $p_threshold  An access level.
  * @return void
  */
-function print_assign_to_option_list( $p_user_id = '', $p_project_id = null, $p_threshold = null ) {
-	if( null === $p_threshold ) {
-		$p_threshold = config_get( 'handle_bug_threshold' );
-	}
-
-	print_user_option_list( $p_user_id, $p_project_id, $p_threshold );
+function print_assign_to_option_list( $p_user_id, $p_project_id = null) {
+	print_user_option_list( $p_user_id, $p_project_id, 'handle_bug_threshold' );
 }
 
 /**
  * Print User option list for bugnote filter field
- * @param integer|string $p_user_id    A user identifier.
+ * @param integer|array $p_user_id    A user identifier, or array of ids
  * @param integer        $p_project_id A project identifier.
- * @param integer        $p_threshold  An access level.
  * @return void
  */
-function print_note_option_list( $p_user_id = '', $p_project_id = null, $p_threshold = null ) {
-	if( null === $p_threshold ) {
-		$p_threshold = config_get( 'add_bugnote_threshold' );
-	}
-
-	print_user_option_list( $p_user_id, $p_project_id, $p_threshold );
+function print_note_option_list( $p_user_id, $p_project_id = null ) {
+	print_user_option_list( $p_user_id, $p_project_id, 'add_bugnote_threshold' );
 }
 
 /**

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -261,46 +261,35 @@ function print_captcha_input( $p_field_name ) {
 
 /**
  * This populates an option list with the appropriate users by access level
- * @todo from print_reporter_option_list
+ * ALL_PROJECTS is a valid input, and show users from all accesible projects
+ * User ids passed asparameter are user to set the default checked state 
+ *  on select field
+ * Access parameter is an access threshold or array of acces levels, (e.g. those 
+ * from config option "report_bug_threshold")
  * @param integer|array $p_user_id    A user identifier or a list of them.
- * @param integer       $p_project_id A project identifier.
- * @param integer       $p_access     An access level.
+ * @param integer|array $p_project_id A project identifier, or array of prjects.
+ * @param integer|array $p_access     An access level.
  * @return void
  */
 function print_user_option_list( $p_user_id, $p_project_id = null, $p_access = ANYBODY ) {
-	$t_current_user = auth_get_current_user_id();
 
+	$t_current_user = auth_get_current_user_id();
 	if( null === $p_project_id ) {
 		$p_project_id = helper_get_current_project();
 	}
 
-	if( $p_project_id === ALL_PROJECTS ) {
-		$t_projects = user_get_accessible_projects( $t_current_user );
-
-		# Get list of users having access level for all accessible projects
-		$t_users = array();
-		foreach( $t_projects as $t_project_id ) {
-			$t_project_users_list = project_get_all_user_rows( $t_project_id, $p_access );
-			# Do a 'smart' merge of the project's user list, into an
-			# associative array (to remove duplicates)
-			foreach( $t_project_users_list as $t_id => $t_user ) {
-				$t_users[$t_id] = $t_user;
-			}
-			# Clear the array to release memory
-			unset( $t_project_users_list );
-		}
-		unset( $t_projects );
+	if( !is_array($p_project_id) && ALL_PROJECTS === (int)$p_project_id ) {
+		# expand ALL_PROJECTS
+		$t_projects = user_get_all_accessible_projects( $t_current_user, ALL_PROJECTS );
 	} else {
-		$t_users = project_get_all_user_rows( $p_project_id, $p_access );
+		$t_projects = $p_project_id;
 	}
-
+	
 	# Add the specified user ID to the list
 	# If we have an array of user IDs, then we've been called from a filter
 	# so don't add anything
-	if( !is_array( $p_user_id ) &&
-		$p_user_id != NO_USER &&
-		!array_key_exists( $p_user_id, $t_users )
-	) {
+	$t_user_rows = array();
+	if( !is_array( $p_user_id ) && $p_user_id != NO_USER ) {
 		$t_row = user_get_row( $p_user_id );
 		if( $t_row === false ) {
 			# User doesn't exist - create a dummy record for display purposes
@@ -309,38 +298,31 @@ function print_user_option_list( $p_user_id, $p_project_id = null, $p_access = A
 				'id' => $p_user_id,
 				'username' => $t_name,
 				'realname' => $t_name,
+				'access_level' => 0
 			);
 		}
-		$t_users[$p_user_id] = $t_row;
+		$t_user_rows[] = $t_row;
 	}
-
-	$t_display = array();
-	$t_sort = array();
-	$t_show_realname = ( ON == config_get( 'show_realname' ) );
-	$t_sort_by_last_name = ( ON == config_get( 'sort_by_last_name' ) );
-	foreach( $t_users as $t_key => $t_user ) {
-		$t_user_name = string_attribute( $t_user['username'] );
-		$t_sort_name = utf8_strtolower( $t_user_name );
-		if( $t_show_realname && ( $t_user['realname'] <> '' ) ) {
-			$t_user_name = string_attribute( $t_user['realname'] );
-			if( $t_sort_by_last_name ) {
-				$t_sort_name_bits = explode( ' ', utf8_strtolower( $t_user_name ), 2 );
-				$t_sort_name = ( isset( $t_sort_name_bits[1] ) ? $t_sort_name_bits[1] . ', ' : '' ) . $t_sort_name_bits[0];
-			} else {
-				$t_sort_name = utf8_strtolower( $t_user_name );
-			}
+	
+	$t_users = project_get_all_user_rows( $t_projects, $p_access, true, $t_user_rows );
+	
+	# If config is set to sort by last name, we have to sort the array
+	# otherwise, its already sorted by username or realname
+	if( ON == config_get( 'sort_by_last_name' ) ) {
+		$t_sort = array();
+		foreach( $t_users as $t_user ) {
+			# last name is already in field 'displayname'
+				$t_sort[] = strtolower( $t_user['displayname'] );
 		}
-		$t_display[] = $t_user_name;
-		$t_sort[] = $t_sort_name;
+		array_multisort( $t_sort, SORT_ASC, SORT_STRING, $t_users);
+		unset( $t_sort );
 	}
-	array_multisort( $t_sort, SORT_ASC, SORT_STRING, $t_users, $t_display );
-	unset( $t_sort );
-	$t_count = count( $t_users );
-	for( $i = 0;$i < $t_count;$i++ ) {
-		$t_row = $t_users[$i];
+	
+	# print the html options
+	foreach( $t_users as $t_row ) {
 		echo '<option value="' . $t_row['id'] . '" ';
 		check_selected( $p_user_id, (int)$t_row['id'] );
-		echo '>' . $t_display[$i] . '</option>';
+		echo '>' . $t_row['displayname'] . '</option>';
 	}
 }
 

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -592,122 +592,227 @@ function project_get_local_user_rows( $p_project_id ) {
 }
 
 /**
- * Return an array of info about users who have access to the the given project
- * For each user we have 'id', 'username', and 'access_level' (overall access level)
- * If the second parameter is given, return only users with an access level
- * higher than the given value.
- * if the first parameter is given as 'ALL_PROJECTS', return the global access level (without
- * any reference to the specific project
- * @param integer $p_project_id           A project identifier.
- * @param integer $p_access_level         Access level.
+ * Return an array of info about users who have access to the the given project(s)
+ * For each user we have:
+ * 'id', 'username', 'realname', 'displayname' and 'access_level' (overall access level)
+ * 'displayname' is calculated according to default preferences to contain 
+ * either 'username' or 'realname'.
+ * 
+ * Parameter inline_include is an array of user rows to be included in the result set,
+ * included here manually to benefit from native sorting.
+ * Note that if a user included by this method may appear in the actual results, 
+ * it should have the correct user_id to avoid duplicating it.
+ * 
+ * (see "project_get_all_user_rows" for more details about parameter uses)
+ * 
+ * The query is ordered by default config to sort either by username or realname.
+ * Sort by last name is NOT available becasue that is not a field in user table.
+ * In that case, external sort must be applied.
+ 
+ * @param integer|array		$p_project_id	Project id or rray of projects.
+ * @param integer|array|string $p_access_level  Access level threshold, or array of specific
+ *		 levels to match, or string for a access level name to be checked against each project
  * @param boolean $p_include_global_users Whether to include global users.
+ * @return complex|null unprocessed result set from db_query()
+ */
+function project_get_all_user_rows_dbquery( $p_projects , $p_access_level, $p_include_global_users = true, $p_inline_include = null ) {
+
+	if( NOBODY == $p_access_level ) {
+		return null;
+	}	
+	
+	# prepare for special cases
+	$t_force_global_access = null;
+	if( !is_array( $p_projects ) ) {
+		if( ALL_PROJECTS === (int)$p_projects ){
+			# bypass any specific project calculation, and store access level for later use
+			$t_force_global_access = access_convert_threshold_to_array( $p_access_level );
+			$p_projects = array();
+		} else {
+			# one single project: format as array
+			$p_projects = array( $p_projects );
+		}
+	}
+	
+	# Explode access levels and configuration for each project.
+	# Since we are fetching users for several projects, some configurations
+	#  can be project-dependant. Store all of them for later use.
+	# All access thresholds are normalized (to an array of numeric access levels)
+
+	# Access values arrays for each project, for requested config eg 'report_bug_threshold', eg arr[ pr_id => arr[40,50,90] ]A
+	$t_access_per_project =  array(); 
+	# Access values arrays for eachproject, for private project global users. eg arr[ pr_id => arr[40,50,90] ]
+	$t_private_per_project = array();
+	# Values of project visibitily for each project. eg arr[ pr_id => VS_PUBLIC ]
+	$t_viewstate_per_project = array();
+	# Consolidated access values for private project global users, eg arr[40,50,90]
+	$t_access_global_users = array();
+	
+	foreach( $p_projects as $t_pr ) {
+		# If access level is string, its a config permission that can be different for each project
+		if( is_string( $p_access_level ) ) {
+			# Get specific configuration for threshold
+			$t_config= config_get( $p_access_level, null, ALL_USERS, $t_pr );
+			if( null === $t_config ) $t_config= config_get( $p_access_level, null, ALL_USERS, ALL_PROJECTS );
+			if( null === $t_config ) $t_config= config_get_global( $p_access_level );
+			$t_access_per_project[$t_pr] = access_convert_threshold_to_array( $t_config );
+		} else {
+			# Apply access level parameter to all projects
+			$t_access_per_project[$t_pr] = access_convert_threshold_to_array( $p_access_level );
+		}
+		
+		# Get private_project_threshold configuration for each project
+		if( $p_include_global_users ){
+			$t_config= config_get( 'private_project_threshold', null, ALL_USERS, $t_pr );
+			if( null === $t_config ) $t_config= config_get( 'private_project_threshold', null, ALL_USERS, ALL_PROJECTS );
+			if( null === $t_config ) $t_config= config_get_global( 'private_project_threshold' );
+			$t_private_per_project[$t_pr] = access_convert_threshold_to_array( $t_config );
+		}
+		
+		# Get view state of projects
+		$t_viewstate_per_project[$t_pr] = project_get_field( $t_pr, 'view_state' );
+		
+		# Union of global users access values. This results in a consolidated array of common appearances.
+		if ( VS_PRIVATE === (int)$t_viewstate_per_project[$t_pr] ) {
+			# If project is private, add global access-level for which users are automatically included
+			$t_access_global_users = array_unique( array_merge( $t_access_global_users, $t_private_per_project[$t_pr] ) );
+		} else {
+			# If project is public, add global access threshold from requested input parameters
+			$t_access_global_users = array_unique( array_merge( $t_access_global_users, $t_access_per_project[$t_pr] ) );
+		}
+	}
+
+	$t_params = array();
+	$t_subquerys = array();
+
+	#
+	# prepare subquery for global users
+	#
+	if( $t_force_global_access ) {
+		# special case for ALL_PROJECTS, force the query for global users.
+		$t_access_global_users = $t_force_global_access;
+	}
+	if( $p_include_global_users && count( $t_access_global_users ) > 0 ) {
+		$t_global_access_clause = db_helper_in_clause( $t_access_global_users );
+		$t_params =  array_merge( $t_params, $t_access_global_users );
+				
+		$t_subquerys[] = 'SELECT U.id, U.username, U.realname, U.access_level'
+				. ' FROM {user} U'
+				. ' WHERE U.enabled=1 AND access_level ' . $t_global_access_clause;
+	}
+	
+	#
+	# Build subquery for project users
+	#
+	if( ALL_PROJECTS !== (int)$p_projects  ) {
+		$t_array_pairs = array();
+		# build project/access_level pairs
+		foreach( $p_projects as $t_pr ) {
+			foreach( $t_access_per_project[$t_pr] as $t_level ) {
+				$t_array_pairs[] = array( $t_pr, $t_level);
+			}
+		}
+		$t_access_clause = db_helper_in2_clause( $t_array_pairs );
+		$t_add_params = call_user_func_array('array_merge', $t_array_pairs);
+		$t_params = array_merge( $t_params, $t_add_params );
+		
+		$t_subquerys[] = 'SELECT U.id, U.username, U.realname, P.access_level'
+			. ' FROM {project_user_list} P JOIN {user} U'
+			. ' ON ( P.user_id = U.id )'
+			. ' WHERE U.enabled=1'
+			. ' AND (P.project_id, P.access_level) ' . $t_access_clause;
+	}
+	
+	#
+	# Build subquery for inline additions
+	#
+	if( $p_inline_include ) {
+		foreach( $p_inline_include as $t_row ) {
+			$t_sub = 'SELECT ' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ' FROM DUAL';
+			$t_add_params = array( $t_row['id'], $t_row['username'], $t_row['realname'], $t_row['access_level']);
+			$t_params = array_merge( $t_params, $t_add_params );
+			$t_subquerys[] = $t_sub;
+		}
+	}
+	
+	#
+	# Build main query
+	#
+	$t_sort_by_last_name = ( ON == config_get( 'sort_by_last_name' ) );
+	$t_show_realname = ON == config_get( 'show_realname' );
+	$t_union = '';
+	$t_display_field = ( $t_show_realname ) ? 'realname' : 'username';
+	$t_main_query = 'SELECT distinct id, username, realname, MAX(access_level) AS access_level, ' . $t_display_field . ' AS displayname'
+			. ' FROM (' . implode(' UNION ALL ', $t_subquerys ) . ') all_users'
+			. ' GROUP BY id, username, realname, displayname'
+			. ' ORDER BY ' . $t_display_field;
+
+	$t_result = db_query( $t_main_query, $t_params );
+	return $t_result;
+
+# Example of generated query:
+//	SELECT distinct id, username, realname, MAX(access_level) AS access_level, username AS displayname
+//	FROM (
+//		SELECT U.id, U.username, U.realname, U.access_level
+//			FROM mantis_user_table U
+//			WHERE U.enabled = 1 AND access_level = 90
+//		UNION ALL 
+//		SELECT U.id, U.username, U.realname, P.access_level
+//		FROM mantis_project_user_list_table P JOIN mantis_user_table U ON (P.user_id = U.id)
+//		WHERE U.enabled = 1 AND (P.project_id , P.access_level)
+//			IN ((21,25), (21,40), (21,55), (21,70), (21,90), (51,25), (51,40), (51,55), (51,70), (51,90))
+//		UNION ALL
+//		SELECT '-3','@@added','@@added','25' FROM DUAL
+//		) all_users
+//	GROUP BY id , username , realname , displayname
+//	ORDER BY username	
+}
+
+/**
+ * Return an array of info about users who have access to the the given project(s)
+ *  If the second parameter is given, using a single value returns only users with an access level
+ *  higher than the given value, using an array of values returns users who match the specified
+ *  access levels.
+ * If the first parameter is given as 'ALL_PROJECTS', return the global access level (without
+ *  any reference to the specific project.
+ * Access level can also be sepecified as string, meaning a config name that will be checked
+ *  against each project (eg, "report_bug_threshold")
+ * 
+ * @param integer|array $p_project_id      A project identifier, or array of projects
+ * @param integer|array $p_access_level    Access level threshold, or array of specific levels
+ * @param boolean $p_include_global_users  Whether to include global users.
  * @return array List of users, array key is user ID
  */
-function project_get_all_user_rows( $p_project_id = ALL_PROJECTS, $p_access_level = ANYBODY, $p_include_global_users = true ) {
-	$c_project_id = (int)$p_project_id;
+function project_get_all_user_rows( $p_project_id = ALL_PROJECTS, $p_access_level = ANYBODY, $p_include_global_users = true, $p_inline_include = null ) {
 
-	# Optimization when access_level is NOBODY
-	if( NOBODY == $p_access_level ) {
+	$t_result = project_get_all_user_rows_dbquery( $p_project_id, $p_access_level, $p_include_global_users, $p_inline_include );
+
+	if( $t_result ) {
+		$t_users = array();
+		$t_show_realname = ( ON == config_get( 'show_realname' ) );
+		$t_sort_by_last_name = ( ON == config_get( 'sort_by_last_name' ) );
+		while( $t_row = db_fetch_array( $t_result ) ) {
+			$t_key = (int)$t_row['id'];
+			$t_users[$t_key] = $t_row;
+
+			# fix realname if it was empty
+			if( $t_show_realname && $t_row['realname'] == '' ){
+				$t_users[$t_key]['displayname'] = $t_row['username'];
+			}
+			# calculate last name
+			if( $t_show_realname && $t_sort_by_last_name ) {
+				$t_name_bits = explode( ' ', utf8_strtolower( string_attribute( $t_row['realname']) ), 2 );
+				$t_users[$t_key]['displayname'] = ( isset( $t_name_bits[1] ) ? $t_name_bits[1] . ', ' : '' ) . $t_name_bits[0];
+			}
+		}
+
+		# @TODO Probably, there is no need to cache user data. If somewhere is necessary, could be done by the caller
+		user_cache_array_rows( array_keys( $t_users ) );
+		return $t_users;
+	}
+	else {
 		return array();
 	}
-
-	$t_on = ON;
-	$t_users = array();
-
-	$t_global_access_level = $p_access_level;
-	if( $c_project_id != ALL_PROJECTS && $p_include_global_users ) {
-
-		# looking for specific project
-		if( VS_PRIVATE == project_get_field( $p_project_id, 'view_state' ) ) {
-			# @todo (thraxisp) this is probably more complex than it needs to be
-			# When a new project is created, those who meet 'private_project_threshold' are added
-			# automatically, but don't have an entry in project_user_list_table.
-			#  if they did, you would not have to add global levels.
-			$t_private_project_threshold = config_get( 'private_project_threshold' );
-			if( is_array( $t_private_project_threshold ) ) {
-				if( is_array( $p_access_level ) ) {
-					# both private threshold and request are arrays, use intersection
-					$t_global_access_level = array_intersect( $p_access_level, $t_private_project_threshold );
-				} else {
-					# private threshold is an array, but request is a number, use values in threshold higher than request
-					$t_global_access_level = array();
-					foreach( $t_private_project_threshold as $t_threshold ) {
-						if( $p_access_level <= $t_threshold ) {
-							$t_global_access_level[] = $t_threshold;
-						}
-					}
-				}
-			} else {
-				if( is_array( $p_access_level ) ) {
-					# private threshold is a number, but request is an array, use values in request higher than threshold
-					$t_global_access_level = array();
-					foreach( $p_access_level as $t_threshold ) {
-						if( $t_threshold >= $t_private_project_threshold ) {
-							$t_global_access_level[] = $t_threshold;
-						}
-					}
-				} else {
-					# both private threshold and request are numbers, use maximum
-					$t_global_access_level = max( $p_access_level, $t_private_project_threshold );
-				}
-			}
-		}
-	}
-
-	if( is_array( $t_global_access_level ) ) {
-		if( 0 == count( $t_global_access_level ) ) {
-			$t_global_access_clause = '>= ' . NOBODY . ' ';
-		} else if( 1 == count( $t_global_access_level ) ) {
-			$t_global_access_clause = '= ' . array_shift( $t_global_access_level ) . ' ';
-		} else {
-			$t_global_access_clause = 'IN (' . implode( ',', $t_global_access_level ) . ')';
-		}
-	} else {
-		$t_global_access_clause = '>= ' . $t_global_access_level . ' ';
-	}
-
-	if( $p_include_global_users ) {
-		$t_query = 'SELECT id, username, realname, access_level
-				FROM {user}
-				WHERE enabled = ' . db_param() . '
-					AND access_level ' . $t_global_access_clause;
-
-		$t_result = db_query( $t_query, array( $t_on ) );
-		while( $t_row = db_fetch_array( $t_result ) ) {
-			$t_users[(int)$t_row['id']] = $t_row;
-		}
-	}
-
-	if( $c_project_id != ALL_PROJECTS ) {
-		# Get the project overrides
-		$t_query = 'SELECT u.id, u.username, u.realname, l.access_level
-				FROM {project_user_list} l, {user} u
-				WHERE l.user_id = u.id
-				AND u.enabled = ' . db_param() . '
-				AND l.project_id = ' . db_param();
-
-		$t_result = db_query( $t_query, array( $t_on, $c_project_id ) );
-
-		while( $t_row = db_fetch_array( $t_result ) ) {
-			if( is_array( $p_access_level ) ) {
-				$t_keep = in_array( $t_row['access_level'], $p_access_level );
-			} else {
-				$t_keep = $t_row['access_level'] >= $p_access_level;
-			}
-
-			if( $t_keep ) {
-				$t_users[(int)$t_row['id']] = $t_row;
-			} else {
-				# If user's overridden level is lower than required, so remove
-				#  them from the list if they were previously there
-				unset( $t_users[(int)$t_row['id']] );
-			}
-		}
-	}
-
-	user_cache_array_rows( array_keys( $t_users ) );
-
-	return $t_users;
 }
 
 /**

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -650,7 +650,7 @@ function project_get_all_user_rows_dbquery( $p_projects , $p_access_level, $p_in
 	
 	foreach( $p_projects as $t_pr ) {
 		# If access level is string, its a config permission that can be different for each project
-		if( is_string( $p_access_level ) ) {
+		if( !is_numeric( $p_access_level ) ) {
 			# Get specific configuration for threshold
 			$t_config= config_get( $p_access_level, null, ALL_USERS, $t_pr );
 			if( null === $t_config ) $t_config= config_get( $p_access_level, null, ALL_USERS, ALL_PROJECTS );

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -694,11 +694,11 @@ function project_get_all_user_rows_dbquery( $p_projects , $p_access_level, $p_in
 	}
 	if( $p_include_global_users && count( $t_access_global_users ) > 0 ) {
 		$t_global_access_clause = db_helper_in_clause( $t_access_global_users );
-		$t_params =  array_merge( $t_params, $t_access_global_users );
-				
 		$t_subquerys[] = 'SELECT U.id, U.username, U.realname, U.access_level'
 				. ' FROM {user} U'
-				. ' WHERE U.enabled=1 AND access_level ' . $t_global_access_clause;
+				. ' WHERE U.enabled=' . db_param() . ' AND access_level ' . $t_global_access_clause;
+		$t_params[] = ON;
+		$t_params =  array_merge( $t_params, $t_access_global_users );
 	}
 	
 	#
@@ -714,13 +714,13 @@ function project_get_all_user_rows_dbquery( $p_projects , $p_access_level, $p_in
 		}
 		$t_access_clause = db_helper_in2_clause( $t_array_pairs );
 		$t_add_params = call_user_func_array('array_merge', $t_array_pairs);
-		$t_params = array_merge( $t_params, $t_add_params );
-		
 		$t_subquerys[] = 'SELECT U.id, U.username, U.realname, P.access_level'
 			. ' FROM {project_user_list} P JOIN {user} U'
 			. ' ON ( P.user_id = U.id )'
-			. ' WHERE U.enabled=1'
+			. ' WHERE U.enabled=' . db_param()
 			. ' AND (P.project_id, P.access_level) ' . $t_access_clause;
+		$t_params[] = ON;
+		$t_params = array_merge( $t_params, $t_add_params );
 	}
 	
 	#

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -684,7 +684,6 @@ function project_get_all_user_rows_dbquery( $p_projects , $p_access_level, $p_in
 
 	$t_params = array();
 	$t_subquerys = array();
-
 	#
 	# prepare subquery for global users
 	#
@@ -696,8 +695,7 @@ function project_get_all_user_rows_dbquery( $p_projects , $p_access_level, $p_in
 		$t_global_access_clause = db_helper_in_clause( $t_access_global_users );
 		$t_subquerys[] = 'SELECT U.id, U.username, U.realname, U.access_level'
 				. ' FROM {user} U'
-				. ' WHERE U.enabled=' . db_param() . ' AND access_level ' . $t_global_access_clause;
-		$t_params[] = ON;
+				. ' WHERE U.enabled = ' . db_prepare_bool( true ) . ' AND access_level ' . $t_global_access_clause;
 		$t_params =  array_merge( $t_params, $t_access_global_users );
 	}
 	
@@ -717,9 +715,8 @@ function project_get_all_user_rows_dbquery( $p_projects , $p_access_level, $p_in
 		$t_subquerys[] = 'SELECT U.id, U.username, U.realname, P.access_level'
 			. ' FROM {project_user_list} P JOIN {user} U'
 			. ' ON ( P.user_id = U.id )'
-			. ' WHERE U.enabled=' . db_param()
+			. ' WHERE U.enabled = ' . db_prepare_bool( true )
 			. ' AND (P.project_id, P.access_level) ' . $t_access_clause;
-		$t_params[] = ON;
 		$t_params = array_merge( $t_params, $t_add_params );
 	}
 	

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -803,8 +803,6 @@ function project_get_all_user_rows( $p_project_id = ALL_PROJECTS, $p_access_leve
 			}
 		}
 
-		# @TODO Probably, there is no need to cache user data. If somewhere is necessary, could be done by the caller
-		user_cache_array_rows( array_keys( $t_users ) );
 		return $t_users;
 	}
 	else {


### PR DESCRIPTION
This is a rewrite of project_get_all_user_rows(). This function is the core functionality of higher level functions that creates user lists based on project assignation, access levels, etc. Mainly for printing user option list for selectable input fields (print_api, filter_api, ...)

The new functionality of this code allows querying on multiple projects, with a per-project access-level check. All the users are retrieved and sorted with one single database query.
Also, the printing of user list does not use temporary space and bypass cache in order to save memory usage.
This helps solving a bug of poor performance detected when user count is very large.

Also, as a direct consequence of allowing multi-project queries, some filter related bugs may be solved now. Example: include the actual filtered projects in the user list search fields, for reporter, monitoring user, etc. 

Regarding "print_user_option_list" improvements, here are some test that i have made to measure times and memory usage, to get an idea:

Test case, 20k users
(It was run in debug mode, and discarding the first run that usually takes longer)
Measuring memory usage with "memory_get_peak_usage(true)", and time with "microtime(true)" on begin and end of print_user_option_list()

For one single project (public)    
  * on branch master:
    * standard: 96468992 (96 MB) (5.34 s)
    * disabling user rows cache: 33554432 (33 MB) (2.9 s)
    
  * on modified branch:
    * sorted by username, realname: 5505024 (5 MB) (2.27 s)
    * sorted by lastname: 99876864 (99 MB) (4.99 s)
    * idem, but disabling cache: 30932992 (30 MB) (2.89 s)

For ALL_PROJECTS best case:
  * master: 115605504 (115 MB)   10.20 s
  * mod: 5505024 (5 MB) 2.11 s