### PR TITLE
Stop caching LDAP passwords

### DIFF
--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -209,7 +209,7 @@ function auth_auto_create_user( $p_username, $p_password ) {
 
 	if( $t_auto_create ) {
 		# attempt to create the user
-		$t_cookie_string = user_create( $p_username, md5( $p_password ) );
+		$t_cookie_string = user_create( $p_username, "!" + auth_generate_random_password() );
 		if( $t_cookie_string === false ) {
 			# it didn't work
 			return false;

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -379,7 +379,11 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
 
 		if( false !== $t_user_id ) {
 
-			$t_fields_to_update = array('password' => md5( $p_password ));
+			$t_fields_to_update = array();
+			# Do we need to wipe a previously cached password?
+			if( substr( user_get_field( $t_user_id, 'password' ), 0, 1) != '!' ) {
+				user_set_field( 'password', '!' + auth_generate_random_password() );
+			}
 
 			if( ON == config_get( 'use_ldap_realname' ) ) {
 				$t_fields_to_update['realname'] = ldap_realname( $t_user_id );


### PR DESCRIPTION
When authenticating against LDAP, mantis does not need to know the
user's password, so it should not remember it.