### PR TITLE
CSS change margin unit px into rem

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -587,6 +587,7 @@ div.field-container {
 	width: 100%;
 	float: left;
 	margin: 0em 0em 1px 0em;
+	margin: 0em 0em 0.1rem 0em;
 	padding: 0em;
 }
 .field-container>.display-label,


### PR DESCRIPTION
Added the margin measure in 'rem' units,
keeping 'px' as fallback.
Seems like Safari on retina display renders
better the 0.1rem (as 1px equivalent)

Fixes #0017816