### PR TITLE
Cache user data for view_all page

### DIFF
--- a/view_all_bug_page.php
+++ b/view_all_bug_page.php
@@ -74,17 +74,19 @@ if( $t_rows === false ) {
 }
 
 $t_bugslist = array();
-$t_users_handlers = array();
-$t_project_ids  = array();
+$t_unique_user_ids = array();
+$t_unique_project_ids = array();
 $t_row_count = count( $t_rows );
 for( $i=0; $i < $t_row_count; $i++ ) {
 	array_push( $t_bugslist, $t_rows[$i]->id );
-	$t_users_handlers[] = $t_rows[$i]->handler_id;
-	$t_project_ids[] = $t_rows[$i]->project_id;
+	$t_handler_id = $t_rows[$i]->handler_id;
+	$t_unique_user_ids[$t_handler_id] = $t_handler_id;
+	$t_reporter_id = $t_rows[$i]->reporter_id;
+	$t_unique_user_ids[$t_reporter_id] = $t_reporter_id;
+	$t_project_id = $t_rows[$i]->project_id;
+	$t_unique_project_ids[$t_project_id] = $t_project_id;
 }
-$t_unique_users_handlers = array_unique( $t_users_handlers );
-$t_unique_project_ids = array_unique( $t_project_ids );
-user_cache_array_rows( $t_unique_users_handlers );
+user_cache_array_rows( $t_unique_user_ids );
 project_cache_array_rows( $t_unique_project_ids );
 
 gpc_set_cookie( config_get( 'bug_list_cookie' ), implode( ',', $t_bugslist ) );


### PR DESCRIPTION
Cache the array of user ids that appear in the bug set to show.
This saves later individual sql queries from user_cache_row()

https://www.mantisbt.org/bugs/view.php?id=20258