### PR TITLE
Fix email notifications for re-assign / unassign

### DIFF
--- a/bug_update.php
+++ b/bug_update.php
@@ -424,9 +424,8 @@ if( $t_resolve_issue ) {
 	email_relationship_child_closed( $f_bug_id );
 } else if( $t_reopen_issue ) {
 	email_bug_reopened( $f_bug_id );
-} else if( $t_existing_bug->handler_id === NO_USER &&
-           $t_updated_bug->handler_id !== NO_USER ) {
-	email_bug_assigned( $f_bug_id );
+} else if( $t_existing_bug->handler_id !== $t_updated_bug->handler_id ) {
+	email_owner_changed( $f_bug_id, $t_existing_bug->handler_id, $t_updated_bug->handler_id );
 } else if( $t_existing_bug->status !== $t_updated_bug->status ) {
 	$t_new_status_label = MantisEnum::getLabel( config_get( 'status_enum_string' ), $t_updated_bug->status );
 	$t_new_status_label = str_replace( ' ', '_', $t_new_status_label );

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -693,9 +693,9 @@ class BugData {
 
 		# allow bypass if user is sending mail separately
 		if( false == $p_bypass_mail ) {
-			# bug assigned
+			# If handler changes, send out owner change email
 			if( $t_old_data->handler_id != $this->handler_id ) {
-				email_bug_assigned( $c_bug_id );
+				email_owner_changed( $c_bug_id, $t_old_data->handler_id, $this->handler_id );
 				return true;
 			}
 
@@ -1668,8 +1668,8 @@ function bug_assign( $p_bug_id, $p_user_id, $p_bugnote_text = '', $p_bugnote_pri
 
 		bug_clear_cache( $p_bug_id );
 
-		# send assigned to email
-		email_bug_assigned( $p_bug_id );
+		# Send email for change of handler
+		email_owner_changed( $p_bug_id, $h_handler_id, $p_user_id );
 	}
 
 	return true;

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -829,12 +829,25 @@ function email_bug_reopened( $p_bug_id ) {
 }
 
 /**
- * send notices when a bug is ASSIGNED
+ * Send notices when a bug handler is changed.
  * @param int $p_bug_id
+ * @param int $p_prev_handler_id
+ * @param int $p_new_handler_id
  * @return null
  */
-function email_bug_assigned( $p_bug_id ) {
-	email_generic( $p_bug_id, 'owner', 'email_notification_title_for_action_bug_assigned' );
+function email_owner_changed($p_bug_id, $p_prev_handler_id, $p_new_handler_id ) {
+	$t_message_id = $p_new_handler_id == NO_USER ?
+			'email_notification_title_for_action_bug_unassigned' :
+			'email_notification_title_for_action_bug_assigned';
+
+	$t_extra_user_ids_to_email = array();
+	if ( $p_prev_handler_id !== NO_USER && $p_prev_handler_id != $p_new_handler_id ) {
+		if ( email_notify_flag( 'owner', 'handler' ) == ON ) {
+			$t_extra_user_ids_to_email[] = $p_prev_handler_id;
+		}
+	}
+
+	email_generic( $p_bug_id, 'owner', $t_message_id, /* headers */ null, $t_extra_user_ids_to_email );
 }
 
 /**

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -291,6 +291,7 @@ $s_email_notification_title_for_status_bug_resolved = 'The following issue has b
 $s_email_notification_title_for_status_bug_closed = 'The following issue has been CLOSED';
 $s_email_notification_title_for_action_bug_submitted = 'The following issue has been SUBMITTED.';
 $s_email_notification_title_for_action_bug_assigned = 'The following issue has been ASSIGNED.';
+$s_email_notification_title_for_action_bug_unassigned = 'The following issue has been UNASSIGNED.';
 $s_email_notification_title_for_action_bug_reopened = 'The following issue has been REOPENED.';
 $s_email_notification_title_for_action_bug_deleted = 'The following issue has been DELETED.';
 $s_email_notification_title_for_action_bug_updated = 'The following issue has been UPDATED.';


### PR DESCRIPTION
- When an issue is unassigned, trigger an "unassigned" notification and
include the user that was unassigned.
- When an issue is re-assigned, trigger an "owner" change notification,
rather than issue update.

Fixes #19731
Fixes #20321