### PR TITLE
Include project name in time tracking lists

### DIFF
--- a/billing_export_to_csv.php
+++ b/billing_export_to_csv.php
@@ -58,6 +58,7 @@ header( 'Content-Transfer-Encoding: BASE64;' );
 header( 'Content-Disposition: attachment; filename="' . urlencode( file_clean_name( $t_filename ) ) . '"' );
 
 echo csv_escape_string( lang_get( 'issue_id' ) ) . $t_separator;
+echo csv_escape_string( lang_get( 'project_name' ) ) . $t_separator;
 echo csv_escape_string( lang_get( 'summary' ) ) . $t_separator;
 
 if( $t_show_realname ) {
@@ -79,6 +80,7 @@ echo "\n";
 
 foreach( $t_billing_rows as $t_billing ) {
 	echo csv_escape_string( bug_format_id( $t_billing['bug_id'] ) ) . $t_separator;
+	echo csv_escape_string( $t_billing['project_name'] ) . $t_separator;
 	echo csv_escape_string( $t_billing['bug_summary'] ) . $t_separator;
 
 	if( $t_show_realname ) {

--- a/billing_export_to_excel.php
+++ b/billing_export_to_excel.php
@@ -57,6 +57,7 @@ header( 'Content-Disposition: attachment; filename="' . urlencode( file_clean_na
 echo excel_get_header( $t_filename );
 echo excel_get_start_row();
 echo excel_format_column_title( lang_get( 'issue_id' ) );
+echo excel_format_column_title( lang_get( 'project_name' ) );
 echo excel_format_column_title( lang_get( 'summary' ) );
 
 if( $t_show_realname ) {
@@ -79,6 +80,7 @@ echo '</Row>';
 foreach( $t_billing_rows as $t_billing ) {
 	echo "\n<Row>\n";
 	echo excel_prepare_number( $t_billing['bug_id'] );
+	echo excel_prepare_string( $t_billing['project_name'] );
 	echo excel_prepare_string( $t_billing['bug_summary'] );
 
 	if( $t_show_realname ) {

--- a/billing_inc.php
+++ b/billing_inc.php
@@ -219,7 +219,8 @@ if( ON == config_get( 'time_tracking_with_billing' ) ) {
 
 			$t_item['sum_time_tracking'] = db_minutes_to_hhmm( $t_item['sum_time_tracking'] );
 			if( $t_item['bug_id'] != $t_prev_id ) {
-				$t_link = sprintf( lang_get( 'label' ), string_get_bug_view_link( $t_item['bug_id'] ) ) . lang_get( 'word_separator' ) . string_display( $t_item['summary'] );
+				$t_project_info = ( !isset( $f_bug_id ) && $f_project_id == ALL_PROJECTS ) ? '[' . project_get_name( $t_item['project_id'] ) . ']' . lang_get( 'word_separator' ) : '';
+				$t_link = sprintf( lang_get( 'label' ), string_get_bug_view_link( $t_item['bug_id'] ) ) . lang_get( 'word_separator' ) . $t_project_info . string_display( $t_item['summary'] );
 				echo '<tr class="row-category-history"><td colspan="4">' . $t_link . '</td></tr>';
 				$t_prev_id = $t_item['bug_id'];
 			}

--- a/core/billing_api.php
+++ b/core/billing_api.php
@@ -90,7 +90,7 @@ function billing_get_for_project( $p_project_id, $p_from, $p_to, $p_cost_per_hou
 	$t_results = array();
 
 	$t_query = 'SELECT bn.id id, bn.time_tracking minutes, bn.date_submitted as date_submitted, bnt.note note,
-			u.realname realname, b.summary bug_summary, bn.bug_id bug_id, bn.reporter_id reporter_id
+			u.realname realname, b.project_id project_id, b.summary bug_summary, bn.bug_id bug_id, bn.reporter_id reporter_id
 			FROM {user} u, {bugnote} bn, {bug} b, {bugnote_text} bnt
 			WHERE u.id = bn.reporter_id AND bn.time_tracking != 0 AND bn.bug_id = b.id AND bnt.id = bn.bugnote_text_id
 			' . $t_project_where . $t_from_where . $t_to_where . '
@@ -135,6 +135,8 @@ function billing_rows_to_array( $p_bugnotes ) {
 		}
 
 		$t_row['bug_id'] = $t_note['bug_id'];
+		$t_row['project_id'] = $t_note['project_id'];
+		$t_row['project_name'] = project_get_name( $t_note['project_id'] );
 		$t_row['bug_summary'] = $t_note['bug_summary'];
 		$t_row['cost'] = $t_note['cost'];
 

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -727,7 +727,7 @@ function bugnote_stats_get_project_array( $p_project_id, $p_from, $p_to, $p_cost
 
 	$t_results = array();
 
-	$t_query = 'SELECT username, realname, summary, bn.bug_id, SUM(time_tracking) AS sum_time_tracking
+	$t_query = 'SELECT username, realname, summary, b.project_id project_id, bn.bug_id, SUM(time_tracking) AS sum_time_tracking
 			FROM {user} u, {bugnote} bn, {bug} b
 			WHERE u.id = bn.reporter_id AND bn.time_tracking != 0 AND bn.bug_id = b.id
 			' . $t_project_where . $t_from_where . $t_to_where . '


### PR DESCRIPTION
When exporting time tracking information across multiple projects, the project associated
with each issue is missing.  This pull request adds it to the web UI and csv/excel exports.

Fixes #20523