### PR TITLE
Provide config option to disable subprojects

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -4069,6 +4069,13 @@ $g_due_date_view_threshold = NOBODY;
 ################
 
 /**
+ * Whether sub-projects feature should be enabled.  Before turning this flag OFF,
+ * make sure all sub-projects are moved to top level projects, otherwise
+ * they won't be accessible.
+ */
+$g_subprojects_enabled = ON;
+
+/**
  * Sub-projects should inherit categories from parent projects.
  */
 $g_subprojects_inherit_categories = ON;

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -610,6 +610,10 @@ function print_project_option_list( $p_project_id = null, $p_include_all_project
  * @return void
  */
 function print_subproject_option_list( $p_parent_id, $p_project_id = null, $p_filter_project_id = null, $p_trace = false, $p_can_report_only = false, array $p_parents = array() ) {
+	if ( config_get( 'subprojects_enabled' ) == OFF ) {
+		return;
+	}
+
 	array_push( $p_parents, $p_parent_id );
 	$t_user_id = auth_get_current_user_id();
 	$t_project_ids = user_get_accessible_subprojects( $t_user_id, $p_parent_id );

--- a/docbook/Admin_Guide/en-US/config/subprojects.xml
+++ b/docbook/Admin_Guide/en-US/config/subprojects.xml
@@ -7,6 +7,16 @@
 
 	<variablelist>
 		<varlistentry>
+			<term>$g_subprojects_enabled</term>
+			<listitem>
+				<para>
+					Whether sub-projects feature should be enabled.  Before turning this flag OFF,
+					make sure all sub-projects are moved to top level projects, otherwise
+					they won't be accessible.  The default value is ON.
+				</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
 			<term>$g_subprojects_inherit_versions</term>
 			<listitem>
 				<para>

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -172,6 +172,9 @@ if( access_has_global_level( config_get( 'delete_project_threshold' ) ) ) { ?>
 </div>
 <?php } ?>
 
+<?php
+if ( config_get( 'subprojects_enabled') == ON ) {
+?>
 <!-- SUBPROJECTS -->
 <div id="manage-project-update-subprojects-div" class="form-container">
 	<h2><?php echo lang_get( 'subprojects' ); ?></h2>
@@ -278,7 +281,10 @@ if( access_has_global_level( config_get( 'delete_project_threshold' ) ) ) { ?>
 		# If there are no subprojects, clear floats to h2 overlap on div border
 ?>
 		<br />
-<?php } ?>
+<?php }
+
+	} # are sub-projects enabled?
+?>
 
 </div>
 

--- a/manage_proj_subproj_add.php
+++ b/manage_proj_subproj_add.php
@@ -58,6 +58,10 @@ $f_subproject_id = gpc_get_int( 'subproject_id' );
 
 access_ensure_project_level( config_get( 'manage_project_threshold' ), $f_project_id );
 
+if ( config_get( 'subprojects_enabled' ) == OFF ) {
+	access_denied();
+}
+
 project_ensure_exists( $f_project_id );
 project_ensure_exists( $f_subproject_id );
 

--- a/manage_proj_subproj_delete.php
+++ b/manage_proj_subproj_delete.php
@@ -54,6 +54,10 @@ $f_subproject_id = gpc_get_int( 'subproject_id' );
 
 access_ensure_project_level( config_get( 'manage_project_threshold' ), $f_project_id );
 
+if ( config_get( 'subprojects_enabled' ) == OFF ) {
+	access_denied();
+}
+
 project_hierarchy_remove( $f_subproject_id, $f_project_id );
 
 form_security_purge( 'manage_proj_subproj_delete' );

--- a/manage_proj_update_children.php
+++ b/manage_proj_update_children.php
@@ -51,6 +51,10 @@ $f_project_id = gpc_get_int( 'project_id' );
 
 access_ensure_project_level( config_get( 'manage_project_threshold' ), $f_project_id );
 
+if ( config_get( 'subprojects_enabled' ) == OFF ) {
+	access_denied();
+}
+
 $t_subproject_ids = current_user_get_accessible_subprojects( $f_project_id, true );
 foreach ( $t_subproject_ids as $t_subproject_id ) {
 	$f_inherit_child = gpc_get_bool( 'inherit_child_' . $t_subproject_id, false );


### PR DESCRIPTION
This will keep the feature enabled by default.  However, it provides the ability to disable this feature so it won't be used by managers and administrators.

Fixes #20348