### PR TITLE
0020483 pgsql manage user page

### DIFF
--- a/manage_user_page.php
+++ b/manage_user_page.php
@@ -203,22 +203,17 @@ $t_total_user_count = 0;
 # Get the user data in $c_sort order
 $t_result = '';
 
-if( 1 == $c_show_disabled ) {
-	$t_show_disabled_cond = '';
-} else {
-	$t_show_disabled_cond = ' AND enabled = ' . db_param();
+if( 1 != $c_show_disabled ) {
+	$t_where .= ' AND enabled = ' . db_param();
 	$t_where_params[] = true;
 }
 
-if( 0 == $c_hide_inactive ) {
-	$t_query = 'SELECT count(*) as user_count FROM {user} WHERE ' . $t_where . $t_show_disabled_cond;
-} else {
-	$t_query = 'SELECT count(*) as user_count FROM {user}
-			WHERE ' . $t_where . $t_show_disabled_cond . '
-			AND ' . db_helper_compare_time( db_param(), '<', 'last_visit', $t_days_old );
+if( 0 != $c_hide_inactive ) {
+	$t_where .= ' AND ' . db_helper_compare_time( db_param(), '<', 'last_visit', $t_days_old );
 	$t_where_params[] = db_now();
 }
 
+$t_query = 'SELECT count(*) as user_count FROM {user} WHERE ' . $t_where;
 $t_result = db_query( $t_query, $t_where_params );
 $t_row = db_fetch_array( $t_result );
 $t_total_user_count = $t_row['user_count'];
@@ -239,16 +234,8 @@ if( $f_page_number < 1 ) {
 }
 
 
-if( 0 == $c_hide_inactive ) {
-	$t_query = 'SELECT * FROM {user} WHERE ' . $t_where . ' ' . $t_show_disabled_cond . ' ORDER BY ' . $c_sort . ' ' . $c_dir;
-	$t_result = db_query( $t_query, $t_where_params, $p_per_page, $t_offset );
-} else {
-	$t_query = 'SELECT * FROM {user}
-			WHERE ' . $t_where . $t_show_disabled_cond . '
-			AND ' . db_helper_compare_time( db_param(), '<', 'last_visit', $t_days_old ) . '
-			ORDER BY ' . $c_sort . ' ' . $c_dir;
-	$t_result = db_query( $t_query, $t_where_params, $p_per_page, $t_offset );
-}
+$t_query = 'SELECT * FROM {user} WHERE ' . $t_where . ' ORDER BY ' . $c_sort . ' ' . $c_dir;
+$t_result = db_query( $t_query, $t_where_params, $p_per_page, $t_offset );
 
 $t_users = array();
 while( $t_row = db_fetch_array( $t_result ) ) {

--- a/manage_user_page.php
+++ b/manage_user_page.php
@@ -105,12 +105,12 @@ if( !db_field_exists( $f_sort, db_get_table( 'user' ) ) ) {
 
 $c_dir = ( $f_dir == 'ASC' ) ? 'ASC' : 'DESC';
 
-# 0 = show inactive users, anything else = hide them
-$c_hide_inactive = ( $f_hide_inactive == 0 ) ? 0 : 1;
+# OFF = show inactive users, anything else = hide them
+$c_hide_inactive = ( $f_hide_inactive == OFF ) ? OFF : ON;
 $t_hide_inactive_filter = '&amp;hideinactive=' . $c_hide_inactive;
 
-# 0 = hide disabled users, anything else = show them
-$c_show_disabled = ( $f_show_disabled == 0 ) ? 0 : 1;
+# OFF = hide disabled users, anything else = show them
+$c_show_disabled = ( $f_show_disabled == OFF ) ? OFF : ON;
 $t_show_disabled_filter = '&amp;showdisabled=' . $c_show_disabled;
 
 # set cookie values for hide inactive, sort by, dir and show disabled
@@ -203,12 +203,12 @@ $t_total_user_count = 0;
 # Get the user data in $c_sort order
 $t_result = '';
 
-if( 1 != $c_show_disabled ) {
+if( ON != $c_show_disabled ) {
 	$t_where .= ' AND enabled = ' . db_param();
 	$t_where_params[] = true;
 }
 
-if( 0 != $c_hide_inactive ) {
+if( OFF != $c_hide_inactive ) {
 	$t_where .= ' AND ' . db_helper_compare_time( db_param(), '<', 'last_visit', $t_days_old );
 	$t_where_params[] = db_now();
 }
@@ -259,8 +259,8 @@ $t_user_count = count( $t_users );
 			<input type="hidden" name="dir" value="<?php echo $c_dir ?>" />
 			<input type="hidden" name="save" value="1" />
 			<input type="hidden" name="filter" value="<?php echo $c_filter ?>" />
-			<input type="checkbox" name="hideinactive" value="1" <?php check_checked( (int)$c_hide_inactive, 1 ); ?> /> <?php echo lang_get( 'hide_inactive' ) ?>
-			<input type="checkbox" name="showdisabled" value="1" <?php check_checked( (int)$c_show_disabled, 1 ); ?> /> <?php echo lang_get( 'show_disabled' ) ?>
+			<input type="checkbox" name="hideinactive" value="<?php echo ON ?>" <?php check_checked( (int)$c_hide_inactive, ON ); ?> /> <?php echo lang_get( 'hide_inactive' ) ?>
+			<input type="checkbox" name="showdisabled" value="<?php echo ON ?>" <?php check_checked( (int)$c_show_disabled, ON ); ?> /> <?php echo lang_get( 'show_disabled' ) ?>
 			<input type="submit" class="button" value="<?php echo lang_get( 'filter_button' ) ?>" />
 		</fieldset>
 	</form>


### PR DESCRIPTION
Fix pgsql query error manage_user_page

Due to pgsql having positional parameters in
parametrized queries, the page is throwing  an
error in some combination of conditions.
The error is caused by the reutilization of a
prepared WHERE condition in a string from
previous query. In the new query, a dp_param()
call is issued, which has the parameter reseted
to 1 (returning "$1").
Then, the resulting query string contains two
"$1" parameters for different values.

With this commit, the query build code is cleaned
to avoid said situation.

Fixes #20483