### PR TITLE
Fix gpc_get_xxx_array for associative arrays

### DIFF
--- a/core/gpc_api.php
+++ b/core/gpc_api.php
@@ -289,9 +289,8 @@ function gpc_get_int_array( $p_var_name, array $p_default = null ) {
 		trigger_error( ERROR_GPC_ARRAY_EXPECTED, ERROR );
 	}
 
-	$t_count = count( $t_result );
-	for( $i = 0; $i < $t_count; $i++ ) {
-		$t_result[$i] = (int)$t_result[$i];
+	foreach( $t_result as $t_key => $t_value ) {
+		$t_result[$t_key] = (int)$t_value;
 	}
 
 	return $t_result;
@@ -316,9 +315,8 @@ function gpc_get_bool_array( $p_var_name, array $p_default = null ) {
 		trigger_error( ERROR_GPC_ARRAY_EXPECTED, ERROR );
 	}
 
-	$t_count = count( $t_result );
-	for( $i = 0; $i < $t_count; $i++ ) {
-		$t_result[$i] = gpc_string_to_bool( $t_result[$i] );
+	foreach( $t_result as $t_key => $t_value ) {
+		$t_result[$t_key] = gpc_string_to_bool( $t_value );
 	}
 
 	return $t_result;


### PR DESCRIPTION
Functions:
gpc_get_int_array(),
gpc_get_bool_array()
dont work properly for html fields named with
associative indexes (numeric out or order, or
strings), becasue it assumes indexes as zero
based sequential numbers.
The code is here changed to keep the original
keys as defined in the field names.

Fixes #20476