### PR TITLE
Do not print inline errors in non-HTML output

### DIFF
--- a/browser_search_plugin.php
+++ b/browser_search_plugin.php
@@ -27,6 +27,9 @@
  * @uses gpc_api.php
  */
 
+# Prevent output of HTML in the content if errors occur
+define( 'DISABLE_INLINE_ERROR_REPORTING', true );
+
 require_once( 'core.php' );
 require_api( 'config_api.php' );
 require_api( 'gpc_api.php' );

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -276,7 +276,9 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 				exit(1);
 
 			case DISPLAY_ERROR_INLINE:
-				echo '<div class="error-inline">', $t_error_type, ': ', $t_error_description, '</div>';
+				if( !defined( 'DISABLE_INLINE_ERROR_REPORTING' ) ) {
+					echo '<div class="error-inline">', $t_error_type, ': ', $t_error_description, '</div>';
+				}
 				$g_error_handled = true;
 				break;
 

--- a/css/common_config.php
+++ b/css/common_config.php
@@ -26,6 +26,9 @@
  * @uses config_api.php
  */
 
+# Prevent output of HTML in the content if errors occur
+define( 'DISABLE_INLINE_ERROR_REPORTING', true );
+
 @require_once( dirname( dirname( __FILE__ ) ) . '/core.php' );
 require_api( 'lang_api.php' );
 require_api( 'config_api.php' );
@@ -40,6 +43,7 @@ header( 'Content-Type: text/css; charset=UTF-8' );
  * http://blogs.msdn.com/b/ie/archive/2008/07/02/ie8-security-part-v-comprehensive-protection.aspx
  */
 header( 'X-Content-Type-Options: nosniff' );
+$g_display_errors = null;
 
 /**
  * WARNING: DO NOT EXPOSE SENSITIVE CONFIGURATION VALUES!

--- a/css/status_config.php
+++ b/css/status_config.php
@@ -25,6 +25,9 @@
  * @uses config_api.php
  */
 
+# Prevent output of HTML in the content if errors occur
+define( 'DISABLE_INLINE_ERROR_REPORTING', true );
+
 @require_once( dirname( dirname( __FILE__ ) ) . '/core.php' );
 require_api( 'config_api.php' );
 

--- a/csv_export.php
+++ b/csv_export.php
@@ -32,6 +32,9 @@
  * @uses print_api.php
  */
 
+# Prevent output of HTML in the content if errors occur
+define( 'DISABLE_INLINE_ERROR_REPORTING', true );
+
 require_once( 'core.php' );
 require_api( 'authentication_api.php' );
 require_api( 'columns_api.php' );

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -36,6 +36,9 @@
  * @uses utility_api.php
  */
 
+# Prevent output of HTML in the content if errors occur
+define( 'DISABLE_INLINE_ERROR_REPORTING', true );
+
 require_once( 'core.php' );
 require_api( 'authentication_api.php' );
 require_api( 'bug_api.php' );

--- a/file_download.php
+++ b/file_download.php
@@ -35,6 +35,9 @@
  * @uses utility_api.php
  */
 
+# Prevent output of HTML in the content if errors occur
+define( 'DISABLE_INLINE_ERROR_REPORTING', true );
+
 $g_bypass_headers = true; # suppress headers as we will send our own later
 define( 'COMPRESSION_DISABLED', true );
 

--- a/javascript_config.php
+++ b/javascript_config.php
@@ -24,6 +24,9 @@
  * @uses config_api.php
  */
 
+# Prevent output of HTML in the content if errors occur
+define( 'DISABLE_INLINE_ERROR_REPORTING', true );
+
 require_once( 'core.php' );
 require_api( 'config_api.php' );
 

--- a/javascript_translations.php
+++ b/javascript_translations.php
@@ -25,6 +25,9 @@
  * @uses lang_api.php
  */
 
+# Prevent output of HTML in the content if errors occur
+define( 'DISABLE_INLINE_ERROR_REPORTING', true );
+
 require_once( 'core.php' );
 require_api( 'lang_api.php' );
 


### PR DESCRIPTION
There are several PHP scripts in MantisBT which are used to dynamically
generate non-HTML content, e.g. javascript_*.php, css/common_config.php,
etc. Printing HTML code in these files generates invalid ouput.

This commit allows these special scripts to prevent inline errors
messages from being printed by defining a constant prior to including
core.php (or the Error API), as follows:

define( 'DISABLE_INLINE_ERROR_REPORTING', true );

Fixes [#20372](https://www.mantisbt.org/bugs/view.php?id=20372)