### PR TITLE
Improvements and bug fixes for Workflow Transitions page

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -671,6 +671,13 @@ div.form-container .info-text {
 	border-right: 1px solid #fff;
 	z-index: 0;
 }
+
+div.form-container .footer {
+	clear: both;
+	display: block;
+	padding: .5em;
+}
+
 .section-links,
 div.form-container .submit-button {
 	clear: both;

--- a/manage_config_workflow_page.php
+++ b/manage_config_workflow_page.php
@@ -503,7 +503,7 @@ if( $g_can_change_flags ) {
 		echo '<input name="revert" type="hidden" value="' . implode( ',', $g_overrides ) . '" />';
 		echo '<input name="project" type="hidden" value="' . $t_project . '" />';
 		echo '<input name="return" type="hidden" value="' . string_attribute( form_action_self() ) .'" />';
-		echo '<input type="submit" class="button" value=';
+		echo '<input type="submit" class="button" value="';
 		if( ALL_PROJECTS == $t_project ) {
 			echo lang_get( 'revert_to_system' );
 		} else {

--- a/manage_config_workflow_page.php
+++ b/manage_config_workflow_page.php
@@ -240,13 +240,19 @@ function threshold_begin( $p_section_name ) {
 function threshold_row( $p_threshold ) {
 	global $g_access, $g_can_change_flags;
 
+	$t_can_change_threshold = ( $g_access >= config_get_access( $p_threshold ) );
+
 	$t_file = config_get_global( $p_threshold );
 	$t_global = config_get( $p_threshold, null, ALL_USERS, ALL_PROJECTS );
 	$t_project = config_get( $p_threshold );
-	$t_can_change_threshold = ( $g_access >= config_get_access( $p_threshold ) );
-
 	$t_color = set_color_override( $t_file, $t_global, $t_project );
-	if( $t_can_change_threshold && $t_color != '' ) {
+
+	$t_file_access = config_get_global( 'admin_site_threshold' );
+	$t_global_access = config_get_access( $p_threshold, ALL_USERS, ALL_PROJECTS);
+	$t_project_access = config_get_access( $p_threshold );
+	$t_color_access = set_color_override( $t_file_access, $t_global_access, $t_project_access );
+
+	if( $t_can_change_threshold && ( $t_color != '' || $t_color_access != '' ) ) {
 		set_overrides( $p_threshold );
 	}
 
@@ -255,8 +261,8 @@ function threshold_row( $p_threshold ) {
 		echo '<td class="center ' . $t_color . '"><select name="threshold_' . $p_threshold . '">';
 		print_enum_string_option_list( 'status', $t_project );
 		echo '</select> </td>' . "\n";
-		echo '<td><select name="access_' . $p_threshold . '">';
-		print_enum_string_option_list( 'access_levels', config_get_access( $p_threshold ) );
+		echo '<td class="' . $t_color_access . '"><select name="access_' . $p_threshold . '">';
+		print_enum_string_option_list( 'access_levels', $t_project_access );
 		echo '</select> </td>' . "\n";
 		$g_can_change_flags = true;
 	} else {

--- a/manage_config_workflow_page.php
+++ b/manage_config_workflow_page.php
@@ -70,13 +70,23 @@ $g_overrides = array();
 
 /**
  * Set overrides
- * @param string $p_config Configuration value.
+ * @param string $p_config     Configuration value.
+ * @param bool   $p_can_change True if user has access level to change config
+ * @param string $p_color      CSS class name
  * @return void
  */
-function set_overrides( $p_config ) {
+function set_overrides( $p_config, $p_can_change, $p_color ) {
 	global $g_overrides;
-	if( !in_array( $p_config, $g_overrides ) ) {
-		$g_overrides[] = $p_config;
+
+	if( !$p_can_change ) {
+		return;
+	}
+
+	$t_project = helper_get_current_project();
+	if(    $t_project == ALL_PROJECTS && $p_color == COLOR_GLOBAL
+		|| $t_project != ALL_PROJECTS && $p_color == COLOR_PROJECT
+	) {
+		$g_overrides[$p_config] = $p_config;
 	}
 }
 
@@ -117,9 +127,7 @@ function show_flag( $p_from_status_id, $p_to_status_id ) {
 		$t_project = isset( $g_project_workflow['exit'][$p_from_status_id][$p_to_status_id] ) ? 1 : 0;
 
 		$t_color = set_color_override( $t_file, $t_global, $t_project );
-		if( $g_can_change_workflow && $t_color != '' ) {
-			set_overrides( 'status_enum_workflow' );
-		}
+		set_overrides( 'status_enum_workflow', $g_can_change_workflow, $t_color );
 		$t_value = '<td class="center ' . $t_color . '">';
 
 		$t_flag = ( 1 == $t_project );
@@ -194,9 +202,8 @@ function capability_row( $p_from_status ) {
 	$t_project = isset( $g_project_workflow['default'][$p_from_status] ) ? $g_project_workflow['default'][$p_from_status] : 0;
 
 	$t_color = set_color_override( $t_file, $t_global, $t_project );
-	if( $g_can_change_workflow && $t_color != '' ) {
-		set_overrides( 'status_enum_workflow' );
-	}
+	set_overrides( 'status_enum_workflow', $g_can_change_workflow, $t_color );
+
 	echo "\t\t\t" . '<td class="center ' . $t_color . '">';
 	if( $g_can_change_workflow ) {
 		echo '<select name="default_' . $p_from_status . '">';
@@ -250,15 +257,13 @@ function threshold_row( $p_threshold ) {
 	$t_global = config_get( $p_threshold, null, ALL_USERS, ALL_PROJECTS );
 	$t_project = config_get( $p_threshold );
 	$t_color = set_color_override( $t_file, $t_global, $t_project );
+	set_overrides( $p_threshold, $t_can_change_threshold, $t_color );
 
 	$t_file_access = config_get_global( 'admin_site_threshold' );
 	$t_global_access = config_get_access( $p_threshold, ALL_USERS, ALL_PROJECTS);
 	$t_project_access = config_get_access( $p_threshold );
 	$t_color_access = set_color_override( $t_file_access, $t_global_access, $t_project_access );
-
-	if( $t_can_change_threshold && ( $t_color != '' || $t_color_access != '' ) ) {
-		set_overrides( $p_threshold );
-	}
+	set_overrides( $p_threshold, $t_can_change_threshold, $t_color_access );
 
 	echo '<tr><td>' . lang_get( 'desc_' . $p_threshold ) . '</td>' . "\n";
 	if( $t_can_change_threshold ) {
@@ -330,9 +335,7 @@ function access_row() {
 
 			$t_can_change = ( $g_access >= config_get_access( 'report_bug_threshold' ) );
 			$t_color = set_color_override( $t_file_new, $t_global_new, $t_project_new );
-			if( $t_can_change  && $t_color != '' ) {
-				set_overrides( 'report_bug_threshold' );
-			}
+			set_overrides( 'report_bug_threshold', $t_can_change, $t_color );
 		} else {
 			# Other statuses
 
@@ -348,9 +351,7 @@ function access_row() {
 
 			$t_can_change = ( $g_access >= config_get_access( 'set_status_threshold' ) );
 			$t_color = set_color_override( $t_level_file, $t_level_global, $t_level_project );
-			if( $t_can_change  && $t_color != '' ) {
-				set_overrides( 'set_status_threshold' );
-			}
+			set_overrides( 'set_status_threshold', $t_can_change, $t_color );
 		}
 
 		if( $t_can_change ) {

--- a/manage_config_workflow_page.php
+++ b/manage_config_workflow_page.php
@@ -161,10 +161,9 @@ function show_flag( $p_from_status_id, $p_to_status_id ) {
 function section_begin( $p_section_name ) {
 	$t_enum_statuses = MantisEnum::getValues( config_get( 'status_enum_string' ) );
 	echo '<div class="form-container">'. "\n";
+	echo '<h2>' . $p_section_name . '</h2>' . "\n";
 	echo "\t<table>\n";
 	echo "\t\t<thead>\n";
-	echo "\t\t" . '<tr>' . "\n\t\t\t" . '<td class="form-title-caps" colspan="' . ( count( $t_enum_statuses ) + 2 ) . '">'
-		. $p_section_name . '</td>' . "\n\t\t" . '</tr>' . "\n";
 	echo "\t\t" . '<tr class="row-category2">' . "\n";
 	echo "\t\t\t" . '<th class="form-title width30" rowspan="2">' . lang_get( 'current_status' ) . '</th>'. "\n";
 	echo "\t\t\t" . '<th class="form-title" style="text-align:center" colspan="' . ( count( $t_enum_statuses ) + 1 ) . '">'
@@ -221,7 +220,19 @@ function capability_row( $p_from_status ) {
  * @return void
  */
 function section_end() {
-	echo '</tbody></table></div><br />' . "\n";
+	global $g_can_change_workflow;
+	echo '</tbody></table>' . "\n";
+
+	echo '<div class="footer">' . "\n";
+	if( $g_can_change_workflow ) {
+		echo lang_get( 'workflow_change_access_label' ) . "&nbsp;\n";
+		echo '<select name="workflow_access">' . "\n";
+		print_enum_string_option_list( 'access_levels', config_get_access( 'status_enum_workflow' ) );
+		echo "\n" . '</select>' . "\n";
+	}
+	echo '</div>' . "\n";
+
+	echo '</div><br />' . "\n";
 }
 
 /**
@@ -231,9 +242,9 @@ function section_end() {
  */
 function threshold_begin( $p_section_name ) {
 	echo '<div class="form-container">';
+	echo '<h2>' . $p_section_name . '</h2>' . "\n";
 	echo '<table>';
 	echo '<thead>';
-	echo "\t" . '<tr><td class="form-title" colspan="3">' . $p_section_name . '</td></tr>' . "\n";
 	echo "\t" . '<tr class="row-category2">';
 	echo "\t\t" . '<th class="form-title width30">' . lang_get( 'threshold' ) . '</th>' . "\n";
 	echo "\t\t" . '<th class="form-title" >' . lang_get( 'status_level' ) . '</th>' . "\n";
@@ -296,13 +307,13 @@ function threshold_end() {
  * @return void
  */
 function access_begin( $p_section_name ) {
-	echo '<div class="form-container">';
+	echo '<div class="form-container">' . "\n";
+	echo '<h2>' . $p_section_name . '</h2>' . "\n";
 	echo '<table>';
-	echo '<thead>';
-	echo "\t\t" . '<tr><td class="form-title" colspan="2">' . $p_section_name . '</td></tr>' . "\n";
+	echo '<thead>' . "\n";
 	echo "\t\t" . '<tr class="row-category2"><th class="form-title" colspan="2">' . lang_get( 'access_change' ) . '</th></tr>' . "\n";
-	echo '</thead>';
-	echo '<tbody>';
+	echo '</thead>' . "\n";
+	echo '<tbody>' . "\n";
 }
 
 /**
@@ -374,7 +385,21 @@ function access_row() {
  * @return void
  */
 function access_end() {
-	echo '</tbody></table></div><br />' . "\n";
+	global $g_access;
+
+	echo '</tbody></table>' . "\n";
+
+	echo '<div class="footer">' . "\n";
+	if( $g_access >= config_get_access( 'set_status_threshold' ) ) {
+		echo lang_get( 'access_change_access_label' ) . "&nbsp;\n";
+		echo '<select name="status_access">' . "\n\t\t";
+		print_enum_string_option_list( 'access_levels', config_get_access( 'set_status_threshold' ) );
+		echo "\n" . '</select>' . "\n";
+	}
+	echo '</div>' . "\n";
+
+	echo '</div>' . "\n";
+	echo '<br />' . "\n\n";
 }
 
 echo '<br /><br />';
@@ -454,7 +479,6 @@ if( !is_array( config_get( 'bug_submit_status' ) ) ) {
 threshold_row( 'bug_resolved_status_threshold' );
 threshold_row( 'bug_reopen_status' );
 threshold_end();
-echo '<br />';
 
 if( '' <> $t_validation_result ) {
 	echo '<table class="width100">';
@@ -478,31 +502,23 @@ foreach ( $t_status_arr as $t_from_status => $t_from_label ) {
 }
 section_end();
 
-if( $g_can_change_workflow ) {
-	echo '<p>' . lang_get( 'workflow_change_access_label' );
-	echo '<select name="workflow_access">';
-	print_enum_string_option_list( 'access_levels', config_get_access( 'status_enum_workflow' ) );
-	echo '</select> </p><br />';
-}
-
 # display the access levels required to move an issue
+echo "\n\n";
 access_begin( lang_get( 'access_levels' ) );
 access_row();
 access_end();
 
-if( $g_access >= config_get_access( 'set_status_threshold' ) ) {
-	echo '<p>' . lang_get( 'access_change_access_label' );
-	echo '<select name="status_access">';
-	print_enum_string_option_list( 'access_levels', config_get_access( 'set_status_threshold' ) );
-	echo '</select> </p><br />';
-}
-
 if( $g_can_change_flags ) {
+	echo '<div class="center">' . "\n";
 	echo '<input type="submit" class="button" value="' . lang_get( 'change_configuration' ) . '" />' . "\n";
+	echo '</div>' . "\n";
+
 	echo '</form>' . "\n";
 
 	if( 0 < count( $g_overrides ) ) {
-		echo '<div class="right"><form id="mail_config_action" method="post" action="manage_config_revert.php">' ."\n";
+		echo '<div class="form-container">';
+		echo '<div class="submit-button">' . "\n";
+		echo '<form id="mail_config_action" method="post" action="manage_config_revert.php">' ."\n";
 		echo '<fieldset>' . "\n";
 		echo form_security_field( 'manage_config_revert' );
 		echo '<input name="revert" type="hidden" value="' . implode( ',', $g_overrides ) . '" />';
@@ -516,8 +532,10 @@ if( $g_can_change_flags ) {
 		}
 		echo '" />' . "\n";
 		echo '</fieldset>' . "\n";
-		echo '</form></div>' . "\n";
+		echo '</form>' . "\n";
+		echo '</div></div>' . "\n";
 	}
+
 
 } else {
 	echo '</form>' . "\n";

--- a/manage_config_workflow_page.php
+++ b/manage_config_workflow_page.php
@@ -58,6 +58,10 @@ html_page_top( lang_get( 'manage_workflow_config' ) );
 print_manage_menu( 'adm_permissions_report.php' );
 print_manage_config_menu( 'manage_config_workflow_page.php' );
 
+# CSS class names for overrides color coding
+define( 'COLOR_GLOBAL', 'color-global' );
+define( 'COLOR_PROJECT', 'color-project' );
+
 $g_access = current_user_get_access_level();
 $t_project = helper_get_current_project();
 $g_can_change_workflow = ( $g_access >= config_get_access( 'status_enum_workflow' ) );
@@ -86,9 +90,9 @@ function set_overrides( $p_config ) {
  */
 function set_color_override( $p_level_file, $p_level_global, $p_level_project ) {
 	if( $p_level_project != $p_level_global ) {
-		$t_color = 'color-project';
+		$t_color = COLOR_PROJECT;
 	} else if( $p_level_global != $p_level_file ) {
-		$t_color = 'color-global';
+		$t_color = COLOR_GLOBAL;
 	} else {
 		$t_color = '';
 	}
@@ -437,9 +441,9 @@ if( ALL_PROJECTS == $t_project ) {
 echo '<p class="bold">' . $t_project_title . '</p>' . "\n";
 echo '<p>' . lang_get( 'colour_coding' ) . '<br />';
 if( ALL_PROJECTS <> $t_project ) {
-	echo '<span class="color-project">' . lang_get( 'colour_project' ) .'</span><br />';
+	echo '<span class="' . COLOR_PROJECT . '">' . lang_get( 'colour_project' ) .'</span><br />';
 }
-echo '<span class="color-global">' . lang_get( 'colour_global' ) . '</span></p>';
+echo '<span class="' . COLOR_GLOBAL . '">' . lang_get( 'colour_global' ) . '</span></p>';
 
 # show the settings used to derive the table
 threshold_begin( lang_get( 'workflow_thresholds' ) );

--- a/manage_config_workflow_set.php
+++ b/manage_config_workflow_set.php
@@ -90,7 +90,7 @@ foreach( $t_valid_thresholds as $t_threshold ) {
 	if( $t_access >= $t_access_current ) {
 		$f_value = gpc_get( 'threshold_' . $t_threshold );
 		$t_value_current = config_get( $t_threshold );
-		$t_value_parent = config_get_parent( $t_project, 'threshold_' . $t_threshold );
+		$t_value_parent = config_get_parent( $t_project, $t_threshold );
 		$f_access = gpc_get( 'access_' . $t_threshold );
 		if( $f_value == $t_value_parent && $f_access == $t_access_current ) {
 			# If new value is equal to parent and access has not changed

--- a/manage_config_workflow_set.php
+++ b/manage_config_workflow_set.php
@@ -68,6 +68,21 @@ function config_get_parent( $p_project, $p_option ) {
 	}
 }
 
+/**
+ * Retrieves the access level needed to change the configuration option in the
+ * project's parent (ALL_PROJECTS level if project, or file-level if all projects)
+ * @param integer $p_project Project.
+ * @param string  $p_option  Configuration option to retrieve.
+ * @return integer access level
+ */
+function config_get_access_parent( $p_project, $p_option ) {
+	if( $p_project == ALL_PROJECTS ) {
+		return config_get_global( 'admin_site_threshold' );
+	} else {
+		return config_get_access( $p_option, null, ALL_PROJECTS );
+	}
+}
+
 
 $t_can_change_level = min( config_get_access( 'notify_flags' ), config_get_access( 'default_notify_flags' ) );
 access_ensure_project_level( $t_can_change_level );
@@ -91,8 +106,11 @@ foreach( $t_valid_thresholds as $t_threshold ) {
 		$f_value = gpc_get( 'threshold_' . $t_threshold );
 		$t_value_current = config_get( $t_threshold );
 		$t_value_parent = config_get_parent( $t_project, $t_threshold );
+
 		$f_access = gpc_get( 'access_' . $t_threshold );
-		if( $f_value == $t_value_parent && $f_access == $t_access_current ) {
+		$t_access_parent = config_get_access_parent( $t_project, $t_threshold );
+
+		if( $f_value == $t_value_parent && $f_access == $t_access_parent ) {
 			# If new value is equal to parent and access has not changed
 			config_delete( $t_threshold, ALL_USERS, $t_project );
 		} else if( $f_value != $t_value_current || $f_access != $t_access_current ) {

--- a/manage_config_workflow_set.php
+++ b/manage_config_workflow_set.php
@@ -90,8 +90,9 @@ foreach( $t_valid_thresholds as $t_threshold ) {
 	if( $t_access >= $t_access_current ) {
 		$f_value = gpc_get( 'threshold_' . $t_threshold );
 		$t_value_current = config_get( $t_threshold );
+		$t_value_parent = config_get_parent( $t_project, 'threshold_' . $t_threshold );
 		$f_access = gpc_get( 'access_' . $t_threshold );
-		if( $f_value == $t_value_current && $f_access == $t_access_current ) {
+		if( $f_value == $t_value_parent && $f_access == $t_access_current ) {
 			# If new value is equal to parent and access has not changed
 			config_delete( $t_threshold, ALL_USERS, $t_project );
 		} else if( $f_value != $t_value_current || $f_access != $t_access_current ) {
@@ -165,10 +166,10 @@ if( config_get_access( 'status_enum_workflow' ) <= $t_access ) {
 }
 
 # process the access level changes
-if( config_get_access( 'status_enum_workflow' ) <= $t_access ) {
+if( config_get_access( 'set_status_threshold' ) <= $t_access ) {
 	# get changes to access level to change these values
 	$f_access = gpc_get( 'status_access' );
-	$t_access_current = config_get_access( 'status_enum_workflow' );
+	$t_access_current = config_get_access( 'set_status_threshold' );
 
 	# Build access level reference arrays (parent level and current config)
 	$t_set_parent = config_get_parent( $t_project, 'set_status_threshold' );
@@ -196,7 +197,7 @@ if( config_get_access( 'status_enum_workflow' ) <= $t_access ) {
 	foreach( $t_enum_status as $t_status_id => $t_status_label ) {
 		$f_level = gpc_get_int( 'access_change_' . $t_status_id );
 		if( config_get( 'bug_submit_status' ) == $t_status_id ) {
-			if( $f_level != config_get( 'report_bug_threshold' ) ) {
+			if( $f_level != $t_set_parent[$t_status_id] ) {
 				config_set( 'report_bug_threshold', (int)$f_level, ALL_USERS, $t_project, $f_access );
 			} else {
 				config_delete( 'report_bug_threshold', ALL_USERS, $t_project );

--- a/manage_config_workflow_set.php
+++ b/manage_config_workflow_set.php
@@ -160,6 +160,7 @@ if( config_get_access( 'status_enum_workflow' ) <= $t_access ) {
 	}
 
 	# Get the parent's workflow, if not set default to all transitions
+	$t_access_parent = config_get_access_parent( $t_project, 'status_enum_workflow' );
 	$t_access_current = config_get_access( 'status_enum_workflow' );
 	$t_workflow_parent = config_get_parent( $t_project, 'status_enum_workflow' );
 	if( 0 == count( $t_workflow_parent ) ) {
@@ -174,7 +175,7 @@ if( config_get_access( 'status_enum_workflow' ) <= $t_access ) {
 		}
 	}
 
-	if( $t_workflow == $t_workflow_parent && $f_access == $t_access_current ) {
+	if( $t_workflow == $t_workflow_parent && $f_access == $t_access_parent ) {
 		# If new value is equal to parent and access has not changed
 		config_delete( 'status_enum_workflow', ALL_USERS, $t_project );
 	} else if( $t_workflow != config_get( 'status_enum_workflow' ) || $f_access != $t_access_current ) {
@@ -187,6 +188,7 @@ if( config_get_access( 'status_enum_workflow' ) <= $t_access ) {
 if( config_get_access( 'set_status_threshold' ) <= $t_access ) {
 	# get changes to access level to change these values
 	$f_access = gpc_get( 'status_access' );
+	$t_access_parent = config_get_access_parent( $t_project, 'set_status_threshold' );
 	$t_access_current = config_get_access( 'set_status_threshold' );
 
 	# Build access level reference arrays (parent level and current config)
@@ -227,7 +229,7 @@ if( config_get_access( 'set_status_threshold' ) <= $t_access ) {
 		}
 	}
 
-	if( $t_set_new == $t_set_parent && $f_access == $t_access_current ) {
+	if( $t_set_new == $t_set_parent && $f_access == $t_access_parent ) {
 		# If new value is equal to parent and access has not changed
 		config_delete( 'set_status_threshold', ALL_USERS, $t_project );
 	} else if( $t_set_new != $t_set_current || $f_access != $t_access_current ) {


### PR DESCRIPTION
This PR fixes several issues with manage_config_workflow_page.php / manage_config_workflow_set.php, and improves behavior and display.

This branch started off with @cproensa's PR https://github.com/mantisbt/mantisbt/pull/646, and evolved to include the following changes
- Original commit (modified: whitespace fixes, reworded), fixes [#19970](https://www.mantisbt.org/bugs/view.php?id=19970)
- Fix a system warning introduced by the original commit
- Display color override for access level
- Proper fix for access level resets when updating workflow ([#16771](https://www.mantisbt.org/bugs/view.php?id=16771))
- Fix a regression introduced by b78f966e013d494ea27d92bba39d797a1266b7b7 ([#20241](https://www.mantisbt.org/bugs/view.php?id=20241))
- Do not display *Delete* button when there's nothing to delete ([#6847](https://www.mantisbt.org/bugs/view.php?id=6847))
- Adjust CSS/HTML and improve page layout
