### PR TITLE
Consistently push query params in all APIs

### DIFF
--- a/core/access_api.php
+++ b/core/access_api.php
@@ -124,6 +124,7 @@ function access_cache_matrix_project( $p_project_id ) {
 	}
 
 	if( !in_array( (int)$p_project_id, $g_cache_access_matrix_project_ids ) ) {
+		db_param_push();
 		$t_query = 'SELECT user_id, access_level FROM {project_user_list} WHERE project_id=' . db_param();
 		$t_result = db_query( $t_query, array( (int)$p_project_id ) );
 		while( $t_row = db_fetch_array( $t_result ) ) {
@@ -154,6 +155,7 @@ function access_cache_matrix_user( $p_user_id ) {
 	global $g_cache_access_matrix, $g_cache_access_matrix_user_ids;
 
 	if( !in_array( (int)$p_user_id, $g_cache_access_matrix_user_ids ) ) {
+		db_param_push();
 		$t_query = 'SELECT project_id, access_level FROM {project_user_list} WHERE user_id=' . db_param();
 		$t_result = db_query( $t_query, array( (int)$p_user_id ) );
 

--- a/core/api_token_api.php
+++ b/core/api_token_api.php
@@ -56,6 +56,7 @@ function api_token_create( $p_token_name, $p_user_id ) {
 	$t_hash = api_token_hash( $t_plain_token );
 	$t_date_created = db_now();
 
+	db_param_push();
 	$t_query = 'INSERT INTO {api_token}
 					( user_id, name, hash, date_created )
 					VALUES ( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
@@ -82,6 +83,7 @@ function api_token_hash( $p_token ) {
  * @param string $p_user_id The user id.
  */
 function api_token_name_ensure_unique( $p_token_name, $p_user_id ) {
+	db_param_push();
 	$t_query = 'SELECT * FROM {api_token} WHERE user_id=' . db_param() . ' AND name=' . db_param();
 	$t_result = db_query( $t_query, array( $p_user_id, $p_token_name ) );
 
@@ -117,6 +119,7 @@ function api_token_validate( $p_username, $p_token ) {
 
 	$t_encrypted_token = api_token_hash( $p_token );
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {api_token} WHERE user_id=' . db_param() . ' AND hash=' . db_param();
 	$t_result = db_query( $t_query, array( $t_user_id, $t_encrypted_token ) );
 
@@ -136,6 +139,7 @@ function api_token_validate( $p_username, $p_token ) {
  * @access public
  */
 function api_token_get_all( $p_user_id ) {
+	db_param_push();
 	$t_query = 'SELECT * FROM {api_token} WHERE user_id=' . db_param() . ' ORDER BY date_used DESC, date_created ASC';
 	$t_result = db_query( $t_query, array( $p_user_id ) );
 
@@ -158,6 +162,7 @@ function api_token_get_all( $p_user_id ) {
 function api_token_touch( $p_api_token_id ) {
 	$t_date_used = db_now();
 
+	db_param_push();
 	$t_query = 'UPDATE {api_token} SET date_used=' . db_param() . ' WHERE id=' . db_param();
 
 	db_query( $t_query, array( $t_date_used, $p_api_token_id ) );
@@ -171,6 +176,7 @@ function api_token_touch( $p_api_token_id ) {
  * @access public
  */
 function api_token_revoke( $p_api_token_id, $p_user_id ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {api_token} WHERE id=' . db_param() . ' AND user_id = ' . db_param();
 	db_query( $t_query, array( $p_api_token_id, $p_user_id ) );
 }

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -671,6 +671,7 @@ function auth_generate_unique_cookie_string() {
  * @access public
  */
 function auth_is_cookie_string_unique( $p_cookie_string ) {
+	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM {user} WHERE cookie_string=' . db_param();
 	$t_result = db_query( $t_query, array( $p_cookie_string ) );
 
@@ -716,6 +717,7 @@ function auth_get_current_user_cookie( $p_login_anonymous = true ) {
 				if( function_exists( 'db_is_connected' ) && db_is_connected() ) {
 
 					# get anonymous information if database is available
+					db_param_push();
 					$t_query = 'SELECT id, cookie_string FROM {user} WHERE username = ' . db_param();
 					$t_result = db_query( $t_query, array( config_get( 'anonymous_account' ) ) );
 
@@ -877,6 +879,7 @@ function auth_is_cookie_valid( $p_cookie_string ) {
 	}
 
 	# look up cookie in the database to see if it is valid
+	db_param_push();
 	$t_query = 'SELECT * FROM {user} WHERE cookie_string=' . db_param();
 	$t_result = db_query( $t_query, array( $p_cookie_string ) );
 
@@ -910,6 +913,7 @@ function auth_get_current_user_id() {
 	}
 
 	# @todo error with an error saying they aren't logged in? Or redirect to the login page maybe?
+	db_param_push();
 	$t_query = 'SELECT id FROM {user} WHERE cookie_string=' . db_param();
 	$t_result = db_query( $t_query, array( $t_cookie_string ) );
 

--- a/core/billing_api.php
+++ b/core/billing_api.php
@@ -66,6 +66,8 @@ function billing_get_for_project( $p_project_id, $p_from, $p_to, $p_cost_per_hou
 		trigger_error( ERROR_GENERIC, ERROR );
 	}
 
+	db_param_push();
+
 	if( ALL_PROJECTS != $p_project_id ) {
 		access_ensure_project_level( config_get( 'view_bug_threshold' ), $p_project_id );
 

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -410,6 +410,7 @@ class BugData {
 			$t_restriction = '';
 		}
 
+		db_param_push();
 		$t_query = 'SELECT COUNT(*) FROM {bugnote}
 					  WHERE bug_id =' . db_param() . ' ' . $t_restriction;
 		$t_result = db_query( $t_query, array( $this->id ) );
@@ -480,6 +481,7 @@ class BugData {
 		}
 
 		# Insert text information
+		db_param_push();
 		$t_query = 'INSERT INTO {bug_text}
 					    ( description, steps_to_reproduce, additional_information )
 					  VALUES
@@ -500,6 +502,7 @@ class BugData {
 		if( 0 == $this->handler_id ) {
 			# if a default user is associated with the category and we know at this point
 			# that that the bug was not assigned to somebody, then assign it automatically.
+			db_param_push();
 			$t_query = 'SELECT user_id FROM {category} WHERE id=' . db_param();
 			$t_result = db_query( $t_query, array( $this->category_id ) );
 			$t_handler = db_result( $t_result );
@@ -517,6 +520,7 @@ class BugData {
 		}
 
 		# Insert the rest of the data
+		db_param_push();
 		$t_query = 'INSERT INTO {bug}
 					    ( project_id,reporter_id, handler_id,duplicate_id,
 					      priority,severity, reproducibility,status,
@@ -534,7 +538,6 @@ class BugData {
 					      ' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',
 					      ' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',
 					      ' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ')';
-
 		db_query( $t_query, array( $this->project_id, $this->reporter_id, $this->handler_id, $this->duplicate_id, $this->priority, $this->severity, $this->reproducibility, $t_status, $this->resolution, $this->projection, $this->category_id, $this->date_submitted, $this->last_updated, $this->eta, $t_text_id, $this->os, $this->os_build, $this->platform, $this->version, $this->build, $this->profile_id, $this->summary, $this->view_state, $this->sponsorship_total, $this->sticky, $this->fixed_in_version, $this->target_version, $this->due_date ) );
 
 		$this->id = db_insert_id( db_get_table( 'bug' ) );
@@ -627,6 +630,7 @@ class BugData {
 		#  as unix timestamps which could confuse the history log and they
 		#  shouldn't get updated like this anyway.  If you really need to change
 		#  them use bug_set_field()
+		db_param_push();
 		$t_query = 'UPDATE {bug}
 					SET project_id=' . db_param() . ', reporter_id=' . db_param() . ',
 						handler_id=' . db_param() . ', duplicate_id=' . db_param() . ',
@@ -707,6 +711,7 @@ class BugData {
 		if( $p_update_extended ) {
 			$t_bug_text_id = bug_get_field( $c_bug_id, 'bug_text_id' );
 
+			db_param_push();
 			$t_query = 'UPDATE {bug_text}
 							SET description=' . db_param() . ',
 								steps_to_reproduce=' . db_param() . ',
@@ -811,6 +816,7 @@ function bug_cache_row( $p_bug_id, $p_trigger_errors = true ) {
 
 	$c_bug_id = (int)$p_bug_id;
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {bug} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $c_bug_id ) );
 
@@ -914,6 +920,7 @@ function bug_text_cache_row( $p_bug_id, $p_trigger_errors = true ) {
 		return $g_cache_bug_text[$c_bug_id];
 	}
 
+	db_param_push();
 	$t_query = 'SELECT bt.* FROM {bug_text} bt, {bug} b
 				  WHERE b.id=' . db_param() . ' AND b.bug_text_id = bt.id';
 	$t_result = db_query( $t_query, array( $c_bug_id ) );
@@ -1163,6 +1170,7 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
 
 	# COPY CUSTOM FIELDS
 	if( $p_copy_custom_fields ) {
+		db_param_push();
 		$t_query = 'SELECT field_id, bug_id, value, text FROM {custom_field_string} WHERE bug_id=' . db_param();
 		$t_result = db_query( $t_query, array( $t_bug_id ) );
 
@@ -1172,6 +1180,7 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
 			$c_value = $t_bug_custom['value'];
 			$c_text = $t_bug_custom['text'];
 
+			db_param_push();
 			$t_query = 'INSERT INTO {custom_field_string}
 						   ( field_id, bug_id, value, text )
 						   VALUES (' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ')';
@@ -1186,17 +1195,20 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
 
 	# Copy bugnotes
 	if( $p_copy_bugnotes ) {
+		db_param_push();
 		$t_query = 'SELECT * FROM {bugnote} WHERE bug_id=' . db_param();
 		$t_result = db_query( $t_query, array( $t_bug_id ) );
 
 		while( $t_bug_note = db_fetch_array( $t_result ) ) {
 			$t_bugnote_text_id = $t_bug_note['bugnote_text_id'];
 
+			db_param_push();
 			$t_query2 = 'SELECT * FROM {bugnote_text} WHERE id=' . db_param();
 			$t_result2 = db_query( $t_query2, array( $t_bugnote_text_id ) );
 
 			$t_bugnote_text_insert_id = -1;
 			if( $t_bugnote_text = db_fetch_array( $t_result2 ) ) {
+				db_param_push();
 				$t_query2 = 'INSERT INTO {bugnote_text}
 							   ( note )
 							   VALUES ( ' . db_param() . ' )';
@@ -1204,6 +1216,7 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
 				$t_bugnote_text_insert_id = db_insert_id( db_get_table( 'bugnote_text' ) );
 			}
 
+			db_param_push();
 			$t_query2 = 'INSERT INTO {bugnote}
 						   ( bug_id, reporter_id, bugnote_text_id, view_state, date_submitted, last_modified )
 						   VALUES ( ' . db_param() . ',
@@ -1231,10 +1244,12 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
 	if( $p_copy_history ) {
 		# @todo problem with this code: the generated history trail is incorrect because the note IDs are those of the original bug, not the copied ones
 		# @todo actually, does it even make sense to copy the history ?
+		db_param_push();
 		$t_query = 'SELECT * FROM {bug_history} WHERE bug_id = ' . db_param();
 		$t_result = db_query( $t_query, array( $t_bug_id ) );
 
 		while( $t_bug_history = db_fetch_array( $t_result ) ) {
+			db_param_push();
 			$t_query = 'INSERT INTO {bug_history}
 						  ( user_id, bug_id, date_modified, field_name, old_value, new_value, type )
 						  VALUES ( ' . db_param() . ',' . db_param() . ',' . db_param() . ',
@@ -1353,10 +1368,12 @@ function bug_delete( $p_bug_id ) {
 	# Delete the bugnote text
 	$t_bug_text_id = bug_get_field( $p_bug_id, 'bug_text_id' );
 
+	db_param_push();
 	$t_query = 'DELETE FROM {bug_text} WHERE id=' . db_param();
 	db_query( $t_query, array( $t_bug_text_id ) );
 
 	# Delete the bug entry
+	db_param_push();
 	$t_query = 'DELETE FROM {bug} WHERE id=' . db_param();
 	db_query( $t_query, array( $c_bug_id ) );
 
@@ -1374,6 +1391,7 @@ function bug_delete( $p_bug_id ) {
 function bug_delete_all( $p_project_id ) {
 	$c_project_id = (int)$p_project_id;
 
+	db_param_push();
 	$t_query = 'SELECT id FROM {bug} WHERE project_id=' . db_param();
 	$t_result = db_query( $t_query, array( $c_project_id ) );
 
@@ -1508,6 +1526,7 @@ function bug_format_summary( $p_bug_id, $p_context ) {
 function bug_get_newest_bugnote_timestamp( $p_bug_id ) {
 	$c_bug_id = (int)$p_bug_id;
 
+	db_param_push();
 	$t_query = 'SELECT last_modified FROM {bugnote} WHERE bug_id=' . db_param() . ' ORDER BY last_modified DESC';
 	$t_result = db_query( $t_query, array( $c_bug_id ), 1 );
 	$t_row = db_result( $t_result );
@@ -1537,6 +1556,7 @@ function bug_get_bugnote_stats( $p_bug_id ) {
 	}
 
 	# @todo - optimise - max(), count()
+	db_param_push();
 	$t_query = 'SELECT last_modified FROM {bugnote} WHERE bug_id=' . db_param() . ' ORDER BY last_modified ASC';
 	$t_result = db_query( $t_query, array( $c_bug_id ) );
 
@@ -1566,6 +1586,7 @@ function bug_get_bugnote_stats( $p_bug_id ) {
  * @uses file_api.php
  */
 function bug_get_attachments( $p_bug_id ) {
+	db_param_push();
 	$t_query = 'SELECT id, title, diskfile, filename, filesize, file_type, date_added, user_id
 		                FROM {bug_file}
 		                WHERE bug_id=' . db_param() . '
@@ -1655,6 +1676,7 @@ function bug_set_field( $p_bug_id, $p_field_name, $p_value ) {
 	}
 
 	# Update fields
+	db_param_push();
 	$t_query = 'UPDATE {bug} SET ' . $p_field_name . '=' . db_param() . ' WHERE id=' . db_param();
 	db_query( $t_query, array( $c_value, $c_bug_id ) );
 
@@ -1710,6 +1732,7 @@ function bug_assign( $p_bug_id, $p_user_id, $p_bugnote_text = '', $p_bugnote_pri
 	if( ( $t_ass_val != $h_status ) || ( $p_user_id != $h_handler_id ) ) {
 
 		# get user id
+		db_param_push();
 		$t_query = 'UPDATE {bug}
 					  SET handler_id=' . db_param() . ', status=' . db_param() . '
 					  WHERE id=' . db_param();
@@ -1886,6 +1909,7 @@ function bug_reopen( $p_bug_id, $p_bugnote_text = '', $p_time_tracking = '0:00',
  * @uses database_api.php
  */
 function bug_update_date( $p_bug_id ) {
+	db_param_push();
 	$t_query = 'UPDATE {bug} SET last_updated=' . db_param() . ' WHERE id=' . db_param();
 	db_query( $t_query, array( db_now(), $p_bug_id ) );
 
@@ -1919,6 +1943,7 @@ function bug_monitor( $p_bug_id, $p_user_id ) {
 	}
 
 	# Insert monitoring record
+	db_param_push();
 	$t_query = 'INSERT INTO {bug_monitor} ( user_id, bug_id ) VALUES (' . db_param() . ',' . db_param() . ')';
 	db_query( $t_query, array( $c_user_id, $c_bug_id ) );
 
@@ -1945,6 +1970,7 @@ function bug_get_monitors( $p_bug_id ) {
 	}
 
 	# get the bugnote data
+	db_param_push();
 	$t_query = 'SELECT user_id, enabled
 			FROM {bug_monitor} m, {user} u
 			WHERE m.bug_id=' . db_param() . ' AND m.user_id = u.id
@@ -1975,12 +2001,14 @@ function bug_monitor_copy( $p_source_bug_id, $p_dest_bug_id ) {
 	$c_source_bug_id = (int)$p_source_bug_id;
 	$c_dest_bug_id = (int)$p_dest_bug_id;
 
+	db_param_push();
 	$t_query = 'SELECT user_id FROM {bug_monitor} WHERE bug_id = ' . db_param();
 	$t_result = db_query( $t_query, array( $c_source_bug_id ) );
 
 	while( $t_bug_monitor = db_fetch_array( $t_result ) ) {
 		if( user_exists( $t_bug_monitor['user_id'] ) &&
 			!user_is_monitoring_bug( $t_bug_monitor['user_id'], $c_dest_bug_id ) ) {
+			db_param_push();
 			$t_query = 'INSERT INTO {bug_monitor} ( user_id, bug_id )
 				VALUES ( ' . db_param() . ', ' . db_param() . ' )';
 			db_query( $t_query, array( $t_bug_monitor['user_id'], $c_dest_bug_id ) );
@@ -2001,6 +2029,7 @@ function bug_monitor_copy( $p_source_bug_id, $p_dest_bug_id ) {
  */
 function bug_unmonitor( $p_bug_id, $p_user_id ) {
 	# Delete monitoring record
+	db_param_push();
 	$t_query = 'DELETE FROM {bug_monitor} WHERE bug_id = ' . db_param();
 	$t_db_query_params[] = $p_bug_id;
 

--- a/core/bug_revision_api.php
+++ b/core/bug_revision_api.php
@@ -59,6 +59,7 @@ function bug_revision_add( $p_bug_id, $p_user_id, $p_type, $p_value, $p_bugnote_
 		$t_timestamp = $p_timestamp;
 	}
 
+	db_param_push();
 	$t_query = 'INSERT INTO {bug_revision} (
 			bug_id, bugnote_id, user_id,
 			timestamp, type, value
@@ -78,6 +79,7 @@ function bug_revision_add( $p_bug_id, $p_user_id, $p_type, $p_value, $p_bugnote_
  * @return boolean Whether or not the bug revision exists
  */
 function bug_revision_exists( $p_revision_id ) {
+	db_param_push();
 	$t_query = 'SELECT id FROM {bug_revision} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_revision_id ) );
 
@@ -94,6 +96,7 @@ function bug_revision_exists( $p_revision_id ) {
  * @return array Revision data row
  */
 function bug_revision_get( $p_revision_id ) {
+	db_param_push();
 	$t_query = 'SELECT * FROM {bug_revision} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_revision_id ) );
 
@@ -135,6 +138,8 @@ function bug_revision_get_type_name( $p_revision_type_id ) {
  * @return void
  */
 function bug_revision_drop( $p_revision_id ) {
+	db_param_push();
+
 	if( is_array( $p_revision_id ) ) {
 		$t_revisions = array();
 		$t_first = true;
@@ -175,6 +180,7 @@ function bug_revision_drop( $p_revision_id ) {
  * @return array|null Array of Revision rows
  */
 function bug_revision_count( $p_bug_id, $p_type = REV_ANY, $p_bugnote_id = 0 ) {
+	db_param_push();
 	$t_params = array( $p_bug_id );
 	$t_query = 'SELECT COUNT(id) FROM {bug_revision} WHERE bug_id=' . db_param();
 
@@ -202,6 +208,7 @@ function bug_revision_count( $p_bug_id, $p_type = REV_ANY, $p_bugnote_id = 0 ) {
  * @return void
  */
 function bug_revision_delete( $p_bug_id, $p_bugnote_id = 0 ) {
+	db_param_push();
 	if( $p_bugnote_id < 1 ) {
 		$t_query = 'DELETE FROM {bug_revision} WHERE bug_id=' . db_param();
 		db_query( $t_query, array( $p_bug_id ) );
@@ -219,6 +226,7 @@ function bug_revision_delete( $p_bug_id, $p_bugnote_id = 0 ) {
  * @return null|array Revision row
  */
 function bug_revision_last( $p_bug_id, $p_type = REV_ANY, $p_bugnote_id = 0 ) {
+	db_param_push();
 	$t_params = array( $p_bug_id );
 	$t_query = 'SELECT * FROM {bug_revision} WHERE bug_id=' . db_param();
 
@@ -253,6 +261,7 @@ function bug_revision_last( $p_bug_id, $p_type = REV_ANY, $p_bugnote_id = 0 ) {
  * @return array/null Array of Revision rows
  */
 function bug_revision_list( $p_bug_id, $p_type = REV_ANY, $p_bugnote_id = 0 ) {
+	db_param_push();
 	$t_params = array( $p_bug_id );
 	$t_query = 'SELECT * FROM {bug_revision} WHERE bug_id=' . db_param();
 
@@ -286,6 +295,7 @@ function bug_revision_list( $p_bug_id, $p_type = REV_ANY, $p_bugnote_id = 0 ) {
  * @return array|null Array of Revision rows
  */
 function bug_revision_like( $p_rev_id ) {
+	db_param_push();
 	$t_query = 'SELECT bug_id, bugnote_id, type FROM {bug_revision} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_rev_id ) );
 
@@ -299,6 +309,7 @@ function bug_revision_like( $p_rev_id ) {
 	$t_bugnote_id = $t_row['bugnote_id'];
 	$t_type = $t_row['type'];
 
+	db_param_push();
 	$t_params = array( $t_bug_id );
 	$t_query = 'SELECT * FROM {bug_revision} WHERE bug_id=' . db_param();
 

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -128,6 +128,7 @@ class BugnoteData {
  * @access public
  */
 function bugnote_exists( $p_bugnote_id ) {
+	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM {bugnote} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_bugnote_id ) );
 
@@ -215,6 +216,7 @@ function bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking = '0:00', $p_
 	$t_bugnote_text = event_signal( 'EVENT_BUGNOTE_DATA', $p_bugnote_text, $c_bug_id );
 
 	# insert bugnote text
+	db_param_push();
 	$t_query = 'INSERT INTO {bugnote_text} ( note ) VALUES ( ' . db_param() . ' )';
 	db_query( $t_query, array( $t_bugnote_text ) );
 
@@ -234,6 +236,7 @@ function bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking = '0:00', $p_
 	}
 
 	# insert bugnote info
+	db_param_push();
 	$t_query = 'INSERT INTO {bugnote}
 			(bug_id, reporter_id, bugnote_text_id, view_state, date_submitted, last_modified, note_type, note_attr, time_tracking)
 		VALUES ('
@@ -307,10 +310,12 @@ function bugnote_delete( $p_bugnote_id ) {
 	$t_bugnote_text_id = bugnote_get_field( $p_bugnote_id, 'bugnote_text_id' );
 
 	# Remove the bugnote
+	db_param_push();
 	$t_query = 'DELETE FROM {bugnote} WHERE id=' . db_param();
 	db_query( $t_query, array( $p_bugnote_id ) );
 
 	# Remove the bugnote text
+	db_param_push();
 	$t_query = 'DELETE FROM {bugnote_text} WHERE id=' . db_param();
 	db_query( $t_query, array( $t_bugnote_text_id ) );
 
@@ -331,17 +336,20 @@ function bugnote_delete( $p_bugnote_id ) {
  */
 function bugnote_delete_all( $p_bug_id ) {
 	# Delete the bugnote text items
+	db_param_push();
 	$t_query = 'SELECT bugnote_text_id FROM {bugnote} WHERE bug_id=' . db_param();
 	$t_result = db_query( $t_query, array( (int)$p_bug_id ) );
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_bugnote_text_id = $t_row['bugnote_text_id'];
 
 		# Delete the corresponding bugnote texts
+		db_param_push();
 		$t_query = 'DELETE FROM {bugnote_text} WHERE id=' . db_param();
 		db_query( $t_query, array( $t_bugnote_text_id ) );
 	}
 
 	# Delete the corresponding bugnotes
+	db_param_push();
 	$t_query = 'DELETE FROM {bugnote} WHERE bug_id=' . db_param();
 	db_query( $t_query, array( (int)$p_bug_id ) );
 }
@@ -356,6 +364,7 @@ function bugnote_get_text( $p_bugnote_id ) {
 	$t_bugnote_text_id = bugnote_get_field( $p_bugnote_id, 'bugnote_text_id' );
 
 	# grab the bugnote text
+	db_param_push();
 	$t_query = 'SELECT note FROM {bugnote_text} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $t_bugnote_text_id ) );
 
@@ -386,6 +395,7 @@ function bugnote_get_field( $p_bugnote_id, $p_field_name ) {
 		trigger_error( ERROR_DB_FIELD_NOT_FOUND, WARNING );
 	}
 
+	db_param_push();
 	$t_query = 'SELECT ' . $p_field_name . ' FROM {bugnote} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_bugnote_id ), 1 );
 
@@ -399,6 +409,7 @@ function bugnote_get_field( $p_bugnote_id, $p_field_name ) {
  * @access public
  */
 function bugnote_get_latest_id( $p_bug_id ) {
+	db_param_push();
 	$t_query = 'SELECT id FROM {bugnote} WHERE bug_id=' . db_param() . ' ORDER by last_modified DESC';
 	$t_result = db_query( $t_query, array( (int)$p_bug_id ), 1 );
 
@@ -530,6 +541,7 @@ function bugnote_get_all_bugnotes( $p_bug_id ) {
 		# Now sorting by submit date and id (#11742). The date_submitted
 		# column is currently not indexed, but that does not seem to affect
 		# performance in a measurable way
+		db_param_push();
 		$t_query = 'SELECT b.*, t.note
 			          	FROM      {bugnote} b
 			          	LEFT JOIN {bugnote_text} t ON b.bugnote_text_id = t.id
@@ -580,6 +592,7 @@ function bugnote_get_all_bugnotes( $p_bug_id ) {
 function bugnote_set_time_tracking( $p_bugnote_id, $p_time_tracking ) {
 	$c_bugnote_time_tracking = helper_duration_to_minutes( $p_time_tracking );
 
+	db_param_push();
 	$t_query = 'UPDATE {bugnote} SET time_tracking = ' . db_param() . ' WHERE id=' . db_param();
 	db_query( $t_query, array( $c_bugnote_time_tracking, $p_bugnote_id ) );
 }
@@ -591,6 +604,7 @@ function bugnote_set_time_tracking( $p_bugnote_id, $p_time_tracking ) {
  * @access public
  */
 function bugnote_date_update( $p_bugnote_id ) {
+	db_param_push();
 	$t_query = 'UPDATE {bugnote} SET last_modified=' . db_param() . ' WHERE id=' . db_param();
 	db_query( $t_query, array( db_now(), $p_bugnote_id ) );
 }
@@ -619,6 +633,7 @@ function bugnote_set_text( $p_bugnote_id, $p_bugnote_text ) {
 		bug_revision_add( $t_bug_id, $t_user_id, REV_BUGNOTE, $t_old_text, $p_bugnote_id, $t_timestamp );
 	}
 
+	db_param_push();
 	$t_query = 'UPDATE {bugnote_text} SET note=' . db_param() . ' WHERE id=' . db_param();
 	db_query( $t_query, array( $p_bugnote_text, $t_bugnote_text_id ) );
 
@@ -652,6 +667,7 @@ function bugnote_set_view_state( $p_bugnote_id, $p_private ) {
 		$t_view_state = VS_PUBLIC;
 	}
 
+	db_param_push();
 	$t_query = 'UPDATE {bugnote} SET view_state=' . db_param() . ' WHERE id=' . db_param();
 	db_query( $t_query, array( $t_view_state, $p_bugnote_id ) );
 
@@ -698,12 +714,12 @@ function bugnote_stats_get_events_array( $p_bug_id, $p_from, $p_to ) {
 
 	$t_results = array();
 
+	db_param_push();
 	$t_query = 'SELECT username, realname, SUM(time_tracking) AS sum_time_tracking
 				FROM {user} u, {bugnote} bn
 				WHERE u.id = bn.reporter_id AND bn.time_tracking != 0 AND
 				bn.bug_id = ' . db_param() . $t_from_where . $t_to_where .
 				' GROUP BY u.username, u.realname';
-
 	$t_result = db_query( $t_query, array( $p_bug_id ) );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {

--- a/core/category_api.php
+++ b/core/category_api.php
@@ -625,6 +625,7 @@ function category_full_name( $p_category_id, $p_show_project = true, $p_current_
  * @access public
  */
 function category_can_delete( $p_category_id ) {
+	db_param_push();
 	$t_query = 'SELECT COUNT(id) FROM {bug} WHERE category_id=' . db_param();
 	$t_bug_count = db_result( db_query( $t_query, array( $p_category_id ) ) );
 	return $t_bug_count == 0;

--- a/core/category_api.php
+++ b/core/category_api.php
@@ -81,6 +81,7 @@ function category_ensure_exists( $p_category_id ) {
  * @access public
  */
 function category_is_unique( $p_project_id, $p_name ) {
+	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM {category}
 					WHERE project_id=' . db_param() . ' AND ' . db_helper_like( 'name' );
 	$t_count = db_result( db_query( $t_query, array( $p_project_id, $p_name ) ) );
@@ -148,6 +149,7 @@ function category_add( $p_project_id, $p_name ) {
 
 	category_ensure_unique( $p_project_id, $p_name );
 
+	db_param_push();
 	$t_query = 'INSERT INTO {category} ( project_id, name )
 				  VALUES ( ' . db_param() . ', ' . db_param() . ' )';
 	db_query( $t_query, array( $p_project_id, $p_name ) );
@@ -172,12 +174,14 @@ function category_update( $p_category_id, $p_name, $p_assigned_to ) {
 
 	$t_old_category = category_get_row( $p_category_id );
 
+	db_param_push();
 	$t_query = 'UPDATE {category} SET name=' . db_param() . ', user_id=' . db_param() . '
 				  WHERE id=' . db_param();
 	db_query( $t_query, array( $p_name, $p_assigned_to, $p_category_id ) );
 
 	# Add bug history entries if we update the category's name
 	if( $t_old_category['name'] != $p_name ) {
+		db_param_push();
 		$t_query = 'SELECT id FROM {bug} WHERE category_id=' . db_param();
 		$t_result = db_query( $t_query, array( $p_category_id ) );
 
@@ -203,10 +207,12 @@ function category_remove( $p_category_id, $p_new_category_id = 0 ) {
 		category_ensure_exists( $p_new_category_id );
 	}
 
+	db_param_push();
 	$t_query = 'DELETE FROM {category} WHERE id=' . db_param();
 	db_query( $t_query, array( $p_category_id ) );
 
 	# update bug history entries
+	db_param_push();
 	$t_query = 'SELECT id FROM {bug} WHERE category_id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_category_id ) );
 
@@ -215,6 +221,7 @@ function category_remove( $p_category_id, $p_new_category_id = 0 ) {
 	}
 
 	# update bug data
+	db_param_push();
 	$t_query = 'UPDATE {bug} SET category_id=' . db_param() . ' WHERE category_id=' . db_param();
 	db_query( $t_query, array( $p_new_category_id, $p_category_id ) );
 }
@@ -237,6 +244,7 @@ function category_remove_all( $p_project_id, $p_new_category_id = 0 ) {
 	category_get_all_rows( $p_project_id );
 
 	# get a list of affected categories
+	db_param_push();
 	$t_query = 'SELECT id FROM {category} WHERE project_id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_project_id ) );
 
@@ -257,6 +265,7 @@ function category_remove_all( $p_project_id, $p_new_category_id = 0 ) {
 	$t_category_ids = join( ',', $t_category_ids );
 
 	# update bug history entries
+	db_param_push();
 	$t_query = 'SELECT id, category_id FROM {bug} WHERE category_id IN ( ' . $t_category_ids . ' )';
 	$t_result = db_query( $t_query );
 
@@ -265,10 +274,12 @@ function category_remove_all( $p_project_id, $p_new_category_id = 0 ) {
 	}
 
 	# update bug data
+	db_param_push();
 	$t_query = 'UPDATE {bug} SET category_id=' . db_param() . ' WHERE category_id IN ( ' . $t_category_ids . ' )';
 	db_query( $t_query, array( $p_new_category_id ) );
 
 	# delete categories
+	db_param_push();
 	$t_query = 'DELETE FROM {category} WHERE project_id=' . db_param();
 	db_query( $t_query, array( $p_project_id ) );
 
@@ -291,6 +302,7 @@ function category_get_row( $p_category_id, $p_error_if_not_exists = true ) {
 		return $g_category_cache[$p_category_id];
 	}
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {category} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_category_id ) );
 	$t_row = db_fetch_array( $t_result );
@@ -562,6 +574,7 @@ function category_get_name( $p_category_id ) {
 function category_get_id_by_name( $p_category_name, $p_project_id, $p_trigger_errors = true ) {
 	$t_project_name = project_get_name( $p_project_id );
 
+	db_param_push();
 	$t_query = 'SELECT id FROM {category} WHERE name=' . db_param() . ' AND project_id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_category_name, (int)$p_project_id ) );
 	$t_id = db_result( $t_result );

--- a/core/cfdefs/cfdef_standard.php
+++ b/core/cfdefs/cfdef_standard.php
@@ -411,6 +411,7 @@ function cfdef_prepare_list_value_to_database( $p_value ) {
  * @return array|boolean
  */
 function cfdef_prepare_list_distinct_values( array $p_field_def ) {
+	db_param_push();
 	$t_query = 'SELECT possible_values FROM {custom_field} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_field_def['id'] ) );
 

--- a/core/config_api.php
+++ b/core/config_api.php
@@ -357,12 +357,14 @@ function config_set( $p_option, $p_value, $p_user = NO_USER, $p_project = ALL_PR
 			user_ensure_exists( $p_user );
 		}
 
+		db_param_push();
 		$t_query = 'SELECT COUNT(*) from {config}
 				WHERE config_id = ' . db_param() . ' AND
 					project_id = ' . db_param() . ' AND
 					user_id = ' . db_param();
 		$t_result = db_query( $t_query, array( $p_option, (int)$p_project, (int)$p_user ) );
 
+		db_param_push();
 		$t_params = array();
 		if( 0 < db_result( $t_result ) ) {
 			$t_set_query = 'UPDATE {config}
@@ -499,6 +501,7 @@ function config_delete( $p_option, $p_user = ALL_USERS, $p_project = ALL_PROJECT
 			return;
 		}
 
+		db_param_push();
 		$t_query = 'DELETE FROM {config}
 				WHERE config_id = ' . db_param() . ' AND
 					project_id=' . db_param() . ' AND
@@ -522,6 +525,7 @@ function config_delete_for_user( $p_option, $p_user_id ) {
 	}
 
 	# Delete the corresponding bugnote texts
+	db_param_push();
 	$t_query = 'DELETE FROM {config} WHERE config_id=' . db_param() . ' AND user_id=' . db_param();
 	db_query( $t_query, array( $p_option, $p_user_id ) );
 }
@@ -533,6 +537,7 @@ function config_delete_for_user( $p_option, $p_user_id ) {
  * @return void
  */
 function config_delete_project( $p_project = ALL_PROJECTS ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {config} WHERE project_id=' . db_param();
 	db_query( $t_query, array( $p_project ) );
 

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -387,15 +387,8 @@ function db_query( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_offset
 							'}' => $s_suffix,
 							) );
 
-	# We assume that '%' tokens won't mix with db_param() generated tokens
-	# Param push is needed in case this query is happening inside an outer
-	# query which is using db_param (eg as part of an api call)
+	# Pushing params to safeguard the ADOdb parameter count (required for pgsql)
 	$g_db_param->push();
-	$p_query = preg_replace_callback(
-							array( "/%s/", "/%d/", "/%b/", "/%l/"),
-							function() use (&$p_pop_param) { $p_pop_param = false; return db_param(); },
-							$p_query
-							);
 
 	if( db_is_oracle() ) {
 		$p_query = db_oracle_adapt_query_syntax( $p_query, $p_arr_parms );
@@ -407,9 +400,7 @@ function db_query( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_offset
 		$t_result = $g_db->Execute( $p_query, $p_arr_parms );
 	}
 
-	# undo the previous param push.
-	# This also restores parameter count in ADOdb, in case this is pgsql,
-	# so that an api sql call dont break token numbering
+	# Restore ADOdb parameter count
 	$g_db_param->pop();
 
 	$t_elapsed = number_format( microtime( true ) - $t_start, 4 );

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -448,7 +448,8 @@ function db_query( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_offset
 		array_push( $g_queries_array, array( '', $t_elapsed ) );
 	}
 
-	if( $p_pop_param ) {
+	# Restore param stack: only pop if asked to AND the query has params
+	if( $p_pop_param && !empty( $p_arr_parms ) ) {
 		$g_db_param->pop();
 	}
 

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -324,7 +324,9 @@ function db_query_bound() {
 /**
  * execute query, requires connection to be opened
  * An error will be triggered if there is a problem executing the query.
- * This will pop the database parameter stack {@see MantisDbParam} after a successful execution
+ * This will pop the database parameter stack {@see MantisDbParam} after a 
+ * successful execution, unless specified otherwise
+ * 
  * @global array of previous executed queries for profiling
  * @global adodb database connection object
  * @global boolean indicating whether queries array is populated
@@ -332,9 +334,10 @@ function db_query_bound() {
  * @param array   $p_arr_parms Array of parameters matching $p_query.
  * @param integer $p_limit     Number of results to return.
  * @param integer $p_offset    Offset query results for paging.
+ * @param boolean $p_pop_param Set to false to leave the parameters on the stack
  * @return IteratorAggregate|boolean adodb result set or false if the query failed.
  */
-function db_query( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_offset = -1 ) {
+function db_query( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_offset = -1, $p_pop_param = true ) {
 	global $g_queries_array, $g_db, $g_db_log_queries, $g_db_param;
 
 	$t_db_type = config_get_global( 'db_type' );
@@ -450,7 +453,9 @@ function db_query( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_offset
 		trigger_error( ERROR_DB_QUERY_FAILED, ERROR );
 		return false;
 	} else {
-		$g_db_param->pop();
+		if( $p_pop_param ) {
+			$g_db_param->pop();
+		}
 		return $t_result;
 	}
 }
@@ -473,6 +478,19 @@ function db_param() {
 function db_param_push() {
 	global $g_db_param;
 	$g_db_param->push();
+}
+
+/**
+ * Pops the previous parameter count from the stack
+ * It is generally not necessary to call this, because the param count is popped
+ * automatically whenever a query is executed via db_query(). There are some
+ * corner cases when doing it manually makes sense, e.g. when a query is built
+ * but not executed.
+ * @return void
+ */
+function db_param_pop() {
+	global $g_db_param;
+	$g_db_param->pop();
 }
 
 /**

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -385,11 +385,12 @@ function db_query( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_offset
 	$p_query = strtr($p_query, array(
 							'{' => $s_prefix,
 							'}' => $s_suffix,
-							'%s' => db_param(),
-							'%d' => db_param(),
-							'%b' => db_param(),
-							'%l' => db_param(),
 							) );
+	$p_query = preg_replace_callback(
+							array( "/%s/", "/%d/", "/%b/", "/%l/"),
+							"db_param",
+							$p_query
+							);
 
 	if( db_is_oracle() ) {
 		$p_query = db_oracle_adapt_query_syntax( $p_query, $p_arr_parms );

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -324,9 +324,9 @@ function db_query_bound() {
 /**
  * execute query, requires connection to be opened
  * An error will be triggered if there is a problem executing the query.
- * This will pop the database parameter stack {@see MantisDbParam} after a 
+ * This will pop the database parameter stack {@see MantisDbParam} after a
  * successful execution, unless specified otherwise
- * 
+ *
  * @global array of previous executed queries for profiling
  * @global adodb database connection object
  * @global boolean indicating whether queries array is populated
@@ -448,14 +448,15 @@ function db_query( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_offset
 		array_push( $g_queries_array, array( '', $t_elapsed ) );
 	}
 
+	if( $p_pop_param ) {
+		$g_db_param->pop();
+	}
+
 	if( !$t_result ) {
 		db_error( $p_query );
 		trigger_error( ERROR_DB_QUERY_FAILED, ERROR );
 		return false;
 	} else {
-		if( $p_pop_param ) {
-			$g_db_param->pop();
-		}
 		return $t_result;
 	}
 }

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -295,6 +295,7 @@ function email_collect_recipients( $p_bug_id, $p_notify_type, array $p_extra_use
 
 	# add users monitoring the bug
 	$t_monitoring_enabled = ON == email_notify_flag( $p_notify_type, 'monitor' );
+	db_param_push();
 	$t_query = 'SELECT DISTINCT user_id FROM {bug_monitor} WHERE bug_id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_bug_id ) );
 
@@ -329,6 +330,7 @@ function email_collect_recipients( $p_bug_id, $p_notify_type, array $p_extra_use
 	$t_bug_date = $t_bug->last_updated;
 
 	$t_notes_enabled = ( ON == email_notify_flag( $p_notify_type, 'bugnotes' ) );
+	db_param_push();
 	$t_query = 'SELECT DISTINCT reporter_id FROM {bugnote} WHERE bug_id = ' . db_param();
 	$t_result = db_query( $t_query, array( $p_bug_id ) );
 	while( $t_row = db_fetch_array( $t_result ) ) {

--- a/core/email_queue_api.php
+++ b/core/email_queue_api.php
@@ -115,6 +115,7 @@ function email_queue_add( EmailData $p_email_data ) {
 	$c_body = $t_email_data->body;
 	$c_metadata = serialize( $t_email_data->metadata );
 
+	db_param_push();
 	$t_query = 'INSERT INTO {email}
 				    ( email, subject, body, submitted, metadata)
 				  VALUES
@@ -164,6 +165,7 @@ function email_queue_row_to_object( $p_row ) {
  * @return boolean|EmailData
  */
 function email_queue_get( $p_email_id ) {
+	db_param_push();
 	$t_query = 'SELECT * FROM {email} WHERE email_id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_email_id ) );
 
@@ -178,6 +180,7 @@ function email_queue_get( $p_email_id ) {
  * @return void
  */
 function email_queue_delete( $p_email_id ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {email} WHERE email_id=' . db_param();
 	db_query( $t_query, array( $p_email_id ) );
 
@@ -189,6 +192,7 @@ function email_queue_delete( $p_email_id ) {
  * @return array
  */
 function email_queue_get_ids() {
+	db_param_push();
 	$t_query = 'SELECT email_id FROM {email} ORDER BY email_id ASC';
 	$t_result = db_query( $t_query );
 

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -385,6 +385,7 @@ function file_delete_attachments( $p_bug_id ) {
 	$t_method = config_get( 'file_upload_method' );
 
 	# Delete files from disk
+	db_param_push();
 	$t_query = 'SELECT diskfile, filename FROM {bug_file} WHERE bug_id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_bug_id ) );
 
@@ -403,6 +404,7 @@ function file_delete_attachments( $p_bug_id ) {
 	}
 
 	# Delete the corresponding db records
+	db_param_push();
 	$t_query = 'DELETE FROM {bug_file} WHERE bug_id=' . db_param();
 	db_query( $t_query, array( $p_bug_id ) );
 
@@ -421,6 +423,7 @@ function file_delete_project_files( $p_project_id ) {
 	# Delete the file physically (if stored via DISK)
 	if( DISK == $t_method ) {
 		# Delete files from disk
+		db_param_push();
 		$t_query = 'SELECT diskfile, filename FROM {project_file} WHERE project_id=' . db_param();
 		$t_result = db_query( $t_query, array( (int)$p_project_id ) );
 
@@ -435,6 +438,7 @@ function file_delete_project_files( $p_project_id ) {
 	}
 
 	# Delete the corresponding database records
+	db_param_push();
 	$t_query = 'DELETE FROM {project_file} WHERE project_id=' . db_param();
 	db_query( $t_query, array( (int)$p_project_id ) );
 }
@@ -464,6 +468,7 @@ function file_get_field( $p_file_id, $p_field_name, $p_table = 'bug' ) {
 		trigger_error( ERROR_DB_FIELD_NOT_FOUND, ERROR );
 	}
 
+	db_param_push();
 	$t_query = 'SELECT ' . $p_field_name . ' FROM ' . $t_bug_file_table . ' WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( (int)$p_file_id ), 1 );
 
@@ -503,6 +508,7 @@ function file_delete( $p_file_id, $p_table = 'bug' ) {
 	}
 
 	$t_file_table = db_get_table( $p_table . '_file' );
+	db_param_push();
 	$t_query = 'DELETE FROM ' . $t_file_table . ' WHERE id=' . db_param();
 	db_query( $t_query, array( $c_file_id ) );
 	return true;
@@ -582,6 +588,7 @@ function file_generate_unique_name( $p_filepath ) {
 function diskfile_is_name_unique( $p_name, $p_filepath ) {
 	$c_name = $p_filepath . $p_name;
 
+	db_param_push();
 	$t_query = 'SELECT count(*)
 		FROM (
 			SELECT diskfile FROM {bug_file} WHERE diskfile=' . db_param() . '
@@ -605,6 +612,7 @@ function diskfile_is_name_unique( $p_name, $p_filepath ) {
 function file_is_name_unique( $p_name, $p_bug_id, $p_table = 'bug' ) {
 	$t_file_table = db_get_table( "${p_table}_file" );
 
+	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM ' . $t_file_table . ' WHERE filename=' . db_param();
 	$t_param = array( $p_name );
 	if( $p_table == 'bug' ) {
@@ -721,6 +729,8 @@ function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p
 
 	$t_file_table = db_get_table( $p_table . '_file' );
 	$t_id_col = $p_table . '_id';
+
+	db_param_push();
 
 	$t_param = array(
 		$t_id_col     => $t_id,
@@ -888,7 +898,7 @@ function file_ensure_uploaded( array $p_file ) {
 function file_get_content( $p_file_id, $p_type = 'bug' ) {
 	# we handle the case where the file is attached to a bug
 	# or attached to a project as a project doc.
-	$t_query = '';
+	db_param_push();
 	switch( $p_type ) {
 		case 'bug':
 			$t_query = 'SELECT * FROM {bug_file} WHERE id=' . db_param();
@@ -997,6 +1007,7 @@ function file_move_bug_attachments( $p_bug_id, $p_project_id_to ) {
 
 	# Initialize the update query to update a single row
 	$c_bug_id = (int)$p_bug_id;
+	db_param_push();
 	$t_query_disk_attachment_update = 'UPDATE {bug_file}
 	                                 SET folder=' . db_param() . '
 	                                 WHERE bug_id=' . db_param() . '
@@ -1020,11 +1031,13 @@ function file_move_bug_attachments( $p_bug_id, $p_project_id_to ) {
 				file_delete_local( $t_disk_file_name_from );
 			}
 			chmod( $t_disk_file_name_to, config_get( 'attachments_file_permissions' ) );
-			db_query( $t_query_disk_attachment_update, array( db_prepare_string( $t_path_to ), $c_bug_id, (int)$t_row['id'] ) );
+			# Don't pop the parameters after query execution since we're in a loop
+			db_query( $t_query_disk_attachment_update, array( db_prepare_string( $t_path_to ), $c_bug_id, (int)$t_row['id'] ), false );
 		} else {
 			trigger_error( ERROR_FILE_DUPLICATE, ERROR );
 		}
 	}
+	db_param_pop();
 }
 
 /**
@@ -1037,6 +1050,7 @@ function file_move_bug_attachments( $p_bug_id, $p_project_id_to ) {
  * @return void
  */
 function file_copy_attachments( $p_source_bug_id, $p_dest_bug_id ) {
+	db_param_push();
 	$t_query = 'SELECT * FROM {bug_file} WHERE bug_id = ' . db_param();
 	$t_result = db_query( $t_query, array( $p_source_bug_id ) );
 	$t_count = db_num_rows( $t_result );
@@ -1066,6 +1080,7 @@ function file_copy_attachments( $p_source_bug_id, $p_dest_bug_id ) {
 			}
 		}
 
+		db_param_push();
 		$t_query = 'INSERT INTO {bug_file} (
 				bug_id, title, description, diskfile, filename, folder,
 				filesize, file_type, date_added, user_id, content

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1120,6 +1120,8 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 
 	$t_view_type = $t_filter['_view_type'];
 
+	db_param_push();
+
 	# project query clauses must be AND-ed always, irrespective of how the filter
 	# clauses are requested by the user ( all matching -> AND, any matching -> OR )
 	$t_where_clauses = array();
@@ -4457,6 +4459,7 @@ function filter_cache_row( $p_filter_id, $p_trigger_errors = true ) {
 		return $g_cache_filter[$p_filter_id];
 	}
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {filters} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_filter_id ) );
 
@@ -4516,6 +4519,7 @@ function filter_db_set_for_current_user( $p_project_id, $p_is_public, $p_name, $
 	}
 
 	# Do I need to update or insert this value?
+	db_param_push();
 	$t_query = 'SELECT id FROM {filters}
 					WHERE user_id=' . db_param() . '
 					AND project_id=' . db_param() . '
@@ -4524,6 +4528,7 @@ function filter_db_set_for_current_user( $p_project_id, $p_is_public, $p_name, $
 
 	$t_row = db_fetch_array( $t_result );
 	if( $t_row ) {
+		db_param_push();
 		$t_query = 'UPDATE {filters}
 					  SET is_public=' . db_param() . ',
 						filter_string=' . db_param() . '
@@ -4532,6 +4537,7 @@ function filter_db_set_for_current_user( $p_project_id, $p_is_public, $p_name, $
 
 		return $t_row['id'];
 	} else {
+		db_param_push();
 		$t_query = 'INSERT INTO {filters}
 						( user_id, project_id, is_public, name, filter_string )
 					  VALUES
@@ -4539,6 +4545,7 @@ function filter_db_set_for_current_user( $p_project_id, $p_is_public, $p_name, $
 		db_query( $t_query, array( $t_user_id, $c_project_id, $p_is_public, $p_name, $p_filter_string ) );
 
 		# Recall the query, we want the filter ID
+		db_param_push();
 		$t_query = 'SELECT id
 						FROM {filters}
 						WHERE user_id=' . db_param() . '
@@ -4578,6 +4585,7 @@ function filter_db_get_filter( $p_filter_id, $p_user_id = null ) {
 		$t_user_id = $p_user_id;
 	}
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {filters} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $c_filter_id ) );
 
@@ -4618,6 +4626,7 @@ function filter_db_get_project_current( $p_project_id, $p_user_id = null ) {
 	}
 
 	# we store current filters for each project with a special project index
+	db_param_push();
 	$t_query = 'SELECT *
 				  FROM {filters}
 				  WHERE user_id=' . db_param() . '
@@ -4640,6 +4649,7 @@ function filter_db_get_project_current( $p_project_id, $p_user_id = null ) {
 function filter_db_get_name( $p_filter_id ) {
 	$c_filter_id = (int)$p_filter_id;
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {filters} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $c_filter_id ) );
 
@@ -4670,12 +4680,12 @@ function filter_db_can_delete_filter( $p_filter_id ) {
 		return true;
 	}
 
+	db_param_push();
 	$t_query = 'SELECT id
 				  FROM {filters}
 				  WHERE id=' . db_param() . '
 				  AND user_id=' . db_param() . '
 				  AND project_id!=' . db_param();
-
 	$t_result = db_query( $t_query, array( $c_filter_id, $t_user_id, -1 ) );
 
 	if( db_result( $t_result ) > 0 ) {
@@ -4697,6 +4707,7 @@ function filter_db_delete_filter( $p_filter_id ) {
 		return false;
 	}
 
+	db_param_push();
 	$t_query = 'DELETE FROM {filters} WHERE id=' . db_param();
 	db_query( $t_query, array( $c_filter_id ) );
 
@@ -4710,6 +4721,7 @@ function filter_db_delete_filter( $p_filter_id ) {
 function filter_db_delete_current_filters() {
 	$t_all_id = ALL_PROJECTS;
 
+	db_param_push();
 	$t_query = 'DELETE FROM {filters} WHERE project_id<=' . db_param() . ' AND name=' . db_param();
 	db_query( $t_query, array( $t_all_id, '' ) );
 }
@@ -4744,6 +4756,7 @@ function filter_db_get_available_queries( $p_project_id = null, $p_user_id = nul
 	# Get the list of available queries. By sorting such that public queries are
 	# first, we can override any query that has the same name as a private query
 	# with that private one
+	db_param_push();
 	$t_query = 'SELECT * FROM {filters}
 					WHERE (project_id=' . db_param() . '
 						OR project_id=0)

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -84,6 +84,7 @@ function history_log_event_direct( $p_bug_id, $p_field_name, $p_old_value, $p_ne
 		$c_old_value = ( is_null( $p_old_value ) ? '' : (string)$p_old_value );
 		$c_new_value = ( is_null( $p_new_value ) ? '' : (string)$p_new_value );
 
+		db_param_push();
 		$t_query = 'INSERT INTO {bug_history}
 						( user_id, bug_id, date_modified, field_name, old_value, new_value, type )
 					VALUES
@@ -124,6 +125,7 @@ function history_log_event_special( $p_bug_id, $p_type, $p_old_value = '', $p_ne
 		$p_new_value = '';
 	}
 
+	db_param_push();
 	$t_query = 'INSERT INTO {bug_history}
 					( user_id, bug_id, date_modified, type, old_value, new_value, field_name )
 				VALUES
@@ -167,6 +169,7 @@ function history_count_user_recent_events( $p_duration_in_seconds, $p_user_id = 
 
 	$t_params = array( db_now() - $p_duration_in_seconds, $t_user_id );
 
+	db_param_push();
 	$t_query = 'SELECT count(*) as event_count FROM {bug_history} WHERE date_modified > ' . db_param() .
 				' AND user_id = ' . db_param();
 	$t_result = db_query( $t_query, $t_params );
@@ -190,6 +193,7 @@ function history_get_range_result( $p_bug_id = null, $p_start_time = null, $p_en
 		$t_history_order = $p_history_order;
 	}
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {bug_history}';
 	$t_params = array();
 	$t_where = array();
@@ -701,6 +705,7 @@ function history_localize_item( $p_field_name, $p_type, $p_old_value, $p_new_val
  * @return void
  */
 function history_delete( $p_bug_id ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {bug_history} WHERE bug_id=' . db_param();
 	db_query( $t_query, array( $p_bug_id ) );
 }

--- a/core/install_helper_functions_api.php
+++ b/core/install_helper_functions_api.php
@@ -211,6 +211,7 @@ function install_category_migrate() {
 		foreach( $t_categories as $t_name => $t_user_id ) {
 			$t_lower_name = utf8_strtolower( trim( $t_name ) );
 			if( !isset( $t_inserted[$t_lower_name] ) ) {
+				db_param_push();
 				$t_query = 'INSERT INTO {category} ( name, project_id, user_id ) VALUES ( ' .
 					db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
 				db_query( $t_query, array( $t_name, $t_project_id, $t_user_id ) );
@@ -220,6 +221,7 @@ function install_category_migrate() {
 				$t_category_id = $t_inserted[$t_lower_name];
 			}
 
+			db_param_push();
 			$t_query = 'UPDATE {bug} SET category_id=' . db_param() . '
 						WHERE project_id=' . db_param() . ' AND category=' . db_param();
 			db_query( $t_query, array( $t_category_id, $t_project_id, $t_name ) );
@@ -280,6 +282,7 @@ function install_date_migrate( array $p_data ) {
 	$t_result = db_query( $t_query );
 
 	if( db_num_rows( $t_result ) > 0 ) {
+		db_param_push();
 		# Build the update query
 		if( $t_date_array ) {
 			$t_pairs = array();
@@ -324,8 +327,11 @@ function install_date_migrate( array $p_data ) {
 				$t_values = array( $t_new_value, $t_id );
 			}
 
-			db_query( $t_query, $t_values );
+			# Don't pop params since we're in a loop
+			db_query( $t_query, $t_values, -1, -1, false );
 		}
+		db_param_pop();
+		
 	}
 
 	# Re-enable query logging if we disabled it
@@ -455,6 +461,7 @@ function install_stored_filter_migrate() {
 			case 'v2':
 			case 'v3':
 			case 'v4':
+				db_param_push();
 				$t_delete_query = 'DELETE FROM {filters} WHERE id=' . db_param();
 				$t_delete_result = db_query( $t_delete_query, array( $t_row['id'] ) );
 				continue;
@@ -473,6 +480,7 @@ function install_stored_filter_migrate() {
 					$t_filter_arr = json_decode( $t_setting_arr[1], /* assoc array */ true );
 			}
 		} else {
+			db_param_push();
 			$t_delete_query = 'DELETE FROM {filters} WHERE id=' . db_param();
 			$t_delete_result = db_query( $t_delete_query, array( $t_row['id'] ) );
 			continue;
@@ -512,6 +520,7 @@ function install_stored_filter_migrate() {
 		$t_filter_serialized = json_encode( $t_filter_arr );
 		$t_filter_string = FILTER_VERSION . '#' . $t_filter_serialized;
 
+		db_param_push();
 		$t_update_query = 'UPDATE {filters} SET filter_string=' . db_param() . ' WHERE id=' . db_param();
 		$t_update_result = db_query( $t_update_query, array( $t_filter_string, $t_row['id'] ) );
 	}
@@ -580,6 +589,7 @@ function install_update_history_long_custom_fields() {
 		# If field name's length is 32, then likely it was truncated so we try to match
 		if( utf8_strlen( $t_field['field_name'] ) == 32 && array_key_exists( $t_field['field_name'], $t_custom_fields ) ) {
 			# Match found, update all history records with this field name
+			db_param_push();
 			$t_update_query = 'UPDATE {bug_history}
 				SET field_name = ' . db_param() . '
 				WHERE field_name = ' . db_param();
@@ -607,6 +617,7 @@ function install_check_project_hierarchy() {
 		$t_parent_id = (int)$t_row['parent_id'];
 
 		if( $t_count > 1 ) {
+			db_param_push();
 			$t_query = 'SELECT inherit_parent, child_id, parent_id FROM {project_hierarchy} WHERE child_id=' . db_param() . ' AND parent_id=' . db_param();
 			$t_result2 = db_query( $t_query, array( $t_child_id, $t_parent_id ) );
 
@@ -615,9 +626,11 @@ function install_check_project_hierarchy() {
 
 			$t_inherit = $t_row2['inherit_parent'];
 
+			db_param_push();
 			$t_query_delete = 'DELETE FROM {project_hierarchy} WHERE child_id=' . db_param() . ' AND parent_id=' . db_param();
 			db_query( $t_query_delete, array( $t_child_id, $t_parent_id ) );
 
+			db_param_push();
 			$t_query_insert = 'INSERT INTO {project_hierarchy} (child_id, parent_id, inherit_parent) VALUES (' . db_param() . ',' . db_param() . ',' . db_param() . ')';
 			db_query( $t_query_insert, array( $t_child_id, $t_parent_id, $t_inherit ) );
 		}
@@ -648,6 +661,7 @@ function install_check_config_serialization() {
 
 		$t_json_config = json_encode( $t_config );
 
+		db_param_push();
 		$t_query = 'UPDATE {config} SET value=' .db_param() . ' WHERE config_id=' .db_param() . ' AND project_id=' .db_param() . ' AND user_id=' .db_param();
 		db_query( $t_query, array( $t_json_config, $config_id, $project_id, $user_id ) );
 	}
@@ -684,6 +698,7 @@ function install_check_token_serialization() {
 
 		$t_json_token = json_encode( $t_token );
 
+		db_param_push();
 		$t_query = 'UPDATE {tokens} SET value=' .db_param() . ' WHERE id=' .db_param();
 		db_query( $t_query, array( $t_json_token, $t_id ) );
 	}

--- a/core/news_api.php
+++ b/core/news_api.php
@@ -67,6 +67,7 @@ function news_create( $p_project_id, $p_poster_id, $p_view_state, $p_announcemen
 		trigger_error( ERROR_EMPTY_FIELD, ERROR );
 	}
 
+	db_param_push();
 	$t_query = 'INSERT INTO {news}
 	    		  ( project_id, poster_id, date_posted, last_modified,
 	    		    view_state, announcement, headline, body )
@@ -94,6 +95,7 @@ function news_create( $p_project_id, $p_poster_id, $p_view_state, $p_announcemen
  * @return void
  */
 function news_delete( $p_news_id ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {news} WHERE id=' . db_param();
 	db_query( $t_query, array( $p_news_id ) );
 }
@@ -105,6 +107,7 @@ function news_delete( $p_news_id ) {
  * @return void
  */
 function news_delete_all( $p_project_id ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {news} WHERE project_id=' . db_param();
 	db_query( $t_query, array( (int)$p_project_id ) );
 }
@@ -132,6 +135,7 @@ function news_update( $p_news_id, $p_project_id, $p_view_state, $p_announcement,
 	}
 
 	# Update entry
+	db_param_push();
 	$t_query = 'UPDATE {news}
 				  SET view_state=' . db_param() . ',
 					announcement=' . db_param() . ',
@@ -140,7 +144,6 @@ function news_update( $p_news_id, $p_project_id, $p_view_state, $p_announcement,
 					project_id=' . db_param() . ',
 					last_modified= ' . db_param() . '
 				  WHERE id=' . db_param();
-
 	db_query( $t_query, array( $p_view_state, $p_announcement, $p_headline, $p_body, $p_project_id, db_now(), $p_news_id ) );
 }
 
@@ -151,6 +154,7 @@ function news_update( $p_news_id, $p_project_id, $p_view_state, $p_announcement,
  * @return array news article
  */
 function news_get_row( $p_news_id ) {
+	db_param_push();
 	$t_query = 'SELECT * FROM {news} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_news_id ) );
 
@@ -269,6 +273,8 @@ function news_get_limited_rows( $p_offset, $p_project_id = null ) {
 
 	switch( config_get( 'news_limit_method' ) ) {
 		case 0:
+			db_param_push();
+			
 			# BY_LIMIT - Select the news posts
 			$t_query = 'SELECT * FROM {news}';
 
@@ -285,6 +291,8 @@ function news_get_limited_rows( $p_offset, $p_project_id = null ) {
 			$t_result = db_query( $t_query, $t_params, $t_news_view_limit, $c_offset );
 			break;
 		case 1:
+			db_param_push();
+			
 			# BY_DATE - Select the news posts
 			$t_query = 'SELECT * FROM {news} WHERE
 						( ' . db_helper_compare_time( db_param(), '<', 'date_posted', $t_news_view_limit_days ) . '

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -659,6 +659,7 @@ function plugin_is_installed( $p_basename ) {
 		}
 	}
 
+	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM {plugin} WHERE basename=' . db_param();
 	$t_result = db_query( $t_query, array( $p_basename ) );
 	return( 0 < db_result( $t_result ) );
@@ -683,6 +684,7 @@ function plugin_install( MantisPlugin $p_plugin ) {
 		return null;
 	}
 
+	db_param_push();
 	$t_query = 'INSERT INTO {plugin} ( basename, enabled )
 				VALUES ( ' . db_param() . ', ' . db_param() . ' )';
 	db_query( $t_query, array( $p_plugin->basename, true ) );
@@ -796,6 +798,7 @@ function plugin_uninstall( MantisPlugin $p_plugin ) {
 		return;
 	}
 
+	db_param_push();
 	$t_query = 'DELETE FROM {plugin} WHERE basename=' . db_param();
 	db_query( $t_query, array( $p_plugin->basename ) );
 
@@ -951,6 +954,7 @@ function plugin_register_installed() {
 	}
 
 	# register plugins installed via the interface/database
+	db_param_push();
 	$t_query = 'SELECT basename, priority, protected FROM {plugin} WHERE enabled=' . db_param() . ' ORDER BY priority DESC';
 	$t_result = db_query( $t_query, array( true ) );
 

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -449,6 +449,7 @@ function print_news_item_option_list() {
 	$t_project_id = helper_get_current_project();
 
 	$t_global = access_has_global_level( config_get_global( 'admin_site_threshold' ) );
+	db_param_push();
 	if( $t_global ) {
 		$t_query = 'SELECT id, headline, announcement, view_state FROM {news} ORDER BY date_posted DESC';
 	} else {
@@ -1133,6 +1134,7 @@ function print_project_user_list_option_list( $p_project_id = null ) {
  * @return void
  */
 function print_project_user_list_option_list2( $p_user_id ) {
+	db_param_push();
 	$t_query = 'SELECT DISTINCT p.id, p.name
 				FROM {project} p
 				LEFT JOIN {project_user_list} u
@@ -1940,6 +1942,7 @@ function print_bug_attachment_preview_text( array $p_attachment ) {
 			}
 			break;
 		case DATABASE:
+			db_param_push();
 			$t_query = 'SELECT * FROM {bug_file} WHERE id=' . db_param();
 			$t_result = db_query( $t_query, array( (int)$p_attachment['id'] ) );
 			$t_row = db_fetch_array( $t_result );

--- a/core/profile_api.php
+++ b/core/profile_api.php
@@ -77,6 +77,7 @@ function profile_create( $p_user_id, $p_platform, $p_os, $p_os_build, $p_descrip
 	}
 
 	# Add profile
+	db_param_push();
 	$t_query = 'INSERT INTO {user_profile}
 				    ( user_id, platform, os, os_build, description )
 				  VALUES
@@ -102,6 +103,7 @@ function profile_delete( $p_user_id, $p_profile_id ) {
 	}
 
 	# Delete the profile
+	db_param_push();
 	$t_query = 'DELETE FROM {user_profile} WHERE id=' . db_param() . ' AND user_id=' . db_param();
 	db_query( $t_query, array( $p_profile_id, $p_user_id ) );
 }
@@ -140,6 +142,7 @@ function profile_update( $p_user_id, $p_profile_id, $p_platform, $p_os, $p_os_bu
 	}
 
 	# Add item
+	db_param_push();
 	$t_query = 'UPDATE {user_profile}
 				  SET platform=' . db_param() . ',
 				  	  os=' . db_param() . ',
@@ -156,6 +159,7 @@ function profile_update( $p_user_id, $p_profile_id, $p_platform, $p_os, $p_os_bu
  * @return array
  */
 function profile_get_row( $p_user_id, $p_profile_id ) {
+	db_param_push();
 	$t_query = 'SELECT * FROM {user_profile} WHERE id=' . db_param() . ' AND user_id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_profile_id, $p_user_id ) );
 
@@ -169,6 +173,7 @@ function profile_get_row( $p_user_id, $p_profile_id ) {
  * @todo relationship of this function to profile_get_row?
  */
 function profile_get_row_direct( $p_profile_id ) {
+	db_param_push();
 	$t_query = 'SELECT * FROM {user_profile} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_profile_id ) );
 
@@ -182,6 +187,7 @@ function profile_get_row_direct( $p_profile_id ) {
  * @return array
  */
 function profile_get_all_rows( $p_user_id, $p_all_users = false ) {
+	db_param_push();
 	$t_query_where = 'user_id = ' . db_param();
 	$t_param[] = (int)$p_user_id;
 
@@ -235,6 +241,7 @@ function profile_get_field_all_for_user( $p_field, $p_user_id = null ) {
 			trigger_error( ERROR_GENERIC, ERROR );
 	}
 
+	db_param_push();
 	$t_query = 'SELECT DISTINCT ' . $c_field . '
 				  FROM {user_profile}
 				  WHERE ( user_id=' . db_param() . ' ) OR ( user_id = 0 )
@@ -280,6 +287,7 @@ function profile_get_all_for_project( $p_project_id ) {
  * @return string
  */
 function profile_get_default( $p_user_id ) {
+	db_param_push();
 	$t_query = 'SELECT default_profile FROM {user_pref} WHERE user_id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_user_id ) );
 

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -102,6 +102,7 @@ function project_cache_row( $p_project_id, $p_trigger_errors = true ) {
 		return false;
 	}
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {project} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_project_id ) );
 
@@ -235,6 +236,7 @@ function project_ensure_exists( $p_project_id ) {
  * @return boolean
  */
 function project_is_name_unique( $p_name ) {
+	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM {project} WHERE name=' . db_param();
 	$t_result = db_query( $t_query, array( $p_name ) );
 
@@ -266,6 +268,7 @@ function project_ensure_name_unique( $p_name ) {
  * @return boolean
  */
 function project_includes_user( $p_project_id, $p_user_id ) {
+	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM {project_user_list}
 				  WHERE project_id=' . db_param() . ' AND
 						user_id=' . db_param();
@@ -330,6 +333,7 @@ function project_create( $p_name, $p_description, $p_status, $p_view_state = VS_
 		$p_file_path = validate_project_file_path( $p_file_path );
 	}
 
+	db_param_push();
 	$t_query = 'INSERT INTO {project}
 					( name, status, enabled, view_state, file_path, description, inherit_global )
 				  VALUES
@@ -385,8 +389,8 @@ function project_delete( $p_project_id ) {
 	user_pref_delete_project( $p_project_id );
 
 	# Delete the project entry
+	db_param_push();
 	$t_query = 'DELETE FROM {project} WHERE id=' . db_param();
-
 	db_query( $t_query, array( $p_project_id ) );
 
 	config_set_cache( 'enable_email_notification', $t_email_notifications, CONFIG_TYPE_INT );
@@ -436,6 +440,7 @@ function project_update( $p_project_id, $p_name, $p_description, $p_status, $p_v
 		$p_file_path = validate_project_file_path( $p_file_path );
 	}
 
+	db_param_push();
 	$t_query = 'UPDATE {project}
 				  SET name=' . db_param() . ',
 					status=' . db_param() . ',
@@ -479,6 +484,7 @@ function project_copy_custom_fields( $p_destination_id, $p_source_id ) {
  * @return integer
  */
 function project_get_id_by_name( $p_project_name ) {
+	db_param_push();
 	$t_query = 'SELECT id FROM {project} WHERE name = ' . db_param();
 	$t_result = db_query( $t_query, array( $p_project_name ), 1 );
 
@@ -557,6 +563,7 @@ function project_get_local_user_access_level( $p_project_id, $p_user_id ) {
 		return false;
 	}
 
+	db_param_push();
 	$t_query = 'SELECT access_level
 				  FROM {project_user_list}
 				  WHERE user_id=' . db_param() . ' AND project_id=' . db_param();
@@ -577,8 +584,8 @@ function project_get_local_user_access_level( $p_project_id, $p_user_id ) {
  * @return array
  */
 function project_get_local_user_rows( $p_project_id ) {
+	db_param_push();
 	$t_query = 'SELECT * FROM {project_user_list} WHERE project_id=' . db_param();
-
 	$t_result = db_query( $t_query, array( (int)$p_project_id ) );
 
 	$t_user_rows = array();
@@ -667,12 +674,13 @@ function project_get_all_user_rows( $p_project_id = ALL_PROJECTS, $p_access_leve
 	}
 
 	if( $p_include_global_users ) {
+		db_param_push();
 		$t_query = 'SELECT id, username, realname, access_level
 				FROM {user}
 				WHERE enabled = ' . db_param() . '
 					AND access_level ' . $t_global_access_clause;
-
 		$t_result = db_query( $t_query, array( $t_on ) );
+
 		while( $t_row = db_fetch_array( $t_result ) ) {
 			$t_users[(int)$t_row['id']] = $t_row;
 		}
@@ -680,12 +688,12 @@ function project_get_all_user_rows( $p_project_id = ALL_PROJECTS, $p_access_leve
 
 	if( $c_project_id != ALL_PROJECTS ) {
 		# Get the project overrides
+		db_param_push();
 		$t_query = 'SELECT u.id, u.username, u.realname, l.access_level
 				FROM {project_user_list} l, {user} u
 				WHERE l.user_id = u.id
 				AND u.enabled = ' . db_param() . '
 				AND l.project_id = ' . db_param();
-
 		$t_result = db_query( $t_query, array( $t_on, $c_project_id ) );
 
 		while( $t_row = db_fetch_array( $t_result ) ) {
@@ -745,6 +753,7 @@ function project_add_user( $p_project_id, $p_user_id, $p_access_level ) {
 		$t_access_level = user_get_access_level( $p_user_id );
 	}
 
+	db_param_push();
 	$t_query = 'INSERT INTO {project_user_list}
 				    ( project_id, user_id, access_level )
 				  VALUES
@@ -762,6 +771,7 @@ function project_add_user( $p_project_id, $p_user_id, $p_access_level ) {
  * @return void
  */
 function project_update_user_access( $p_project_id, $p_user_id, $p_access_level ) {
+	db_param_push();
 	$t_query = 'UPDATE {project_user_list}
 				  SET access_level=' . db_param() . '
 				  WHERE	project_id=' . db_param() . ' AND
@@ -793,6 +803,7 @@ function project_set_user_access( $p_project_id, $p_user_id, $p_access_level ) {
  * @return void
  */
 function project_remove_user( $p_project_id, $p_user_id ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {project_user_list}
 				  WHERE project_id=' . db_param() . ' AND user_id=' . db_param();
 
@@ -809,6 +820,7 @@ function project_remove_user( $p_project_id, $p_user_id ) {
  * @return void
  */
 function project_remove_all_users( $p_project_id, $p_access_level_limit = null ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {project_user_list} WHERE project_id = ' . db_param();
 
 	if( $p_access_level_limit !== null ) {

--- a/core/project_hierarchy_api.php
+++ b/core/project_hierarchy_api.php
@@ -47,11 +47,11 @@ function project_hierarchy_add( $p_child_id, $p_parent_id, $p_inherit_parent = t
 		trigger_error( ERROR_PROJECT_RECURSIVE_HIERARCHY, ERROR );
 	}
 
+	db_param_push();
 	$t_query = 'INSERT INTO {project_hierarchy}
 		                ( child_id, parent_id, inherit_parent )
 						VALUES
 						( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
-
 	db_query( $t_query, array( $p_child_id, $p_parent_id, $p_inherit_parent ) );
 }
 
@@ -63,6 +63,7 @@ function project_hierarchy_add( $p_child_id, $p_parent_id, $p_inherit_parent = t
  * @return void
  */
 function project_hierarchy_update( $p_child_id, $p_parent_id, $p_inherit_parent = true ) {
+	db_param_push();
 	$t_query = 'UPDATE {project_hierarchy}
 					SET inherit_parent=' . db_param() . '
 					WHERE child_id=' . db_param() . '
@@ -77,6 +78,7 @@ function project_hierarchy_update( $p_child_id, $p_parent_id, $p_inherit_parent 
  * @return void
  */
 function project_hierarchy_remove( $p_child_id, $p_parent_id ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {project_hierarchy} WHERE child_id = ' . db_param() . '
 						AND parent_id = ' . db_param();
 
@@ -89,6 +91,7 @@ function project_hierarchy_remove( $p_child_id, $p_parent_id ) {
  * @return void
  */
 function project_hierarchy_remove_all( $p_project_id ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {project_hierarchy} WHERE child_id = ' . db_param() . '
 						  OR parent_id = ' . db_param();
 
@@ -151,6 +154,7 @@ function project_hierarchy_cache( $p_show_disabled = false ) {
 	}
 	$g_cache_show_disabled = $p_show_disabled;
 
+	db_param_push();
 	$t_enabled_clause = $p_show_disabled ? '1=1' : 'p.enabled = ' . db_param();
 
 	$t_query = 'SELECT DISTINCT p.id, ph.parent_id, p.name, p.inherit_global, ph.inherit_parent

--- a/core/relationship_api.php
+++ b/core/relationship_api.php
@@ -219,6 +219,7 @@ function relationship_add( $p_src_bug_id, $p_dest_bug_id, $p_relationship_type )
 		$c_relationship_type = (int)$p_relationship_type;
 	}
 
+	db_param_push();
 	$t_query = 'INSERT INTO {bug_relationship}
 				( source_bug_id, destination_bug_id, relationship_type )
 				VALUES
@@ -255,6 +256,7 @@ function relationship_update( $p_relationship_id, $p_src_bug_id, $p_dest_bug_id,
 		$c_relationship_type = (int)$p_relationship_type;
 	}
 
+	db_param_push();
 	$t_query = 'UPDATE {bug_relationship}
 				SET source_bug_id=' . db_param() . ',
 					destination_bug_id=' . db_param() . ',
@@ -278,6 +280,7 @@ function relationship_update( $p_relationship_id, $p_src_bug_id, $p_dest_bug_id,
  * @return void
  */
 function relationship_delete( $p_relationship_id ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {bug_relationship} WHERE id=' . db_param();
 	db_query( $t_query, array( (int)$p_relationship_id ) );
 }
@@ -288,6 +291,7 @@ function relationship_delete( $p_relationship_id ) {
  * @return void
  */
 function relationship_delete_all( $p_bug_id ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {bug_relationship}
 				WHERE source_bug_id=' . db_param() . ' OR
 				destination_bug_id=' . db_param();
@@ -320,6 +324,7 @@ function relationship_copy_all( $p_bug_id, $p_new_bug_id ) {
  * @return null|BugRelationshipData BugRelationshipData object
  */
 function relationship_get( $p_relationship_id ) {
+	db_param_push();
 	$t_query = 'SELECT * FROM {bug_relationship} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( (int)$p_relationship_id ) );
 
@@ -344,6 +349,7 @@ function relationship_get( $p_relationship_id ) {
  * @return array Array of BugRelationshipData objects
  */
 function relationship_get_all_src( $p_src_bug_id ) {
+	db_param_push();
 	$t_query = 'SELECT {bug_relationship}.id, {bug_relationship}.relationship_type,
 				{bug_relationship}.source_bug_id, {bug_relationship}.destination_bug_id,
 				{bug}.project_id
@@ -384,6 +390,7 @@ function relationship_get_all_src( $p_src_bug_id ) {
  * @return array Array of BugRelationshipData objects
  */
 function relationship_get_all_dest( $p_dest_bug_id ) {
+	db_param_push();
 	$t_query = 'SELECT {bug_relationship}.id, {bug_relationship}.relationship_type,
 				{bug_relationship}.source_bug_id, {bug_relationship}.destination_bug_id,
 				{bug}.project_id
@@ -447,6 +454,7 @@ function relationship_exists( $p_src_bug_id, $p_dest_bug_id ) {
 	$c_src_bug_id = (int)$p_src_bug_id;
 	$c_dest_bug_id = (int)$p_dest_bug_id;
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {bug_relationship}
 				WHERE (source_bug_id=' . db_param() . ' AND destination_bug_id=' . db_param() . ')
 				OR

--- a/core/sponsorship_api.php
+++ b/core/sponsorship_api.php
@@ -116,6 +116,7 @@ function sponsorship_cache_row( $p_sponsorship_id, $p_trigger_errors = true ) {
 		return $g_cache_sponsorships[$c_sponsorship_id];
 	}
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {sponsorship} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $c_sponsorship_id ) );
 
@@ -176,6 +177,7 @@ function sponsorship_get_id( $p_bug_id, $p_user_id = null ) {
 		$c_user_id = (int)$p_user_id;
 	}
 
+	db_param_push();
 	$t_query = 'SELECT id FROM {sponsorship} WHERE bug_id=' . db_param() . ' AND user_id = ' . db_param();
 	$t_result = db_query( $t_query, array( (int)$p_bug_id, $c_user_id ), 1 );
 
@@ -227,6 +229,7 @@ function sponsorship_get_all_ids( $p_bug_id ) {
 		return $s_cache_sponsorship_bug_ids[$c_bug_id];
 	}
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {sponsorship} WHERE bug_id = ' . db_param();
 	$t_result = db_query( $t_query, array( $c_bug_id ) );
 
@@ -326,11 +329,11 @@ function sponsorship_set( SponsorshipData $p_sponsorship ) {
 	# if new sponsorship
 	if( $c_id == 0 ) {
 		# Insert
+		db_param_push();
 		$t_query = 'INSERT INTO {sponsorship}
 				    ( bug_id, user_id, amount, logo, url, date_submitted, last_updated )
 				  VALUES
 				    (' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ')';
-
 		db_query( $t_query, array( $c_bug_id, $c_user_id, $c_amount, $c_logo, $c_url, $c_now, $c_now ) );
 
 		$t_sponsorship_id = db_insert_id( db_get_table( 'sponsorship' ) );
@@ -345,6 +348,7 @@ function sponsorship_set( SponsorshipData $p_sponsorship ) {
 		}
 
 		# Update
+		db_param_push();
 		$t_query = 'UPDATE {sponsorship}
 					SET	bug_id = ' . db_param() . ',
 						user_id = ' . db_param() . ',
@@ -379,6 +383,7 @@ function sponsorship_set( SponsorshipData $p_sponsorship ) {
  * @return void
  */
 function sponsorship_delete_all( $p_bug_id ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {sponsorship} WHERE bug_id=' . db_param();
 	db_query( $t_query, array( (int)$p_bug_id ) );
 
@@ -403,6 +408,7 @@ function sponsorship_delete( $p_sponsorship_id ) {
 	$t_sponsorship = sponsorship_get( $p_sponsorship_id );
 
 	# Delete the bug entry
+	db_param_push();
 	$t_query = 'DELETE FROM {sponsorship} WHERE id=' . db_param();
 	db_query( $t_query, array( (int)$p_sponsorship_id ) );
 
@@ -423,6 +429,7 @@ function sponsorship_delete( $p_sponsorship_id ) {
 function sponsorship_update_paid( $p_sponsorship_id, $p_paid ) {
 	$t_sponsorship = sponsorship_get( $p_sponsorship_id );
 
+	db_param_push();
 	$t_query = 'UPDATE {sponsorship} SET last_updated=' . db_param() . ', paid=' . db_param() . ' WHERE id=' . db_param();
 	db_query( $t_query, array( db_now(), (int)$p_paid, (int)$p_sponsorship_id ) );
 
@@ -438,6 +445,7 @@ function sponsorship_update_paid( $p_sponsorship_id, $p_paid ) {
  * @return boolean
  */
 function sponsorship_update_date( $p_sponsorship_id ) {
+	db_param_push();
 	$t_query = 'UPDATE {sponsorship} SET last_updated=' . db_param() . ' WHERE id=' . db_param();
 	db_query( $t_query, array( db_now(), (int)$p_sponsorship_id ) );
 

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -254,6 +254,7 @@ function summary_new_bug_count_by_date( $p_num_days = 1 ) {
 		return 0;
 	}
 
+	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM {bug}
 				WHERE ' . db_helper_compare_time( db_param(), '<=', 'date_submitted', $c_time_length ) . ' AND ' . $t_specific_where;
 	$t_result = db_query( $t_query, array( db_now() ) );
@@ -278,6 +279,7 @@ function summary_resolved_bug_count_by_date( $p_num_days = 1 ) {
 		return 0;
 	}
 
+	db_param_push();
 	$t_query = 'SELECT COUNT(DISTINCT(b.id))
 				FROM {bug} b
 				LEFT JOIN {bug_history} h
@@ -345,6 +347,7 @@ function summary_print_by_activity() {
 	$t_project_id = helper_get_current_project();
 	$t_resolved = config_get( 'bug_resolved_status_threshold' );
 
+	db_param_push();
 	$t_specific_where = helper_project_specific_where( $t_project_id );
 	if( ' 1<>1' == $t_specific_where ) {
 		return;
@@ -405,6 +408,7 @@ function summary_print_by_age() {
 	if( ' 1<>1' == $t_specific_where ) {
 		return;
 	}
+	db_param_push();
 	$t_query = 'SELECT * FROM {bug}
 				WHERE status < ' . db_param() . '
 				AND ' . $t_specific_where . '
@@ -565,6 +569,7 @@ function summary_print_by_reporter() {
 
 	foreach( $t_reporters as $t_reporter ) {
 		$v_reporter_id = $t_reporter;
+		db_param_push();
 		$t_query = 'SELECT COUNT(id) as bugcount, status FROM {bug}
 					WHERE reporter_id=' . db_param() . '
 					AND ' . $t_specific_where . '

--- a/core/tag_api.php
+++ b/core/tag_api.php
@@ -61,6 +61,7 @@ require_api( 'utility_api.php' );
  * @return boolean True if tag exists
  */
 function tag_exists( $p_tag_id ) {
+	db_param_push();
 	$t_query = 'SELECT id FROM {tag} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_tag_id ) );
 
@@ -347,6 +348,7 @@ function tag_count( $p_name_filter ) {
 function tag_get( $p_tag_id ) {
 	tag_ensure_exists( $p_tag_id );
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {tag} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_tag_id ) );
 
@@ -365,6 +367,7 @@ function tag_get( $p_tag_id ) {
  * @return array|boolean Tag row
  */
 function tag_get_by_name( $p_name ) {
+	db_param_push();
 	$t_query = 'SELECT * FROM {tag} WHERE ' . db_helper_like( 'name' );
 	$t_result = db_query( $t_query, array( $p_name ) );
 
@@ -417,11 +420,11 @@ function tag_create( $p_name, $p_user_id = null, $p_description = '' ) {
 
 	$c_date_created = db_now();
 
+	db_param_push();
 	$t_query = 'INSERT INTO {tag}
 				( user_id, name, description, date_created, date_updated )
 				VALUES
 				( ' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ',' . db_param() . ')';
-
 	db_query( $t_query, array( $p_user_id, trim( $p_name ), trim( $p_description ), $c_date_created, $c_date_created ) );
 
 	return db_insert_id( db_get_table( 'tag' ) );
@@ -466,6 +469,7 @@ function tag_update( $p_tag_id, $p_name, $p_user_id, $p_description ) {
 
 	$c_date_updated = db_now();
 
+	db_param_push();
 	$t_query = 'UPDATE {tag}
 					SET user_id=' . db_param() . ',
 						name=' . db_param() . ',
@@ -500,6 +504,7 @@ function tag_delete( $p_tag_id ) {
 		tag_bug_detach( $p_tag_id, $t_bug_id );
 	}
 
+	db_param_push();
 	$t_query = 'DELETE FROM {tag} WHERE id=' . db_param();
 	db_query( $t_query, array( $p_tag_id ) );
 
@@ -514,11 +519,13 @@ function tag_delete( $p_tag_id ) {
  * @return array The array of tag rows, each with id, name, and description.
  */
 function tag_get_candidates_for_bug( $p_bug_id ) {
+	db_param_push();
 	$t_params = array();
 	if( 0 != $p_bug_id ) {
 		$t_params[] = $p_bug_id;
 
 		if( config_get_global( 'db_type' ) == 'odbc_mssql' ) {
+			db_param_push();
 			$t_query = 'SELECT t.id FROM {tag} t
 					LEFT JOIN {bug_tag} b ON t.id=b.tag_id
 					WHERE b.bug_id IS NULL OR b.bug_id != ' . db_param();
@@ -533,7 +540,8 @@ function tag_get_candidates_for_bug( $p_bug_id ) {
 			}
 
 			if( count( $t_subquery_results ) == 0 ) {
-			    return array();
+				db_param_pop();
+				return array();
 			}
 
 			$t_query = 'SELECT id, name, description FROM {tag} WHERE id IN ( ' . implode( ', ', $t_subquery_results ) . ')';
@@ -567,6 +575,7 @@ function tag_get_candidates_for_bug( $p_bug_id ) {
  * @return boolean True if the tag is attached
  */
 function tag_bug_is_attached( $p_tag_id, $p_bug_id ) {
+	db_param_push();
 	$t_query = 'SELECT bug_id FROM {bug_tag} WHERE tag_id=' . db_param() . ' AND bug_id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_tag_id, $p_bug_id ) );
 	return( db_result( $t_result ) !== false );
@@ -579,6 +588,7 @@ function tag_bug_is_attached( $p_tag_id, $p_bug_id ) {
  * @return array Tag attachment row
  */
 function tag_bug_get_row( $p_tag_id, $p_bug_id ) {
+	db_param_push();
 	$t_query = 'SELECT * FROM {bug_tag} WHERE tag_id=' . db_param() . ' AND bug_id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_tag_id, $p_bug_id ) );
 
@@ -595,6 +605,7 @@ function tag_bug_get_row( $p_tag_id, $p_bug_id ) {
  * @return array Array of tag rows with attachment information
  */
 function tag_bug_get_attached( $p_bug_id ) {
+	db_param_push();
 	$t_query = 'SELECT t.*, b.user_id as user_attached, b.date_attached
 					FROM {tag} t
 					LEFT JOIN {bug_tag} b
@@ -617,6 +628,7 @@ function tag_bug_get_attached( $p_bug_id ) {
  * @return array Array of bug ID's.
  */
 function tag_get_bugs_attached( $p_tag_id ) {
+	db_param_push();
 	$t_query = 'SELECT bug_id FROM {bug_tag} WHERE tag_id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_tag_id ) );
 
@@ -652,6 +664,7 @@ function tag_bug_attach( $p_tag_id, $p_bug_id, $p_user_id = null ) {
 		user_ensure_exists( $p_user_id );
 	}
 
+	db_param_push();
 	$t_query = 'INSERT INTO {bug_tag}
 					( tag_id, bug_id, user_id, date_attached )
 					VALUES
@@ -695,6 +708,7 @@ function tag_bug_detach( $p_tag_id, $p_bug_id, $p_add_history = true, $p_user_id
 
 	access_ensure_bug_level( $t_detach_level, $p_bug_id, $t_user_id );
 
+	db_param_push();
 	$t_query = 'DELETE FROM {bug_tag} WHERE tag_id=' . db_param() . ' AND bug_id=' . db_param();
 	db_query( $t_query, array( $p_tag_id, $p_bug_id ) );
 
@@ -816,6 +830,7 @@ function tag_bug_get_all( $p_bug_id ) {
  * @return int Number of attached bugs
  */
 function tag_stats_attached( $p_tag_id ) {
+	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM {bug_tag} WHERE tag_id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_tag_id ) );
 
@@ -834,6 +849,7 @@ function tag_stats_attached( $p_tag_id ) {
 function tag_stats_related( $p_tag_id, $p_limit = 5 ) {
 	$c_user_id = auth_get_current_user_id();
 
+	db_param_push();
 	$t_subquery = 'SELECT b.id FROM {bug} b
 					LEFT JOIN {project_user_list} p
 						ON p.project_id=b.project_id AND p.user_id=' . db_param() . # 2nd Param

--- a/core/tokens_api.php
+++ b/core/tokens_api.php
@@ -44,6 +44,7 @@ $g_tokens_purged = false;
  * @return boolean True if token exists
  */
 function token_exists( $p_token_id ) {
+	db_param_push();
 	$t_query = 'SELECT id FROM {tokens} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_token_id ), 1 );
 
@@ -79,6 +80,7 @@ function token_get( $p_type, $p_user_id = null ) {
 	$c_type = (int)$p_type;
 	$c_user_id = (int)( $p_user_id == null ? auth_get_current_user_id() : $p_user_id );
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {tokens} WHERE type=' . db_param() . ' AND owner=' . db_param();
 	$t_result = db_query( $t_query, array( $c_type, $c_user_id ) );
 
@@ -134,6 +136,7 @@ function token_touch( $p_token_id, $p_expiry = TOKEN_EXPIRY ) {
 	token_ensure_exists( $p_token_id );
 
 	$c_token_expiry = time() + $p_expiry;
+	db_param_push();
 	$t_query = 'UPDATE {tokens} SET expiry=' . db_param() . ' WHERE id=' . db_param();
 	db_query( $t_query, array( $c_token_expiry, $p_token_id ) );
 }
@@ -151,6 +154,7 @@ function token_delete( $p_type, $p_user_id = null ) {
 		$c_user_id = (int)$p_user_id;
 	}
 
+	db_param_push();
 	$t_query = 'DELETE FROM {tokens} WHERE type=' . db_param() . ' AND owner=' . db_param();
 	db_query( $t_query, array( $p_type, $c_user_id ) );
 }
@@ -167,6 +171,7 @@ function token_delete_by_owner( $p_user_id = null ) {
 		$c_user_id = (int)$p_user_id;
 	}
 
+	db_param_push();
 	$t_query = 'DELETE FROM {tokens} WHERE owner=' . db_param();
 	db_query( $t_query, array( $c_user_id ) );
 }
@@ -190,6 +195,7 @@ function token_create( $p_type, $p_value, $p_expiry = TOKEN_EXPIRY, $p_user_id =
 	$c_timestamp = db_now();
 	$c_expiry = time() + $p_expiry;
 
+	db_param_push();
 	$t_query = 'INSERT INTO {tokens}
 					( type, value, timestamp, expiry, owner )
 					VALUES ( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
@@ -209,6 +215,7 @@ function token_update( $p_token_id, $p_value, $p_expiry = TOKEN_EXPIRY ) {
 	$c_token_id = (int)$p_token_id;
 	$c_expiry = time() + $p_expiry;
 
+	db_param_push();
 	$t_query = 'UPDATE {tokens}
 					SET value=' . db_param() . ', expiry=' . db_param() . '
 					WHERE id=' . db_param();
@@ -223,6 +230,7 @@ function token_update( $p_token_id, $p_value, $p_expiry = TOKEN_EXPIRY ) {
  * @return boolean always true.
  */
 function token_delete_by_type( $p_token_type ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {tokens} WHERE type=' . db_param();
 	db_query( $t_query, array( $p_token_type ) );
 
@@ -237,6 +245,7 @@ function token_delete_by_type( $p_token_type ) {
 function token_purge_expired( $p_token_type = null ) {
 	global $g_tokens_purged;
 
+	db_param_push();
 	$t_query = 'DELETE FROM {tokens} WHERE ' . db_param() . ' > expiry';
 	if( !is_null( $p_token_type ) ) {
 		$t_query .= ' AND type=' . db_param();

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -271,6 +271,7 @@ function user_is_email_unique( $p_email, $p_user_id = null ) {
 
 	$p_email = trim( $p_email );
 
+	db_push_param();
 	if ( $p_user_id === null ) {
 		$t_query = 'SELECT email FROM {user} WHERE email=' . db_param();
 		$t_result = db_query( $t_query, array( $p_email ), 1 );
@@ -817,6 +818,7 @@ function user_get_id_by_email( $p_email ) {
  * @return array The user ids or an empty array.
  */
 function user_get_enabled_ids_by_email( $p_email ) {
+	db_push_param();
 	$t_query = 'SELECT * FROM {user} WHERE email=' . db_param() .
 		' AND enabled=' . db_param() . ' ORDER BY access_level DESC';
 	$t_result = db_query( $t_query, array( $p_email, 1 ) );

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -78,6 +78,7 @@ function user_cache_row( $p_user_id, $p_trigger_errors = true ) {
 		return $g_cache_user[$p_user_id];
 	}
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {user} WHERE id=' . db_param();
 	$t_result = db_query( $t_query, array( $p_user_id ) );
 
@@ -236,6 +237,7 @@ function user_ensure_exists( $p_user_id ) {
  * @return boolean
  */
 function user_is_name_unique( $p_username ) {
+	db_param_push();
 	$t_query = 'SELECT username FROM {user} WHERE username=' . db_param();
 	$t_result = db_query( $t_query, array( $p_username ), 1 );
 
@@ -329,6 +331,7 @@ function user_is_realname_unique( $p_username, $p_realname ) {
 		}
 
 		# check to see if the realname is unique
+		db_param_push();
 		$t_query = 'SELECT id FROM {user} WHERE realname=' . db_param();
 		$t_result = db_query( $t_query, array( $p_realname ) );
 
@@ -409,6 +412,7 @@ function user_ensure_name_valid( $p_username ) {
  * @return boolean
  */
 function user_is_monitoring_bug( $p_user_id, $p_bug_id ) {
+	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM {bug_monitor}
 				  WHERE user_id=' . db_param() . ' AND bug_id=' . db_param();
 
@@ -502,6 +506,7 @@ function user_is_enabled( $p_user_id ) {
  * @return integer The number of users.
  */
 function user_count_level( $p_level = ANYBODY, $p_enabled = null ) {
+	db_param_push();
 	$t_query = 'SELECT COUNT(id) FROM {user} WHERE access_level >= ' . db_param();
 	$t_param = array( $p_level );
 
@@ -537,6 +542,7 @@ function user_get_logged_in_user_ids( $p_session_duration_in_minutes ) {
 	$t_last_timestamp_threshold = mktime( date( 'H' ), date( 'i' ) - 1 * $t_session_duration_in_minutes, date( 's' ), date( 'm' ), date( 'd' ), date( 'Y' ) );
 
 	# Execute query
+	db_param_push();
 	$t_query = 'SELECT id FROM {user} WHERE last_visit > ' . db_param();
 	$t_result = db_query( $t_query, array( $t_last_timestamp_threshold ), 1 );
 
@@ -582,6 +588,7 @@ function user_create( $p_username, $p_password, $p_email = '',
 
 	$t_cookie_string = auth_generate_unique_cookie_string();
 
+	db_param_push();
 	$t_query = 'INSERT INTO {user}
 				    ( username, email, password, date_created, last_visit,
 				     enabled, access_level, login_count, cookie_string, realname )
@@ -666,6 +673,7 @@ function user_signup( $p_username, $p_email = null ) {
 function user_delete_project_specific_access_levels( $p_user_id ) {
 	user_ensure_unprotected( $p_user_id );
 
+	db_param_push();
 	$t_query = 'DELETE FROM {project_user_list} WHERE user_id=' . db_param();
 	db_query( $t_query, array( (int)$p_user_id ) );
 
@@ -684,6 +692,7 @@ function user_delete_profiles( $p_user_id ) {
 	user_ensure_unprotected( $p_user_id );
 
 	# Remove associated profiles
+	db_param_push();
 	$t_query = 'DELETE FROM {user_profile} WHERE user_id=' . db_param();
 	db_query( $t_query, array( (int)$p_user_id ) );
 
@@ -718,6 +727,7 @@ function user_delete( $p_user_id ) {
 	# unset non-unique realname flags if necessary
 	if( config_get( 'differentiate_duplicates' ) ) {
 		$c_realname = user_get_field( $p_user_id, 'realname' );
+		db_param_push();
 		$t_query = 'SELECT id FROM {user} WHERE realname=' . db_param();
 		$t_result = db_query( $t_query, array( $c_realname ) );
 
@@ -740,6 +750,7 @@ function user_delete( $p_user_id ) {
 	user_clear_cache( $p_user_id );
 
 	# Remove account
+	db_param_push();
 	$t_query = 'DELETE FROM {user} WHERE id=' . db_param();
 	db_query( $t_query, array( $c_user_id ) );
 
@@ -758,6 +769,7 @@ function user_get_id_by_name( $p_username ) {
 		return $t_user['id'];
 	}
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {user} WHERE username=' . db_param();
 	$t_result = db_query( $t_query, array( $p_username ) );
 
@@ -781,6 +793,7 @@ function user_get_id_by_email( $p_email ) {
 		return $t_user['id'];
 	}
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {user} WHERE email=' . db_param();
 	$t_result = db_query( $t_query, array( $p_email ) );
 
@@ -829,6 +842,7 @@ function user_get_id_by_realname( $p_realname ) {
 		return $t_user['id'];
 	}
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {user} WHERE realname=' . db_param();
 	$t_result = db_query( $t_query, array( $p_realname ) );
 
@@ -1013,6 +1027,7 @@ function user_get_accessible_projects( $p_user_id, $p_show_disabled = false ) {
 		$t_public = VS_PUBLIC;
 		$t_private = VS_PRIVATE;
 
+		db_param_push();
 		$t_query = 'SELECT p.id, p.name, ph.parent_id
 						  FROM {project} p
 						  LEFT JOIN {project_user_list} u
@@ -1200,6 +1215,7 @@ function user_get_all_accessible_projects( $p_user_id = null, $p_project_id = AL
  *		The array contains the id, name, view state, and project access level for the user.
  */
 function user_get_assigned_projects( $p_user_id ) {
+	db_param_push();
 	$t_query = 'SELECT DISTINCT p.id, p.name, p.view_state, u.access_level
 				FROM {project} p
 				LEFT JOIN {project_user_list} u
@@ -1229,6 +1245,7 @@ function user_get_unassigned_by_project_id( $p_project_id = null ) {
 	}
 
 	$t_adm = config_get_global( 'admin_site_threshold' );
+	db_param_push();
 	$t_query = 'SELECT DISTINCT u.id, u.username, u.realname
 				FROM {user} u
 				LEFT JOIN {project_user_list} p
@@ -1281,6 +1298,7 @@ function user_get_assigned_open_bug_count( $p_user_id, $p_project_id = ALL_PROJE
 
 	$t_resolved = config_get( 'bug_resolved_status_threshold' );
 
+	db_param_push();
 	$t_query = 'SELECT COUNT(*)
 				  FROM {bug}
 				  WHERE ' . $t_where_prj . '
@@ -1303,6 +1321,7 @@ function user_get_reported_open_bug_count( $p_user_id, $p_project_id = ALL_PROJE
 
 	$t_resolved = config_get( 'bug_resolved_status_threshold' );
 
+	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM {bug}
 				  WHERE ' . $t_where_prj . '
 						  status<' . db_param() . ' AND
@@ -1320,6 +1339,7 @@ function user_get_reported_open_bug_count( $p_user_id, $p_project_id = ALL_PROJE
  * @return array
  */
 function user_get_profile_row( $p_user_id, $p_profile_id ) {
+	db_param_push();
 	$t_query = 'SELECT * FROM {user_profile}
 				  WHERE id=' . db_param() . ' AND
 						user_id=' . db_param();
@@ -1400,8 +1420,8 @@ function user_update_last_visit( $p_user_id ) {
 	$c_user_id = (int)$p_user_id;
 	$c_value = db_now();
 
+	db_param_push();
 	$t_query = 'UPDATE {user} SET last_visit=' . db_param() . ' WHERE id=' . db_param();
-
 	db_query( $t_query, array( $c_value, $c_user_id ) );
 
 	user_update_cache( $c_user_id, 'last_visit', $c_value );
@@ -1417,8 +1437,8 @@ function user_update_last_visit( $p_user_id ) {
  * @return boolean always true
  */
 function user_increment_login_count( $p_user_id ) {
+	db_param_push();
 	$t_query = 'UPDATE {user} SET login_count=login_count+1 WHERE id=' . db_param();
-
 	db_query( $t_query, array( (int)$p_user_id ) );
 
 	user_clear_cache( $p_user_id );
@@ -1433,6 +1453,7 @@ function user_increment_login_count( $p_user_id ) {
  * @return boolean always true
  */
 function user_reset_failed_login_count_to_zero( $p_user_id ) {
+	db_param_push();
 	$t_query = 'UPDATE {user} SET failed_login_count=0 WHERE id=' . db_param();
 	db_query( $t_query, array( (int)$p_user_id ) );
 
@@ -1448,6 +1469,7 @@ function user_reset_failed_login_count_to_zero( $p_user_id ) {
  * @return boolean always true
  */
 function user_increment_failed_login_count( $p_user_id ) {
+	db_param_push();
 	$t_query = 'UPDATE {user} SET failed_login_count=failed_login_count+1 WHERE id=' . db_param();
 	db_query( $t_query, array( $p_user_id ) );
 
@@ -1463,6 +1485,7 @@ function user_increment_failed_login_count( $p_user_id ) {
  * @return boolean always true
  */
 function user_reset_lost_password_in_progress_count_to_zero( $p_user_id ) {
+	db_param_push();
 	$t_query = 'UPDATE {user} SET lost_password_request_count=0 WHERE id=' . db_param();
 	db_query( $t_query, array( $p_user_id ) );
 
@@ -1478,6 +1501,7 @@ function user_reset_lost_password_in_progress_count_to_zero( $p_user_id ) {
  * @return boolean always true
  */
 function user_increment_lost_password_in_progress_count( $p_user_id ) {
+	db_param_push();
 	$t_query = 'UPDATE {user}
 				SET lost_password_request_count=lost_password_request_count+1
 				WHERE id=' . db_param();
@@ -1504,6 +1528,7 @@ function user_set_fields( $p_user_id, array $p_fields ) {
 		user_ensure_unprotected( $p_user_id );
 	}
 
+	db_param_push();
 	$t_query = 'UPDATE {user}';
 	$t_parameters = array();
 
@@ -1572,6 +1597,7 @@ function user_set_password( $p_user_id, $p_password, $p_allow_protected = false 
 
 	$c_password = auth_process_plain_password( $p_password );
 
+	db_param_push();
 	$t_query = 'UPDATE {user}
 				  SET password=' . db_param() . ', cookie_string=' . db_param() . '
 				  WHERE id=' . db_param();

--- a/core/user_pref_api.php
+++ b/core/user_pref_api.php
@@ -331,8 +331,8 @@ function user_pref_cache_array_rows( array $p_user_id_array, $p_project_id = ALL
 		return;
 	}
 
+	db_param_push();
 	$t_query = 'SELECT * FROM {user_pref} WHERE user_id IN (' . implode( ',', $c_user_id_array ) . ') AND project_id=' . db_param();
-
 	$t_result = db_query( $t_query, array( (int)$p_project_id ) );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
@@ -407,6 +407,8 @@ function user_pref_insert( $p_user_id, $p_project_id, UserPreferences $p_prefs )
 
 	$t_values = array();
 
+	db_param_push();
+
 	$t_params[] = db_param(); # user_id
 	$t_values[] = $c_user_id;
 	$t_params[] = db_param(); # project_id
@@ -445,6 +447,8 @@ function user_pref_update( $p_user_id, $p_project_id, UserPreferences $p_prefs )
 	$t_pairs = array();
 	$t_values = array();
 
+	db_param_push();
+
 	foreach( $s_vars as $t_var => $t_val ) {
 		array_push( $t_pairs, $t_var . ' = ' . db_param() ) ;
 		array_push( $t_values, $p_prefs->$t_var );
@@ -471,6 +475,7 @@ function user_pref_update( $p_user_id, $p_project_id, UserPreferences $p_prefs )
 function user_pref_delete( $p_user_id, $p_project_id = ALL_PROJECTS ) {
 	user_ensure_unprotected( $p_user_id );
 
+	db_param_push();
 	$t_query = 'DELETE FROM {user_pref}
 				  WHERE user_id=' . db_param() . ' AND
 				  		project_id=' . db_param();
@@ -492,6 +497,7 @@ function user_pref_delete( $p_user_id, $p_project_id = ALL_PROJECTS ) {
 function user_pref_delete_all( $p_user_id ) {
 	user_ensure_unprotected( $p_user_id );
 
+	db_param_push();
 	$t_query = 'DELETE FROM {user_pref} WHERE user_id=' . db_param();
 	db_query( $t_query, array( $p_user_id ) );
 
@@ -508,6 +514,7 @@ function user_pref_delete_all( $p_user_id ) {
  * @return void
  */
 function user_pref_delete_project( $p_project_id ) {
+	db_param_push();
 	$t_query = 'DELETE FROM {user_pref} WHERE project_id=' . db_param();
 	db_query( $t_query, array( $p_project_id ) );
 }


### PR DESCRIPTION
Prior to building a database query, our APIs must ensure that they leave
the parameters numbering in the same state as it was prior to the
function call.

While failure to do so does not have any impact with MySQL, it
causes SQL errors with RDBMS which rely on strict parameter ordering
(PostgreSQL and Oracle) when a query is executed while another is being
built, because the parameter count is reset (see #20479, #20483 for
recent examples).

All MantisBT APIs have been reviewed, and db_push_param() calls added
where needed to ensure that the caller always finds the environment in
the same state as it was prior the API call.

A new db_pop_param() API was added to cover rare cases where a query is
called multiple times, or built but never executed.

Fixes [#20479](https://www.mantisbt.org/bugs/view.php?id=20479)