### PR TITLE
Fix passing parameters for EVENT_TYPE_OUTPUT events

### DIFF
--- a/core/event_api.php
+++ b/core/event_api.php
@@ -230,26 +230,27 @@ function event_type_execute( $p_event, array $p_callbacks, $p_params = null ) {
  * If there are no callbacks, then nothing will be sent as output.
  * @param string $p_event     Event name.
  * @param array  $p_callbacks Array of callback function/plugin base name key/value pairs.
- * @param mixed  $p_params    Output separator (if single string) or indexed array of pre, mid, and post strings.
+ * @param mixed  $p_params    Parameters to event callback (array, or single object)
+ * @param mixed  $p_format    Output separator (if single string) or indexed array of pre, mid, and post strings.
  * @access public
  * @return void
  */
-function event_type_output( $p_event, array $p_callbacks, $p_params = null ) {
+function event_type_output( $p_event, array $p_callbacks, $p_params = null, $p_format = null ) {
 	$t_prefix = '';
 	$t_separator = '';
 	$t_postfix = '';
 
-	if( is_array( $p_params ) ) {
-		switch( count( $p_params ) ) {
+	if( is_array( $p_format ) ) {
+		switch( count( $p_format ) ) {
 			case 3:
-				$t_postfix = $p_params[2];
+				$t_postfix = $p_format[2];
 			case 2:
-				$t_separator = $p_params[1];
+				$t_separator = $p_format[1];
 			case 1:
-				$t_prefix = $p_params[0];
+				$t_prefix = $p_format[0];
 		}
 	} else {
-		$t_separator = $p_params;
+		$t_separator = $p_format;
 	}
 
 	$t_output = array();

--- a/docbook/Developers_Guide/en-US/Events.xml
+++ b/docbook/Developers_Guide/en-US/Events.xml
@@ -155,10 +155,31 @@ event_hook( $events, [$plugin] );
 			<para>
 				These events only use the first parameter array, and return values from
 				hooked functions are immediately sent to the output buffer via 'echo'.
+				Another parameter <parameter>$format</parameter> can be used to model
+				how the results are printed. This parameter can be either:
+				<itemizedlist>
+					<listitem>
+						<para>
+							null, or ommited: The returned values are printed without further processing
+						</para>
+					</listitem>
+					<listitem>
+						<para>
+							&lt;String&gt;: A string to be used as separator for printed values
+						</para>
+					</listitem>
+					<listitem>
+						<para>
+							&lt;Array&gt;: An array of (prefix, separator, postfix) to be used for the printed values
+						</para>
+					</listitem>
+				</itemizedlist>
+			</para>
+			<para>
 				Example usage:
 			</para>
 
-			<programlisting>event_signal( $event_name, [ array( $param, ... ) ] );</programlisting>
+			<programlisting>event_signal( $event_name, [ array( $param, ... ) ], [ $format ] );</programlisting>
 		</blockquote>
 
 		<blockquote id="dev.events.types.chain">


### PR DESCRIPTION
Fix passing parameters for EVENT_TYPE_OUTPUT events

Some events of EVENT_TYPE_OUTPUT specify a parameter
to be passed to the callback function.
However the event dispatcher for that type was not
designed to receive a parameter in that way.

Modified the event function to allow for that parameter
to be passed on, thus matching documented specification
and current use in code base.

Affected events are:
EVENT_MANAGE_OVERVIEW_INFO
EVENT_VIEW_BUG_ATTACHMENT

Those events have not been working properly until now.

Fixes #20535