### PR TITLE
Fix attachment uploading with MySQL in STRICT_ALL_TABLES sql_mode

### DIFF
--- a/admin/schema.php
+++ b/admin/schema.php
@@ -856,6 +856,12 @@ $g_upgrade[201] = array( 'CreateIndexSQL', array( 'idx_user_id_name', db_get_tab
 
 $g_upgrade[202] = array( 'CreateIndexSQL', array( 'idx_email', db_get_table( 'user' ), 'email' ) );
 
+# Ensure consistent definition of file attachment blob columns, see #20547
+$g_upgrade[203] = array( 'AlterColumnSQL', array( db_get_table( 'bug_file' ), "
+	content					B		NULL " . $t_blob_default ) );
+$g_upgrade[204] = array( 'AlterColumnSQL', array( db_get_table( 'project_file' ), "
+	content					B		NULL " . $t_blob_default ) );
+
 # Release marker: 1.3.0
 
 

--- a/api/soap/mc_file_api.php
+++ b/api/soap/mc_file_api.php
@@ -165,7 +165,7 @@ function mci_file_add( $p_id, $p_name, $p_content, $p_file_type, $p_table, $p_ti
 		( ' . implode(', ', array_keys( $t_param ) ) . ' )
 	VALUES
 		( ' . $t_query_param . ' )';
-	db_query( $t_query, $t_param );
+	db_query( $t_query, array_values( $t_param ) );
 
 	# get attachment id
 	$t_attachment_id = db_insert_id( $t_file_table );

--- a/api/soap/mc_file_api.php
+++ b/api/soap/mc_file_api.php
@@ -140,28 +140,38 @@ function mci_file_add( $p_id, $p_name, $p_content, $p_file_type, $p_table, $p_ti
 	$t_file_table = db_get_table( $p_table . '_file' );
 	$t_id_col = $p_table . '_id';
 
+	$t_param = array(
+		$t_id_col     => $t_id,
+		'title'       => $p_title,
+		'description' => $p_desc,
+		'diskfile'    => $t_unique_name,
+		'filename'    => $p_name,
+		'folder'      => $t_file_path,
+		'filesize'    => $t_file_size,
+		'file_type'   => $p_file_type,
+		'date_added'  => db_now(),
+		'user_id'     => (int)$p_user_id,
+	);
+	# Oracle has to update BLOBs separately
+	if( !db_is_oracle() ) {
+		$t_param['content'] = $c_content;
+	}
+	$t_query_param = db_param();
+	for( $i = 1; $i < count( $t_param ); $i++ ) {
+		$t_query_param .= ', ' . db_param();
+	}
+
 	$t_query = 'INSERT INTO ' . $t_file_table . '
-				( ' . $t_id_col . ', title, description, diskfile, filename, folder, filesize, file_type, date_added, user_id )
-		VALUES
-				( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', '
-				    . db_param() . ', ' . db_param() . ', ' . db_param() . ', '
-				    . db_param() . ', ' . db_param() . ', ' . db_param() . ', '
-				    . db_param() . ' )';
-	db_query( $t_query, array(
-		$t_id, $p_title, $p_desc,
-		$t_unique_name, $p_name, $t_file_path,
-		$t_file_size, $p_file_type, db_now(),
-		(int)$p_user_id,
-	) );
+		( ' . implode(', ', array_keys( $t_param ) ) . ' )
+	VALUES
+		( ' . $t_query_param . ' )';
+	db_query( $t_query, $t_param );
 
 	# get attachment id
 	$t_attachment_id = db_insert_id( $t_file_table );
 
 	if( db_is_oracle() ) {
 		db_update_blob( $t_file_table, 'content', $c_content, "diskfile='$t_unique_name'" );
-	} else {
-		$t_query = "UPDATE $t_file_table SET content=" . db_param() . " WHERE id = " . db_param();
-		db_query( $t_query, array( $c_content, $t_attachment_id ) );
 	}
 
 	if( 'bug' == $p_table ) {

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -722,20 +722,35 @@ function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p
 	$t_file_table = db_get_table( $p_table . '_file' );
 	$t_id_col = $p_table . '_id';
 
-	$t_query = 'INSERT INTO ' . $t_file_table . ' ( ' . $t_id_col . ', title, description, diskfile, filename, folder,
-		filesize, file_type, date_added, user_id )
+	$t_param = array(
+		$t_id_col     => $t_id,
+		'title'       => $p_title,
+		'description' => $p_desc,
+		'diskfile'    => $t_unique_name,
+		'filename'    => $t_file_name,
+		'folder'      => $t_file_path,
+		'filesize'    => $t_file_size,
+		'file_type'   => $p_file['type'],
+		'date_added'  => $p_date_added,
+		'user_id'     => (int)$p_user_id,
+	);
+	# Oracle has to update BLOBs separately
+	if( !db_is_oracle() ) {
+		$t_param['content'] = $c_content;
+	}
+	$t_query_param = db_param();
+	for( $i = 1; $i < count( $t_param ); $i++ ) {
+		$t_query_param .= ', ' . db_param();
+	}
+
+	$t_query = 'INSERT INTO ' . $t_file_table . '
+		( ' . implode(', ', array_keys( $t_param ) ) . ' )
 	VALUES
-		( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() .
-		  ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
-	db_query( $t_query, array( $t_id, $p_title, $p_desc, $t_unique_name, $t_file_name, $t_file_path,
-									 $t_file_size, $p_file['type'], $p_date_added, (int)$p_user_id ) );
-	$t_attachment_id = db_insert_id( $t_file_table );
+		( ' . $t_query_param . ' )';
+	db_query( $t_query, $t_param );
 
 	if( db_is_oracle() ) {
-		db_update_blob( $t_file_table, 'content', $c_content, 'diskfile=\'$t_unique_name\'' );
-	} else {
-		$t_query = 'UPDATE ' . $t_file_table . ' SET content=' . db_param() . ' WHERE id = ' . db_param();
-		db_query( $t_query, array( $c_content, $t_attachment_id ) );
+		db_update_blob( $t_file_table, 'content', $c_content, "diskfile='$t_unique_name'" );
 	}
 
 	if( 'bug' == $p_table ) {

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -747,7 +747,7 @@ function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p
 		( ' . implode(', ', array_keys( $t_param ) ) . ' )
 	VALUES
 		( ' . $t_query_param . ' )';
-	db_query( $t_query, $t_param );
+	db_query( $t_query, array_values( $t_param ) );
 
 	if( db_is_oracle() ) {
 		db_update_blob( $t_file_table, 'content', $c_content, "diskfile='$t_unique_name'" );


### PR DESCRIPTION
As described in [#20547](https://www.mantisbt.org/bugs/view.php?id=20547), when Mantis is running on MySQL with SQL_MODE set to *STRICT_ALL_TABLES* with a database created in 1.2.x and upgraded to 1.3.x, it is no longer possible to add attachments: MySQL throws error 1364: Field 'content' doesn't have a default value for the query.

This fixes the issue by performing the insertion as a single SQL statement instead of an INSERT followed by an UPDATE for the BLOB's contents.

As a follow-up, cleanup action, add schema upgrade steps to make sure BLOBs created in 1.2 or before are defined the same way as those created in 1.3.x