### PR TITLE
Tag with description are attached incorrectly

### DIFF
--- a/core/print_api.php
+++ b/core/print_api.php
@@ -405,9 +405,6 @@ function print_tag_option_list( $p_bug_id = 0 ) {
 	echo '<option value="0">', string_html_specialchars( lang_get( 'tag_existing' ) ), '</option>';
 	foreach ( $t_rows as $t_row ) {
 		$t_string = $t_row['name'];
-		if( !empty( $t_row['description'] ) ) {
-			$t_string .= ' - ' . utf8_substr( $t_row['description'], 0, 20 );
-		}
 		echo '<option value="', $t_row['id'], '" title="', string_attribute( $t_row['name'] ), '">', string_attribute( $t_string ), '</option>';
 	}
 }

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -404,8 +404,8 @@ function print_tag_option_list( $p_bug_id = 0 ) {
 
 	echo '<option value="0">', string_html_specialchars( lang_get( 'tag_existing' ) ), '</option>';
 	foreach ( $t_rows as $t_row ) {
-		$t_string = $t_row['name'];
-		echo '<option value="', $t_row['id'], '" title="', string_attribute( $t_row['name'] ), '">', string_attribute( $t_string ), '</option>';
+		echo '<option value="', $t_row['id'], '" title="', string_attribute( $t_row['description'] );
+		echo '">', string_attribute( $t_row['name'] ), '</option>';
 	}
 }
 


### PR DESCRIPTION
The tag dropdown shows the "tag - description", selecting it adds
"tag - description" as a new tag rather than using "tag".

Fixes #20724