### PR TITLE
Allow administrators to impersonate users

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2764,6 +2764,12 @@ $g_project_user_threshold = MANAGER;
 $g_manage_user_threshold = ADMINISTRATOR;
 
 /**
+ * Threshold needed to impersonate a user or NOBODY to disable the feature.
+ * @global integer $g_impersonate_user_threshold
+ */
+$g_impersonate_user_threshold = ADMINISTRATOR;
+
+/**
  * Delete bug threshold
  * @global integer $g_delete_bug_threshold
  */
@@ -4429,6 +4435,7 @@ $g_public_config_names = array(
 	'html_make_links',
 	'html_valid_tags_single_line',
 	'html_valid_tags',
+	'impersonate_user_threshold',
 	'inline_file_exts',
 	'limit_reporters',
 	'logo_image',

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -325,9 +325,7 @@ function auth_impersonate( $p_user_id ) {
  * @return bool true: can impersonate, false: can't.
  */
 function auth_can_impersonate( $p_user_id ) {
-	# Make sure the logged in user can impersonate other users.  If user can
-	# manage users, then they would be able to impersonate them.
-	if( !access_has_global_level( config_get( 'manage_user_threshold' ) ) ) {
+	if( !access_has_global_level( config_get( 'impersonate_user_threshold' ) ) ) {
 		return false;
 	}
 

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -312,12 +312,44 @@ function auth_attempt_login( $p_username, $p_password, $p_perm_login = false ) {
  * @return void
  */
 function auth_impersonate( $p_user_id ) {
-	# Make sure the logged in user can impersonate other users.  If user can
-	# manage users, then they would be able to impersonate them.
-	access_ensure_global_level( config_get( 'manage_user_threshold' ) );
+	auth_ensure_can_impersonate( $p_user_id );
 
 	auth_set_cookies( $p_user_id, /* perm_login */ false );
 	auth_set_tokens( $p_user_id );
+}
+
+/**
+ * Check whether the logged in user can impersonate the specified user.
+ *
+ * @param int $p_user_id  The user id to be impersonated.
+ * @return bool true: can impersonate, false: can't.
+ */
+function auth_can_impersonate( $p_user_id ) {
+	# Make sure the logged in user can impersonate other users.  If user can
+	# manage users, then they would be able to impersonate them.
+	if( !access_has_global_level( config_get( 'manage_user_threshold' ) ) ) {
+		return false;
+	}
+
+	# User can't impersonate themselves
+	if( $p_user_id == auth_get_current_user_id() ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Ensure that the logged in user can impersonate the specified user.  If not,
+ * then an error page will be generated.
+ *
+ * @param int $p_user_id  The user id to be impersonated.
+ * @return void.
+ */
+function auth_ensure_can_impersonate( $p_user_id ) {
+	if( !auth_can_impersonate( $p_user_id ) ) {
+		access_denied();
+	}
 }
 
 /**

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -306,6 +306,21 @@ function auth_attempt_login( $p_username, $p_password, $p_perm_login = false ) {
 }
 
 /**
+ * Impersonates the specified user by logging in.
+ *
+ * @param int $p_user_id The user id.
+ * @return void
+ */
+function auth_impersonate( $p_user_id ) {
+	# Make sure the logged in user can impersonate other users.  If user can
+	# manage users, then they would be able to impersonate them.
+	access_ensure_global_level( config_get( 'manage_user_threshold' ) );
+
+	auth_set_cookies( $p_user_id, /* perm_login */ false );
+	auth_set_tokens( $p_user_id );
+}
+
+/**
  * Allows scripts to login using a login name or ( login name + password )
  *
  * There are multiple scenarios where this is used:

--- a/docbook/Admin_Guide/en-US/Configuration.xml
+++ b/docbook/Admin_Guide/en-US/Configuration.xml
@@ -45,4 +45,5 @@
 	<xi:include href="config/soap.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 	<xi:include href="config/antispam.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 	<xi:include href="config/duedate.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
+	<xi:include href="config/user.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>
 </chapter>

--- a/docbook/Admin_Guide/en-US/User_Management.xml
+++ b/docbook/Admin_Guide/en-US/User_Management.xml
@@ -180,6 +180,16 @@
 	resetting password will set the password to an empty string.</para>
     </section>
 
+	<section id="admin.user.impersonation">
+		<title>Impersonating a user</title>
+
+		<para>Administrators are able to impersonate users in order to reproduce
+		an issue reported by a user, test their access making sure they can
+		access the expected projects/issues/fields, or to create API tokens for
+		service accounts that are used to grant other systems limited access to
+		MantisBT.</para>
+	</section>
+
     <section id="admin.user.passwordchange">
         <title>Changing Password</title>
 

--- a/docbook/Admin_Guide/en-US/config/user.xml
+++ b/docbook/Admin_Guide/en-US/config/user.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE section PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+ <!ENTITY % BOOK_ENTITIES SYSTEM "Admin_Guide.ent">
+]>
+<section id="admin.config.users">
+	<title>User Management</title>
+
+	<variablelist>
+		<varlistentry>
+			<term>$g_impersonate_user_threshold</term>
+			<listitem>
+				<para>
+					The threshold for a user to be able to impersonate another user,
+					or NOBODY to disable impersonation.  Default ADMINISTRATOR.
+				</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
+			<term>$g_manage_user_threshold</term>
+			<listitem>
+				<para>
+					The threshold for a user to manage user accounts.
+					Default ADMINISTRATOR.
+				</para>
+			</listitem>
+		</varlistentry>
+	</variablelist>
+</section>

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -977,6 +977,7 @@ $s_edit_user_title = 'Edit User';
 $s_account_unlock_button = 'Unlock Account';
 $s_reset_password_button = 'Reset Password';
 $s_delete_user_button = 'Delete User';
+$s_impersonate_user_button = 'Impersonate User';
 $s_reset_password_msg = 'Reset Password sends the confirmation URL via e-mail.';
 $s_reset_password_msg2 = 'Reset Password resets the password to be blank.';
 $s_show_all_users = 'All';

--- a/manage_user_edit_page.php
+++ b/manage_user_edit_page.php
@@ -184,16 +184,26 @@ print_manage_menu();
 <?php
 # User action buttons: RESET/UNLOCK and DELETE
 
-$t_not_logged_in_user = $t_user['id'] != auth_get_current_user_id();
-$t_reset = $t_not_logged_in_user
+$t_reset = $t_user['id'] != auth_get_current_user_id()
 	&& helper_call_custom_function( 'auth_can_change_password', array() );
 $t_unlock = OFF != config_get( 'max_failed_login_count' ) && $t_user['failed_login_count'] > 0;
 $t_delete = !( ( user_is_administrator( $t_user_id ) && ( user_count_level( config_get_global( 'admin_site_threshold' ) ) <= 1 ) ) );
-$t_impersonate = $t_not_logged_in_user;
+$t_impersonate = auth_can_impersonate( $t_user['id'] );
 
 if( $t_reset || $t_unlock || $t_delete || $t_impersonate ) {
 ?>
 <div id="manage-user-actions-div" class="form-container">
+
+<!-- Impersonate Button -->
+<?php if( $t_impersonate ) { ?>
+	<form id="manage-user-impersonate-form" method="post" action="manage_user_impersonate.php" class="action-button">
+		<fieldset>
+			<?php echo form_security_field( 'manage_user_impersonate' ) ?>
+			<input type="hidden" name="user_id" value="<?php echo $t_user['id'] ?>" />
+			<span><input type="submit" class="button" value="<?php echo lang_get( 'impersonate_user_button' ) ?>" /></span>
+		</fieldset>
+	</form>
+<?php } ?>
 
 <!-- Reset/Unlock Button -->
 <?php if( $t_reset || $t_unlock ) { ?>
@@ -217,17 +227,6 @@ if( $t_reset || $t_unlock || $t_delete || $t_impersonate ) {
 			<?php echo form_security_field( 'manage_user_delete' ) ?>
 			<input type="hidden" name="user_id" value="<?php echo $t_user['id'] ?>" />
 			<span><input type="submit" class="button" value="<?php echo lang_get( 'delete_user_button' ) ?>" /></span>
-		</fieldset>
-	</form>
-<?php } ?>
-
-<!-- Impersonate Button -->
-<?php if( $t_impersonate ) { ?>
-	<form id="manage-user-impersonate-form" method="post" action="manage_user_impersonate.php" class="action-button">
-		<fieldset>
-			<?php echo form_security_field( 'manage_user_impersonate' ) ?>
-			<input type="hidden" name="user_id" value="<?php echo $t_user['id'] ?>" />
-			<span><input type="submit" class="button" value="<?php echo lang_get( 'impersonate_user_button' ) ?>" /></span>
 		</fieldset>
 	</form>
 <?php } ?>

--- a/manage_user_edit_page.php
+++ b/manage_user_edit_page.php
@@ -184,12 +184,14 @@ print_manage_menu();
 <?php
 # User action buttons: RESET/UNLOCK and DELETE
 
-$t_reset = $t_user['id'] != auth_get_current_user_id()
+$t_not_logged_in_user = $t_user['id'] != auth_get_current_user_id();
+$t_reset = $t_not_logged_in_user
 	&& helper_call_custom_function( 'auth_can_change_password', array() );
 $t_unlock = OFF != config_get( 'max_failed_login_count' ) && $t_user['failed_login_count'] > 0;
 $t_delete = !( ( user_is_administrator( $t_user_id ) && ( user_count_level( config_get_global( 'admin_site_threshold' ) ) <= 1 ) ) );
+$t_impersonate = $t_not_logged_in_user;
 
-if( $t_reset || $t_unlock || $t_delete ) {
+if( $t_reset || $t_unlock || $t_delete || $t_impersonate ) {
 ?>
 <div id="manage-user-actions-div" class="form-container">
 
@@ -218,6 +220,18 @@ if( $t_reset || $t_unlock || $t_delete ) {
 		</fieldset>
 	</form>
 <?php } ?>
+
+<!-- Impersonate Button -->
+<?php if( $t_impersonate ) { ?>
+	<form id="manage-user-impersonate-form" method="post" action="manage_user_impersonate.php" class="action-button">
+		<fieldset>
+			<?php echo form_security_field( 'manage_user_impersonate' ) ?>
+			<input type="hidden" name="user_id" value="<?php echo $t_user['id'] ?>" />
+			<span><input type="submit" class="button" value="<?php echo lang_get( 'impersonate_user_button' ) ?>" /></span>
+		</fieldset>
+	</form>
+<?php } ?>
+
 </div>
 <?php } ?>
 

--- a/manage_user_impersonate.php
+++ b/manage_user_impersonate.php
@@ -1,0 +1,58 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * User Impersonation
+ *
+ * @package MantisBT
+ * @copyright Copyright 2000 - 2002  Kenzaburo Ito - kenito@300baud.org
+ * @copyright Copyright 2002  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ *
+ * @uses core.php
+ * @uses access_api.php
+ * @uses constant_inc.php
+ * @uses form_api.php
+ * @uses gpc_api.php
+ * @uses helper_api.php
+ * @uses html_api.php
+ */
+
+require_once( 'core.php' );
+require_api( 'access_api.php' );
+require_api( 'constant_inc.php' );
+require_api( 'form_api.php' );
+require_api( 'gpc_api.php' );
+require_api( 'helper_api.php' );
+require_api( 'html_api.php' );
+
+form_security_validate( 'manage_user_impersonate' );
+
+auth_reauthenticate();
+
+$f_user_id	= gpc_get_int( 'user_id' );
+
+auth_impersonate( $f_user_id );
+
+form_security_purge( 'manage_user_impersonate' );
+
+$t_redirect_to = config_get( 'default_home_page' );
+
+html_page_top( null, $t_redirect_to );
+
+html_operation_successful( $t_redirect_to );
+
+html_page_bottom();

--- a/view_user_page.php
+++ b/view_user_page.php
@@ -110,7 +110,21 @@ html_page_top();
 	</div>
 	<span class="section-links">
 	<?php if( $t_can_manage ) { ?>
-			<span id="manage-user-link"><a href="<?php echo string_html_specialchars( 'manage_user_edit_page.php?user_id=' . $f_user_id ); ?>"><?php echo lang_get( 'manage_user' ); ?></a></span>
+		<form id="manage-user-form" method="get" action="manage_user_edit_page.php" class="action-button">
+			<fieldset>
+				<input type="hidden" name="user_id" value="<?php echo $f_user_id ?>" />
+				<span><input type="submit" class="button" value="<?php echo lang_get( 'manage_user' ) ?>" /></span>
+			</fieldset>
+		</form>
+	<?php } ?>
+	<?php if( auth_can_impersonate( $f_user_id ) ) { ?>
+		<form id="manage-user-impersonate-form" method="post" action="manage_user_impersonate.php" class="action-button">
+			<fieldset>
+				<?php echo form_security_field( 'manage_user_impersonate' ) ?>
+				<input type="hidden" name="user_id" value="<?php echo $f_user_id ?>" />
+				<span><input type="submit" class="button" value="<?php echo lang_get( 'impersonate_user_button' ) ?>" /></span>
+			</fieldset>
+		</form>
 	<?php } ?>
 	</span>
 </div><?php


### PR DESCRIPTION
There are multiple scenarios where user impersonation is a useful feature. For example:

1. When an administrator is troubleshooting an error reported by one of the users.
2. When an administrator wants to verify what issues/projects are and are not visible to specific user.
3. When a user creates an (service) account and wants to create an API key for such account.

Any user with the access of managing users, should be able to do the above. Hence,
instead of specifically checking for "administrator" access level, use the config
option 'manage_user_threshold'.

Fixes #20772