### PR TITLE
Print caller trace in file log

### DIFF
--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -124,7 +124,7 @@ function log_event( $p_level, $p_msg ) {
 		}
 	}
 
-	$t_php_event = $t_now . ' ' . $t_level . ' ' . $t_msg;
+	$t_php_event = $t_now . ' ' . $t_level . ' ' . $t_caller . ' ' . $t_msg;
 
 	switch( $t_destination ) {
 		case 'none':


### PR DESCRIPTION
Include info for call trace when the log
destination is "file". This information is
already printed on "page" destination

Fix #20408