### PR TITLE
Allow adding comma-separated monitor list

### DIFF
--- a/bug_monitor_add.php
+++ b/bug_monitor_add.php
@@ -55,26 +55,35 @@ form_security_validate( 'bug_monitor_add' );
 
 $f_bug_id = gpc_get_int( 'bug_id' );
 $t_bug = bug_get( $f_bug_id, true );
-$f_username = gpc_get_string( 'username', '' );
+$f_usernames = trim( gpc_get_string( 'username', '' ) );
 
 $t_logged_in_user_id = auth_get_current_user_id();
 
-if( is_blank( $f_username ) ) {
-	$t_user_id = $t_logged_in_user_id;
-} else {
-	$t_user_id = user_get_id_by_name( $f_username );
-	if( $t_user_id === false ) {
-		$t_user_id = user_get_id_by_realname( $f_username );
-
-		if( $t_user_id === false ) {
-			error_parameters( $f_username );
-			trigger_error( ERROR_USER_BY_NAME_NOT_FOUND, E_USER_ERROR );
-		}
+if( is_blank( $f_usernames ) ) {
+	if( user_is_anonymous( $t_logged_in_user_id ) ) {
+		trigger_error( ERROR_PROTECTED_ACCOUNT, E_USER_ERROR );
 	}
-}
+	$t_user_ids = array( $t_logged_in_user_id );
+} else {
+	$t_usernames = preg_split( '/[,|]/', $f_usernames, -1, PREG_SPLIT_NO_EMPTY );
+	$t_usernames = array_unique( $t_usernames );
+	$t_user_ids = array();
+	foreach( $t_usernames as $t_username ) {
+		$t_username = trim( $t_username );
+		$t_user_id = user_get_id_by_name( $t_username );
+		if( $t_user_id === false ) {
+			$t_user_id = user_get_id_by_realname( $t_username );
 
-if( user_is_anonymous( $t_user_id ) ) {
-	trigger_error( ERROR_PROTECTED_ACCOUNT, E_USER_ERROR );
+			if( $t_user_id === false ) {
+				error_parameters( $t_username );
+				trigger_error( ERROR_USER_BY_NAME_NOT_FOUND, E_USER_ERROR );
+			}
+		}
+		if( user_is_anonymous( $t_user_id ) ) {
+			trigger_error( ERROR_PROTECTED_ACCOUNT, E_USER_ERROR );
+		}
+		$t_user_ids[$t_user_id] = $t_user_id;
+	}
 }
 
 bug_ensure_exists( $f_bug_id );
@@ -85,13 +94,19 @@ if( $t_bug->project_id != helper_get_current_project() ) {
 	$g_project_override = $t_bug->project_id;
 }
 
-if( $t_logged_in_user_id == $t_user_id ) {
-	access_ensure_bug_level( config_get( 'monitor_bug_threshold' ), $f_bug_id );
-} else {
-	access_ensure_bug_level( config_get( 'monitor_add_others_bug_threshold' ), $f_bug_id );
+# Check all monitors first,
+foreach( $t_user_ids as $t_user_id ) {
+	if( $t_logged_in_user_id == $t_user_id ) {
+		access_ensure_bug_level( config_get( 'monitor_bug_threshold' ), $f_bug_id );
+	} else {
+		access_ensure_bug_level( config_get( 'monitor_add_others_bug_threshold' ), $f_bug_id );
+	}
 }
 
-bug_monitor( $f_bug_id, $t_user_id );
+# then add only if all can be added.
+foreach( $t_user_ids as $t_user_id ) {
+	bug_monitor( $f_bug_id, $t_user_id );
+}
 
 form_security_purge( 'bug_monitor_add' );
 


### PR DESCRIPTION
This helps adding the same herd of monitors to similar bugs: just copy
the list, comma-separated into the "username" field.