### PR TITLE
Stop caching LDAP passwords (take 3)

### DIFF
--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -209,7 +209,7 @@ function auth_auto_create_user( $p_username, $p_password ) {
 
 	if( $t_auto_create ) {
 		# attempt to create the user
-		$t_cookie_string = user_create( $p_username, md5( $p_password ) );
+		$t_cookie_string = user_create( $p_username, "!" + auth_generate_random_password() );
 		if( $t_cookie_string === false ) {
 			# it didn't work
 			return false;

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -209,7 +209,7 @@ function auth_auto_create_user( $p_username, $p_password ) {
 
 	if( $t_auto_create ) {
 		# attempt to create the user
-		$t_cookie_string = user_create( $p_username, "!" + auth_generate_random_password() );
+		$t_cookie_string = user_create( $p_username, auth_generate_nocache_password() );
 		if( $t_cookie_string === false ) {
 			# it didn't work
 			return false;
@@ -538,6 +538,30 @@ function auth_process_plain_password( $p_password, $p_salt = null, $p_method = n
  */
 function auth_generate_random_password() {
 	return crypto_generate_uri_safe_nonce( 16 );
+}
+
+/**
+ * Generate a random string to use when we should not store the actual password.
+ * When relying on an external authentication system (e.g. LDAP), we should not
+ * store the user's password for security reasons. To avoid creating another
+ * security hole by populating the password field with a known value, we use a
+ * random string that can be identified as a 'nocache' password by its prefix.
+ * @return string Random password, prefixed by '!'
+ * @access public
+ */
+function auth_generate_nocache_password() {
+	return '!' . crypto_generate_strong_random_string( 31 );
+}
+
+/**
+ * Determine whether the given string is a 'no-cache' password.
+ * @see auth_generate_nocache_password()
+ * @param string
+ * @return boolean true if the string is a 'nocache' password, false otherwise
+ * @access public
+ */
+function auth_is_nocache_password( $p_password ) {
+	return $p_password != '' && $p_password[0] == '!';
 }
 
 /**

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -379,7 +379,11 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
 
 		if( false !== $t_user_id ) {
 
-			$t_fields_to_update = array('password' => md5( $p_password ));
+			$t_fields_to_update = array();
+			# Do we need to wipe a previously cached password?
+			if( substr( user_get_field( $t_user_id, 'password' ), 0, 1) != '!' ) {
+				user_set_field( 'password', '!' + auth_generate_random_password() );
+			}
 
 			if( ON == config_get( 'use_ldap_realname' ) ) {
 				$t_fields_to_update['realname'] = ldap_realname( $t_user_id );

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -373,16 +373,16 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
 
 	# If user authenticated successfully then update the local DB with information
 	# from LDAP.  This will allow us to use the local data after login without
-	# having to go back to LDAP.  This will also allow fallback to DB if LDAP is down.
+	# having to go back to LDAP.
 	if( $t_authenticated ) {
 		$t_user_id = user_get_id_by_name( $p_username );
 
 		if( false !== $t_user_id ) {
-
 			$t_fields_to_update = array();
-			# Do we need to wipe a previously cached password?
+
+			# Wipe previously cached password if necessary
 			if( substr( user_get_field( $t_user_id, 'password' ), 0, 1) != '!' ) {
-				user_set_field( 'password', '!' + auth_generate_random_password() );
+				$t_fields_to_update['password'] = '!' + auth_generate_random_password();
 			}
 
 			if( ON == config_get( 'use_ldap_realname' ) ) {

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -381,8 +381,8 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
 			$t_fields_to_update = array();
 
 			# Wipe previously cached password if necessary
-			if( substr( user_get_field( $t_user_id, 'password' ), 0, 1) != '!' ) {
-				$t_fields_to_update['password'] = '!' + auth_generate_random_password();
+			if( auth_is_nocache_password( user_get_field( $t_user_id, 'password' ) ) ) {
+				$t_fields_to_update['password'] = auth_generate_nocache_password() );
 			}
 
 			if( ON == config_get( 'use_ldap_realname' ) ) {


### PR DESCRIPTION
This builds upon @seveas pull request #714, with the following changes.

- original commit rebased on top of latest master
- corrected minor issues found during review
- added 2 new API calls to handle *no-cache passwords*, as per @vboctor's suggestion in https://github.com/mantisbt/mantisbt/pull/714#discussion_r51292184

Fixes [#12957](https://www.mantisbt.org/bugs/view.php?id=12957)

In https://github.com/mantisbt/mantisbt/pull/714#discussion_r51292184, @vboctor also wrote

> Add a schema update step to reset all passwords in case of LDAP -- I think this is risky since if someone has an approach where they having mixed login, we will delete all their user passwords.

The approach to wipe previously cached passwords incrementally as they are used still bothers me. I believe that doing this in a single pass would be much better because

- we increase security by removing all unsalted passwords stored in the DB once and for all
- the code is more efficient because we don't need to check for a 'no-cache' password all the time

I am not aware of a scenario where we can have mixed logins today. Do you have a specific case in mind ? If so, we could try to detect that in the upgrade step. As an alternative, maybe we could provide an admin check combined with some admin tool to wipe cached passwords.

Let me know your thoughts.
