### PR TITLE
Fix gpc_get regression by b53f7ca

### DIFF
--- a/core/gpc_api.php
+++ b/core/gpc_api.php
@@ -288,9 +288,10 @@ function gpc_get_int_array( $p_var_name, array $p_default = null ) {
 		error_parameters( $p_var_name );
 		trigger_error( ERROR_GPC_ARRAY_EXPECTED, ERROR );
 	}
-
-	foreach( $t_result as $t_key => $t_value ) {
-		$t_result[$t_key] = (int)$t_value;
+	if( is_array( $t_result ) ) {
+		foreach( $t_result as $t_key => $t_value ) {
+			$t_result[$t_key] = (int)$t_value;
+		}
 	}
 
 	return $t_result;
@@ -315,8 +316,10 @@ function gpc_get_bool_array( $p_var_name, array $p_default = null ) {
 		trigger_error( ERROR_GPC_ARRAY_EXPECTED, ERROR );
 	}
 
-	foreach( $t_result as $t_key => $t_value ) {
-		$t_result[$t_key] = gpc_string_to_bool( $t_value );
+	if( is_array( $t_result ) ) {
+		foreach( $t_result as $t_key => $t_value ) {
+			$t_result[$t_key] = gpc_string_to_bool( $t_value );
+		}
 	}
 
 	return $t_result;


### PR DESCRIPTION
This fixes a regression introduced by commit
b53f7ca
When loop is changed into 'foreach', null values
produce error if not checked.

This happens when default value passed as parameter is explicitly null.
Sorry i didnt catch it in original commit