### PR TITLE
Support notes field as a column field

### DIFF
--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -433,6 +433,51 @@ function bugnote_get_all_visible_bugnotes( $p_bug_id, $p_user_bugnote_order, $p_
 }
 
 /**
+ * Build a string that captures all the notes visible to the logged in user along with their
+ * metadata.  The string will contain information about each note including reporter, timestamp,
+ * time tracking, view state.  This will result in multi-line string with "\n" as the line
+ * separator.
+ *
+ * @param integer $p_bug_id             A bug identifier.
+ * @param integer $p_user_bugnote_order Sort order.
+ * @param integer $p_user_bugnote_limit Number of bugnotes to display to user.
+ * @param integer $p_user_id            An user identifier.
+ * @return string The string containing all visible notes.
+ * @access public
+ */
+function bugnote_get_all_visible_as_string( $p_bug_id, $p_user_bugnote_order, $p_user_bugnote_limit, $p_user_id = null ) {
+	$t_notes = bugnote_get_all_visible_bugnotes( $p_bug_id, $p_user_bugnote_order, $p_user_bugnote_limit, $p_user_id );
+	$t_date_format = config_get( 'normal_date_format' );
+	$t_show_time_tracking = access_has_bug_level( config_get( 'time_tracking_view_threshold' ), $p_bug_id );
+
+	$t_output = '';
+
+	foreach( $t_notes as $t_note ) {
+		$t_note_string = '@' . user_get_name( $t_note->reporter_id );
+		if ( $t_note->view_state != VS_PUBLIC ) {
+			$t_note_string .= ' (' . lang_get( 'private' ) . ')';
+		}
+
+		$t_note_string .= ' ' . date( $t_date_format, $t_note->date_submitted );
+
+		if ( $t_show_time_tracking && $t_note->note_type == TIME_TRACKING ) {
+			$t_time_tracking_hhmm = db_minutes_to_hhmm( $t_note->time_tracking );
+			$t_note_string .= ' ' . lang_get( 'time_tracking_time_spent' ) . ' ' . $t_time_tracking_hhmm;
+		}
+
+		$t_note_string .= "\n" . $t_note->note . "\n";
+
+		if ( !empty( $t_output ) ) {
+			$t_output .= "---\n";
+		}
+
+		$t_output .= $t_note_string;
+	}
+
+	return $t_output;
+}
+
+/**
  * Build the bugnotes array for the given bug_id.
  * Return BugnoteData class object with raw values from the tables except the field
  * last_modified - it is UNIX_TIMESTAMP.

--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -159,6 +159,8 @@ function columns_get_standard( $p_enabled_columns_only = true ) {
 	# legacy field
 	unset( $t_columns['duplicate_id'] );
 
+	$t_columns['notes'] = null;
+
 	return array_keys( $t_columns );
 }
 
@@ -900,6 +902,21 @@ function print_column_title_description( $p_sort, $p_dir, $p_columns_target = CO
 }
 
 /**
+ * Print table header for notes column.
+ *
+ * @param string  $p_sort           Sort.
+ * @param string  $p_dir            Direction.
+ * @param integer $p_columns_target See COLUMNS_TARGET_* in constant_inc.php.
+ * @return void
+ * @access public
+ */
+function print_column_title_notes( $p_sort, $p_dir, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
+	echo '<th class="column-notes">';
+	echo lang_get( 'bug_notes_title' );
+	echo '</th>';
+}
+
+/**
  * Print table header for column steps to reproduce
  *
  * @param string  $p_sort           Sort.
@@ -1408,6 +1425,20 @@ function print_column_description( BugData $p_bug, $p_columns_target = COLUMNS_T
 	$t_description = string_display_links( $p_bug->description );
 
 	echo '<td class="column-description">', $t_description, '</td>';
+}
+
+/**
+ * Print column content for notes column
+ *
+ * @param BugData $p_bug            BugData object.
+ * @param integer $p_columns_target See COLUMNS_TARGET_* in constant_inc.php.
+ * @return void
+ * @access public
+ */
+function print_column_notes( BugData $p_bug, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
+	$t_notes = bugnote_get_all_visible_as_string( $p_bug->id, /* user_bugnote_order */ 'DESC', /* user_bugnote_limit */ 0 );
+
+	echo '<td class="column-notes">', string_display_links( $t_notes ), '</td>';
 }
 
 /**

--- a/core/csv_api.php
+++ b/core/csv_api.php
@@ -344,6 +344,18 @@ function csv_format_description( BugData $p_bug ) {
 }
 
 /**
+ * Return the notes associated with the specified bug as a string.
+ *
+ * @param BugData $p_bug A BugData object.
+ * @return string The notes formatted as a string.
+ * @access public
+ */
+function csv_format_notes( BugData $p_bug ) {
+	$t_notes = bugnote_get_all_visible_as_string( $p_bug->id, /* user_bugnote_order */ 'DESC', /* user_bugnote_limit */ 0 );
+	return csv_escape_string( $t_notes );
+}
+
+/**
  * return the steps to reproduce
  * @param BugData $p_bug A BugData object.
  * @return string formatted steps to reproduce

--- a/core/excel_api.php
+++ b/core/excel_api.php
@@ -463,6 +463,16 @@ function excel_format_description( BugData $p_bug ) {
 }
 
 /**
+ * Gets the formatted notes field.
+ * @param BugData $p_bug A bug object.
+ * @return string The formatted notes (multi-line).
+ */
+function excel_format_notes( BugData $p_bug ) {
+	$t_notes = bugnote_get_all_visible_as_string( $p_bug->id, /* user_bugnote_order */ 'DESC', /* user_bugnote_limit */ 0 );
+	return excel_prepare_string( $t_notes );
+}
+
+/**
  * Gets the formatted 'steps to reproduce' field.
  * @param BugData $p_bug A bug object.
  * @return string The formatted steps to reproduce (multi-line).

--- a/css/default.css
+++ b/css/default.css
@@ -85,12 +85,14 @@ td.my-buglist-description	{ width: 100%; vertical-align: top; }
 /**
  * view_all_bug_page.php
  */
-#buglist td, #buglist th	{ text-align: center; }
+#buglist td { text-align: center; vertical-align: top; }
+#buglist th	{ text-align: center; }
 #buglist .column-summary,
 #buglist .column-description,
+#buglist .column-notes,
 #buglist .column-steps-to-reproduce,
 #buglist .column-additional-information
-	{ text-align: left; }
+	{ text-align: left; vertical-align: top; }
 
 
 tr.bugnote .bugnote-meta { background-color: #c8c8e8; color: #000000; font-weight: bold; width: 25%; line-height: 1.4; vertical-align: top; }

--- a/print_all_bug_page.php
+++ b/print_all_bug_page.php
@@ -183,7 +183,7 @@ $t_icon_path = config_get( 'icon_path' );
 
 <form method="post" action="print_all_bug_page.php">
 <?php # CSRF protection not required here - form does not result in modifications ?>
-<table class="width100" cellspacing="1" cellpadding="2px">
+<table id="buglist" class="width100" cellspacing="1" cellpadding="2px">
 <tr>
 	<td class="form-title" colspan="<?php echo $t_num_of_columns / 2 + $t_num_of_columns % 2; ?>">
 		<?php


### PR DESCRIPTION
- Added support for notes field in View Issues, Print Issues, CSV,
  and Excel.
- Add vertical align top to the style for column values which is
  useful when the view includes a multi-line column.
- Apply CSS styles for column values to Print Issues page.

Fixes #20383