### PR TITLE
Fix defaulting of issue page time tracking range

### DIFF
--- a/billing_inc.php
+++ b/billing_inc.php
@@ -107,14 +107,15 @@ if( ON == config_get( 'time_tracking_with_billing' ) ) {
 		<tr class="row-2">
 			<td class="category" width="25%">
 				<?php
-					$g_filter = array();
-					$g_filter[FILTER_PROPERTY_FILTER_BY_DATE] = 'on';
-					$g_filter[FILTER_PROPERTY_START_DAY] = $t_bugnote_stats_from_d;
-					$g_filter[FILTER_PROPERTY_START_MONTH] = $t_bugnote_stats_from_m;
-					$g_filter[FILTER_PROPERTY_START_YEAR] = $t_bugnote_stats_from_y;
-					$g_filter[FILTER_PROPERTY_END_DAY] = $t_bugnote_stats_to_d;
-					$g_filter[FILTER_PROPERTY_END_MONTH] = $t_bugnote_stats_to_m;
-					$g_filter[FILTER_PROPERTY_END_YEAR] = $t_bugnote_stats_to_y;
+					$t_filter = array();
+					$t_filter[FILTER_PROPERTY_FILTER_BY_DATE] = 'on';
+					$t_filter[FILTER_PROPERTY_START_DAY] = $t_bugnote_stats_from_d;
+					$t_filter[FILTER_PROPERTY_START_MONTH] = $t_bugnote_stats_from_m;
+					$t_filter[FILTER_PROPERTY_START_YEAR] = $t_bugnote_stats_from_y;
+					$t_filter[FILTER_PROPERTY_END_DAY] = $t_bugnote_stats_to_d;
+					$t_filter[FILTER_PROPERTY_END_MONTH] = $t_bugnote_stats_to_m;
+					$t_filter[FILTER_PROPERTY_END_YEAR] = $t_bugnote_stats_to_y;
+					filter_init( $t_filter );
 					print_filter_do_filter_by_date( true );
 				?>
 			</td>

--- a/bugnote_stats_inc.php
+++ b/bugnote_stats_inc.php
@@ -96,14 +96,15 @@ $f_get_bugnote_stats_button = gpc_get_string( 'get_bugnote_stats_button', '' );
 		<tr class="row-2">
 			<td class="category" width="25%">
 				<?php
-					$g_filter = array();
-					$g_filter[FILTER_PROPERTY_FILTER_BY_DATE] = 'on';
-					$g_filter[FILTER_PROPERTY_START_DAY] = $t_bugnote_stats_from_d;
-					$g_filter[FILTER_PROPERTY_START_MONTH] = $t_bugnote_stats_from_m;
-					$g_filter[FILTER_PROPERTY_START_YEAR] = $t_bugnote_stats_from_y;
-					$g_filter[FILTER_PROPERTY_END_DAY] = $t_bugnote_stats_to_d;
-					$g_filter[FILTER_PROPERTY_END_MONTH] = $t_bugnote_stats_to_m;
-					$g_filter[FILTER_PROPERTY_END_YEAR] = $t_bugnote_stats_to_y;
+					$t_filter = array();
+					$t_filter[FILTER_PROPERTY_FILTER_BY_DATE] = 'on';
+					$t_filter[FILTER_PROPERTY_START_DAY] = $t_bugnote_stats_from_d;
+					$t_filter[FILTER_PROPERTY_START_MONTH] = $t_bugnote_stats_from_m;
+					$t_filter[FILTER_PROPERTY_START_YEAR] = $t_bugnote_stats_from_y;
+					$t_filter[FILTER_PROPERTY_END_DAY] = $t_bugnote_stats_to_d;
+					$t_filter[FILTER_PROPERTY_END_MONTH] = $t_bugnote_stats_to_m;
+					$t_filter[FILTER_PROPERTY_END_YEAR] = $t_bugnote_stats_to_y;
+					filter_init( $t_filter );
 					print_filter_do_filter_by_date( true );
 				?>
 			</td>

--- a/bugnote_stats_inc.php
+++ b/bugnote_stats_inc.php
@@ -96,14 +96,14 @@ $f_get_bugnote_stats_button = gpc_get_string( 'get_bugnote_stats_button', '' );
 		<tr class="row-2">
 			<td class="category" width="25%">
 				<?php
-					$t_filter = array();
-					$t_filter[FILTER_PROPERTY_FILTER_BY_DATE] = 'on';
-					$t_filter[FILTER_PROPERTY_START_DAY] = $t_bugnote_stats_from_d;
-					$t_filter[FILTER_PROPERTY_START_MONTH] = $t_bugnote_stats_from_m;
-					$t_filter[FILTER_PROPERTY_START_YEAR] = $t_bugnote_stats_from_y;
-					$t_filter[FILTER_PROPERTY_END_DAY] = $t_bugnote_stats_to_d;
-					$t_filter[FILTER_PROPERTY_END_MONTH] = $t_bugnote_stats_to_m;
-					$t_filter[FILTER_PROPERTY_END_YEAR] = $t_bugnote_stats_to_y;
+					$g_filter = array();
+					$g_filter[FILTER_PROPERTY_FILTER_BY_DATE] = 'on';
+					$g_filter[FILTER_PROPERTY_START_DAY] = $t_bugnote_stats_from_d;
+					$g_filter[FILTER_PROPERTY_START_MONTH] = $t_bugnote_stats_from_m;
+					$g_filter[FILTER_PROPERTY_START_YEAR] = $t_bugnote_stats_from_y;
+					$g_filter[FILTER_PROPERTY_END_DAY] = $t_bugnote_stats_to_d;
+					$g_filter[FILTER_PROPERTY_END_MONTH] = $t_bugnote_stats_to_m;
+					$g_filter[FILTER_PROPERTY_END_YEAR] = $t_bugnote_stats_to_y;
 					print_filter_do_filter_by_date( true );
 				?>
 			</td>


### PR DESCRIPTION
The start date should be defaulted to issue submission date.
The end date should be defaulted to today.

They were defaulted to Jan 1st of current year.

Fixes #20655