### PR TITLE
CSS add outline to field-container div

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -591,6 +591,7 @@ div.field-container {
 	width: 100%;
 	float: left;
 	margin: 0em 0em 1px 0em;
+	outline: 1px solid #fff;
 	padding: 0em;
 }
 .field-container>.display-label,


### PR DESCRIPTION
Added the property 'outline' to the field-container
div class.
Seems like it has a more consistent rendering that
margins or borders defined at 1px
Keep the previous definition of margin 1px as fallback
for old browsers

see issue [#0017816](https://www.mantisbt.org/bugs/view.php?id=0017816)