### PR TITLE
Move Bug update events into BugData

### DIFF
--- a/bug_actiongroup.php
+++ b/bug_actiongroup.php
@@ -196,8 +196,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( config_get( 'update_bug_threshold' ), $t_bug_id ) ) {
 				$f_priority = gpc_get_int( 'priority' );
 				# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-				bug_set_field( $t_bug_id, 'priority', $f_priority );
-				email_bug_updated( $t_bug_id );
+				$t_bugdata = bug_get( $t_bug_id );
+				$t_bugdata->priority = $f_priority;
+				$t_bugdata->update();
 				helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 			} else {
 				$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_access' );
@@ -208,16 +209,29 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( access_get_status_threshold( $f_status, $t_bug->project_id ), $t_bug_id ) ) {
 				if( true == bug_check_workflow( $t_status, $f_status ) ) {
 					# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-					bug_set_field( $t_bug_id, 'status', $f_status );
+					$t_bugdata = bug_get( $t_bug_id );
+					$t_bugdata->status = $f_status;
 
-					# Add bugnote if supplied
-					if( !is_blank( $f_bug_notetext ) ) {
-						bugnote_add( $t_bug_id, $f_bug_notetext, null, $f_bug_noteprivate );
-						# No need to call email_generic(), bugnote_add() does it
-					} else {
-						email_bug_updated( $t_bug_id );
+					if( !class_exists( 'Bug_actiongroup_upstatus_callback' ) ) {
+						class Bug_actiongroup_upstatus_callback {
+							public $bug_notetext, $bug_noteprivate;
+							function __invoke( $p_bugdata ) {
+								# Add bugnote if supplied
+								if( !is_blank( $this->bug_notetext ) ) {
+									bugnote_add( $p_bugdata->id, $this->bug_notetext, null, $this->bug_noteprivate );
+									# No need to call email_generic(), bugnote_add() does it
+								} else {
+									email_bug_updated( $p_bugdata->id );
+								}
+							}
+						}
 					}
 
+					$t_callback = new Bug_actiongroup_upstatus_callback();
+					$t_callback->bug_notetext = $f_bug_notetext;
+					$t_callback->bug_noteprivate = $f_bug_noteprivate;
+
+					$t_bugdata->update( false, true, $t_callback );
 					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 				} else {
 					$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_status' );
@@ -231,8 +245,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( config_get( 'update_bug_threshold' ), $t_bug_id ) ) {
 				if( category_exists( $f_category_id ) ) {
 					# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-					bug_set_field( $t_bug_id, 'category_id', $f_category_id );
-					email_bug_updated( $t_bug_id );
+					$t_bugdata = bug_get( $t_bug_id );
+					$t_bugdata->category_id = $f_category_id;
+					$t_bugdata->update();
 					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 				} else {
 					$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_category' );
@@ -246,8 +261,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( config_get( 'update_bug_threshold' ), $t_bug_id ) ) {
 				if( $f_product_version === '' || version_get_id( $f_product_version, $t_bug->project_id ) !== false ) {
 					/** @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) ); */
-					bug_set_field( $t_bug_id, 'version', $f_product_version );
-					email_bug_updated( $t_bug_id );
+					$t_bugdata = bug_get( $t_bug_id );
+					$t_bugdata->version = $f_product_version;
+					$t_bugdata->update();
 					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 				} else {
 					$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_version' );
@@ -261,9 +277,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( config_get( 'update_bug_threshold' ), $t_bug_id ) ) {
 				if( $f_fixed_in_version === '' || version_get_id( $f_fixed_in_version, $t_bug->project_id ) !== false ) {
 					# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-					bug_set_field( $t_bug_id, 'fixed_in_version', $f_fixed_in_version );
-					email_bug_updated( $t_bug_id );
-					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
+					$t_bugdata = bug_get( $t_bug_id );
+					$t_bugdata->fixed_in_version = $f_fixed_in_version;
+					$t_bugdata->update();
 					} else {
 						$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_version' );
 				}
@@ -276,8 +292,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( config_get( 'roadmap_update_threshold' ), $t_bug_id ) ) {
 				if( $f_target_version === '' || version_get_id( $f_target_version, $t_bug->project_id ) !== false ) {
 					# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-					bug_set_field( $t_bug_id, 'target_version', $f_target_version );
-					email_bug_updated( $t_bug_id );
+					$t_bugdata = bug_get( $t_bug_id );
+					$t_bugdata->target_version = $f_target_version;
+					$t_bugdata->update();
 					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 				} else {
 					$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_version' );
@@ -290,8 +307,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( config_get( 'change_view_status_threshold' ), $t_bug_id ) ) {
 				$f_view_status = gpc_get_int( 'view_status' );
 				# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-				bug_set_field( $t_bug_id, 'view_state', $f_view_status );
-				email_bug_updated( $t_bug_id );
+				$t_bugdata = bug_get( $t_bug_id );
+				$t_bugdata->view_state = $f_view_status;
+				$t_bugdata->update();
 				helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 			} else {
 				$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_access' );
@@ -302,8 +320,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 				$f_sticky = bug_get_field( $t_bug_id, 'sticky' );
 				# The new value is the inverted old value
 				# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-				bug_set_field( $t_bug_id, 'sticky', intval( !$f_sticky ) );
-				helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
+				$t_bugdata = bug_get( $t_bug_id );
+				$t_bugdata->sticky = intval( !$f_sticky );
+				$t_bugdata->update();
 			} else {
 				$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_access' );
 			}

--- a/bug_actiongroup_update_product_build_inc.php
+++ b/bug_actiongroup_update_product_build_inc.php
@@ -108,6 +108,8 @@ function action_update_product_build_validate( $p_bug_id ) {
 function action_update_product_build_process( $p_bug_id ) {
 	$t_build = gpc_get_string( 'build' );
 
-	bug_set_field( $p_bug_id, 'build', $t_build );
+	$t_bugdata = bug_get( $p_bug_id );
+	$t_bugdata->build = $t_build;
+	$t_bugdata->update();
 	return null;
 }

--- a/bug_actiongroup_update_severity_inc.php
+++ b/bug_actiongroup_update_severity_inc.php
@@ -113,6 +113,9 @@ function action_update_severity_validate( $p_bug_id ) {
  */
 function action_update_severity_process( $p_bug_id ) {
 	$f_severity = gpc_get_string( 'severity' );
-	bug_set_field( $p_bug_id, 'severity', $f_severity );
+
+	$t_bugdata = bug_get( $p_bug_id );
+	$t_bugdata->severity = $f_severity;
+	$t_bugdata->update();
 	return null;
 }

--- a/bug_stick.php
+++ b/bug_stick.php
@@ -55,7 +55,9 @@ if( $t_bug->project_id != helper_get_current_project() ) {
 
 access_ensure_bug_level( config_get( 'set_bug_sticky_threshold' ), $f_bug_id );
 
-bug_set_field( $f_bug_id, 'sticky', 'stick' == $f_action );
+$t_bugdata = bug_get( $p_bug_id );
+$t_bugdata->sticky = ( 'stick' == $f_action );
+$t_bugdata->update();
 
 form_security_purge( 'bug_stick' );
 

--- a/bugnote_add.php
+++ b/bugnote_add.php
@@ -104,10 +104,11 @@ if( config_get( 'reassign_on_feedback' ) &&
 	 $t_bug->handler_id !== auth_get_current_user_id() &&
 	 $t_bug->reporter_id === auth_get_current_user_id() ) {
 	if( $t_bug->handler_id !== NO_USER ) {
-		bug_set_field( $t_bug->id, 'status', config_get( 'bug_assigned_status' ) );
+		$t_bug->status = config_get( 'bug_assigned_status' );
 	} else {
-		bug_set_field( $t_bug->id, 'status', config_get( 'bug_submit_status' ) );
+		$t_bug->status = config_get( 'bug_submit_status' );
 	}
+	$t_bug->update( false, true );
 }
 
 form_security_purge( 'bugnote_add' );

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1841,10 +1841,13 @@ function bug_reopen( $p_bug_id, $p_bugnote_text = '', $p_time_tracking = '0:00',
 	# Add bugnote if supplied
 	# Moved bugnote_add before bug_set_field calls in case time_tracking_no_note is off.
 	# Error condition stopped execution but status had already been changed
+	# @todo cproensa: is the comment above still valid? bugnote will be added even if bug-update cant be performed
 	bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking, $p_bugnote_private, 0, '', null, false );
 
-	bug_set_field( $p_bug_id, 'status', config_get( 'bug_reopen_status' ) );
-	bug_set_field( $p_bug_id, 'resolution', config_get( 'bug_reopen_resolution' ) );
+	$t_bugdata = bug_get( $p_bug_id );
+	$t_bugdata->status = config_get( 'bug_reopen_status' );
+	$t_bugdata->resolution = config_get( 'bug_reopen_resolution' );
+	$t_bugdata->update( false, true );
 
 	email_bug_reopened( $p_bug_id );
 

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1747,65 +1747,74 @@ function bug_resolve( $p_bug_id, $p_resolution, $p_fixed_in_version = '', $p_bug
 	# Add bugnote if supplied
 	# Moved bugnote_add before bug_set_field calls in case time_tracking_no_note is off.
 	# Error condition stopped execution but status had already been changed
+	# @todo cproensa: is the comment above still valid? bugnote will be added even if bug-update cant be performed
 	bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking, $p_bugnote_private, 0, '', null, false );
 
+	$t_bugdata = bug_get( $p_bug_id );
+
+	$t_bugdata->status = config_get( 'bug_resolved_status_threshold' );
+	$t_bugdata->fixed_in_version = $p_fixed_in_version;
+	$t_bugdata->resolution = $c_resolution;
+
+	# only set handler if specified explicitly or if bug was not assigned to a handler
+	if( null == $p_handler_id ) {
+		if( $t_bugdata->handler_id == 0 ) {
+			$t_bugdata->handler_id = auth_get_current_user_id();
+		}
+	} else {
+		$t_bugdata->handler_id = $p_handler_id;
+	}
+
+	if( !class_exists( 'Bug_resolve_post_callback' ) ) {
+		class Bug_resolve_post_callback {
+			function __invoke( $p_bugdata, $p_existing_bug ) {
+				$t_duplicate = !is_blank( $p_bugdata->duplicate_id ) && ( $p_bugdata->duplicate_id != 0 );
+				if( $t_duplicate ) {
+					# check if there is other relationship between the bugs...
+					$t_id_relationship = relationship_same_type_exists( $p_bugdata->id, $p_bugdata->duplicate_id, BUG_DUPLICATE );
+					if( $t_id_relationship > 0 ) {
+						# Update the relationship
+						relationship_update( $t_id_relationship, $p_bugdata->id, $p_bugdata->duplicate_id, BUG_DUPLICATE );
+
+						# Add log line to the history (both bugs)
+						history_log_event_special( $p_bugdata->id, BUG_REPLACE_RELATIONSHIP, BUG_DUPLICATE, $p_bugdata->duplicate_id );
+						history_log_event_special( $p_bugdata->duplicate_id, BUG_REPLACE_RELATIONSHIP, BUG_HAS_DUPLICATE, $p_bugdata->id );
+					} else if( $t_id_relationship != -1 ) {
+						# Add the new relationship
+						relationship_add( $p_bugdata->id, $p_bugdata->duplicate_id, BUG_DUPLICATE );
+
+						# Add log line to the history (both bugs)
+						history_log_event_special( $p_bugdata->id, BUG_ADD_RELATIONSHIP, BUG_DUPLICATE, $p_bugdata->duplicate_id );
+						history_log_event_special( $p_bugdata->duplicate_id, BUG_ADD_RELATIONSHIP, BUG_HAS_DUPLICATE, $p_bugdata->id );
+					} # else relationship is -1 - same type exists, do nothing
+
+					# Copy list of users monitoring the duplicate bug to the original bug
+					if( user_exists( $p_existing_bug->reporter_id ) ) {
+						bug_monitor( $p_bugdata->duplicate_id, $p_existing_bug->reporter_id );
+					}
+					if( user_exists( $p_existing_bug->handler_id ) ) {
+						bug_monitor( $p_bugdata->duplicate_id, $p_existing_bug->handler_id );
+					}
+					bug_monitor_copy( $p_bugdata->id, $p_duplicate_id );
+				}
+			}
+		}
+	}
+
+	$t_callback = null;
 	$t_duplicate = !is_blank( $p_duplicate_id ) && ( $p_duplicate_id != 0 );
 	if( $t_duplicate ) {
 		if( $p_bug_id == $p_duplicate_id ) {
 			trigger_error( ERROR_BUG_DUPLICATE_SELF, ERROR );
-
-			# never returns
 		}
-
 		# the related bug exists...
 		bug_ensure_exists( $p_duplicate_id );
 
-		# check if there is other relationship between the bugs...
-		$t_id_relationship = relationship_same_type_exists( $p_bug_id, $p_duplicate_id, BUG_DUPLICATE );
-
-		 if( $t_id_relationship > 0 ) {
-			# Update the relationship
-			relationship_update( $t_id_relationship, $p_bug_id, $p_duplicate_id, BUG_DUPLICATE );
-
-			# Add log line to the history (both bugs)
-			history_log_event_special( $p_bug_id, BUG_REPLACE_RELATIONSHIP, BUG_DUPLICATE, $p_duplicate_id );
-			history_log_event_special( $p_duplicate_id, BUG_REPLACE_RELATIONSHIP, BUG_HAS_DUPLICATE, $p_bug_id );
-		} else if( $t_id_relationship != -1 ) {
-			# Add the new relationship
-			relationship_add( $p_bug_id, $p_duplicate_id, BUG_DUPLICATE );
-
-			# Add log line to the history (both bugs)
-			history_log_event_special( $p_bug_id, BUG_ADD_RELATIONSHIP, BUG_DUPLICATE, $p_duplicate_id );
-			history_log_event_special( $p_duplicate_id, BUG_ADD_RELATIONSHIP, BUG_HAS_DUPLICATE, $p_bug_id );
-		} # else relationship is -1 - same type exists, do nothing
-
-		# Copy list of users monitoring the duplicate bug to the original bug
-		$t_old_reporter_id = bug_get_field( $p_bug_id, 'reporter_id' );
-		$t_old_handler_id = bug_get_field( $p_bug_id, 'handler_id' );
-		if( user_exists( $t_old_reporter_id ) ) {
-			bug_monitor( $p_duplicate_id, $t_old_reporter_id );
-		}
-		if( user_exists( $t_old_handler_id ) ) {
-			bug_monitor( $p_duplicate_id, $t_old_handler_id );
-		}
-		bug_monitor_copy( $p_bug_id, $p_duplicate_id );
-
-		bug_set_field( $p_bug_id, 'duplicate_id', (int)$p_duplicate_id );
+		$p_bugdata->duplicate_id = $p_duplicate_id;
+		$t_callback = new Bug_resolve_post_callback();
 	}
 
-	bug_set_field( $p_bug_id, 'status', config_get( 'bug_resolved_status_threshold' ) );
-	bug_set_field( $p_bug_id, 'fixed_in_version', $p_fixed_in_version );
-	bug_set_field( $p_bug_id, 'resolution', $c_resolution );
-
-	# only set handler if specified explicitly or if bug was not assigned to a handler
-	if( null == $p_handler_id ) {
-		if( bug_get_field( $p_bug_id, 'handler_id' ) == 0 ) {
-			$p_handler_id = auth_get_current_user_id();
-			bug_set_field( $p_bug_id, 'handler_id', $p_handler_id );
-		}
-	} else {
-		bug_set_field( $p_bug_id, 'handler_id', $p_handler_id );
-	}
+	$t_bugdata->update( false, true, $t_callback );
 
 	email_resolved( $p_bug_id );
 	email_relationship_child_resolved( $p_bug_id );

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1714,9 +1714,12 @@ function bug_close( $p_bug_id, $p_bugnote_text = '', $p_bugnote_private = false,
 	# Add bugnote if supplied ignore a false return
 	# Moved bugnote_add before bug_set_field calls in case time_tracking_no_note is off.
 	# Error condition stopped execution but status had already been changed
+	# @todo cproensa: is the comment above still valid? bugnote will be added even if bug-update cant be performed
 	bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking, $p_bugnote_private, 0, '', null, false );
 
-	bug_set_field( $p_bug_id, 'status', config_get( 'bug_closed_status_threshold' ) );
+	$t_bugdata = bug_get( $p_bug_id );
+	$t_bugdata->status = config_get( 'bug_closed_status_threshold' );
+	$t_bugdata->update( false, true );
 
 	email_close( $p_bug_id );
 	email_relationship_child_closed( $p_bug_id );

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1215,20 +1215,17 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
  * @access public
  */
 function bug_move( $p_bug_id, $p_target_project_id ) {
-	# Attempt to move disk based attachments to new project file directory.
-	file_move_bug_attachments( $p_bug_id, $p_target_project_id );
-
-	# Move the issue to the new project.
-	bug_set_field( $p_bug_id, 'project_id', $p_target_project_id );
+	$t_bugdata = bug_get( $p_bug_id );
+	$t_bugdata->project_id = $p_target_project_id;
 
 	# Update the category if needed
-	$t_category_id = bug_get_field( $p_bug_id, 'category_id' );
+	$t_category_id = $t_bugdata->category_id;
 
 	# Bug has no category
 	if( $t_category_id == 0 ) {
 		# Category is required in target project, set it to default
 		if( ON != config_get( 'allow_no_category', null, null, $p_target_project_id ) ) {
-			bug_set_field( $p_bug_id, 'category_id', config_get( 'default_category_for_moves', null, null, $p_target_project_id ) );
+			$t_bugdata->category_id = config_get( 'default_category_for_moves', null, null, $p_target_project_id );
 		}
 	} else {
 		# Check if the category is global, and if not attempt mapping it to the new project
@@ -1244,9 +1241,21 @@ function bug_move( $p_bug_id, $p_target_project_id ) {
 				# Use target project's default category for moves, since there is no match by name.
 				$t_target_project_category_id = config_get( 'default_category_for_moves', null, null, $p_target_project_id );
 			}
-			bug_set_field( $p_bug_id, 'category_id', $t_target_project_category_id );
+			$t_bugdata->category_id = $t_target_project_category_id;
 		}
 	}
+
+	if( !class_exists( 'Bug_move_post_callback' ) ) {
+		class Bug_move_post_callback {
+			function __invoke( $p_bugdata ) {
+				# Attempt to move disk based attachments to new project file directory.
+				file_move_bug_attachments( $p_bugdata->id, $p_bugdata->project_id );
+			}
+		}
+	}
+
+	# @todo cproensa: email is bypassed, add a notification for MOVE
+	$t_bugdata->update( false, true, new Bug_move_post_callback() );
 }
 
 /**

--- a/core/sponsorship_api.php
+++ b/core/sponsorship_api.php
@@ -289,8 +289,9 @@ function sponsorship_format_amount( $p_amount ) {
  */
 function sponsorship_update_bug( $p_bug_id ) {
 	$t_total_amount = sponsorship_get_amount( sponsorship_get_all_ids( $p_bug_id ) );
-	bug_set_field( $p_bug_id, 'sponsorship_total', $t_total_amount );
-	bug_update_date( $p_bug_id );
+	$t_bugdata = bug_get( $p_bug_id );
+	$t_bugdata->sponsorship_total = $t_total_amount;
+	$t_bugdata->update();
 }
 
 /**


### PR DESCRIPTION
EVENT_UPDATE_BUG_DATA and EVENT_UPDATE_BUG
are now triggered in the BugData update function, as suggested in #0020577

A new parameter for a callback is introduced in
BugData::update(), to allow for bug related data
to be saved before EVENT_UPDATE_BUG

The callback thing is to guarantee that all bug related data has been created/saved at the point the final event is triggered.
This should be a transitional situation... to keep current code structure with minimal changes, when migrating other functions into the use of BugData for modifications
As a first step, i've adapted bug_update page, and refactored bug_move function.

Ideally, the functionality for checks, side effects, notifications, etc should be moved into a managed object system. Something like what BugData tries to achieve, but also accounting for custom fields, bugnotes, attachments, etc. to implement atomic modifications, and non-redundant "bussiness logic".