### PR TITLE
Fix query order in history get range result

### DIFF
--- a/core/history_api.php
+++ b/core/history_api.php
@@ -213,7 +213,7 @@ function history_get_range_result( $p_bug_id = null, $p_start_time = null, $p_en
 		$t_query .= ' WHERE ' . implode( ' AND ', $t_where );
 	}
 
-	$t_query .= ' ORDER BY date_modified ' . $t_history_order . ',id';
+	$t_query .= ' ORDER BY date_modified ' . $t_history_order . ',id ' . $t_history_order;
 
 	$t_result = db_query( $t_query, $t_params );
 


### PR DESCRIPTION
Fixes the query order to be consistent.
When the query is requested as DESC ordered,
some events, created simultaneously, were
showed in reverse order than their creation,
because id field was still being sorted by
default (ASC) order.

However: probably, order by 'date_modified' is redundant if 'id' sequence is assumed to be chronological already?