### PR TITLE
Use JSON format in Configuration Report

### DIFF
--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -124,7 +124,7 @@ function print_config_value_as_string( $p_type, $p_value, $p_for_display = true 
 	if( $t_corrupted ) {
 		$t_output = $p_for_display ? lang_get( 'configuration_corrupted' ) : '';
 	} else {
-		$t_output = var_export( $t_value, true );
+		$t_output = json_encode( $t_value, JSON_PRETTY_PRINT | JSON_NUMERIC_CHECK );
 	}
 
 	if( $p_for_display ) {

--- a/adm_config_set.php
+++ b/adm_config_set.php
@@ -114,7 +114,7 @@ switch( $t_type ) {
 		break;
 	case CONFIG_TYPE_COMPLEX:
 	default:
-		$t_value = process_complex_value( $f_value );
+		$t_value = process_complex_json_value( $f_value );
 		break;
 }
 
@@ -124,82 +124,21 @@ form_security_purge( 'adm_config_set' );
 
 print_successful_redirect( 'adm_config_report.php' );
 
-
 /**
  * Helper function to recursively process complex types
- * We support the following kind of variables here:
- * 1. constant values (like the ON/OFF switches): they are defined as constants mapping to numeric values
- * 2. simple arrays with the form: array( a, b, c, d )
- * 3. associative arrays with the form: array( a=>1, b=>2, c=>3, d=>4 )
- * 4. multi-dimensional arrays
- * commas and '=>' within strings are handled
+ * Input should be a JSON frmatted structure. If JSON parsin fails, we try to
+ * parse an integer, or else, return as a plain string
  *
- * @param string  $p_value      Complex value to process.
- * @param boolean $p_trim_quotes Whether to trim quotes.
- * @return parsed variable
+ * @param string $p_value
+ * @return mixed Parsed variable
  */
-function process_complex_value( $p_value, $p_trim_quotes = false ) {
-	static $s_regex_array = null;
-	static $s_regex_string = null;
-	static $s_regex_element = null;
-
-	$t_value = trim( $p_value );
-
-	# Parsing regex initialization
-	if( is_null( $s_regex_array ) ) {
-		$s_regex_array = '^array[\s]*\((.*)\)[;]*$';
-		$s_regex_string =
-			# unquoted string (word)
-			'[\w]+' . '|' .
-			# single-quoted string
-			"'(?:[^'\\\\]|\\\\.)*'" . '|' .
-			# double-quoted string
-			'"(?:[^"\\\\]|\\\\.)*"';
-		# The following complex regex will parse individual array elements,
-		# taking into consideration sub-arrays, associative arrays and single,
-		# double and un-quoted strings
-		# @TODO dregad reverse pattern logic for sub-array to avoid match on array(xxx)=>array(xxx)
-		$s_regex_element = '('
-			# Main sub-pattern - match one of
-			. '(' .
-					# sub-array: ungreedy, no-case match ignoring nested parenthesis
-					'(?:(?iU:array\s*(?:\\((?:(?>[^()]+)|(?1))*\\))))' . '|' .
-					$s_regex_string
-			. ')'
-			# Optional pattern for associative array, back-referencing the
-			# above main pattern
-			. '(?:\s*=>\s*(?2))?' .
-			')';
-	}
-
-	if( preg_match( '/' . $s_regex_array . '/s', $t_value, $t_match ) === 1 ) {
-		# It's an array - process each element
-		$t_processed = array();
-
-		if( preg_match_all( '/' . $s_regex_element . '/', $t_match[1], $t_elements ) ) {
-			foreach( $t_elements[0] as $t_key => $t_element ) {
-				if( !trim( $t_element ) ) {
-					# Empty element - skip it
-					continue;
-				}
-				# Check if element is associative array
-				preg_match_all( '/(' . $s_regex_string . ')\s*=>\s*(.*)/', $t_element, $t_split );
-				if( !empty( $t_split[0] ) ) {
-					# associative array
-					$t_new_key = constant_replace( trim( $t_split[1][0], " \t\n\r\0\x0B\"'" ) );
-					$t_new_value = process_complex_value( $t_split[2][0], true );
-					$t_processed[$t_new_key] = $t_new_value;
-				} else {
-					# regular array
-					$t_new_value = process_complex_value( $t_element );
-					$t_processed[$t_key] = $t_new_value;
-				}
-			}
-		}
+function process_complex_json_value( $p_value ) {
+	$t_processed = json_decode( $p_value, true );
+	if( null !== $t_processed ) {
 		return $t_processed;
 	} else {
 		# Scalar value
-		$t_value = trim( $t_value, " \t\n\r\0\x0B" );
+		$t_value = trim( $p_value, " \t\n\r\0\x0B" );
 
 		if( is_numeric( $t_value ) ) {
 			return (int)$t_value;
@@ -218,50 +157,6 @@ function process_complex_value( $p_value, $p_trim_quotes = false ) {
 		return $t_value;
 	}
 }
-
-/**
- * Split by commas, but ignore commas that are within quotes or parenthesis.
- * Ignoring commas within parenthesis helps allow for multi-dimensional arrays.
- * @param string $p_string String to split.
- * @return array
- */
-function special_split ( $p_string ) {
-	$t_values = array();
-	$t_array_element = '';
-	$t_paren_level = 0;
-	$t_inside_quote = false;
-	$t_escape_next = false;
-
-	foreach( str_split( trim( $p_string ) ) as $t_character ) {
-		if( $t_escape_next ) {
-			$t_array_element .= $t_character;
-			$t_escape_next = false;
-		} else if( $t_character == ',' && $t_paren_level==0 && !$t_inside_quote ) {
-			array_push( $t_values, $t_array_element );
-			$t_array_element = '';
-		} else {
-			if( $t_character == '(' && !$t_inside_quote ) {
-				$t_paren_level++;
-			} else if( $t_character == ')' && !$t_inside_quote ) {
-				$t_paren_level--;
-			} else if( $t_character == '\'' ) {
-				$t_inside_quote = !$t_inside_quote;
-			} else if( $t_character == '\\' ) {
-				# escape character
-				$t_escape_next = true;
-				# keep the escape if the string will be going through another recursion
-				if( $t_paren_level > 0 ) {
-					$t_array_element .= $t_character;
-				}
-				continue;
-			}
-			$t_array_element .= $t_character;
-		}
-	}
-	array_push( $t_values, $t_array_element );
-	return $t_values;
-}
-
 
 /**
  * Check if the passed string is a constant and returns its value


### PR DESCRIPTION
Use JSON format for displaying and parsing complex type configuration
values.
Due to some errors in the current parser (eg, #20787, #20812, #20813), moving to JSON may be a solution to forget all the troubles that come with parsing regexps.
The core problem is that some complex expressions, as stored and displayed by this page, cannot be parsed back correctly.

This PR is a stub, that if found valid, can be further developed and refined.