### PR TITLE
CSS/HTML fixes for consistent display of mandatory fields

### DIFF
--- a/account_page.php
+++ b/account_page.php
@@ -132,7 +132,7 @@ if( $t_verify || $t_reset_password ) {
 
 $t_force_pw_reset_html = '';
 if( $t_force_pw_reset ) {
-	$t_force_pw_reset_html = ' class="has-required"';
+	$t_force_pw_reset_html = ' class="required"';
 }
 ?>
 

--- a/account_prof_edit_page.php
+++ b/account_prof_edit_page.php
@@ -79,62 +79,75 @@ if( profile_is_global( $f_profile_id ) ) {
 
 <?php # Edit Profile Form BEGIN ?>
 <br />
-<div>
+<div class="form-container">
+
+<h2><?php echo lang_get( 'edit_profile_title' ) ?></h2>
+<div class="right">
+	<?php
+		if( !profile_is_global( $f_profile_id ) ) {
+			print_account_menu();
+		}
+	?>
+</div>
+
 <form method="post" action="account_prof_update.php">
-<?php  echo form_security_field( 'profile_update' )?>
-<input type="hidden" name="action" value="update" />
-<table class="width75" cellspacing="1">
-<tr>
-	<td class="form-title">
-		<input type="hidden" name="profile_id" value="<?php echo $v_id ?>" />
-		<?php echo lang_get( 'edit_profile_title' ) ?>
-	</td>
-	<td class="right">
-		<?php
-			if( !profile_is_global( $f_profile_id ) ) {
-				print_account_menu();
-			}
-		?>
-	</td>
-</tr>
-<tr class="row-1">
-	<th class="category" width="25%">
-		<span class="required">*</span><?php echo lang_get( 'platform' ) ?>
-	</th>
-	<td width="75%">
-		<input type="text" name="platform" size="32" maxlength="32" value="<?php echo string_attribute( $v_platform ) ?>" />
-	</td>
-</tr>
-<tr class="row-2">
-	<th class="category">
-		<span class="required">*</span><?php echo lang_get( 'os' ) ?>
-	</th>
-	<td>
-		<input type="text" name="os" size="32" maxlength="32" value="<?php echo string_attribute( $v_os ) ?>" />
-	</td>
-</tr>
-<tr class="row-1">
-	<th class="category">
-		<span class="required">*</span><?php echo lang_get( 'os_version' ) ?>
-	</th>
-	<td>
-		<input type="text" name="os_build" size="16" maxlength="16" value="<?php echo string_attribute( $v_os_build ) ?>" />
-	</td>
-</tr>
-<tr class="row-2">
-	<th class="category">
-		<?php echo lang_get( 'additional_description' ) ?>
-	</th>
-	<td>
-		<textarea name="description" cols="60" rows="8"><?php echo string_textarea( $v_description ) ?></textarea>
-	</td>
-</tr>
-<tr>
-	<td class="center" colspan="2">
+
+<fieldset>
+	<?php echo form_security_field( 'profile_update' )?>
+
+	<input type="hidden" name="action" value="update" />
+	<input type="hidden" name="profile_id" value="<?php echo $v_id ?>" />
+
+	<div class="field-container">
+		<label for="platform" class="required">
+			<span><?php echo lang_get( 'platform' ) ?></span>
+		</label>
+		<span class="input">
+			<input type="text" name="platform" size="32" maxlength="32" 
+				value="<?php echo string_attribute( $v_platform ) ?>" />
+		</span>
+		<span class="label-style"></span>
+	</div>
+
+	<div class="field-container">
+		<label for="os" class="required">
+			<span><?php echo lang_get( 'os' ) ?></span>
+		</label>
+		<span class="input">
+			<input type="text" name="os" size="32" maxlength="32" 
+				value="<?php echo string_attribute( $v_os ) ?>" />
+		</span>
+		<span class="label-style"></span>
+	</div>
+
+	<div class="field-container">
+		<label for="os_version" class="required">
+			<span><?php echo lang_get( 'os_version' ) ?></span>
+		</label>
+		<span class="input">
+			<input type="text" name="os_build" size="32" maxlength="32" 
+				value="<?php echo string_attribute( $v_os_build ) ?>" />
+		</span>
+		<span class="label-style"></span>
+	</div>
+
+	<div class="field-container">
+		<label for="description" class="required">
+			<span><?php echo lang_get( 'additional_description' ) ?></span>
+		</label>
+		<span class="textarea">
+			<textarea name="description" cols="60" rows="8"><?php 
+				echo string_textarea( $v_description );
+			?></textarea>
+		</span>
+		<span class="label-style"></span>
+	</div>
+
+	<div class="submit-button">
 		<input type="submit" class="button" value="<?php echo lang_get( 'update_profile_button' ) ?>" />
-	</td>
-</tr>
-</table>
+	</div>
+
+</fieldset>
 </form>
 </div>
 <?php

--- a/account_prof_menu_page.php
+++ b/account_prof_menu_page.php
@@ -86,7 +86,7 @@ if( $g_global_profiles ) {
 ?>
 <div id="account-profile-div" class="form-container">
 	<form id="account-profile-form" method="post" action="account_prof_update.php">
-		<fieldset class="has-required">
+		<fieldset class="required">
 			<legend><span><?php echo lang_get( 'add_profile_title' ) ?></span></legend>
 			<?php  echo form_security_field( 'profile_update' )?>
 			<input type="hidden" name="action" value="add" />

--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -137,41 +137,42 @@ print_recently_visited();
 <br />
 <div id="bug-change-status-div" class="form-container">
 
-<form id="bug-change-status-form" name="bug_change_status_form" method="post" action="bug_update.php">
-
-	<?php echo form_security_field( 'bug_update' ) ?>
-	<table>
-		<thead>
-			<!-- Title -->
-			<tr>
-				<td class="form-title" colspan="2">
-					<input type="hidden" name="bug_id" value="<?php echo $f_bug_id ?>" />
-					<input type="hidden" name="status" value="<?php echo $f_new_status ?>" />
-					<input type="hidden" name="last_updated" value="<?php echo $t_bug->last_updated ?>" />
-					<?php echo lang_get( $t_status_label . '_bug_title' ) ?>
-				</td>
-			</tr>
+<h2><?php echo lang_get( $t_status_label . '_bug_title' ); ?></h2>
 <?php
 	if( $f_new_status >= $t_resolved ) {
 		if( relationship_can_resolve_bug( $f_bug_id ) == false ) {
-			echo '<tr><td colspan="2">' . lang_get( 'relationship_warning_blocking_bugs_not_resolved_2' ) . '</td></tr>';
+			echo '<div class="footer">';
+			echo lang_get( 'relationship_warning_blocking_bugs_not_resolved_2' );
+			echo '</div>';
 		}
 	}
 ?>
-		</thead>
-		<tbody>
+
+<form id="bug-change-status-form" name="bug_change_status_form" method="post" action="bug_update.php">
+
+<fieldset>
+
+	<?php echo form_security_field( 'bug_update' ) ?>
+
+	<input type="hidden" name="bug_id" value="<?php echo $f_bug_id ?>" />
+	<input type="hidden" name="status" value="<?php echo $f_new_status ?>" />
+	<input type="hidden" name="last_updated" value="<?php echo $t_bug->last_updated ?>" />
+	<input type="hidden" name="action_type" value="<?php echo $f_change_type; ?>" />
+
 <?php
-$t_current_resolution = $t_bug->resolution;
-$t_bug_is_open = $t_current_resolution < $t_resolved;
-if( ( $f_new_status >= $t_resolved ) && ( ( $f_new_status < $t_closed ) || ( $t_bug_is_open ) ) ) { ?>
-<!-- Resolution -->
-			<tr>
-				<th class="category">
-					<?php echo lang_get( 'resolution' ) ?>
-				</th>
-				<td>
-					<select name="resolution">
-			<?php
+	$t_current_resolution = $t_bug->resolution;
+	$t_bug_is_open = $t_current_resolution < $t_resolved;
+
+	if( ( $f_new_status >= $t_resolved ) && ( ( $f_new_status < $t_closed ) || ( $t_bug_is_open ) ) ) {
+?>
+	<!-- Resolution -->
+	<div class="field-container">
+		<label for="resolution">
+			<span><?php echo lang_get( 'resolution' ) ?></span>
+		</label>
+		<span class="select">
+ 			<select name="resolution">
+<?php
 				$t_resolution = $t_bug_is_open ? config_get( 'bug_resolution_fixed_threshold' ) : $t_current_resolution;
 
 				$t_relationships = relationship_get_all_src( $f_bug_id );
@@ -183,216 +184,235 @@ if( ( $f_new_status >= $t_resolved ) && ( ( $f_new_status < $t_closed ) || ( $t_
 				}
 
 				print_enum_string_option_list( 'resolution', $t_resolution );
-			?>
-					</select>
-				</td>
-			</tr>
-<?php } ?>
-
-<?php
-if( $f_new_status >= $t_resolved
-	&& $f_new_status < $t_closed
-	&& $t_resolution != config_get( 'bug_duplicate_resolution' ) ) { ?>
-<!-- Duplicate ID -->
-			<tr>
-				<th class="category">
-					<?php echo lang_get( 'duplicate_id' ) ?>
-				</th>
-				<td>
-					<input type="text" name="duplicate_id" maxlength="10" />
-				</td>
-			</tr>
-<?php } ?>
-
-<?php
-if( access_has_bug_level( config_get( 'update_bug_assign_threshold', config_get( 'update_bug_threshold' ) ), $f_bug_id ) ) {
-	$t_suggested_handler_id = $t_bug->handler_id;
-
-	if( $t_suggested_handler_id == NO_USER && access_has_bug_level( config_get( 'handle_bug_threshold' ), $f_bug_id ) ) {
-		$t_suggested_handler_id = $t_current_user_id;
-	}
 ?>
-<!-- Assigned To -->
-			<tr>
-				<th class="category">
-					<?php echo lang_get( 'assigned_to' ) ?>
-				</th>
-				<td>
-					<select name="handler_id">
-						<option value="0"></option>
-						<?php print_assign_to_option_list( $t_suggested_handler_id, $t_bug->project_id ) ?>
-					</select>
-				</td>
-			</tr>
-<?php } ?>
-
-<?php if( $t_can_update_due_date ) {
-	$t_date_to_display = '';
-	if( !date_is_null( $t_bug->due_date ) ) {
-		$t_date_to_display = date( config_get( 'calendar_date_format' ), $t_bug->due_date );
-	}
-?>
-<!-- Due date -->
-			<tr>
-				<th class="category">
-					<?php print_documentation_link( 'due_date' ) ?>
-				</th>
-				<td>
-					<?php echo '<input ' . helper_get_tab_index() . ' type="text" id="due_date" name="due_date" class="datetime" size="20" maxlength="16" value="' . $t_date_to_display . '" />' ?>
-				</td>
-			</tr>
-<?php } ?>
-
-<!-- Custom Fields -->
-<?php
-/** @todo thraxisp - I undid part of the change for #5068 for #5527
- * We really need to say what fields are shown in which statusses. For now,
- * this page will show required custom fields in update mode, or
- *  display or required fields on resolve or close
- */
-$t_custom_status_label = 'update'; # Don't show custom fields by default
-if( ( $f_new_status == $t_resolved ) && ( $f_new_status < $t_closed ) ) {
-	$t_custom_status_label = 'resolved';
-}
-if( $t_closed == $f_new_status ) {
-	$t_custom_status_label = 'closed';
-}
-
-$t_related_custom_field_ids = custom_field_get_linked_ids( $t_bug->project_id );
-
-foreach( $t_related_custom_field_ids as $t_id ) {
-	$t_def = custom_field_get_definition( $t_id );
-	$t_display = $t_def['display_' . $t_custom_status_label];
-	$t_require = $t_def['require_' . $t_custom_status_label];
-
-	if( ( 'update' == $t_custom_status_label ) && ( !$t_require ) ) {
-		continue;
-	}
-	if( in_array( $t_custom_status_label, array( 'resolved', 'closed' ) ) && !( $t_display || $t_require ) ) {
-		continue;
-	}
-	if( custom_field_has_write_access( $t_id, $f_bug_id ) ) {
-?>
-			<tr>
-				<th class="category">
-					<?php if( $t_require ) { ?>
-						<span class="required">*</span>
-					<?php }
-					echo lang_get_defaulted( $t_def['name'] )
-					?>
-				</th>
-				<td>
-					<?php
-						print_custom_field_input( $t_def, $f_bug_id );
-					?>
-				</td>
-			</tr>
-<?php
-	} else if( custom_field_has_read_access( $t_id, $f_bug_id ) ) {
-		#  custom_field_has_write_access( $t_id, $f_bug_id ) )
-?>
-			<tr>
-				<th class="category">
-					<?php echo lang_get_defaulted( $t_def['name'] ) ?>
-				</th>
-				<td>
-					<?php print_custom_field_value( $t_def, $t_id, $f_bug_id );			?>
-				</td>
-			</tr>
-<?php
-	} # custom_field_has_read_access( $t_id, $f_bug_id ) )
-} # foreach( $t_related_custom_field_ids as $t_id )
-?>
-
-<?php
-if( ( $f_new_status >= $t_resolved ) ) {
-	if( version_should_show_product_version( $t_bug->project_id )
-		&& !bug_is_readonly( $f_bug_id )
-		&& access_has_bug_level( config_get( 'update_bug_threshold' ), $f_bug_id )
-	) {
-?>
-			<!-- Fixed in Version -->
-			<tr>
-				<th class="category">
-					<?php echo lang_get( 'fixed_in_version' ) ?>
-				</th>
-				<td>
-					<select name="fixed_in_version">
-						<?php print_version_option_list( $t_bug->fixed_in_version, $t_bug->project_id, VERSION_ALL ) ?>
-					</select>
-				</td>
-			</tr>
+			</select>
+		</span>
+		<span class="label-style"></span>
+	</div>
 <?php
 	}
-}
+
+	if( $f_new_status >= $t_resolved
+		&& $f_new_status < $t_closed
+		&& $t_resolution != config_get( 'bug_duplicate_resolution' ) ) {
 ?>
-<?php event_signal( 'EVENT_UPDATE_BUG_STATUS_FORM', array( $f_bug_id ) ); ?>
-<?php if( $f_change_type == BUG_UPDATE_TYPE_REOPEN ) { ?>
-<!-- Bug was re-opened -->
+	<!-- Duplicate ID -->
+	<div class="field-container">
+		<label for="duplicate_id">
+			<span><?php echo lang_get( 'duplicate_id' ) ?></span>
+		</label>
+		<span class="input">
+ 			<input type="text" name="duplicate_id" maxlength="10" />
+		</span>
+		<span class="label-style"></span>
+	</div>
+
 <?php
-	printf( '	<input type="hidden" name="resolution" value="%s" />' . "\n", config_get( 'bug_reopen_resolution' ) );
-}
+	}
+
+	if( access_has_bug_level( config_get( 'update_bug_assign_threshold', config_get( 'update_bug_threshold' ) ), $f_bug_id ) ) {
+		$t_suggested_handler_id = $t_bug->handler_id;
+
+		if( $t_suggested_handler_id == NO_USER && access_has_bug_level( config_get( 'handle_bug_threshold' ), $f_bug_id ) ) {
+			$t_suggested_handler_id = $t_current_user_id;
+		}
+
 ?>
-			<!-- Bugnote -->
-			<tr id="bug-change-status-note">
-				<th class="category">
-					<?php echo lang_get( 'add_bugnote_title' ) ?>
-				</th>
-				<td>
-					<textarea name="bugnote_text" cols="80" rows="10"></textarea>
-				</td>
-			</tr>
-<?php if( access_has_bug_level( config_get( 'private_bugnote_threshold' ), $f_bug_id ) ) { ?>
-			<tr>
-				<th class="category">
-					<?php echo lang_get( 'view_status' ) ?>
-				</th>
-				<td>
+	<!-- Assigned To -->
+	<div class="field-container">
+		<label for="handler_id">
+			<span><?php echo lang_get( 'assigned_to' ) ?></span>
+		</label>
+		<span class="select">
+			<select name="handler_id">
+				<option value="0"></option>
+				<?php print_assign_to_option_list( $t_suggested_handler_id, $t_bug->project_id ) ?>
+			</select>
+		</span>
+		<span class="label-style"></span>
+	</div>
+
 <?php
+	}
+
+	if( true || $t_can_update_due_date ) {
+		$t_date_to_display = '';
+
+		if( !date_is_null( $t_bug->due_date ) ) {
+			$t_date_to_display = date( config_get( 'calendar_date_format' ), $t_bug->due_date );
+		}
+?>
+	<!-- Due date -->
+	<div class="field-container">
+		<label for="due_date">
+			<span><?php echo lang_get( 'due_date' ) ?></span>
+		</label>
+		<span class="input">
+ 			<input type="text" id="due_date" name="due_date"
+ 				class="datetime" size="20" maxlength="16"
+ 				<?php helper_get_tab_index() ?>
+ 				value="<?php echo $t_date_to_display ?>" />
+		</span>
+		<span class="label-style"></span>
+	</div>
+
+<?php
+	}
+?>
+
+	<!-- Custom Fields -->
+<?php
+	/**
+	 * @todo thraxisp - I undid part of the change for #5068 for #5527
+	 * We really need to say what fields are shown in which statusses. For now,
+	 * this page will show required custom fields in update mode, or
+	 * display or required fields on resolve or close
+	 */
+	$t_custom_status_label = 'update'; # Don't show custom fields by default
+	if( ( $f_new_status == $t_resolved ) && ( $f_new_status < $t_closed ) ) {
+		$t_custom_status_label = 'resolved';
+	}
+	if( $t_closed == $f_new_status ) {
+		$t_custom_status_label = 'closed';
+	}
+
+	$t_related_custom_field_ids = custom_field_get_linked_ids( $t_bug->project_id );
+
+	foreach( $t_related_custom_field_ids as $t_id ) {
+		$t_def = custom_field_get_definition( $t_id );
+		$t_display = $t_def['display_' . $t_custom_status_label];
+		$t_require = $t_def['require_' . $t_custom_status_label];
+
+		if( ( 'update' == $t_custom_status_label ) && ( !$t_require ) ) {
+			continue;
+		}
+		if( in_array( $t_custom_status_label, array( 'resolved', 'closed' ) ) && !( $t_display || $t_require ) ) {
+			continue;
+		}
+		$t_has_write_access = custom_field_has_write_access( $t_id, $f_bug_id );
+		$t_class_required = $t_require && $t_has_write_access ? 'class="required"' : '';
+?>
+	<div class="field-container">
+		<label <?php echo $t_class_required ?> for="due_date">
+			<span><?php echo lang_get_defaulted( $t_def['name'] ) ?></span>
+		</label>
+		<span class="input">
+<?php
+			if( $t_has_write_access ) {
+				print_custom_field_input( $t_def, $f_bug_id );
+			} elseif( custom_field_has_read_access( $t_id, $f_bug_id ) ) {
+				print_custom_field_value( $t_def, $t_id, $f_bug_id );
+			}
+?>
+		</span>
+		<span class="label-style"></span>
+	</div>
+
+<?php
+	} # foreach( $t_related_custom_field_ids as $t_id )
+
+	if( ( $f_new_status >= $t_resolved ) ) {
+		if( version_should_show_product_version( $t_bug->project_id )
+			&& !bug_is_readonly( $f_bug_id )
+			&& access_has_bug_level( config_get( 'update_bug_threshold' ), $f_bug_id )
+		) {
+?>
+	<!-- Fixed in Version -->
+	<div class="field-container">
+		<label for="due_date">
+			<span><?php echo lang_get( 'fixed_in_version' ) ?></span>
+		</label>
+		<span class="select">
+			<select name="fixed_in_version">
+				<?php print_version_option_list( $t_bug->fixed_in_version, $t_bug->project_id, VERSION_ALL ) ?>
+			</select>
+		</span>
+		<span class="label-style"></span>
+	</div>
+<?php
+		}
+	}
+
+	event_signal( 'EVENT_UPDATE_BUG_STATUS_FORM', array( $f_bug_id ) );
+
+	if( $f_change_type == BUG_UPDATE_TYPE_REOPEN ) {
+?>
+	<!-- Bug was re-opened -->
+<?php
+		printf( '	<input type="hidden" name="resolution" value="%s" />' . "\n", config_get( 'bug_reopen_resolution' ) );
+	}
+?>
+
+	<!-- Bugnote -->
+	<div class="field-container">
+		<label for="bugnote_text">
+			<span><?php echo lang_get( 'add_bugnote_title' ) ?></span>
+		</label>
+		<span class="textarea">
+			<textarea name="bugnote_text" cols="80" rows="10"></textarea>
+		</span>
+		<span class="label-style"></span>
+	</div>
+
+<?php
+	if( access_has_bug_level( config_get( 'private_bugnote_threshold' ), $f_bug_id ) ) {
 		$t_default_bugnote_view_status = config_get( 'default_bugnote_view_status' );
+?>
+	<!-- View status -->
+	<div class="field-container">
+		<label for="private">
+			<span><?php echo lang_get( 'view_status' ) ?></span>
+		</label>
+		<span class="checkbox">
+<?php
 		if( access_has_bug_level( config_get( 'set_view_status_threshold' ), $f_bug_id ) ) {
 ?>
-			<input type="checkbox" name="private" <?php check_checked( $t_default_bugnote_view_status, VS_PRIVATE ); ?> />
+			<input type="checkbox" name="private"
+				<?php check_checked( $t_default_bugnote_view_status, VS_PRIVATE ); ?> />
 <?php
 			echo lang_get( 'private' );
 		} else {
 			echo get_enum_element( 'project_view_state', $t_default_bugnote_view_status );
 		}
 ?>
-				</td>
-			</tr>
-<?php } ?>
+		</span>
+		<span class="label-style"></span>
+	</div>
 
-<?php if( config_get( 'time_tracking_enabled' ) ) { ?>
-<?php 	if( access_has_bug_level( config_get( 'private_bugnote_threshold' ), $f_bug_id ) ) { ?>
-<?php 		if( access_has_bug_level( config_get( 'time_tracking_edit_threshold' ), $f_bug_id ) ) { ?>
-			<tr>
-				<th class="category">
-					<?php echo lang_get( 'time_tracking' ) ?>
-				</th>
-				<td>
-					<input type="text" name="time_tracking" size="5" placeholder="hh:mm" />
-				</td>
-			</tr>
-<?php 		} ?>
-<?php 	} ?>
-<?php } ?>
+<?php
+	}
 
-<?php event_signal( 'EVENT_BUGNOTE_ADD_FORM', array( $f_bug_id ) ); ?>
+	if(     config_get( 'time_tracking_enabled' )
+		&& access_has_bug_level( config_get( 'private_bugnote_threshold' ), $f_bug_id )
+		&& access_has_bug_level( config_get( 'time_tracking_edit_threshold' ), $f_bug_id )
+	) {
+?>
+	<!-- Time tracking -->
+	<div class="field-container">
+		<label for="time_tracking">
+			<span><?php echo lang_get( 'time_tracking' ) ?></span>
+		</label>
+		<span class="input">
+			<input type="text" name="time_tracking" size="5" placeholder="hh:mm" />
+		</span>
+		<span class="label-style"></span>
+	</div>
+<?php
+	}
 
-			<!-- Submit Button -->
-			<tr>
-				<td class="center" colspan="2">
-					<input type="submit" class="button" value="<?php echo lang_get( $t_status_label . '_bug_button' ) ?>" />
-				</td>
-			</tr>
-		</tbody>
-	</table>
-	<input type="hidden" name="action_type" value="<?php echo $f_change_type; ?>" />
+	event_signal( 'EVENT_BUGNOTE_ADD_FORM', array( $f_bug_id ) );
+?>
+
+	<!-- Submit Button -->
+	<span class="submit-button">
+		<input type="submit" class="button" value="<?php echo lang_get( $t_status_label . '_bug_button' ) ?>" />
+	</span>
+
 </form>
-
 </div>
-<br />
+
+<br>
+
 <?php
 define( 'BUG_VIEW_INC_ALLOW', true );
 include( dirname( __FILE__ ) . '/bug_view_inc.php' );

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -244,10 +244,9 @@ if( $t_show_attachments ) {
 			if( $t_show_category ) {
 			?>
 			<div class="field-container">
-				<label><span><?php
-					echo config_get( 'allow_no_category' ) ? '' : '<span class="required">*</span>';
-					print_documentation_link( 'category' );
-				?></span></label>
+				<label <?php echo config_get( 'allow_no_category' ) ? '' : 'class="required"' ?>>
+					<span><?php print_documentation_link( 'category' ); ?></span>
+				</label>
 				<span class="select">
 					<?php if( $t_changed_project ) {
 						echo '[' . project_get_field( $t_bug->project_id, 'name' ) . '] ';
@@ -502,7 +501,7 @@ if( $t_show_attachments ) {
 <?php event_signal( 'EVENT_REPORT_BUG_FORM', array( $t_project_id ) ) ?>
 
 			<div class="field-container">
-				<label><span class="required">*</span><span><?php print_documentation_link( 'summary' ) ?></span></label>
+				<label class="required"><span><?php print_documentation_link( 'summary' ) ?></span></label>
 				<span class="input">
 					<input <?php echo helper_get_tab_index() ?> type="text" id="summary" name="summary" size="105" maxlength="128" value="<?php echo string_attribute( $f_summary ) ?>" />
 				</span>
@@ -510,7 +509,7 @@ if( $t_show_attachments ) {
 			</div>
 
 			<div class="field-container">
-				<label><span><span class="required">*</span><?php print_documentation_link( 'description' ) ?></span></label>
+				<label class="required"><span><?php print_documentation_link( 'description' ) ?></span></label>
 				<span class="textarea">
 					<textarea <?php echo helper_get_tab_index() ?> id="description" name="description" cols="80" rows="10"><?php echo string_textarea( $f_description ) ?></textarea>
 				</span>
@@ -545,20 +544,20 @@ if( $t_show_attachments ) {
 		$t_def = custom_field_get_definition( $t_id );
 		if( ( $t_def['display_report'] || $t_def['require_report']) && custom_field_has_write_access_to_project( $t_id, $t_project_id ) ) {
 			$t_custom_fields_found = true;
+
+			$t_required_class = $t_def['require_report'] ? 'class="required" ' : '';
+
+			if( $t_def['type'] != CUSTOM_FIELD_TYPE_RADIO && $t_def['type'] != CUSTOM_FIELD_TYPE_CHECKBOX ) {
+				$t_label_for = 'for="custom_field_' . string_attribute( $t_def['id'] ) . '" ';
+			} else {
+				$t_label_for = '';
+			}
 ?>
 			<div class="field-container">
-				<label>
-					<span>
-						<?php if( $t_def['require_report'] ) { ?>
-						<span class="required">*</span>
-						<?php } ?>
-						<?php if( $t_def['type'] != CUSTOM_FIELD_TYPE_RADIO && $t_def['type'] != CUSTOM_FIELD_TYPE_CHECKBOX ) { ?>
-							<label for="custom_field_<?php echo string_attribute( $t_def['id'] ) ?>"><?php echo string_display( lang_get_defaulted( $t_def['name'] ) ) ?></label>
-						<?php } else {
-							echo string_display( lang_get_defaulted( $t_def['name'] ) );
-						} ?>
-					</span>
-				</label>
+				<label <?php echo $t_required_class, $t_label_for; ?>><span><?php
+					echo string_display( lang_get_defaulted( $t_def['name'] ) );
+				?></span></label>
+
 				<span class="input">
 					<?php print_custom_field_input( $t_def, ( $f_master_bug_id === 0 ) ? null : $f_master_bug_id ) ?>
 				</span>

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -232,7 +232,7 @@ if( $t_show_attachments ) {
 ?>
 <div id="report-bug-div" class="form-container">
 	<form id="report-bug-form" method="post" <?php echo $t_form_encoding; ?> action="bug_report.php?posted=1">
-		<fieldset class="has-required">
+		<fieldset class="required">
 			<legend><span><?php echo lang_get( 'enter_report_details_title' ) ?></span></legend>
 			<?php echo form_security_field( 'bug_report' ) ?>
 			<input type="hidden" name="m_id" value="<?php echo $f_master_bug_id ?>" />

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -687,16 +687,19 @@ foreach ( $t_related_custom_field_ids as $t_id ) {
 	if( ( $t_def['display_update'] || $t_def['require_update'] ) && custom_field_has_write_access( $t_id, $t_bug_id ) ) {
 		$t_custom_fields_found = true;
 
+		$t_required_class = $t_def['require_update'] ? ' class="required" ' : '';
+
+		if( $t_def['type'] != CUSTOM_FIELD_TYPE_RADIO && $t_def['type'] != CUSTOM_FIELD_TYPE_CHECKBOX ) {
+			$t_label_for = ' for="custom_field_' . string_attribute( $t_def['id'] ) . '" ';
+		} else {
+			$t_label_for = '';
+		}
+
 		echo '<tr>';
 		echo '<td class="category">';
-		if( $t_def['require_update'] ) {
-			echo '<span class="required">*</span>';
-		}
-		if( $t_def['type'] != CUSTOM_FIELD_TYPE_RADIO && $t_def['type'] != CUSTOM_FIELD_TYPE_CHECKBOX ) {
-			echo '<label for="custom_field_' . string_attribute( $t_def['id'] ) . '">' . string_display( lang_get_defaulted( $t_def['name'] ) ) . '</label>';
-		} else {
-			echo string_display( lang_get_defaulted( $t_def['name'] ) );
-		}
+		echo '<label', $t_required_class, $t_label_for, '>';
+		echo '<span>', string_display( lang_get_defaulted( $t_def['name'] ) ), '</span>';
+		echo '</label>';
 		echo '</td><td colspan="5">';
 		print_custom_field_input( $t_def, $t_bug_id );
 		echo '</td></tr>';

--- a/css/common_config.php
+++ b/css/common_config.php
@@ -56,7 +56,7 @@ $g_display_errors = null;
  * should only be known internally to the server.
  */
 ?>
-div.form-container fieldset.has-required:after {
+div.form-container fieldset.required:after {
 	position: absolute;
 	margin: -1.75em 0em 0em .5em;
 	font-size: 8pt;

--- a/css/default.css
+++ b/css/default.css
@@ -532,6 +532,7 @@ div.form-container fieldset legend {
 	font-weight: bold;
 }
 div.form-container fieldset label.required:before,
+th label.required:before,
 td label.required:before {
 	font-size: 8pt;
 	content: '* ';

--- a/css/default.css
+++ b/css/default.css
@@ -30,7 +30,7 @@ select				{}
 
 span				{ font-family: Verdana, Arial, Helvetica, sans-serif; font-size: 10pt; }
 span.print			{ font-size: 8pt; }
-span.required 		{ font-size: 8pt; color: #bb0000; }
+span.required 		{ font-size: 8pt; color: red; }
 span.small 			{ font-size: 8pt; font-weight: normal; }
 span.bracket-link	{ white-space: nowrap; }
 
@@ -531,7 +531,8 @@ div.form-container fieldset legend {
 	border: none;
 	font-weight: bold;
 }
-div.form-container fieldset label.required:before {
+div.form-container fieldset label.required:before,
+td label.required:before {
 	font-size: 8pt;
 	content: '* ';
 	color: red;

--- a/manage_columns_inc.php
+++ b/manage_columns_inc.php
@@ -80,7 +80,7 @@ $t_excel = implode( ', ', $t_columns );
 
 <div id="manage-columns-div" class="form-container">
 	<form id="manage-columns-form" method="post" action="manage_config_columns_set.php">
-		<fieldset class="has-required">
+		<fieldset class="required">
 			<legend><span><?php echo lang_get( 'manage_columns_config' ) ?></span></legend>
 			<?php
 			if( $t_account_page ) {

--- a/manage_proj_create_page.php
+++ b/manage_proj_create_page.php
@@ -69,7 +69,7 @@ if( project_table_empty() ) {
 
 <div id="manage-project-create-div" class="form-container">
 	<form method="post" id="manage-project-create-form" action="manage_proj_create.php">
-		<fieldset class="has-required"><?php
+		<fieldset class="required"><?php
 			echo form_security_field( 'manage_proj_create' );
 			if( null !== $f_parent_id ) {
 				$f_parent_id = (int)$f_parent_id; ?>

--- a/manage_tags_page.php
+++ b/manage_tags_page.php
@@ -164,7 +164,7 @@ print_manage_menu( 'manage_tags_page.php' ); ?>
 <div id="manage-tags-create-div" class="form-container">
 	<a name="tagcreate" />
 	<form id="manage-tags-create-form" method="post" action="tag_create.php">
-		<fieldset class="has-required">
+		<fieldset class="required">
 			<legend><span><?php echo lang_get( 'tag_create' ) ?></span></legend>
 			<?php echo form_security_field( 'tag_create' ); ?>
 			<div class="field-container">

--- a/news_edit_page.php
+++ b/news_edit_page.php
@@ -93,7 +93,7 @@ html_page_top( lang_get( 'edit_news_title' ) );
 
 <div id="news-update-div" class="form-container">
 	<form id="news-update-form" method="post" action="news_update.php">
-		<fieldset class="has-required">
+		<fieldset class="required">
 			<legend><span><?php echo lang_get( 'headline' ) ?></span></legend>
 			<div class="section-link"><?php print_bracket_link( 'news_menu_page.php', lang_get( 'go_back' ) ) ?></div>
 			<?php echo form_security_field( 'news_update' ); ?>

--- a/news_menu_page.php
+++ b/news_menu_page.php
@@ -54,7 +54,7 @@ html_page_top( lang_get( 'edit_news_link' ) );
 
 <div id="news-add-div" class="form-container">
 	<form id="news-add-form" method="post" action="news_add.php">
-		<fieldset class="has-required">
+		<fieldset class="required">
 			<legend><span><?php echo lang_get( 'add_news_title' ) ?></span></legend>
 			<?php echo form_security_field( 'news_add' ); ?>
 			<div class="field-container">

--- a/proj_doc_add_page.php
+++ b/proj_doc_add_page.php
@@ -70,7 +70,7 @@ html_page_top();
 </tr>
 <tr class="row-1">
 	<th class="category" width="25%">
-		<span class="required">*</span><?php echo lang_get( 'title' ) ?>
+		<label class="required"><span><?php echo lang_get( 'title' ) ?></span></label>
 	</th>
 	<td width="75%">
 		<input type="text" name="title" size="70" maxlength="250" />
@@ -86,7 +86,7 @@ html_page_top();
 </tr>
 <tr class="row-1">
 	<td class="category">
-		<span class="required">*</span><?php echo lang_get( 'select_file' ); ?>
+		<label class="required"><span><?php echo lang_get( 'select_file' ) ?></span></label>
 		<br />
 		<?php print_max_filesize( $t_max_file_size ); ?>
 	</td>

--- a/proj_doc_edit_page.php
+++ b/proj_doc_edit_page.php
@@ -91,7 +91,7 @@ html_page_top();
 </tr>
 <tr class="row-1">
 	<th class="category" width="20%">
-		<span class="required">*</span><?php echo lang_get( 'title' ) ?>
+		<label class="required"><span><?php echo lang_get( 'title' ) ?></span></label>
 	</th>
 	<td width="80%">
 		<input type="text" name="title" size="70" maxlength="250" value="<?php echo $v_title ?>" />


### PR DESCRIPTION
This started off as a quick fix for [#20395](https://www.mantisbt.org/bugs/view.php?id=20395), and expanded to a broader series of related fixes.

With this, we should hopefully have a consistent use of 'required' class for mandatory fields throughout the codebase.
