### PR TITLE
Dont use serialization for Session variables

### DIFF
--- a/core/session_api.php
+++ b/core/session_api.php
@@ -135,7 +135,7 @@ class MantisPHPSession extends MantisSession {
 	 */
 	function get( $p_name, $p_default = null ) {
 		if( isset( $_SESSION[$this->key][$p_name] ) ) {
-			return unserialize( $_SESSION[$this->key][$p_name] );
+			return $_SESSION[$this->key][$p_name];
 		}
 
 		if( func_num_args() > 1 ) {
@@ -153,7 +153,7 @@ class MantisPHPSession extends MantisSession {
 	 * @return void
 	 */
 	function set( $p_name, $p_value ) {
-		$_SESSION[$this->key][$p_name] = serialize( $p_value );
+		$_SESSION[$this->key][$p_name] = $p_value;
 	}
 
 	/**

--- a/core/session_api.php
+++ b/core/session_api.php
@@ -100,7 +100,7 @@ class MantisPHPSession extends MantisSession {
 	function __construct( $p_session_id = null ) {
 		global $g_cookie_secure_flag_enabled;
 
-		$this->key = hash( 'whirlpool', 'session_key' . config_get_global( 'crypto_master_salt' ), false );
+		$this->key = hash( 'whirlpool', 'session_key_v_2' . config_get_global( 'crypto_master_salt' ), false );
 
 		# Save session information where specified or with PHP's default
 		$t_session_save_path = config_get_global( 'session_save_path' );


### PR DESCRIPTION
There is no need to serialize data inserted in
$_SESSION, as php does it at the end of script

This is a performance hit when a session key
is used multiple times (eg: 'form_security_tokens')

Fixes #20142, #18016