### PR TITLE
Keep temporary filter though column sorting

### DIFF
--- a/core/current_user_api.php
+++ b/core/current_user_api.php
@@ -245,8 +245,10 @@ function current_user_get_bug_filter( $p_project_id = null ) {
 			$t_token = token_get_value( TOKEN_FILTER );
 			if( null != $t_token ) {
 				$t_filter = json_decode( $t_token, true );
+				$t_filter['token_id'] = $f_filter_string;
 			}
 		} else {
+			// TODO @cproensa remove this, remainders of ancient #4609
 			$t_filter = json_decode( $f_filter_string, true );
 		}
 		$t_filter = filter_ensure_valid_filter( $t_filter );

--- a/core/current_user_api.php
+++ b/core/current_user_api.php
@@ -240,16 +240,11 @@ function current_user_get_bug_filter( $p_project_id = null ) {
 	$f_filter_string = gpc_get_string( 'filter', '' );
 	$t_filter = '';
 
-	if( !is_blank( $f_filter_string ) ) {
-		if( is_numeric( $f_filter_string ) ) {
-			$t_token = token_get_value( TOKEN_FILTER );
-			if( null != $t_token ) {
-				$t_filter = json_decode( $t_token, true );
-				$t_filter['token_id'] = $f_filter_string;
-			}
-		} else {
-			// TODO @cproensa remove this, remainders of ancient #4609
-			$t_filter = json_decode( $f_filter_string, true );
+	if( !is_blank( $f_filter_string ) && is_numeric( $f_filter_string ) ) {
+		$t_token = token_get_value( TOKEN_FILTER );
+		if( null != $t_token ) {
+			$t_filter = json_decode( $t_token, true );
+			$t_filter['token_id'] = $f_filter_string;
 		}
 		$t_filter = filter_ensure_valid_filter( $t_filter );
 	} else if( !filter_is_cookie_valid() ) {

--- a/core/current_user_api.php
+++ b/core/current_user_api.php
@@ -244,7 +244,7 @@ function current_user_get_bug_filter( $p_project_id = null ) {
 		$t_token = token_get_value( TOKEN_FILTER );
 		if( null != $t_token ) {
 			$t_filter = json_decode( $t_token, true );
-			$t_filter['token_id'] = $f_filter_string;
+			$t_filter[FILTER_PROPERTY_TEMP_TOKEN_ID] = $f_filter_string;
 		}
 		$t_filter = filter_ensure_valid_filter( $t_filter );
 	} else if( !filter_is_cookie_valid() ) {

--- a/core/filter_constants_inc.php
+++ b/core/filter_constants_inc.php
@@ -67,3 +67,6 @@ define( 'FILTER_PROPERTY_PROFILE_ID', 'profile_id' ); # show_profile
 define( 'FILTER_PROPERTY_PLATFORM', 'platform' );
 define( 'FILTER_PROPERTY_OS', 'os' );
 define( 'FILTER_PROPERTY_OS_BUILD', 'os_build' );
+
+# runtime properties
+define( 'FILTER_PROPERTY_TEMP_TOKEN_ID', 'token_id' );

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1285,7 +1285,7 @@ function print_view_bug_sort_link( $p_string, $p_sort_field, $p_sort, $p_dir, $p
 			return;
 	}
 
-	$t_filter_id_param = isset( $g_filter['token_id'] ) ? '&filter=' . $g_filter['token_id'] : '' ;
+	$t_filter_id_param = isset( $g_filter[FILTER_PROPERTY_TEMP_TOKEN_ID] ) ? '&filter=' . $g_filter[FILTER_PROPERTY_TEMP_TOKEN_ID] : '' ;
 
 	if( $p_sort_field == $p_sort ) {
 		# We toggle between ASC and DESC if the user clicks the same sort order

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1271,6 +1271,9 @@ function print_formatted_severity_string( BugData $p_bug ) {
  * @return void
  */
 function print_view_bug_sort_link( $p_string, $p_sort_field, $p_sort, $p_dir, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
+	$t_filter = current_user_get_bug_filter();
+	$t_filter_id_param = isset( $t_filter['token_id'] ) ? '&filter=' . $t_filter['token_id'] : '' ;
+	
 	if( $p_columns_target == COLUMNS_TARGET_PRINT_PAGE ) {
 		if( $p_sort_field == $p_sort ) {
 			# We toggle between ASC and DESC if the user clicks the same sort order
@@ -1285,7 +1288,7 @@ function print_view_bug_sort_link( $p_string, $p_sort_field, $p_sort, $p_dir, $p
 		}
 
 		$t_sort_field = rawurlencode( $p_sort_field );
-		print_link( 'view_all_set.php?sort=' . $t_sort_field . '&dir=' . $p_dir . '&type=2&print=1', $p_string );
+		print_link( 'view_all_set.php?sort=' . $t_sort_field . '&dir=' . $p_dir . '&type=2&print=1' . $t_filter_id_param, $p_string );
 	} else if( $p_columns_target == COLUMNS_TARGET_VIEW_PAGE ) {
 		if( $p_sort_field == $p_sort ) {
 
@@ -1300,7 +1303,7 @@ function print_view_bug_sort_link( $p_string, $p_sort_field, $p_sort, $p_dir, $p
 			$p_dir = 'ASC';
 		}
 		$t_sort_field = rawurlencode( $p_sort_field );
-		print_link( 'view_all_set.php?sort=' . $t_sort_field . '&dir=' . $p_dir . '&type=2', $p_string );
+		print_link( 'view_all_set.php?sort=' . $t_sort_field . '&dir=' . $p_dir . '&type=2' . $t_filter_id_param, $p_string );
 	} else {
 		echo $p_string;
 	}

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1271,42 +1271,36 @@ function print_formatted_severity_string( BugData $p_bug ) {
  * @return void
  */
 function print_view_bug_sort_link( $p_string, $p_sort_field, $p_sort, $p_dir, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
-	$t_filter = current_user_get_bug_filter();
-	$t_filter_id_param = isset( $t_filter['token_id'] ) ? '&filter=' . $t_filter['token_id'] : '' ;
-	
-	if( $p_columns_target == COLUMNS_TARGET_PRINT_PAGE ) {
-		if( $p_sort_field == $p_sort ) {
-			# We toggle between ASC and DESC if the user clicks the same sort order
-			if( 'ASC' == $p_dir ) {
-				$p_dir = 'DESC';
-			} else {
-				$p_dir = 'ASC';
-			}
-		} else {
-			# Otherwise always start with ascending
-			$p_dir = 'ASC';
-		}
+	global $g_filter;
 
-		$t_sort_field = rawurlencode( $p_sort_field );
-		print_link( 'view_all_set.php?sort=' . $t_sort_field . '&dir=' . $p_dir . '&type=2&print=1' . $t_filter_id_param, $p_string );
-	} else if( $p_columns_target == COLUMNS_TARGET_VIEW_PAGE ) {
-		if( $p_sort_field == $p_sort ) {
-
-			# we toggle between ASC and DESC if the user clicks the same sort order
-			if( 'ASC' == $p_dir ) {
-				$p_dir = 'DESC';
-			} else {
-				$p_dir = 'ASC';
-			}
-		} else {
-			# Otherwise always start with ascending
-			$p_dir = 'ASC';
-		}
-		$t_sort_field = rawurlencode( $p_sort_field );
-		print_link( 'view_all_set.php?sort=' . $t_sort_field . '&dir=' . $p_dir . '&type=2' . $t_filter_id_param, $p_string );
-	} else {
-		echo $p_string;
+	switch( $p_columns_target ) {
+		case COLUMNS_TARGET_PRINT_PAGE:
+			$t_print_page_param = '&print=1';
+			break;
+		case COLUMNS_TARGET_VIEW_PAGE:
+			$t_print_page_param = '';
+			break;
+		default:
+			echo $p_string;
+			return;
 	}
+
+	$t_filter_id_param = isset( $g_filter['token_id'] ) ? '&filter=' . $g_filter['token_id'] : '' ;
+
+	if( $p_sort_field == $p_sort ) {
+		# We toggle between ASC and DESC if the user clicks the same sort order
+		if( 'ASC' == $p_dir ) {
+			$p_dir = 'DESC';
+		} else {
+			$p_dir = 'ASC';
+		}
+	} else {
+		# Otherwise always start with ascending
+		$p_dir = 'ASC';
+	}
+
+	$t_sort_field = rawurlencode( $p_sort_field );
+	print_link( 'view_all_set.php?sort=' . $t_sort_field . '&dir=' . $p_dir . '&type=2' . $t_print_page_param . $t_filter_id_param, $p_string );
 }
 
 /**

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -115,7 +115,7 @@ html_status_legend( STATUS_LEGEND_POSITION_TOP, true );
 		<span class="floatleft small">
 		<?php
 			# -- Print and Export links --
-			$t_filter_param =  isset( $t_filter['token_id'] ) ? '?filter=' . $t_filter['token_id'] : '' ;
+			$t_filter_param =  isset( $t_filter[FILTER_PROPERTY_TEMP_TOKEN_ID] ) ? '?filter=' . $t_filter[FILTER_PROPERTY_TEMP_TOKEN_ID] : '' ;
 			echo '&#160;';
 			print_bracket_link( 'print_all_bug_page.php' . $t_filter_param, lang_get( 'print_all_bug_page_link' ) );
 			echo '&#160;';

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -115,12 +115,13 @@ html_status_legend( STATUS_LEGEND_POSITION_TOP, true );
 		<span class="floatleft small">
 		<?php
 			# -- Print and Export links --
+			$t_filter_param =  isset( $t_filter['token_id'] ) ? '?filter=' . $t_filter['token_id'] : '' ;
 			echo '&#160;';
-			print_bracket_link( 'print_all_bug_page.php', lang_get( 'print_all_bug_page_link' ) );
+			print_bracket_link( 'print_all_bug_page.php' . $t_filter_param, lang_get( 'print_all_bug_page_link' ) );
 			echo '&#160;';
-			print_bracket_link( 'csv_export.php', lang_get( 'csv_export' ) );
+			print_bracket_link( 'csv_export.php' . $t_filter_param, lang_get( 'csv_export' ) );
 			echo '&#160;';
-			print_bracket_link( 'excel_xml_export.php', lang_get( 'excel_export' ) );
+			print_bracket_link( 'excel_xml_export.php' . $t_filter_param, lang_get( 'excel_export' ) );
 
 			$t_event_menu_options = $t_links = event_signal( 'EVENT_MENU_FILTER' );
 

--- a/view_all_set.php
+++ b/view_all_set.php
@@ -60,6 +60,7 @@ auth_ensure_user_authenticated();
 $f_type					= gpc_get_int( 'type', -1 );
 $f_source_query_id		= gpc_get_int( 'source_query_id', -1 );
 $f_print				= gpc_get_bool( 'print' );
+$f_filter_token			= gpc_get( 'filter', null );
 $f_temp_filter			= gpc_get_bool( 'temporary' );
 
 # validate filter type
@@ -414,26 +415,32 @@ if( ( $f_type == 3 ) && ( $f_source_query_id == -1 ) ) {
 # 	25: $f_relationship_bug
 # 	26: $f_show_profile
 
-# Set new filter values.  These are stored in a cookie
-$t_view_all_cookie_id = gpc_get_cookie( config_get( 'view_all_cookie' ), '' );
-$t_view_all_cookie = filter_db_get_filter( $t_view_all_cookie_id );
+if( null !== $f_filter_token ) {
+	# Here the filter is retrieved by the filter gpc parameter
+	$t_setting_arr = current_user_get_bug_filter();
+}
+else {
+	# Set new filter values.  These are stored in a cookie
+	$t_view_all_cookie_id = gpc_get_cookie( config_get( 'view_all_cookie' ), '' );
+	$t_view_all_cookie = filter_db_get_filter( $t_view_all_cookie_id );
 
-# process the cookie if it exists, it may be blank in a new install
-if( !is_blank( $t_view_all_cookie ) ) {
-	$t_setting_arr = filter_deserialize( $t_view_all_cookie );
-	if( false === $t_setting_arr ) {
-		# couldn't deserialize, if we were trying to use the filter, clear it and reload
-		# for ftype = 0, 1, or 3, we are going to re-write the filter anyways
-		if( !in_array( $f_type, array( 0, 1, 3 ) ) ) {
-			gpc_clear_cookie( 'view_all_cookie' );
-			error_proceed_url( 'view_all_set.php?type=0' );
-			trigger_error( ERROR_FILTER_TOO_OLD, ERROR );
-			exit; # stop here
+	# process the cookie if it exists, it may be blank in a new install
+	if( !is_blank( $t_view_all_cookie ) ) {
+		$t_setting_arr = filter_deserialize( $t_view_all_cookie );
+		if( false === $t_setting_arr ) {
+			# couldn't deserialize, if we were trying to use the filter, clear it and reload
+			# for ftype = 0, 1, or 3, we are going to re-write the filter anyways
+			if( !in_array( $f_type, array( 0, 1, 3 ) ) ) {
+				gpc_clear_cookie( 'view_all_cookie' );
+				error_proceed_url( 'view_all_set.php?type=0' );
+				trigger_error( ERROR_FILTER_TOO_OLD, ERROR );
+				exit; # stop here
+			}
 		}
+	} else {
+		# no cookie found, set it
+		$f_type = 1;
 	}
-} else {
-	# no cookie found, set it
-	$f_type = 1;
 }
 
 $t_cookie_version = FILTER_VERSION;
@@ -595,7 +602,7 @@ $t_settings_serialized = json_encode( $t_setting_arr );
 $t_settings_string = $t_cookie_version . '#' . $t_settings_serialized;
 
 # If only using a temporary filter, don't store it in the database
-if( !$f_temp_filter ) {
+if( !$f_temp_filter && null === $f_filter_token ) {
 	# Store the filter string in the database: its the current filter, so some values won't change
 	$t_project_id = helper_get_current_project();
 	$t_project_id = ( $t_project_id * -1 );
@@ -612,8 +619,9 @@ if( $f_print ) {
 	$t_redirect_url = 'view_all_bug_page.php';
 }
 
-if( $f_temp_filter ) {
+if( $f_temp_filter || null !== $f_filter_token ) {
 	$t_token_id = token_set( TOKEN_FILTER, $t_settings_serialized );
 	$t_redirect_url = $t_redirect_url . '?filter=' . $t_token_id;
 }
+
 print_header_redirect( $t_redirect_url );


### PR DESCRIPTION
Filter management is quite messed up...
This one is a less-damage approach to get temporary filters (like those from my_view) working with column sorting, export pages, etc.

Fixes #0008204
