### PR TITLE
New password activation

### DIFF
--- a/account_page.php
+++ b/account_page.php
@@ -171,13 +171,13 @@ if( $t_force_pw_reset ) {
 			} else {
 			?>
 			<div class="field-container">
-				<label for="password" <?php echo $t_force_pw_reset_html ?>><span><?php echo lang_get( 'current_password' ) ?></span></label>
+				<label for="password-current" <?php echo $t_force_pw_reset_html ?>><span><?php echo lang_get( 'current_password' ) ?></span></label>
 				<span class="input"><input id="password-current" type="password" name="password_current" size="32" maxlength="<?php echo auth_get_password_max_size(); ?>" /></span>
 				<span class="label-style"></span>
 			</div>
 			<?php } ?>
 			<div class="field-container">
-				<label for="password" <?php echo $t_force_pw_reset_html ?>><span><?php echo lang_get( 'password' ) ?></span></label>
+				<label for="password" <?php echo $t_force_pw_reset_html ?>><span><?php echo lang_get( 'new_password' ) ?></span></label>
 				<span class="input"><input id="password" type="password" name="password" size="32" maxlength="<?php echo auth_get_password_max_size(); ?>" /></span>
 				<span class="label-style"></span>
 			</div>

--- a/account_update.php
+++ b/account_update.php
@@ -101,9 +101,7 @@ if( !( $t_ldap && config_get( 'use_ldap_email' ) )
 }
 
 # Update real name (but only if LDAP isn't being used)
-# Do not update real name for a user verification
-if( !( $t_ldap && config_get( 'use_ldap_realname' ) )
-	&& !$t_account_verification	) {
+if( !( $t_ldap && config_get( 'use_ldap_realname' ) ) ) {
 	# strip extra spaces from real name
 	$t_realname = string_normalize( $f_realname );
 	if( $t_realname != user_get_field( $t_user_id, 'realname' ) ) {

--- a/account_update.php
+++ b/account_update.php
@@ -88,6 +88,12 @@ $t_email_updated = false;
 $t_password_updated = false;
 $t_realname_updated = false;
 
+# Do not allow blank passwords in account verification/reset
+if( $t_account_verification && is_blank( $f_password ) ) {
+	error_parameters( lang_get( 'password' ) );
+	trigger_error( ERROR_EMPTY_FIELD, ERROR );
+}
+
 $t_ldap = ( LDAP == config_get( 'login_method' ) );
 
 # Update email (but only if LDAP isn't being used)

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -494,6 +494,7 @@ define( 'TOKEN_LAST_VISITED', 3 );
 define( 'TOKEN_AUTHENTICATED', 4 );
 define( 'TOKEN_COLLAPSE', 5 );
 define( 'TOKEN_ACCOUNT_VERIFY', 6 );
+define( 'TOKEN_ACCOUNT_ACTIVATION', 7 );
 define( 'TOKEN_USER', 1000 );
 
 # token expirations
@@ -503,6 +504,7 @@ define( 'TOKEN_EXPIRY', 60 * 60 );
 define( 'TOKEN_EXPIRY_LAST_VISITED', 24 * 60 * 60 );
 define( 'TOKEN_EXPIRY_AUTHENTICATED', 5 * 60 );
 define( 'TOKEN_EXPIRY_COLLAPSE', 365 * 24 * 60 * 60 );
+define( 'TOKEN_EXPIRY_ACCOUNT_ACTIVATION', 24 * 60 * 60 );
 
 # config types
 define( 'CONFIG_TYPE_DEFAULT', 0 );

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -602,6 +602,7 @@ function user_create( $p_username, $p_password, $p_email = '',
 	# Send notification email
 	if( !is_blank( $p_email ) ) {
 		$t_confirm_hash = auth_generate_confirm_hash( $t_user_id );
+		token_set( TOKEN_ACCOUNT_ACTIVATION, $t_confirm_hash, TOKEN_EXPIRY_ACCOUNT_ACTIVATION, $t_user_id );
 		email_signup( $t_user_id, $t_confirm_hash, $p_admin_name );
 	}
 
@@ -1566,6 +1567,8 @@ function user_set_password( $p_user_id, $p_password, $p_allow_protected = false 
 	# When the password is changed, invalidate the cookie to expire sessions that
 	# may be active on all browsers.
 	$c_cookie_string = auth_generate_unique_cookie_string();
+	# Delete token for password activation if there is any
+	token_delete( TOKEN_ACCOUNT_ACTIVATION, $p_user_id );
 
 	$c_password = auth_process_plain_password( $p_password );
 
@@ -1661,6 +1664,7 @@ function user_reset_password( $p_user_id, $p_send_email = true ) {
 		# Send notification email
 		if( $p_send_email ) {
 			$t_confirm_hash = auth_generate_confirm_hash( $p_user_id );
+			token_set( TOKEN_ACCOUNT_ACTIVATION, $t_confirm_hash, TOKEN_EXPIRY_ACCOUNT_ACTIVATION, $p_user_id );
 			email_send_confirm_hash_url( $p_user_id, $t_confirm_hash );
 		}
 	} else {

--- a/css/default.css
+++ b/css/default.css
@@ -480,6 +480,7 @@ div.form-container table th,
 div.table-container table th {
 	text-align: left;
 }
+div#verify-div,
 div#reauth-div,
 div#login-div,
 div#lost-password-div,

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -353,13 +353,14 @@ $s_realname_label = 'Real Name';
 $s_email = 'E-mail';
 $s_email_label = 'E-mail';
 $s_password = 'Password';
+$s_new_password = 'New password';
 $s_no_password_change = 'The password is controlled by another system, hence cannot be edited here.';
 $s_confirm_password = 'Confirm Password';
 $s_current_password = 'Current Password';
 $s_access_level = 'Access Level';
 $s_access_level_label = 'Access Level';
 $s_update_user_button = 'Update User';
-$s_verify_warning = 'Your account information has been verified. The account confirmation message you have received is now invalid.';
+$s_verify_warning = 'Your account information has been verified.';
 $s_verify_change_password = 'You must set a password here to allow you to log in again.';
 
 # API tokens page

--- a/lost_pwd.php
+++ b/lost_pwd.php
@@ -95,6 +95,7 @@ if( !user_is_lost_password_request_allowed( $t_user_id ) ) {
 }
 
 $t_confirm_hash = auth_generate_confirm_hash( $t_user_id );
+token_set( TOKEN_ACCOUNT_ACTIVATION, $t_confirm_hash, TOKEN_EXPIRY_ACCOUNT_ACTIVATION, $t_user_id );
 email_send_confirm_hash_url( $t_user_id, $t_confirm_hash );
 
 user_increment_lost_password_in_progress_count( $t_user_id );

--- a/verify.php
+++ b/verify.php
@@ -122,7 +122,7 @@ if( $t_can_change_password ) {
 			token_set( TOKEN_ACCOUNT_VERIFY, true, TOKEN_EXPIRY_AUTHENTICATED, $u_id );
 			?>
 			<div class="field-container">
-				<label for="password" class="required"><span><?php echo lang_get( 'password' ) ?></span></label>
+				<label for="password" class="required"><span><?php echo lang_get( 'new_password' ) ?></span></label>
 				<span class="input"><input id="password" type="password" name="password" size="32" maxlength="<?php echo auth_get_password_max_size(); ?>" /></span>
 				<span class="label-style"></span>
 			</div>

--- a/verify.php
+++ b/verify.php
@@ -92,12 +92,19 @@ html_page_top2a();
 <div id="reset-passwd-msg" class="important-msg">
 	<ul>
 		<?php
-		echo '<li>' . lang_get( 'verify_warning' ) . '</li>';
-		echo '<li>' . lang_get( 'verify_change_password' ) . '</li>';
+		if( $t_can_change_password ) {
+			echo '<li>' . lang_get( 'verify_warning' ) . '</li>';
+			echo '<li>' . lang_get( 'verify_change_password' ) . '</li>';
+		} else {
+			echo '<li>' . lang_get( 'no_password_change' ) . '</li>';
+		}
 		?>
 	</ul>
 </div>
 
+<?php
+if( $t_can_change_password ) {
+?>
 
 <div id="verify-div" class="form-container">
 	<form id="account-update-form" method="post" action="account_update.php">
@@ -109,10 +116,8 @@ html_page_top2a();
 				<span class="label-style"></span>
 			</div>
 			<input type="hidden" name="verify_user_id" value="<?php echo $u_id ?>">
-			<?php echo form_security_field( 'account_update' );
-			if( $t_can_change_password ) {
-			?>
 			<?php
+			echo form_security_field( 'account_update' );
 			# When verifying account, set a token and don't display current password
 			token_set( TOKEN_ACCOUNT_VERIFY, true, TOKEN_EXPIRY_AUTHENTICATED, $u_id );
 			?>
@@ -127,10 +132,11 @@ html_page_top2a();
 				<span class="label-style"></span>
 			</div>
 			<span class="submit-button"><input type="submit" class="button" value="<?php echo lang_get( 'update_user_button' ) ?>" /></span>
-			<?php } ?>
 		</fieldset>
 	</form>
 </div>
 
 <?php
+}
+
 html_page_bottom1a( __FILE__ );

--- a/verify.php
+++ b/verify.php
@@ -122,6 +122,13 @@ if( $t_can_change_password ) {
 			token_set( TOKEN_ACCOUNT_VERIFY, true, TOKEN_EXPIRY_AUTHENTICATED, $u_id );
 			?>
 			<div class="field-container">
+				<label for="realname"><span><?php echo lang_get( 'realname' ) ?></span></label>
+				<span class="input">
+					<input id="realname" type="text" size="32" maxlength="<?php echo DB_FIELD_SIZE_REALNAME ?>" name="realname" value="<?php echo string_attribute( $u_realname ) ?>" />
+				</span>
+				<span class="label-style"></span>
+			</div>
+			<div class="field-container">
 				<label for="password" class="required"><span><?php echo lang_get( 'new_password' ) ?></span></label>
 				<span class="input"><input id="password" type="password" name="password" size="32" maxlength="<?php echo auth_get_password_max_size(); ?>" /></span>
 				<span class="label-style"></span>

--- a/verify.php
+++ b/verify.php
@@ -61,9 +61,9 @@ if( auth_is_user_authenticated() ) {
 	print_header_redirect( 'verify.php?id=' . $f_user_id . '&confirm_hash=' . $f_confirm_hash );
 }
 
-$t_calculated_confirm_hash = auth_generate_confirm_hash( $f_user_id );
+$t_token_confirm_hash = token_get_value( TOKEN_ACCOUNT_ACTIVATION, $f_user_id );
 
-if( $f_confirm_hash != $t_calculated_confirm_hash ) {
+if( $f_confirm_hash != $t_token_confirm_hash ) {
 	trigger_error( ERROR_LOST_PASSWORD_CONFIRM_HASH_INVALID, ERROR );
 }
 


### PR DESCRIPTION
Manage the password reset hash as a token.
Refactor verify.php to be a not-logged-in page, like login_page.php, so the only action the user can do is change the password, and not navigate into the site.
If the user does not change the password and quits tue page, the activation token is still valid until the change is effectively done (or token timeout)

Fix #0020686, #0006009