### PR TITLE
Support tokens in addition to passwords for API usage

### DIFF
--- a/account_page.php
+++ b/account_page.php
@@ -86,11 +86,18 @@ current_user_ensure_unprotected();
 
 html_page_top( lang_get( 'account_link' ) );
 
+$t_user_id = auth_get_current_user_id();
+
 # extracts the user information for the currently logged in user
 # and prefixes it with u_
-$t_row = user_get_row( auth_get_current_user_id() );
+$t_row = user_get_row( $t_user_id );
 
 extract( $t_row, EXTR_PREFIX_ALL, 'u' );
+
+if ( is_blank( $u_token ) ) {
+	$u_token = auth_generate_secret_token();
+	user_set_field( $t_user_id, 'token', $u_token );
+}
 
 $t_ldap = ( LDAP == config_get( 'login_method' ) );
 
@@ -229,6 +236,15 @@ if( $t_force_pw_reset ) {
 				<span class="input"><span class="field-value"><?php echo get_enum_element( 'access_levels', current_user_get_access_level() ); ?></span></span>
 				<span class="label-style"></span>
 			</div>
+			<div class="field-container">
+				<span class="display-label">
+					<span>
+						<?php echo lang_get( 'user_token' ) . '<br />' . lang_get( 'user_token_description' ); ?>
+					</span>
+				</span>
+				<span class="input"><span class="field-value"><?php echo $u_token; ?></span></span>
+				<span class="label-style"></span>
+			</div>
 			<?php
 			$t_projects = user_get_assigned_projects( auth_get_current_user_id() );
 			if( count( $t_projects ) > 0 ) {
@@ -257,18 +273,25 @@ if( $t_force_pw_reset ) {
 		</fieldset>
 	</form>
 </div>
+
+<div class="form-container">
+	<fieldset>
+	<span class="submit-button">
+<form method="post" action="account_revoke_token.php">
+		<?php echo form_security_field( 'account_revoke_token' ) ?>
+		<input type="submit" class="button" value="<?php echo lang_get( 'revoke_token_button' ) ?>" />
+</form>
+
 <?php # check if users can't delete their own accounts
 if( ON == config_get( 'allow_account_delete' ) ) { ?>
-
-<!-- Delete Button -->
-<div class="form-container">
+	<!-- Delete Button -->
 	<form method="post" action="account_delete.php">
-		<fieldset>
 			<?php echo form_security_field( 'account_delete' ) ?>
-			<span class="submit-button"><input type="submit" class="button" value="<?php echo lang_get( 'delete_account_button' ) ?>" /></span>
-		</fieldset>
+			<input type="submit" class="button" value="<?php echo lang_get( 'delete_account_button' ) ?>" />
 	</form>
-</div>
 <?php
 }
+
+echo '</span></fieldset></div>';
+
 html_page_bottom();

--- a/account_revoke_token.php
+++ b/account_revoke_token.php
@@ -1,0 +1,47 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * This page stores the reported bug
+ *
+ * @package MantisBT
+ * @copyright Copyright 2000 - 2002  Kenzaburo Ito - kenito@300baud.org
+ * @copyright Copyright 2002  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ *
+ * @uses authentication_api.php
+ * @uses core.php
+ * @uses print_api.php
+ * @uses user_api.php
+ */
+
+require_once( 'core.php' );
+require_api( 'authentication_api.php' );
+require_api( 'print_api.php' );
+require_api( 'user_api.php' );
+
+auth_ensure_user_authenticated();
+auth_reauthenticate();
+
+$t_user_id = auth_get_current_user_id();
+
+user_ensure_unprotected( $t_user_id );
+
+$t_token = auth_generate_secret_token();
+user_set_field( $t_user_id, 'token', $t_token );
+
+print_successful_redirect( 'account_page.php' );
+

--- a/admin/schema.php
+++ b/admin/schema.php
@@ -750,5 +750,9 @@ $g_upgrade[197] = array( 'AlterColumnSQL', array( db_get_table( 'user' ), "realn
 $g_upgrade[198] = array( 'AlterColumnSQL', array( db_get_table( 'user' ), "password C(64) $t_notnull DEFAULT \" '' \"" ) );
 $g_upgrade[199] = array( 'AlterColumnSQL', array( db_get_table( 'user' ), "email C(255) $t_notnull DEFAULT \" '' \"" ) );
 
-# Release marker: 1.3.0-beta.1
+# Release marker: 1.3.0-beta.3
+
+$g_upgrade[200] = array( 'AddColumnSQL',array( db_get_table( 'user' ), 'token C(128) ' . $t_notnull . ' DEFAULT " \'\' "' ) );
+
 # Release marker: 1.3.0
+

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -360,6 +360,9 @@ $s_access_level_label = 'Access Level';
 $s_update_user_button = 'Update User';
 $s_verify_warning = 'Your account information has been verified. The account confirmation message you have received is now invalid.';
 $s_verify_change_password = 'You must set a password here to allow you to log in again.';
+$s_user_token = 'Secret Token';
+$s_user_token_description = '(used for API access and integrations)';
+$s_revoke_token_button = 'Revoke Token';
 
 # account_prefs_page.php
 $s_default_account_preferences_title = 'Account Preferences';


### PR DESCRIPTION
- Schema change to add token field to user table with empty default.
- Account page populates the token, if empty, before displaying it.
- Ability to revoke a token and get a new one from account page.
- API authentications accepts tokens or passwords in the password field.  Header support will be added later.

This is phase 1 which provides the basic functionality + the language strings + the schema change.  There will be follow up work to support tokens to be passed in headers in the API.

<img width="865" alt="screenshot 2015-11-22 09 00 59" src="https://cloud.githubusercontent.com/assets/6446/11325021/a306e1b4-90f7-11e5-8027-47248a31836f.png">

Issue [#17766](https://www.mantisbt.org/bugs/view.php?id=17766)