### PR TITLE
0020424 csv memory

### DIFF
--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -749,8 +749,8 @@ function mc_issue_add( $p_username, $p_password, stdClass $p_issue ) {
 	$t_bug_data->resolution = $t_resolution_id;
 	$t_bug_data->projection = $t_projection_id;
 	$t_bug_data->category_id = $t_category_id;
-	$t_bug_data->date_submitted = isset( $p_issue['date_submitted'] ) ? $p_issue['date_submitted'] : '';
-	$t_bug_data->last_updated = isset( $p_issue['last_updated'] ) ? $p_issue['last_updated'] : '';
+	$t_bug_data->date_submitted = isset( $p_issue['date_submitted'] ) ? SoapObjectsFactory::parseDateTimeString($p_issue['date_submitted']) : '';
+	$t_bug_data->last_updated = isset( $p_issue['last_updated'] ) ? SoapObjectsFactory::parseDateTimeString($p_issue['last_updated']) : '';
 	$t_bug_data->eta = $t_eta_id;
 	$t_bug_data->profile_id = isset( $p_issue['profile_id'] ) ? $p_issue['profile_id'] : 0;
 	$t_bug_data->os = isset( $p_issue['os'] ) ? $p_issue['os'] : '';

--- a/bug_actiongroup.php
+++ b/bug_actiongroup.php
@@ -151,11 +151,7 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			break;
 		case 'ASSIGN':
 			$f_assign = gpc_get_int( 'assign' );
-			if( ON == config_get( 'auto_set_status_to_assigned' ) ) {
-				$t_assign_status = config_get( 'bug_assigned_status' );
-			} else {
-				$t_assign_status = $t_status;
-			}
+			$t_assign_status = bug_get_status_for_assign( $t_bug->handler_id, $f_assign, $t_status );
 			# check that new handler has rights to handle the issue, and
 			#  that current user has rights to assign the issue
 			$t_threshold = access_get_status_threshold( $t_assign_status, $t_bug->project_id );

--- a/bug_update.php
+++ b/bug_update.php
@@ -373,14 +373,7 @@ if( $t_bug_note->note &&
 }
 
 # Handle automatic assignment of issues.
-if( $t_existing_bug->handler_id == NO_USER &&
-	$t_updated_bug->handler_id != NO_USER &&
-	$t_updated_bug->status == $t_existing_bug->status &&
-	$t_updated_bug->status < config_get( 'bug_assigned_status' ) &&
-	config_get( 'auto_set_status_to_assigned' )
-) {
-	$t_updated_bug->status = config_get( 'bug_assigned_status' );
-}
+$t_updated_bug->status = bug_get_status_for_assign( $t_existing_bug->handler_id, $t_updated_bug->handler_id, $t_existing_bug->status, $t_updated_bug->status );
 
 # Allow a custom function to validate the proposed bug updates. Note that
 # custom functions are being deprecated in MantisBT. You should migrate to

--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -271,7 +271,7 @@ foreach ( $t_links as $t_plugin => $t_hooks ) {
 					print_bracket_link( $t_href, $t_label );
 				}
 			}
-		} else {
+		} elseif( !empty( $t_hook ) ) {
 			print_bracket_link_prepared( $t_hook );
 		}
 	}

--- a/core/bug_group_action_api.php
+++ b/core/bug_group_action_api.php
@@ -202,12 +202,7 @@ function bug_group_action_get_commands( array $p_project_ids = null ) {
 
 		if( !isset( $t_commands['ASSIGN'] ) &&
 			access_has_project_level( config_get( 'update_bug_assign_threshold', null, null, $t_project_id ), $t_project_id ) ) {
-			if( ON == config_get( 'auto_set_status_to_assigned', null, null, $t_project_id ) &&
-				access_has_project_level( access_get_status_threshold( config_get( 'bug_assigned_status', null, null, $t_project_id ), $t_project_id ), $t_project_id ) ) {
-				$t_commands['ASSIGN'] = lang_get( 'actiongroup_menu_assign' );
-			} else {
-				$t_commands['ASSIGN'] = lang_get( 'actiongroup_menu_assign' );
-			}
+			$t_commands['ASSIGN'] = lang_get( 'actiongroup_menu_assign' );
 		}
 
 		if( !isset( $t_commands['CLOSE'] ) &&

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -21,7 +21,7 @@
 /**
  * Mantis Version
  */
-define( 'MANTIS_VERSION', '1.3.0-rc.3-dev' );
+define( 'MANTIS_VERSION', '1.3.0' );
 define( 'FILTER_VERSION', 'v9' );
 
 # --- constants -------------------

--- a/core/event_api.php
+++ b/core/event_api.php
@@ -230,26 +230,27 @@ function event_type_execute( $p_event, array $p_callbacks, $p_params = null ) {
  * If there are no callbacks, then nothing will be sent as output.
  * @param string $p_event     Event name.
  * @param array  $p_callbacks Array of callback function/plugin base name key/value pairs.
- * @param mixed  $p_params    Output separator (if single string) or indexed array of pre, mid, and post strings.
+ * @param mixed  $p_params    Parameters to event callback (array, or single object)
+ * @param mixed  $p_format    Output separator (if single string) or indexed array of pre, mid, and post strings.
  * @access public
  * @return void
  */
-function event_type_output( $p_event, array $p_callbacks, $p_params = null ) {
+function event_type_output( $p_event, array $p_callbacks, $p_params = null, $p_format = null ) {
 	$t_prefix = '';
 	$t_separator = '';
 	$t_postfix = '';
 
-	if( is_array( $p_params ) ) {
-		switch( count( $p_params ) ) {
+	if( is_array( $p_format ) ) {
+		switch( count( $p_format ) ) {
 			case 3:
-				$t_postfix = $p_params[2];
+				$t_postfix = $p_format[2];
 			case 2:
-				$t_separator = $p_params[1];
+				$t_separator = $p_format[1];
 			case 1:
-				$t_prefix = $p_params[0];
+				$t_prefix = $p_format[0];
 		}
 	} else {
-		$t_separator = $p_params;
+		$t_separator = $p_format;
 	}
 
 	$t_output = array();

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1076,6 +1076,122 @@ function filter_get_bug_count( array $p_query_clauses ) {
  * @return boolean|array
  */
 function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p_bug_count, $p_custom_filter = null, $p_project_id = null, $p_user_id = null, $p_show_sticky = null ) {
+	# assigning to $p_* for this function writes the values back in case the caller wants to know
+
+	if( $p_custom_filter === null ) {
+		$t_filter = filter_get_bug_rows_filter( $p_project_id, $p_user_id );
+	} else {
+		$t_filter = $p_custom_filter;
+	}
+
+	# Get the query clauses
+	$t_query_clauses = filter_get_bug_rows_query_clauses( $t_filter, $p_project_id, $p_user_id, $p_show_sticky );
+
+	# Get the total number of bugs that meet the criteria.
+	$p_bug_count = filter_get_bug_count( $t_query_clauses );
+	if( 0 == $p_bug_count ) {
+		return array();
+	}
+
+	# Calculate pagination
+	$p_per_page = filter_per_page( $t_filter, $p_bug_count, $p_per_page );
+	$p_page_count = filter_page_count( $p_bug_count, $p_per_page );
+	$p_page_number = filter_valid_page_number( $p_page_number, $p_page_count );
+	$t_offset = filter_offset( $p_page_number, $p_per_page );
+	# Execute query
+	$t_result = filter_get_bug_rows_result( $t_query_clauses, $p_per_page, $t_offset );
+
+	# Read results into rows array
+	$t_bug_id_array = array();
+	while( $t_row = db_fetch_array( $t_result ) ) {
+		$t_bug_id_array[] = (int)$t_row['id'];
+		$t_rows[] = $t_row;
+	}
+
+	# Return the processed rows: cache data, convert to bug objects
+	return filter_cache_result( $t_rows, $t_bug_id_array );
+}
+
+/**
+ * Get the filter defined by user and project.
+ * @param integer $p_project_id    Project id to use in filtering.
+ * @param integer $p_user_id       User id to use as current user when filtering.
+ * @return array
+ */
+function filter_get_bug_rows_filter( $p_project_id = null, $p_user_id = null ) {
+	$t_current_user_id = auth_get_current_user_id();
+
+	if( $p_user_id === null || $p_user_id === 0 ) {
+		$t_user_id = $t_current_user_id;
+	} else {
+		$t_user_id = $p_user_id;
+	}
+
+	if( null === $p_project_id ) {
+		# @@@ If project_id is not specified, then use the project id(s) in the filter if set, otherwise, use current project.
+		$t_project_id = helper_get_current_project();
+	} else {
+		$t_project_id = $p_project_id;
+	}
+
+	if( $t_user_id == $t_current_user_id ) {
+		$t_filter = current_user_get_bug_filter();
+	} else {
+		$t_filter = user_get_bug_filter( $t_user_id, $t_project_id );
+	}
+
+	# if filter isn't return above, create a new filter from an empty array.
+	if( false === $t_filter ) {
+		$t_filter = array();
+	}
+	return $t_filter;
+}
+
+/**
+ * Creates a sql query with the supplied filter query clauses, and returns the unprocessed result set opbject
+ * @param array   $p_query_clauses Array of query clauses
+ * @param integer $p_count         The number of rows to return
+ *                                 -1 or null indicates default query (no limits)
+ * @param integer $p_offset        Offset query results for paging (number of rows)
+ *                                 -1 or null indicates default query (no offset)
+ * @return IteratorAggregate|boolean adodb result set or false if the query failed.
+ */
+function filter_get_bug_rows_result( array $p_query_clauses, $p_count = null, $p_offset = null ) {
+	if( null === $p_count ) {
+		$t_count = -1;
+	} else {
+		$t_count = $p_count;
+	}
+	if( null === $p_offset ) {
+		$t_offset = -1;
+	} else {
+		$t_offset = $p_offset;
+	}
+	$t_query_clauses = $p_query_clauses;
+	$t_select_string = 'SELECT DISTINCT ' . implode( ', ', $t_query_clauses['select'] );
+	$t_from_string = ' FROM ' . implode( ', ', $t_query_clauses['from'] );
+	$t_order_string = ' ORDER BY ' . implode( ', ', $t_query_clauses['order'] );
+	$t_join_string = count( $t_query_clauses['join'] ) > 0 ? implode( ' ', $t_query_clauses['join'] ) : ' ';
+	$t_where_string = ' WHERE '. implode( ' AND ', $t_query_clauses['project_where'] );
+	if( count( $t_query_clauses['where'] ) > 0 ) {
+		$t_where_string .= ' AND ( ';
+		$t_where_string .= implode( $t_query_clauses['operator'], $t_query_clauses['where'] );
+		$t_where_string .= ' ) ';
+	}
+
+	$t_result = db_query( $t_select_string . $t_from_string . $t_join_string . $t_where_string . $t_order_string, $t_query_clauses['where_values'], $t_count, $t_offset );	
+	return $t_result;
+}
+
+/**
+ * Creates an array of formatted query clauses, based on the supplied filter and parameters
+ * @param array   $p_filter       Filter array object
+ * @param integer $p_project_id   Project id to use in filtering.
+ * @param integer $p_user_id      User id to use as current user when filtering.
+ * @param boolean $p_show_sticky  True/false - get sticky issues only.
+ * @return array
+ */
+function filter_get_bug_rows_query_clauses( array $p_filter, $p_project_id = null, $p_user_id = null, $p_show_sticky = null ) {
 	log_event( LOG_FILTERING, 'START NEW FILTER QUERY' );
 
 	$t_limit_reporters = config_get( 'limit_reporters' );
@@ -1099,24 +1215,7 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 		$t_project_id = $p_project_id;
 	}
 
-	if( $p_custom_filter === null ) {
-		# Prefer current_user_get_bug_filter() over user_get_filter() when applicable since it supports
-		# cookies set by previous version of the code.
-		if( $t_user_id == $t_current_user_id ) {
-			$t_filter = current_user_get_bug_filter();
-		} else {
-			$t_filter = user_get_bug_filter( $t_user_id, $t_project_id );
-		}
-	} else {
-		$t_filter = $p_custom_filter;
-	}
-
-	# if filter isn't return above, create a new filter from an empty array.
-	if( false === $t_filter ) {
-		$t_filter = array();
-	}
-
-	$t_filter = filter_ensure_valid_filter( $t_filter );
+	$t_filter = filter_ensure_valid_filter( $p_filter );
 
 	$t_view_type = $t_filter['_view_type'];
 
@@ -2066,37 +2165,8 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 	$t_query_clauses['operator'] = $t_join_operator;
 	$t_query_clauses = filter_get_query_sort_data( $t_filter, $p_show_sticky, $t_query_clauses );
 
-	# assigning to $p_* for this function writes the values back in case the caller wants to know
-	# Get the total number of bugs that meet the criteria.
-	$p_bug_count = filter_get_bug_count( $t_query_clauses );
-	if( 0 == $p_bug_count ) {
-		return array();
-	}
-	$p_per_page = filter_per_page( $t_filter, $p_bug_count, $p_per_page );
-	$p_page_count = filter_page_count( $p_bug_count, $p_per_page );
-	$p_page_number = filter_valid_page_number( $p_page_number, $p_page_count );
-	$t_offset = filter_offset( $p_page_number, $p_per_page );
 	$t_query_clauses = filter_unique_query_clauses( $t_query_clauses );
-	$t_select_string = 'SELECT DISTINCT ' . implode( ', ', $t_query_clauses['select'] );
-	$t_from_string = ' FROM ' . implode( ', ', $t_query_clauses['from'] );
-	$t_order_string = ' ORDER BY ' . implode( ', ', $t_query_clauses['order'] );
-	$t_join_string = count( $t_query_clauses['join'] ) > 0 ? implode( ' ', $t_query_clauses['join'] ) : ' ';
-	$t_where_string = ' WHERE '. implode( ' AND ', $t_query_clauses['project_where'] );
-	if( count( $t_query_clauses['where'] ) > 0 ) {
-		$t_where_string .= ' AND ( ';
-		$t_where_string .= implode( $t_join_operator, $t_query_clauses['where'] );
-		$t_where_string .= ' ) ';
-	}
-
-	$t_result = db_query( $t_select_string . $t_from_string . $t_join_string . $t_where_string . $t_order_string, $t_query_clauses['where_values'], $p_per_page, $t_offset );
-
-	$t_id_array_lastmod = array();
-	while( $t_row = db_fetch_array( $t_result ) ) {
-		$t_id_array_lastmod[] = (int)$t_row['id'];
-		$t_rows[] = $t_row;
-	}
-
-	return filter_cache_result( $t_rows, $t_id_array_lastmod );
+	return $t_query_clauses;
 }
 
 /**

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1626,12 +1626,6 @@ function html_button_bug_change_status( BugData $p_bug ) {
  */
 function html_button_bug_assign_to( BugData $p_bug ) {
 	# make sure status is allowed of assign would cause auto-set-status
-	# workflow implementation
-	if( ON == config_get( 'auto_set_status_to_assigned' )
-		&& !bug_check_workflow( $p_bug->status, config_get( 'bug_assigned_status' ) )
-	) {
-		return;
-	}
 
 	# make sure current user has access to modify bugs.
 	if( !access_has_bug_level( config_get( 'update_bug_assign_threshold', config_get( 'update_bug_threshold' ) ), $p_bug->id ) ) {

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -388,7 +388,11 @@ function html_css() {
  * @return void
  */
 function html_css_link( $p_filename ) {
-	echo "\t", '<link rel="stylesheet" type="text/css" href="', string_sanitize_url( helper_mantis_url( 'css/' . $p_filename ), true ), '" />' . "\n";
+	# If no path is specified, look for CSS files in default directory
+	if( $p_filename == basename( $p_filename ) ) {
+		$p_filename = 'css/' . $p_filename;
+	}
+	echo "\t", '<link rel="stylesheet" type="text/css" href="', string_sanitize_url( helper_mantis_url( $p_filename ), true ), '" />' . "\n";
 }
 
 

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -367,7 +367,7 @@ function html_css() {
 	html_css_link( config_get( 'css_include_file' ) );
 
 	if ( config_get_global( 'cdn_enabled' ) == ON ) {
-		echo '<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/' . JQUERY_UI_VERSION . '/themes/smoothness/jquery-ui.css">' . "\n";
+		echo '<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/' . JQUERY_UI_VERSION . '/themes/smoothness/jquery-ui.min.css">' . "\n";
 	} else {
 		html_css_link( 'jquery-ui-' . JQUERY_UI_VERSION . '.min.css' );
 	}

--- a/css/default.css
+++ b/css/default.css
@@ -11,12 +11,12 @@ p.compact		{ margin: 0;}
 
 pre				{ margin-top: 0px; margin-bottom: 0px; }
 
-a					{}
+a					{ color: royalblue; }
 a:active 			{}
-a:link    			{}
+a:link    			{ text-decoration: none; }
+a:hover 			{ color: red; }
 a:visited 			{}
-a.subtle			{ color: blue; text-decoration: none; }
-a.resolved			{ text-decoration: line-through underline; }
+a.resolved			{ text-decoration: line-through; }
 a > img				{ border: none; }
 
 form				{ display: inline; }
@@ -38,11 +38,11 @@ span.bracket-link	{ white-space: nowrap; }
 table				{ border: none; }
 table td, table th	{ border: none; border-spacing: 0px; }
 table.hide			{ width: 100%; border: solid 0px #ffffff; }
-table.width100		{ width: 100%; border: solid 1px #000000; }
-table.width90		{ width: 90%;  margin-left: 5%; margin-right: 5%; border: solid 1px #000000; }
-table.width75		{ width: 74%;  margin-left: 13%; margin-right: 13%; border: solid 1px #000000; }
-table.width60		{ width: 60%;  margin-left: 20%; margin-right: 20%; border: solid 1px #000000; }
-table.width50		{ width: 50%;  margin-left: 25%; margin-right: 25%; border: solid 1px #000000; }
+table.width100		{ width: 100%; border: solid 1px #999; }
+table.width90		{ width: 90%;  margin-left: 5%; margin-right: 5%; border: solid 1px #999; }
+table.width75		{ width: 74%;  margin-left: 13%; margin-right: 13%; border: solid 1px #999; }
+table.width60		{ width: 60%;  margin-left: 20%; margin-right: 20%; border: solid 1px #999; }
+table.width50		{ width: 50%;  margin-left: 25%; margin-right: 25%; border: solid 1px #999; }
 
 td,th 				{ font-family: Verdana, Arial, Helvetica, sans-serif; font-size: 10pt; padding: 4px; text-align: left; }
 td.center			{ text-align: center; }
@@ -53,8 +53,8 @@ td.category2, th.category2		{ background-color: #c8c8e8; color: #000000; vertica
 td.overdue			{ background-color: #ff0000; color: #000000; font-weight: bold; }
 td.sticky-header 	{ background-color: #999999; }
 td.width30, th.width30			{ width: 30%; }
-td.col-1			{ background-color: #d8d8d8; color: #000000; }
-td.col-2			{ background-color: #e8e8e8; color: #000000; }
+td.col-1			{ background-color: #ebebeb; color: #000000; }
+td.col-2			{ background-color: #f3f3f3; color: #000000; }
 td.form-title		{ background-color: #ffffff; color: #000000; font-weight: bold; text-align: left; }
 td.form-title-caps	{ background-color: #ffffff; color: #000000; font-weight: bold; text-align: left; text-transform: uppercase; }
 td.nopad			{ padding: 0px; }
@@ -62,14 +62,14 @@ td.small-caption, th.small-caption	{ font-size: 8pt; }
 td.print			{ font-size: 8pt; text-align: left; padding: 2px; }
 td.print-category, th.print-category	{ font-size: 8pt; color: #000000; font-weight: bold; text-align: right; padding: 2px; }
 td.print-overdue	{ font-size: 8pt; color: #000000; font-weight: bold; padding: 2px; }
-td.print-bottom		{ border-bottom: 1px solid #000000; }
+td.print-bottom		{ border-bottom: 1px solid #999; }
 td.print-spacer		{ background-color: #ffffff; color: #000000; font-size: 1pt; line-height: 0.1; padding: 0px;}
 td.print > a:link.user { text-decoration: none; color: black; }
 
 tr					{}
 tr.spacer			{ background-color: #ffffff !important; color: #000000; height: 5px; }
-tr.row-1			{ background-color: #d8d8d8; color: #000000; }
-tr.row-2			{ background-color: #e8e8e8; color: #000000; }
+tr.row-1			{ background-color: #ebebeb; color: #000000; }
+tr.row-2			{ background-color: #f3f3f3; color: #000000; }
 tr.row-category		{ background-color: #c8c8e8; color: #000000; font-weight: bold;}
 tr.row-category td  {  text-align:center; }
 tr.row-category2	{ background-color: #c8c8e8; color: #000000; }
@@ -97,7 +97,7 @@ td.my-buglist-description	{ width: 100%; vertical-align: top; }
 
 
 tr.bugnote .bugnote-meta { background-color: #c8c8e8; color: #000000; font-weight: bold; width: 25%; line-height: 1.4; vertical-align: top; }
-tr.bugnote .bugnote-note { background-color: #e8e8e8; color: #000000; width: 75%; vertical-align: top; }
+tr.bugnote .bugnote-note { background-color: #f3f3f3; color: #000000; width: 75%; vertical-align: top; }
 tr.bugnote .time-tracked,
 .time-tracking-total .time-tracked { font-weight:bold; margin: 0 0 1em; padding:0; }
 .time-tracking-total { text-align:right; }
@@ -133,10 +133,10 @@ tr.bugnote .time-tracked,
 
 .info-bar { font-size: small; margin: 0.1em 0 0.4em 0; padding: .2em 0; }
 
-.main-menu { float: left; width: 100%; padding: 0; border: 1px solid #999; background-color: #e8e8e8; z-index: 99; }
+.main-menu { float: left; width: 100%; padding: 0; border: 1px solid #999; background-color: #ebebeb; z-index: 99; }
 .main-menu ul { clear: left; float: left; list-style: none; position: relative; margin: 0; padding: .25em; }
 .main-menu ul li { display:block; float: left; list-style: none; padding: .15em 0; margin: 0; position: relative; }
-.main-menu ul li a { padding: 0 .9em; border-right: 1px solid #000; text-decoration: underline; }
+.main-menu ul li a { padding: 0 .9em; border-right: 1px solid #999; text-decoration: none; }
 .main-menu ul li > a#logout-link { border-right: none; }
 .main-menu div#bug-jump { float: right; margin: 0; padding: 2px 0; position: relative; z-index: 100; border: none; }
 .main-menu input { font-size: 9pt; }
@@ -181,7 +181,7 @@ tr.bugnote .time-tracked,
 #manage-user-filter-menu ul a,
 #manage-tags-filter-menu ul a,
 #admin-menu ul a
-	{ text-decoration: underline; padding: 0 .25em; }
+	{ text-decoration: none; padding: 0 .25em; }
 
 #manage-menu ul span,
 #manage-config-menu ul span,
@@ -232,7 +232,7 @@ br { clear:both; }
 
 td.menu
 {
-	background-color: #e8e8e8;
+	background-color: #f3f3f3;
 	color: #000000;
 	text-align: center;
 	width: 100%;
@@ -244,15 +244,15 @@ td.menu a
 	white-space: nowrap;
 }
 
-td.news-heading-public	{ background-color: #c8c8e8; color: #000000; text-align: left; border-bottom: 1px solid #000000; }
-td.news-heading-private	{ background-color: #d8d8d8;       color: #000000; text-align: left; border-bottom: 1px solid #000000; }
+td.news-heading-public	{ background-color: #c8c8e8; color: #000000; text-align: left; border-bottom: 1px solid #999; }
+td.news-heading-private	{ background-color: #ebebeb;       color: #000000; text-align: left; border-bottom: 1px solid #999; }
 td.news-body			{ background-color: #ffffff;         color: #000000; padding: 16px; }
 
 div#news-items { clear: both; }
 div.news-item { border: 1px solid #000; padding: 0em; width: 75%; margin: 2em auto; }
 div#news-items div:first-child { margin-top: 3em; }
-h3.news-heading-public	{ background-color: #c8c8e8; color: #000000; text-align: left; border-bottom: 1px solid #000000; margin: 0em; padding: .25em; }
-h3.news-heading-private	{ background-color: #d8d8d8; color: #000000; text-align: left; border-bottom: 1px solid #000000; margin: 0em; padding: .25em; }
+h3.news-heading-public	{ background-color: #c8c8e8; color: #000000; text-align: left; border-bottom: 1px solid #999; margin: 0em; padding: .25em; }
+h3.news-heading-private	{ background-color: #ebebeb; color: #000000; text-align: left; border-bottom: 1px solid #999; margin: 0em; padding: .25em; }
 p.news-body			{ background-color: #ffffff; color: #000000; margin: 0em; padding: 1em; }
 .news-date-posted { font-style: italic; font-size: .8em; font-weight: normal; }
 .news-author { font-weight: normal; }
@@ -268,7 +268,7 @@ img.icon				{ width: 11px; height: 11px; }
 img.delete-icon			{ position: relative; top: 5px; border: 0; }
 
 div						{ padding: 3px; }
-div.menu				{ background-color: #e8e8e8; color: #000000; text-align: center; width: 100%; padding: 1px; }
+div.menu				{ background-color: #f3f3f3; color: #000000; text-align: center; width: 100%; padding: 1px; }
 
 div.center {
 	width: 50%;
@@ -279,7 +279,7 @@ div.center {
 div.border
 {
 	background-color: #ffffff;
-	border: solid 1px #000000;
+	border: solid 1px #999;
 	text-align: center;
 	position: relative;
 }
@@ -366,7 +366,7 @@ td.tainted { color: red; }
 td.tainted input[type="text"], td.tainted select { background-color: #ffffff; color: red; border: 1px solid red; }
 select.tainted { background-color: #ffffff; color: red; }
 
-#filter_open, #filter_closed { position: relative; border: 1px solid #000; padding: 0; margin: 0; }
+#filter_open, #filter_closed { position: relative; border: 1px solid #999; padding: 0; margin: 0; }
 #filter_open_link, #filter_closed_link { float: left; position: relative; top: 0.5em; padding: 0 .5em; margin: 0; }
 .search-box { float: left; position: relative; padding: 0 0 0 0.5em; margin: 0; }
 .filter-links, .manage-queries, .reset-query, .save-query, .search-box, .stored-queries, .submit-query { top: .3em; }
@@ -380,7 +380,7 @@ div#save-filter { text-align: center; }
 .stored-queries select { font-size: .9em; }
 #error-msg { clear: both; }
 .error-msg { color: red; text-align: center; }
-div#error-msg { width: 60%; margin: 0em auto; border: 1px solid #000; }
+div#error-msg { width: 60%; margin: 0em auto; border: 1px solid #999; }
 div.error-type { font-weight: bold; }
 div.error-description { color: red; text-align: center; margin: 1.5em; }
 div.error-info { text-align: center; margin: 1em; }
@@ -431,7 +431,7 @@ div.table-container {
 	margin: 2em auto 0em auto;
 	padding: 1px;
 	min-width: 50em;
-	border: 1px solid #000;
+	border: 1px solid #999;
 	width: 90%; /* default width */
 }
 
@@ -562,7 +562,7 @@ div.form-container > table > tbody > tr:nth-child(odd),
 div.form-container > table > tr:nth-child(odd),
 div.form-container div.field-container:nth-child(odd),
 div.section-container div.field-container:nth-child(odd)
-	{ background-color: #e8e8e8; }
+	{ background-color: #f3f3f3; }
 
 fieldset > .field-container:nth-child(even),
 form > table > tr:nth-child(even),
@@ -575,7 +575,7 @@ div.form-container > table > tbody > tr:nth-child(even),
 div.form-container div.field-container:nth-child(even),
 div.section-container div.field-container:nth-child(even),
 div.form-container > table > tr:nth-child(even)
-	{ background-color: #d8d8d8; }
+	{ background-color: #ebebeb; }
 
 form > table > tr:last-child,
 div.table-container > table > tbody > tr > td.buttons,
@@ -642,7 +642,7 @@ div.form-container .file,
 	position: relative;
 	float: left;
 	padding: .25em;
-	margin: 0em .5em;
+	margin: 0em .25em;
 }
 div.form-container .radio input,
 div.form-container .checkbox input,
@@ -753,7 +753,7 @@ ul.project-list li span.access-level, ul.project-list li span.view-state { displ
 	margin: 0em .5em;
 }
 
-tr.bugnote-private td.bugnote-meta { background-color: #e8e8e8; }
+tr.bugnote-private td.bugnote-meta { background-color: #f3f3f3; }
 
 div#mantis.centered_page div#banner { text-align: center; }
 
@@ -772,7 +772,7 @@ div.summary-container {
 div.summary-container table {
 	width: 100%;
 	border-spacing: 1px;
-	border: solid 1px #000000;
+	border: solid 1px #999;
 	position: relative;
 	margin-bottom: 10px;
 }
@@ -786,7 +786,7 @@ div#summary-bottom	{ width: 99.8%; clear: both; }
  */
 
 /* timeline header styles */
-div.timeline { width: 34%; float: right; border: solid 1px #000000; margin-top: 10px; padding: 3px 20px 15px 20px; margin-bottom: 10px; }
+div.timeline { width: 34%; float: right; border: solid 1px #999; margin-top: 10px; padding: 3px 20px 15px 20px; margin-bottom: 10px; }
 div.timeline div { padding: 0; }
 div.timeline .heading { font-size: x-large; padding-top: 3px; padding-bottom: 3px; }
 div.timeline .date-range { font-size: small; }

--- a/csv_export.php
+++ b/csv_export.php
@@ -49,25 +49,27 @@ auth_ensure_user_authenticated();
 
 helper_begin_long_process();
 
-$t_page_number = 1;
-$t_per_page = -1;
-$t_bug_count = null;
-$t_page_count = null;
-
 $t_nl = csv_get_newline();
 $t_sep = csv_get_separator();
 
-# Get bug rows according to the current filter
-$t_rows = filter_get_bug_rows( $t_page_number, $t_per_page, $t_page_count, $t_bug_count );
-if( $t_rows === false ) {
+# Get current filter
+$t_filter = filter_get_bug_rows_filter();
+
+# Get the query clauses
+$t_query_clauses = filter_get_bug_rows_query_clauses( $t_filter, $p_project_id, $p_user_id, $p_show_sticky );
+
+# Get the total number of bugs that meet the criteria.
+$p_bug_count = filter_get_bug_count( $t_query_clauses );
+
+if( 0 == $p_bug_count ) {
 	print_header_redirect( 'view_all_set.php?type=0' );
 }
 
+# Execute query
+$t_result = filter_get_bug_rows_result( $t_query_clauses );
+
 # Get columns to be exported
 $t_columns = csv_get_columns();
-
-# pre-cache custom column data
-columns_plugin_cache_issue_data( $t_rows, $t_columns );
 
 csv_start( csv_get_default_filename() );
 
@@ -100,29 +102,74 @@ if( strcmp( $t_first_three_chars, 'ID' . $t_sep ) == 0 ) {
 
 echo $t_header;
 
-# export the rows
-foreach ( $t_rows as $t_row ) {
-	$t_first_column = true;
 
-	foreach ( $t_columns as $t_column ) {
-		if( !$t_first_column ) {
-			echo $t_sep;
-		} else {
-			$t_first_column = false;
+define( 'EXPORT_BLOCK_SIZE', 500 );
+
+$t_end_of_results = false;
+do {
+	# Clear cache for next block
+	unset( $g_cache_bug );
+	unset( $g_cache_bug_text );
+
+	# Keep reading until reaching max block size or end of result set
+	$t_read_rows = array();
+	$t_count = 0;
+	$t_bug_id_array = array();
+	$t_unique_user_ids = array();
+	while( $t_count < EXPORT_BLOCK_SIZE ) {
+		$t_row = db_fetch_array( $t_result );
+		if( false === $t_row ) {
+			$t_end_of_results = true;
+			break;
+		}
+		$t_bug_id_array[] = (int)$t_row['id'];
+		$t_handler_id = (int)$t_row['handler_id'];
+		$t_unique_user_ids[$t_handler_id] = $t_handler_id;
+		$t_reporter_id = (int)$t_row['reporter_id'];
+		$t_unique_user_ids[$t_reporter_id] = $t_reporter_id;
+
+		$t_read_rows[] = $t_row;
+		$t_count++;
+	}
+	# Max block size has been reached, or no more rows left to complete the block.
+	# Either way, process what we have
+
+	# convert and cache data
+	$t_rows = filter_cache_result( $t_read_rows, $t_bug_id_array );
+	user_cache_array_rows( $t_unique_user_ids );
+	columns_plugin_cache_issue_data( $t_rows, $t_columns );
+
+	# Clear arrays that are not needed
+	unset( $t_read_rows );
+	unset( $t_unique_user_ids );
+	unset( $t_bug_id_array );
+
+	# export the rows
+	foreach ( $t_rows as $t_row ) {
+		$t_first_column = true;
+
+		foreach ( $t_columns as $t_column ) {
+			if( !$t_first_column ) {
+				echo $t_sep;
+			} else {
+				$t_first_column = false;
+			}
+
+			if( column_get_custom_field_name( $t_column ) !== null || column_is_plugin_column( $t_column ) ) {
+				ob_start();
+				$t_column_value_function = 'print_column_value';
+				helper_call_custom_function( $t_column_value_function, array( $t_column, $t_row, COLUMNS_TARGET_CSV_PAGE ) );
+				$t_value = ob_get_clean();
+
+				echo csv_escape_string( $t_value );
+			} else {
+				$t_function = 'csv_format_' . $t_column;
+				echo $t_function( $t_row );
+			}
 		}
 
-		if( column_get_custom_field_name( $t_column ) !== null || column_is_plugin_column( $t_column ) ) {
-			ob_start();
-			$t_column_value_function = 'print_column_value';
-			helper_call_custom_function( $t_column_value_function, array( $t_column, $t_row, COLUMNS_TARGET_CSV_PAGE ) );
-			$t_value = ob_get_clean();
-
-			echo csv_escape_string( $t_value );
-		} else {
-			$t_function = 'csv_format_' . $t_column;
-			echo $t_function( $t_row );
-		}
+		echo $t_nl;
 	}
 
-	echo $t_nl;
-}
+} while ( false === $t_end_of_results );
+

--- a/docbook/Admin_Guide/en-US/Revision_History.xml
+++ b/docbook/Admin_Guide/en-US/Revision_History.xml
@@ -6,6 +6,20 @@
 	<simpara>
 		<revhistory>
 			<revision>
+				<revnumber>1.3-9</revnumber>
+				<date>Thu Jul 9 2016</date>
+				<author>
+					<firstname>Victor</firstname>
+					<surname>Boctor</surname>
+					<email>vboctor@mantisbt.org</email>
+				</author>
+				<revdescription>
+					<simplelist>
+						<member>Release 1.3.0 stable</member>
+					</simplelist>
+				</revdescription>
+			</revision>
+			<revision>
 				<revnumber>1.3-10</revnumber>
 				<date>Thu Jul 3 2016</date>
 				<author>

--- a/docbook/Developers_Guide/en-US/Contributors.xml
+++ b/docbook/Developers_Guide/en-US/Contributors.xml
@@ -187,9 +187,9 @@ git remote add --tags upstream git://github.com/mantisbt/mantisbt.git
 			</para>
 			<para>
 				The following command will set up a tracking branch for the
-				current stable branch, <literal>master-1.2.x</literal>.
+				current stable branch, <literal>master-1.3.x</literal>.
 <programlisting>
-git checkout -b master-1.2.x origin/master-1.2.x
+git checkout -b master-1.3.x origin/master-1.3.x
 </programlisting>
 			</para>
 
@@ -270,7 +270,7 @@ sed -rn "s/^.*path\s*=\s*(.*)$/\1/p" .gitmodules |xargs -n 1 basename |xargs -I{
 			In order to keep your local repository up-to-date with the
 			official one, there are a few simple commands needed for any
 			tracking branches that you may have, including
-			<literal>master</literal> and <literal>master-1.2.x</literal>.
+			<literal>master</literal> and <literal>master-1.3.x</literal>.
 		</para>
 
 		<para>

--- a/docbook/Developers_Guide/en-US/Events.xml
+++ b/docbook/Developers_Guide/en-US/Events.xml
@@ -155,10 +155,31 @@ event_hook( $events, [$plugin] );
 			<para>
 				These events only use the first parameter array, and return values from
 				hooked functions are immediately sent to the output buffer via 'echo'.
+				Another parameter <parameter>$format</parameter> can be used to model
+				how the results are printed. This parameter can be either:
+				<itemizedlist>
+					<listitem>
+						<para>
+							null, or ommited: The returned values are printed without further processing
+						</para>
+					</listitem>
+					<listitem>
+						<para>
+							&lt;String&gt;: A string to be used as separator for printed values
+						</para>
+					</listitem>
+					<listitem>
+						<para>
+							&lt;Array&gt;: An array of (prefix, separator, postfix) to be used for the printed values
+						</para>
+					</listitem>
+				</itemizedlist>
+			</para>
+			<para>
 				Example usage:
 			</para>
 
-			<programlisting>event_signal( $event_name, [ array( $param, ... ) ] );</programlisting>
+			<programlisting>event_signal( $event_name, [ array( $param, ... ) ], [ $format ] );</programlisting>
 		</blockquote>
 
 		<blockquote id="dev.events.types.chain">

--- a/docbook/Developers_Guide/en-US/Revision_History.xml
+++ b/docbook/Developers_Guide/en-US/Revision_History.xml
@@ -8,6 +8,20 @@
 	<simpara>
 		<revhistory>
 			<revision>
+				<revnumber>1.3-9</revnumber>
+				<date>Thu Jul 9 2016</date>
+				<author>
+					<firstname>Victor</firstname>
+					<surname>Boctor</surname>
+					<email>vboctor@mantisbt.org</email>
+				</author>
+				<revdescription>
+					<simplelist>
+						<member>Release 1.3.0 stable</member>
+					</simplelist>
+				</revdescription>
+			</revision>
+			<revision>
 				<revnumber>1.3-8</revnumber>
 				<date>Thu Jul 3 2016</date>
 				<author>

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -65,15 +65,6 @@ $t_export_title = excel_get_default_filename();
 
 $t_short_date_format = config_get( 'short_date_format' );
 
-# This is where we used to do the entire actual filter ourselves
-$t_page_number = gpc_get_int( 'page_number', 1 );
-$t_per_page = 100;
-
-$t_result = filter_get_bug_rows( $t_page_number, $t_per_page, $t_page_count, $t_bug_count );
-if( $t_result === false ) {
-	print_header_redirect( 'view_all_set.php?type=0&print=1' );
-}
-
 header( 'Content-Type: application/vnd.ms-excel; charset=UTF-8' );
 header( 'Pragma: public' );
 header( 'Content-Disposition: attachment; filename="' . urlencode( file_clean_name( $t_export_title ) ) . '.xml"' ) ;
@@ -85,38 +76,96 @@ $f_bug_arr = explode( ',', $f_export );
 
 $t_columns = excel_get_columns();
 
+
+# Get current filter
+$t_filter = filter_get_bug_rows_filter();
+
+# Get the query clauses
+$t_query_clauses = filter_get_bug_rows_query_clauses( $t_filter, $p_project_id, $p_user_id, $p_show_sticky );
+
+# Get the total number of bugs that meet the criteria.
+$p_bug_count = filter_get_bug_count( $t_query_clauses );
+
+if( 0 == $p_bug_count ) {
+	print_header_redirect( 'view_all_set.php?type=0&print=1' );
+}
+
+# Execute query
+$t_result = filter_get_bug_rows_result( $t_query_clauses );
+
+
+
+define( 'EXPORT_BLOCK_SIZE', 500 );
+
+$t_end_of_results = false;
 do {
-	# pre-cache custom column data
+	# Clear cache for next block
+	unset( $g_cache_bug );
+	unset( $g_cache_bug_text );
+
+	# Keep reading until reaching max block size or end of result set
+	$t_read_rows = array();
+	$t_count = 0;
+	$t_bug_id_array = array();
+	$t_unique_user_ids = array();
+	while( $t_count < EXPORT_BLOCK_SIZE ) {
+		$t_row = db_fetch_array( $t_result );
+		if( false === $t_row ) {
+			$t_end_of_results = true;
+			break;
+		}
+		# @TODO, the "export" bug list parameter functionality should be implemented in a more efficient way
+		if( is_blank( $f_export ) || in_array( $t_row['id'], $f_bug_arr ) ) {
+			$t_bug_id_array[] = (int)$t_row['id'];
+			$t_handler_id = (int)$t_row['handler_id'];
+			$t_unique_user_ids[$t_handler_id] = $t_handler_id;
+			$t_reporter_id = (int)$t_row['reporter_id'];
+			$t_unique_user_ids[$t_reporter_id] = $t_reporter_id;
+
+			$t_read_rows[] = $t_row;
+			$t_count++;
+		}
+	}
+	# Max block size has been reached, or no more rows left to complete the block.
+	# Either way, process what we have
+	if( 0 === $t_count && !$t_end_of_results ) {
+		continue;
+	}
+	if( 0 === $t_count && $t_end_of_results ) {
+		break;
+	}
+
+	# convert and cache data
+	$t_rows = filter_cache_result( $t_read_rows, $t_bug_id_array );
+	user_cache_array_rows( $t_unique_user_ids );
 	columns_plugin_cache_issue_data( $t_result, $t_columns );
 
-	foreach( $t_result as $t_row ) {
-		if( is_blank( $f_export ) || in_array( $t_row->id, $f_bug_arr ) ) {
-			echo excel_get_start_row();
+	# Clear arrays that are not needed
+	unset( $t_read_rows );
+	unset( $t_unique_user_ids );
+	unset( $t_bug_id_array );
 
-			foreach ( $t_columns as $t_column ) {
-				$t_custom_field = column_get_custom_field_name( $t_column );
-				if( $t_custom_field !== null ) {
-					echo excel_format_custom_field( $t_row->id, $t_row->project_id, $t_custom_field );
-				} else if( column_is_plugin_column( $t_column ) ) {
-					echo excel_format_plugin_column_value( $t_column, $t_row );
-				} else {
-					$t_function = 'excel_format_' . $t_column;
-					echo $t_function( $t_row );
-				}
+	# export the rows
+	foreach ( $t_rows as $t_row ) {
+
+		echo excel_get_start_row();
+
+		foreach ( $t_columns as $t_column ) {
+			$t_custom_field = column_get_custom_field_name( $t_column );
+			if( $t_custom_field !== null ) {
+				echo excel_format_custom_field( $t_row->id, $t_row->project_id, $t_custom_field );
+			} else if( column_is_plugin_column( $t_column ) ) {
+				echo excel_format_plugin_column_value( $t_column, $t_row );
+			} else {
+				$t_function = 'excel_format_' . $t_column;
+				echo $t_function( $t_row );
 			}
+		}
 
-			echo excel_get_end_row();
-		} #in_array
-	} #for loop
-
-	# Get the next page if we are not processing the last one
-	# @@@ Note that since we are not using a transaction, there is a risk that we get a duplicate record or we miss
-	# one due to a submit or update that happens in parallel.
-	$t_more = ( $t_page_number < $t_page_count );
-	if( $t_more ) {
-		$t_page_number++;
-		$t_result = filter_get_bug_rows( $t_page_number, $t_per_page, $t_page_count, $t_bug_count );
+		echo excel_get_end_row();
 	}
-} while( $t_more );
+
+} while ( false === $t_end_of_results );
 
 echo excel_get_footer();
+

--- a/manage_tags_page.php
+++ b/manage_tags_page.php
@@ -121,7 +121,7 @@ print_manage_menu( 'manage_tags_page.php' ); ?>
 <div class="table-container">
 	<h2><?php echo lang_get( 'manage_tags_link' ) ?> [<?php echo $t_total_tag_count ?>]</h2>
 	<?php if( $t_can_edit ) { ?>
-	<div class="section-link"><?php print_link( '#tagcreate', lang_get( 'tag_create' ) ) ?></div>
+	<div class="section-link"><?php print_link( '#manage-tags-create-div', lang_get( 'tag_create' ) ) ?></div>
 	<?php } ?>
 	<table>
 		<thead>
@@ -162,7 +162,6 @@ print_manage_menu( 'manage_tags_page.php' ); ?>
 
 <?php if( $t_can_edit ) { ?>
 <div id="manage-tags-create-div" class="form-container">
-	<a name="tagcreate"></a>
 	<form id="manage-tags-create-form" method="post" action="tag_create.php">
 		<fieldset class="required">
 			<legend><span><?php echo lang_get( 'tag_create' ) ?></span></legend>

--- a/manage_tags_page.php
+++ b/manage_tags_page.php
@@ -162,7 +162,7 @@ print_manage_menu( 'manage_tags_page.php' ); ?>
 
 <?php if( $t_can_edit ) { ?>
 <div id="manage-tags-create-div" class="form-container">
-	<a name="tagcreate" />
+	<a name="tagcreate"></a>
 	<form id="manage-tags-create-form" method="post" action="tag_create.php">
 		<fieldset class="required">
 			<legend><span><?php echo lang_get( 'tag_create' ) ?></span></legend>

--- a/roadmap_page.php
+++ b/roadmap_page.php
@@ -80,9 +80,8 @@ function print_version_header( array $p_version_row ) {
 
 	$t_release_title = '<a href="roadmap_page.php?project_id=' . $t_project_id . '">' . string_display_line( $t_project_name ) . '</a> - <a href="roadmap_page.php?version_id=' . $t_version_id . '">' . string_display_line( $t_version_name ) . '</a>';
 
-	if( config_get( 'show_roadmap_dates' ) ) {
-		$t_version_timestamp = $p_version_row['date_order'];
-
+	$t_version_timestamp = $p_version_row['date_order'];
+	if( config_get( 'show_roadmap_dates' ) && !date_is_null( $t_version_timestamp ) ) {
 		$t_scheduled_release_date = ' (' . lang_get( 'scheduled_release' ) . ' ' . string_display_line( date( config_get( 'short_date_format' ), $t_version_timestamp ) ) . ')';
 	} else {
 		$t_scheduled_release_date = '';

--- a/tests/soap/IssueAddTest.php
+++ b/tests/soap/IssueAddTest.php
@@ -134,6 +134,9 @@ class IssueAddTest extends SoapBase {
 		$t_issue_to_add['fixed_in_version'] = 'fixed version';
 		$t_issue_to_add['target_version'] = 'target version';
 		$t_issue_to_add['sticky'] = true;
+		
+		$t_dt = new DateTime();
+		$t_issue_to_add['last_updated'] = $t_dt->format( DateTime::ISO8601 );
 
 		$t_issue_id = $this->client->mc_issue_add( $this->userName, $this->password, $t_issue_to_add );
 
@@ -149,6 +152,10 @@ class IssueAddTest extends SoapBase {
 		$this->assertEquals( $t_issue_to_add['fixed_in_version'], $t_issue->fixed_in_version );
 		$this->assertEquals( $t_issue_to_add['target_version'], $t_issue->target_version );
 		$this->assertEquals( $t_issue_to_add['sticky'], $t_issue->sticky );
+		
+		$t_read_dt = DateTime::createFromFormat( DateTime::ISO8601, $t_issue->last_updated );
+		
+		$this->assertEquals( $t_dt, $t_read_dt );
 	}
 
 	/**


### PR DESCRIPTION
There is a problem with the exports to CSV and Excel functions when retrieving a large list of issues to export.
It is getting the list through filter_api:filter_get_bug_rows(), which pre-process the list loading it into memory, and doing cache of some bug data. Because of this, the memory usage grows linearly and php memory limit may be reached.
Excel export has a work around that uses pagination to get the data in batches, however there is still some redundancy because each time the function filter_get_bug_rows is called, a new query is being composed and executed.

The changes here are:
filter_get_bug_rows is a function which does all in one:
- prepare pagination
- compose query conditions
- execute query and load results in memory, add to cache related data

First modification is refactoring filter_get_bug_rows by separating the outer layers of logic (the core query composer is untouched and still that ugly block of code with hundreds of lines...).
However, now the result set can be accessed before its loaded and cached into memory.
To me it makes sense, to separate the query building and execution, from pagination which is very screen oriented.

Next modifications are the export procedures, which now reads directly from the result set. 
By reading rows in batches, memory used to store data and cache is controlled, and cleared between each batch.

fixes #0020424
