### PR TITLE
ldap authentication: add an option not to cache passwords

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -1968,6 +1968,14 @@ $g_use_ldap_email = OFF;
  */
 $g_ldap_simulation_file_path = '';
 
+/**
+ * Cache passwords in LDAP. Disabling this will mean that you cannot log into
+ * mantis if LDAP is down
+ * @global boolean $g_ldap_cache_passwords
+ */
+
+$g_ldap_cache_passwords = ON;
+
 ###################
 # Status Settings #
 ###################

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -201,15 +201,18 @@ function auth_auto_create_user( $p_username, $p_password ) {
 
 	if( $t_login_method == BASIC_AUTH ) {
 		$t_auto_create = true;
+		$t_auto_create_password = md5( $p_password );
 	} else if( $t_login_method == LDAP && ldap_authenticate_by_username( $p_username, $p_password ) ) {
 		$t_auto_create = true;
+		$t_cache_password = config_get( 'ldap_cache_passwords' );
+		$t_auto_create_password = $t_cache_password ? md5( $p_password ) : 'external-password';
 	} else {
 		$t_auto_create = false;
 	}
 
 	if( $t_auto_create ) {
 		# attempt to create the user
-		$t_cookie_string = user_create( $p_username, md5( $p_password ) );
+		$t_cookie_string = user_create( $p_username, $t_auto_create_password );
 		if( $t_cookie_string === false ) {
 			# it didn't work
 			return false;

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -379,7 +379,10 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
 
 		if( false !== $t_user_id ) {
 
-			$t_fields_to_update = array('password' => md5( $p_password ));
+			$t_fields_to_update = array();
+			if( ON == config_get( 'ldap_cache_passwords' ) ) {
+				$t_fields_to_update['password'] = md5( $p_password );
+			}
 
 			if( ON == config_get( 'use_ldap_realname' ) ) {
 				$t_fields_to_update['realname'] = ldap_realname( $t_user_id );

--- a/docbook/Admin_Guide/en-US/config/auth.xml
+++ b/docbook/Admin_Guide/en-US/config/auth.xml
@@ -283,6 +283,16 @@ ldaps://ldap.example.com:3269/
 			</varlistentry>
 
 			<varlistentry>
+				<term>$g_ldap_cache_passwords</term>
+
+				<listitem>
+					<para>Cache md5sums of passwords in the mantis database to
+					allow logins even if ldap is down. Defaults to
+					</para>
+				</listitem>
+			</varlistentry>
+
+			<varlistentry>
 				<term>$g_ldap_port</term>
 
 				<listitem>


### PR DESCRIPTION
Not everyone wants to cache passwords, even in hashed format. This new
option caters to those users.