### PR TITLE
Fix deletion of default category on MSSQL/Oracle

### DIFF
--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -269,7 +269,14 @@ function mc_project_delete_category ( $p_username, $p_password, $p_project_id, $
 	# find the id of the category
 	$p_category_id = category_get_id_by_name( $p_category_name, $p_project_id );
 
-	# delete the category and link all the issue to the default category
+	if( !category_can_remove( $p_category_id ) ) {
+		return SoapObjectsFactory::newSoapFault(
+			'Client',
+			"'$p_category_name' is used as default category for moves and can't be deleted."
+		);
+	}
+
+	# delete the category and link all the issues to the default category
 	return category_remove( $p_category_id, config_get( 'default_category_for_moves' ) );
 }
 

--- a/core/category_api.php
+++ b/core/category_api.php
@@ -107,6 +107,33 @@ function category_ensure_unique( $p_project_id, $p_name ) {
 }
 
 /**
+ * Checks whether the category can be deleted.
+ * It is not allowed to delete a category if it is defined as 'default for moves'
+ * @see $g_default_category_for_moves
+ * @param integer $p_category_id Category identifier.
+ * @return boolean True if category can be deleted, false otherwise
+ * @access public
+ */
+function category_can_remove( $p_category_id ) {
+	$t_default_category_id = config_get( 'default_category_for_moves', null, ALL_USERS, ALL_PROJECTS );
+
+	return $p_category_id != $t_default_category_id
+		&& !config_is_defined( 'default_category_for_moves', $p_category_id );
+}
+
+/**
+ * Trigger an error if the category cannot be deleted.
+ * @param integer $p_category_id Category identifier.
+ * @return void
+ * @access public
+ */
+function category_ensure_can_remove( $p_category_id ) {
+	if( !category_can_remove( $p_category_id ) ) {
+		trigger_error( ERROR_CATEGORY_CANNOT_DELETE_DEFAULT, ERROR );
+	}
+}
+
+/**
  * Add a new category to the project
  * @param integer $p_project_id Project identifier.
  * @param string  $p_name       Category Name.

--- a/core/category_api.php
+++ b/core/category_api.php
@@ -198,6 +198,7 @@ function category_remove( $p_category_id, $p_new_category_id = 0 ) {
 	$t_category_row = category_get_row( $p_category_id );
 
 	category_ensure_exists( $p_category_id );
+	category_ensure_can_remove( $p_category_id );
 	if( 0 != $p_new_category_id ) {
 		category_ensure_exists( $p_new_category_id );
 	}
@@ -219,7 +220,8 @@ function category_remove( $p_category_id, $p_new_category_id = 0 ) {
 }
 
 /**
- * Remove all categories associated with a project
+ * Remove all categories associated with a project.
+ * This will skip processing of categories that can't be deleted.
  * @param integer $p_project_id      A Project identifier.
  * @param integer $p_new_category_id New category id (to replace existing category).
  * @return boolean
@@ -240,6 +242,10 @@ function category_remove_all( $p_project_id, $p_new_category_id = 0 ) {
 
 	$t_category_ids = array();
 	while( $t_row = db_fetch_array( $t_result ) ) {
+		# Don't add category to the list if it can't be deleted
+		if( !category_can_remove( $t_row['id'] ) ) {
+			continue;
+		}
 		$t_category_ids[] = $t_row['id'];
 	}
 

--- a/core/config_api.php
+++ b/core/config_api.php
@@ -78,7 +78,6 @@ function config_get( $p_option, $p_default = null, $p_user = null, $p_project = 
 	$t_bypass_lookup = !config_can_set_in_database( $p_option );
 
 	# @@ debug @@ if( $t_bypass_lookup ) { echo "bp=$p_option match=$t_match_pattern <br />"; }
-
 	if( !$t_bypass_lookup ) {
 		if( $g_project_override !== null && $p_project === null ) {
 			$p_project = $g_project_override;
@@ -132,7 +131,6 @@ function config_get( $p_option, $p_default = null, $p_user = null, $p_project = 
 
 			# @@ debug @@ echo 'pr= '; var_dump($t_projects);
 			# @@ debug @@ echo 'u= '; var_dump($t_users);
-
 			if( !$g_cache_filled ) {
 				$t_query = 'SELECT config_id, user_id, project_id, type, value, access_reqd FROM {config}';
 				$t_result = db_query( $t_query );
@@ -689,3 +687,38 @@ function config_is_private( $p_config_var ) {
 	return !in_array( $p_config_var, $g_public_config_names, true );
 }
 
+/**
+ * Check if a configuration is defined in the database with the given value.
+ *
+ * @param string  $p_option  The configuration option to retrieve.
+ * @param string  $p_value   Value to check for (defaults to null = any value).
+ * @return boolean True if option is defined
+ */
+function config_is_defined( $p_option, $p_value = null ) {
+	global $g_cache_filled, $g_cache_config;
+
+	if( !$g_cache_filled ) {
+		config_get( $p_option, -1 );
+	}
+
+	if( !isset( $g_cache_config[$p_option] ) ) {
+		# Option is not in cache
+		return false;
+	} elseif( $p_value === null ) {
+		# We're not checking any specific value
+		return true;
+	}
+
+	# Check the cache for specified value
+	foreach( $g_cache_config[$p_option] as $t_project ) {
+		foreach( $t_project as $t_opt ) {
+			list( , $t_value ) = explode( ';', $t_opt );
+			if( $t_value == $p_value ) {
+				return true;
+			}
+		}
+	}
+
+	# Value not found in cache
+	return false;
+}

--- a/manage_proj_cat_delete.php
+++ b/manage_proj_cat_delete.php
@@ -67,9 +67,9 @@ access_ensure_project_level( config_get( 'manage_project_threshold' ), $t_projec
 
 # Protect the 'default category for moves' from deletion
 $t_default_category_id = config_get( 'default_category_for_moves', /* default */ null, ALL_USERS, ALL_PROJECTS );
-$t_query = 'SELECT count(config_id) FROM {config} WHERE config_id = ' . db_param() . ' AND value = ' . db_param();
-$t_default_cat_count = db_result( db_query( $t_query, array( 'default_category_for_moves', (string)$f_category_id ) ) );
-if( $t_default_cat_count > 0 || $f_category_id == $t_default_category_id ) {
+if(    $f_category_id == $t_default_category_id
+	|| config_is_defined( 'default_category_for_moves', $f_category_id )
+) {
 	trigger_error( ERROR_CATEGORY_CANNOT_DELETE_DEFAULT, ERROR );
 }
 

--- a/manage_proj_cat_delete.php
+++ b/manage_proj_cat_delete.php
@@ -68,7 +68,7 @@ access_ensure_project_level( config_get( 'manage_project_threshold' ), $t_projec
 # Protect the 'default category for moves' from deletion
 $t_default_category_id = config_get( 'default_category_for_moves', /* default */ null, ALL_USERS, ALL_PROJECTS );
 $t_query = 'SELECT count(config_id) FROM {config} WHERE config_id = ' . db_param() . ' AND value = ' . db_param();
-$t_default_cat_count = db_result( db_query( $t_query, array( 'default_category_for_moves', $f_category_id ) ) );
+$t_default_cat_count = db_result( db_query( $t_query, array( 'default_category_for_moves', (string)$f_category_id ) ) );
 if( $t_default_cat_count > 0 || $f_category_id == $t_default_category_id ) {
 	trigger_error( ERROR_CATEGORY_CANNOT_DELETE_DEFAULT, ERROR );
 }

--- a/manage_proj_cat_delete.php
+++ b/manage_proj_cat_delete.php
@@ -66,12 +66,7 @@ $t_project_id = $t_row['project_id'];
 access_ensure_project_level( config_get( 'manage_project_threshold' ), $t_project_id );
 
 # Protect the 'default category for moves' from deletion
-$t_default_category_id = config_get( 'default_category_for_moves', /* default */ null, ALL_USERS, ALL_PROJECTS );
-if(    $f_category_id == $t_default_category_id
-	|| config_is_defined( 'default_category_for_moves', $f_category_id )
-) {
-	trigger_error( ERROR_CATEGORY_CANNOT_DELETE_DEFAULT, ERROR );
-}
+category_ensure_can_remove( $f_category_id );
 
 # Protect the category from deletion which is associted with an issue.
 category_ensure_can_delete( $f_category_id );


### PR DESCRIPTION
$f_category_id is of type int, but the config table's config_id column
is defined as VARCHAR(64). This causes a type mismatch on some RDBMS:

- Oracle (ORA-00932: inconsistent data types: expected -, found CLOB)
- MSSQL

Problem resolved by casting the variable to string when passing it to
db_query().

Fixes [#16384](https://www.mantisbt.org/bugs/view.php?id=16834)