### PR TITLE
Implement bugnotes_count, attachment_count in CSV, Excel export

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1465,7 +1465,7 @@ function bug_get_newest_bugnote_timestamp( $p_bug_id ) {
  * associated with the bug was modified and the total bugnote
  * count in one db query
  * @param integer $p_bug_id Integer representing bug identifier.
- * @return object consisting of bugnote stats
+ * @return object consisting of bugnote stats, null if no stats exits
  * @access public
  * @uses database_api.php
  */
@@ -1487,7 +1487,7 @@ function bug_get_bugnote_stats( $p_bug_id ) {
 	}
 
 	if( $t_bugnote_count === 0 ) {
-		return false;
+		return null;
 	}
 
 	$t_stats['last_modified'] = $t_row['last_modified'];

--- a/core/csv_api.php
+++ b/core/csv_api.php
@@ -438,3 +438,35 @@ function csv_format_due_date( BugData $p_bug ) {
 function csv_format_sponsorship_total( BugData $p_bug ) {
 	return csv_escape_string( $p_bug->sponsorship_total );
 }
+
+/**
+ * return the attachment count for an issue
+ * @param BugData $p_bug A BugData object.
+ * @return string
+ * @access public
+ */
+function csv_format_attachment_count( BugData $p_bug ) {
+	# Check for attachments
+	$t_attachment_count = 0;
+	if( file_can_view_bug_attachments( $p_bug->id, null ) ) {
+		$t_attachment_count = file_bug_attachment_count( $p_bug->id );
+	}
+	return csv_escape_string( $t_attachment_count );
+}
+
+/**
+ * return the bug note count for an issue
+ * @param BugData $p_bug A BugData object.
+ * @return string
+ * @access public
+ */
+function csv_format_bugnotes_count( BugData $p_bug ) {
+	# grab the bugnote count
+	$t_bugnote_stats = bug_get_bugnote_stats( $p_bug->id );
+	if( null !== $t_bugnote_stats ) {
+		$t_bugnote_count = $t_bugnote_stats['count'];
+	} else {
+		$t_bugnote_count = 0;
+	}
+	return csv_escape_string( $t_bugnote_count );
+}

--- a/core/excel_api.php
+++ b/core/excel_api.php
@@ -252,15 +252,6 @@ function excel_format_reporter_id( BugData $p_bug ) {
 }
 
 /**
- * Gets the formatted number of bug notes.
- * @param BugData $p_bug A bug object.
- * @return string The number of bug notes.
- */
-function excel_format_bugnotes_count( BugData $p_bug ) {
-	return excel_prepare_number( $p_bug->bugnotes_count );
-}
-
-/**
  * Gets the formatted handler id.
  * @param BugData $p_bug A bug object.
  * @return string The handler user name or empty string.
@@ -555,6 +546,38 @@ function excel_format_due_date( BugData $p_bug ) {
  */
 function excel_format_sponsorship_total( BugData $p_bug ) {
 	return excel_prepare_string( $p_bug->sponsorship_total );
+}
+
+/**
+ * Gets the attachment count for an issue
+ * @param BugData $p_bug A bug object.
+ * @return string
+ * @access public
+ */
+function excel_format_attachment_count( BugData $p_bug ) {
+	# Check for attachments
+	$t_attachment_count = 0;
+	if( file_can_view_bug_attachments( $p_bug->id, null ) ) {
+		$t_attachment_count = file_bug_attachment_count( $p_bug->id );
+	}
+	return excel_prepare_number( $t_attachment_count );
+}
+
+/**
+ * Gets the bug note count for an issue
+ * @param BugData $p_bug A bug object.
+ * @return string
+ * @access public
+ */
+function excel_format_bugnotes_count( BugData $p_bug ) {
+	# grab the bugnote count
+	$t_bugnote_stats = bug_get_bugnote_stats( $p_bug->id );
+	if( null !== $t_bugnote_stats ) {
+		$t_bugnote_count = $t_bugnote_stats['count'];
+	} else {
+		$t_bugnote_count = 0;
+	}
+	return excel_prepare_number( $t_bugnote_count );
 }
 
 /**

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -528,13 +528,7 @@ function helper_get_columns_to_view( $p_columns_target = COLUMNS_TARGET_VIEW_PAG
 	if( $p_columns_target == COLUMNS_TARGET_CSV_PAGE || $p_columns_target == COLUMNS_TARGET_EXCEL_PAGE ) {
 		$t_keys_to_remove[] = 'selection';
 		$t_keys_to_remove[] = 'edit';
-		$t_keys_to_remove[] = 'bugnotes_count';
-		$t_keys_to_remove[] = 'attachment_count';
 		$t_keys_to_remove[] = 'overdue';
-	}
-
-	if( $p_columns_target == COLUMNS_TARGET_CSV_PAGE || $p_columns_target == COLUMNS_TARGET_EXCEL_PAGE ) {
-		$t_keys_to_remove[] = 'attachment_count';
 	}
 
 	$t_current_project_id = helper_get_current_project();


### PR DESCRIPTION
As per issue
#0019284

Columns bugnotes_count, attachment_count are being silently dropped from the columns set for CSV and Excel export, even when the user is able to select them.

This is still an incomplete fix, because it opens another show-stopper:
The bugnote cache function chokes when the list of bug ids passed is long enough. This happens easily as the csv/excel export are not limited by pagination.
The query used has an IN clause, which grows out of the runtime limits.
(@dregad This brings up the issue of long IN sql clauses, which has been talked before.)

![seleccion_084](https://cloud.githubusercontent.com/assets/14123811/11942924/59fbe8ca-a83a-11e5-8b2c-42954160c9be.png)

For further addressing this case, (and until a more unified approach is taken for the IN issue), the query could be partitioned. In that case, i suggest to review first Pr #650, which is already refactoring the affected code (for changes to be done on the query, i'd rather do it on top of those)
