### PR TITLE
Check workflow for reopening bug

### DIFF
--- a/core/access_api.php
+++ b/core/access_api.php
@@ -560,6 +560,13 @@ function access_can_reopen_bug( BugData $p_bug, $p_user_id = null ) {
 		$p_user_id = auth_get_current_user_id();
 	}
 
+	$t_reopen_status = config_get( 'bug_reopen_status', null, null, $p_bug->project_id );
+
+	# Reopen status must be reachable by workflow
+	if( !bug_check_workflow( $p_bug->status, $t_reopen_status ) ) {
+		return false;
+	}
+
 	# If allow_reporter_reopen is enabled, then reporters can always reopen
 	# their own bugs as long as their access level is reporter or above
 	if( ON == config_get( 'allow_reporter_reopen', null, null, $p_bug->project_id )
@@ -572,7 +579,6 @@ function access_can_reopen_bug( BugData $p_bug, $p_user_id = null ) {
 	# Other users's access level must allow them to reopen bugs
 	$t_reopen_bug_threshold = config_get( 'reopen_bug_threshold', null, null, $p_bug->project_id );
 	if( access_has_bug_level( $t_reopen_bug_threshold, $p_bug->id, $p_user_id ) ) {
-		$t_reopen_status = config_get( 'bug_reopen_status', null, null, $p_bug->project_id );
 
 		# User must be allowed to change status to reopen status
 		$t_reopen_status_threshold = access_get_status_threshold( $t_reopen_status, $p_bug->project_id );


### PR DESCRIPTION
Add a check to access_can_reopen_bug() for
testing if the reopen status is reachable
by current workflow configuration.
In case the status is not reachable, returns
false.

Currently, the reopen operation would fail
anyway at the moment of changing status.
With this early check, a fail can be detected
before the action is made.

A direct benefit from this is that the
"reopen" button is not shown to the user if
the reopen action is not possible

Fix #0020256