### PR TITLE
Improved checkin script to allow for more elaborate regular expressions

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2679,6 +2679,29 @@
 	 * @global string $g_source_control_fixed_regexp
 	 */
 	$g_source_control_fixed_regexp = "%source_control_regexp%";
+	
+	/**
+	 * Regular expression used to detect issue ids within $g_source_control_regexp and
+	 * $g_source_control_fixed_regexp matches. This two-step matching makes it possible
+	 * to match more elaborate patterns.
+	 *
+	 * Example:
+	 *   $g_source_control_regexp = '/\b (?: feature | bug | issue)s? (?: \s+ | : \s*) (\#\d+ (?: (?: \s* , \s* | \s+ and \s+ | \s+) \#\d+)*) \b/xi';
+	 *   $g_source_control_fixed_regexp = '/\b (?: implement(?: ed|s) | fix(?: ed|es) | clos(?: ed|es)) (?: \s+ (?: feature | bug | issue)s?)? (?: \s+ | : \s*) (\#\d+ (?: (?: \s* , \s* | \s+ and \s+ | \s+) \#\d+)*) \b/xi';
+	 *   $g_source_control_issue_regexp = '/\d+/';
+	 *
+	 * Applied to the following checking comment:
+	 *   Worked on #1, #2 and #3.
+	 *   Related bug: #4.
+	 *   Fixed bug #5 and #6.
+	 *   Implemented features #7, #8.
+	 *   Closes #9.
+	 *
+	 * Will add a comment on issues 1, 2, 3, 4 and mark issues 5, 6, 7, 8, 9 as fixed.
+	 *
+	 * @global string $g_source_control_issue_regexp
+	 */
+	$g_source_control_issue_regexp = '/\d+/';
 
 	/**
 	 * Bug Linking

--- a/scripts/checkin.php
+++ b/scripts/checkin.php
@@ -41,25 +41,30 @@ if( !defined( "STDIN" ) ) {
 # Detect references to issues + concat all lines to have the comment log.
 $t_commit_regexp = config_get( 'source_control_regexp' );
 $t_commit_fixed_regexp = config_get( 'source_control_fixed_regexp' );
+$t_commit_issue_regexp = config_get( 'source_control_issue_regexp' );
+
+function match_issues( $p_regexp, $p_issue_regexp, $p_line, &$p_issues )
+{
+	if( preg_match_all( $p_regexp, $p_line, $t_matches ) ) {
+		$t_count = count( $t_matches[0] );
+		for( $i = 0;$i < $t_count;++$i ) {
+			if( preg_match_all( $p_issue_regexp, $t_matches[1][$i], $t_issue_matches ) ) {
+				$t_issue_count = count( $t_issue_matches[0] );
+				for ( $j = 0;$j < $t_issue_count;++$j ) {
+					$p_issues[] = $t_issue_matches[0][$j];
+				}
+			}
+		}
+	}
+}
 
 $t_comment = '';
 $t_issues = array();
 $t_fixed_issues = array();
 while(( $t_line = fgets( STDIN, 1024 ) ) ) {
 	$t_comment .= $t_line;
-	if( preg_match_all( $t_commit_regexp, $t_line, $t_matches ) ) {
-		$t_count = count( $t_matches[0] );
-		for( $i = 0;$i < $t_count;++$i ) {
-			$t_issues[] = $t_matches[1][$i];
-		}
-	}
-
-	if( preg_match_all( $t_commit_fixed_regexp, $t_line, $t_matches ) ) {
-		$t_count = count( $t_matches[0] );
-		for( $i = 0;$i < $t_count;++$i ) {
-			$t_fixed_issues[] = $t_matches[1][$i];
-		}
-	}
+	match_issues( $t_commit_regexp, $t_commit_issue_regexp, $t_line, $t_issues );
+	match_issues( $t_commit_fixed_regexp, $t_commit_issue_regexp, $t_line, $t_fixed_issues );
 }
 
 # If no issues found, then no work to do.


### PR DESCRIPTION
Added new config setting: source_control_issue_regexp
Checkin script now matches this regexp within matches of
source_control_regexp and source_control_fixed_regexp.
This allows those regexps to match a more elaborate pattern,
e.g. a sentence mentioning more than one issue id.
The source_control_issue_regexp is then used to extract
issue ids from those matches.

PS: Should not break existing setups.