### PR TITLE
Status legend doesn't show final workflow states

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1390,10 +1390,21 @@ function html_status_legend( $p_display_position, $p_restrict_by_filter = false 
 	$t_workflow = config_get( 'status_enum_workflow' );
 	if( !empty( $t_workflow ) ) {
 		foreach( $t_status_array as $t_status => $t_name ) {
+			# Check if the workflow allows leaving the state
 			if( !isset( $t_workflow[$t_status] ) ) {
+				# Check if the workflow allows entering the state
+				$t_can_enter = false;
+				foreach( $t_workflow as $t_values ) {
+					if( MantisEnum::hasValue( $t_values, $t_status ) ) {
+						$t_can_enter = true;
+						break;
+					}
+				}
 
 				# drop elements that are not in the workflow
-				unset( $t_status_array[$t_status] );
+				if( !$t_can_enter ) {
+					unset( $t_status_array[$t_status] );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The patch for issue [#11553](https://www.mantisbt.org/bugs/view.php?id=11553) did not properly fix the problem, as the code only checked for the workflow allowing to leave a state.

We now also cover the case of entering the state.

Fixes [#20746](https://www.mantisbt.org/bugs/view.php?id=20746)