### PR TITLE
Avatar plugin support related fixes

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -1067,19 +1067,8 @@ $g_differentiate_duplicates = OFF;
 $g_sort_by_last_name = OFF;
 
 /**
- * Show user avatar
- *
- * The config can be either set to OFF (avatars disabled) or set to a string
- * defining the default avatar to be used when none is associated with the
- * user's email. Valid values:
- * - OFF (default)
- * - ON (equivalent to 'identicon')
- * - One of Gravatar's defaults (mm, identicon, monsterid, wavatar, retro)
- *   @link http://en.gravatar.com/site/implement/images/
- * - An URL to the default image to be used (for example,
- *   "http:/path/to/unknown.jpg" or "%path%images/no_avatar.png")
- *
- * @global integer|string $g_show_avatar
+ * Show user avatars
+ * @global integer $g_show_avatar
  * @see $g_show_avatar_threshold
  */
 $g_show_avatar = OFF;

--- a/core/classes/Avatar.class.php
+++ b/core/classes/Avatar.class.php
@@ -57,14 +57,15 @@ class Avatar
      * @return array The array with avatar information.
      */
     public static function get( $p_user_id, $p_size = 80 ) {
-        $t_enabled = config_get( 'show_avatar' ) !== OFF &&
-            access_has_project_level( config_get( 'show_avatar_threshold' ) );
+        $t_enabled = config_get( 'show_avatar' ) !== OFF;
         $t_avatar = null;
 
         if ( $t_enabled ) {
-        	$t_avatar = event_signal(
-        	    'EVENT_USER_AVATAR',
-        	    array( $p_user_id, $p_size ) );
+            if ( access_has_project_level( config_get( 'show_avatar_threshold' ), null, $p_user_id ) ) {
+                $t_avatar = event_signal(
+                    'EVENT_USER_AVATAR',
+                    array( $p_user_id, $p_size ) );
+            }
 
             if( $t_avatar === null ) {
                 $t_avatar = new Avatar();

--- a/core/classes/Avatar.class.php
+++ b/core/classes/Avatar.class.php
@@ -65,15 +65,15 @@ class Avatar
         	$t_avatar = event_signal(
         	    'EVENT_USER_AVATAR',
         	    array( $p_user_id, $p_size ) );
+
+            if( $t_avatar === null ) {
+                $t_avatar = new Avatar();
+            }
+
+            $t_avatar->normalize( $p_user_id );
         }
 
-        if( $t_avatar === null ) {
-            $t_avatar = new Avatar();
-        }
-
-        $t_avatar->normalize( $p_user_id );
-
-    	return $t_avatar;
+        return $t_avatar;
     }
 
     /**

--- a/core/classes/TimelineEvent.class.php
+++ b/core/classes/TimelineEvent.class.php
@@ -73,6 +73,10 @@ class TimelineEvent {
 	 */
 	public function html_start() {
 		$t_avatar = Avatar::get( $this->user_id, 32 );
+		if( $t_avatar === null ) {
+			return sprintf(
+				'<div class="entry"><div class="timestamp">%s</div>', $this->format_timestamp( $this->timestamp ) );
+		}
 
 		return sprintf(
 			'<div class="entry"><div class="avatar"><a href="%s"><img class="avatar" src="%s" alt="%s" width="32" height="32" /></a></div><div class="timestamp">%s</div>',

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -187,6 +187,9 @@ function print_successful_redirect( $p_redirect_to ) {
  */
 function print_avatar( $p_user_id, $p_size = 80 ) {
 	$t_avatar = Avatar::get( $p_user_id, $p_size );
+	if( $t_avatar === null ) {
+		return;
+	}
 
 	$t_image = htmlspecialchars( $t_avatar->image );
 	$t_link = htmlspecialchars( $t_avatar->link );

--- a/docbook/Admin_Guide/en-US/config/display.xml
+++ b/docbook/Admin_Guide/en-US/config/display.xml
@@ -190,46 +190,22 @@
 		<varlistentry>
 			<term>$g_show_avatar</term>
 			<listitem>
-				<para>Show the user's avatar
-				</para>
-				<para>The current implementation is based on
-					<ulink url="http://www.gravatar.com">Gravatar</ulink>;
-					Users will need to register there the same email address
-					used in this MantisBT installation to have their avatar
-					shown.
-					Please note: upon registration or avatar change, it may
-					take some time for the updated gravatar images to show
-					on sites
-				</para>
-				<para>The config can be either set to OFF (avatars disabled),
-					or to a string defining the default avatar to be used
-					when none is associated with the user's email.
-					Valid values are:
-					<itemizedlist>
-						<listitem><para>OFF (default)</para>
-						</listitem>
-						<listitem><para>ON (equivalent to 'identicon')
-						</para></listitem>
-						<listitem><para>One of Gravatar's defaults
-							(mm, identicon, monsterid, wavatar, retro);
-							refer to
-							<ulink url="http://en.gravatar.com/site/implement/images/">
-								Image Requests documentation
-							</ulink>
-							for further details.
-						</para></listitem>
-						<listitem><para>An URL to the default image to be used
-							(for example, &quot;http:/path/to/unknown.jpg&quot;
-							or &quot;%path%images/no_avatar.png&quot;).
-						</para></listitem>
-					</itemizedlist>
+				<para>Show the users' avatar</para>
+				<para>In addition to enabling this configuration option it is
+					necessary to install an avatar plugin like the
+					<ulink url="http://www.gravatar.com">Gravatar</ulink>
+					plugin which is bundled out of the box.
 				</para>
 			</listitem>
 		</varlistentry>
 		<varlistentry>
 			<term>$g_show_avatar_threshold</term>
 			<listitem>
-				<para>The threshold of users for which MantisBT should attempt to show the avatar (default DEVELOPER).  Note that the threshold is related to the user for whom the avatar is being shown, rather than the user who is currently logged in.</para>
+				<para>
+					The threshold of users for which MantisBT should show the avatar (default DEVELOPER).
+					Note that the threshold is related to the user for whom the avatar is being shown,
+					rather than the user who is currently logged in.
+				</para>
 			</listitem>
 		</varlistentry>
 	</variablelist>

--- a/plugins/Gravatar/Gravatar.php
+++ b/plugins/Gravatar/Gravatar.php
@@ -81,13 +81,6 @@ class GravatarPlugin extends MantisPlugin {
 	 * @return array
 	 */
 	function config() {
-		$t_default_avatar = config_get( 'show_avatar' );
-
-		# Set default avatar for legacy configuration
-		if( ON === $t_default_avatar || OFF === $t_default_avatar) {
-			$t_default_avatar = self::GRAVATAR_DEFAULT_IDENTICON;
-		}
-
 		return array(
 			/**
 			 * The rating of the avatar to show: 'G', 'PG', 'R', 'X'
@@ -103,7 +96,7 @@ class GravatarPlugin extends MantisPlugin {
 			 * - An URL to the default image to be used (for example,
 			 *   "http:/path/to/unknown.jpg" or "%path%images/avatar.png")
 			 */
-			'default_avatar' => $t_default_avatar,
+			'default_avatar' => self::GRAVATAR_DEFAULT_IDENTICON
 		);
 	}
 
@@ -144,12 +137,7 @@ class GravatarPlugin extends MantisPlugin {
 	 * @return object An instance of class Avatar or null.
 	 */
 	function user_get_avatar( $p_event, $p_user_id, $p_size = 80 ) {
-		$t_default_avatar = config_get( 'show_avatar' );
-
-		# Set default avatar for legacy configuration
-		if( ON === $t_default_avatar || OFF === $t_default_avatar ) {
-			$t_default_avatar = 'identicon';
-		}
+		$t_default_avatar = plugin_config_get( 'default_avatar' );
 
 		# Default avatar is either one of Gravatar's options, or
 		# assumed to be an URL to a default avatar image


### PR DESCRIPTION
- Don't show avatars when they are disabled.
- Avatar threshold should check user for which to display avatar and not logged in user.
- If avatar is off and a user doesn't match threshold, then show default avatar.  This way we don't end up with a mix of no image and image.
- Remove gravatar specific settings from core config.
- Gravatar plugin to use its own default_config instead of show avatar.

Fixes #20641
Fixes #20642