### PR TITLE
Custom field description

### DIFF
--- a/admin/schema.php
+++ b/admin/schema.php
@@ -884,6 +884,9 @@ $g_upgrade[209] = array( 'AlterColumnSQL', array( db_get_table( 'api_token' ), "
 
 # Release marker: 1.3.0
 
+# Add description field to custom field definition
+$g_upgrade[210] = array( 'AddColumnSQL', array( db_get_table( 'custom_field' ), "
+	description					XL		$t_notnull DEFAULT \" '' \"" ) );
 
 # ----------------------------------------------------------------------------
 # End of schema definition, clear local variables

--- a/api/soap/mantisconnect.wsdl
+++ b/api/soap/mantisconnect.wsdl
@@ -328,6 +328,7 @@
    <xsd:element name="require_update" type="xsd:boolean" minOccurs="0"/>
    <xsd:element name="require_resolved" type="xsd:boolean" minOccurs="0"/>
    <xsd:element name="require_closed" type="xsd:boolean" minOccurs="0"/>
+   <xsd:element name="description" type="xsd:string" minOccurs="0"/>
   </xsd:all>
  </xsd:complexType>
  <xsd:complexType name="FilterCustomField">

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -664,6 +664,7 @@ function mc_project_get_custom_fields( $p_username, $p_password, $p_project_id )
 				'require_update' => $t_def['require_update'],
 				'require_resolved' => $t_def['require_resolved'],
 				'require_closed' => $t_def['require_closed'],
+				'description' => $t_def['description'],
 			);
 		}
 	}

--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -292,6 +292,8 @@ print_recently_visited();
 	<div class="field-container">
 		<label <?php echo $t_class_required ?> for="due_date">
 			<span><?php echo lang_get_defaulted( $t_def['name'] ) ?></span>
+			<br />
+			<span class="small"><?php echo string_display_links( $t_def['description'] ) ?></span>
 		</label>
 		<span class="input">
 <?php

--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -292,8 +292,10 @@ print_recently_visited();
 	<div class="field-container">
 		<label <?php echo $t_class_required ?> for="due_date">
 			<span><?php echo lang_get_defaulted( $t_def['name'] ) ?></span>
-			<br />
-			<span class="small"><?php echo string_display_links( $t_def['description'] ) ?></span>
+			<?php if( !is_blank( $t_def['description'] ) ) {
+				echo '<br />';
+				echo '<span class="small">' . string_display_links( $t_def['description'] ) . '</span>';
+			} ?>
 		</label>
 		<span class="input">
 <?php

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -577,8 +577,10 @@ if( $t_show_attachments ) {
 			<div class="field-container">
 				<label <?php echo $t_required_class, $t_label_for; ?>>
 					<span><?php echo string_display( lang_get_defaulted( $t_def['name'] ) ) ?></span>
-					<br />
-					<span class="small"><?php echo string_display_links( $t_def['description'] ) ?></span>
+					<?php if ( !is_blank( $t_def['description'] ) ) {
+						echo '<br />';
+						echo '<span class="small">' . string_display_links( $t_def['description'] ) . '</span>';
+					} ?>
 				</label>
 
 				<span class="input">

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -575,9 +575,11 @@ if( $t_show_attachments ) {
 			}
 ?>
 			<div class="field-container">
-				<label <?php echo $t_required_class, $t_label_for; ?>><span><?php
-					echo string_display( lang_get_defaulted( $t_def['name'] ) );
-				?></span></label>
+				<label <?php echo $t_required_class, $t_label_for; ?>>
+					<span><?php echo string_display( lang_get_defaulted( $t_def['name'] ) ) ?></span>
+					<br />
+					<span class="small"><?php echo string_display_links( $t_def['description'] ) ?></span>
+				</label>
 
 				<span class="input">
 					<?php print_custom_field_input( $t_def, ( $f_master_bug_id === 0 ) ? null : $f_master_bug_id ) ?>

--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -475,6 +475,10 @@ function custom_field_update( $p_field_id, array $p_def_array ) {
 				$t_update .= $t_field . '=' . db_param() . ', ';
 				$t_params[] = (bool)$t_value;
 				break;
+			case 'description':
+				$t_update .= $t_field . '=' . db_param() . ', ';
+				$t_params[] = empty($t_value) ? '' : (string)$t_value;
+				break;
 		}
 	}
 

--- a/docbook/Admin_Guide/en-US/Customizing.xml
+++ b/docbook/Admin_Guide/en-US/Customizing.xml
@@ -160,6 +160,12 @@ $s_CODE = STRING;
 					</para></note>
 				</listitem>
 				<listitem>
+					<para>Description is a text that will be displayed alongside the filed name
+						in the label section of form inputs. This can be used to hint the user for
+						expected values, or as informative description of its usage.
+					</para>
+				</listitem>
+				<listitem>
 					<para>Custom field type. Available types are defined as this table:
 					</para>
 					<informaltable>

--- a/docbook/Admin_Guide/en-US/Customizing.xml
+++ b/docbook/Admin_Guide/en-US/Customizing.xml
@@ -75,75 +75,75 @@ $s_CODE = STRING;
 		</para></warning>
 	</section>
 
-    <section id="admin.customize.customfields">
-        <title>Custom Fields</title>
+	<section id="admin.customize.customfields">
+		<title>Custom Fields</title>
 
 	<section id="admin.customize.customfields.overview">
 	<title>Overview</title>
 
-        <para>Different teams typically like to capture different information
-	as users report issues, in some cases, the data required is even
-	different from one project to another.  Hence, MantisBT provides the
-	ability for managers and administrators to define custom fields as way
-	to extend MantisBT to deal with information that is specific to their
-	teams or their projects.  The aim is for this to keep MantisBT native
-	fields to a minimum.
+		<para>Different teams typically like to capture different information
+			as users report issues, in some cases, the data required is even
+			different from one project to another.  Hence, MantisBT provides the
+			ability for managers and administrators to define custom fields as way
+			to extend MantisBT to deal with information that is specific to their
+			teams or their projects.  The aim is for this to keep MantisBT native
+			fields to a minimum.
 
-	Following are some facts about the implementation of
-        custom fields in MantisBT:
-            <itemizedlist>
-                <listitem>
-                    <para>Custom fields are defined system wide.</para>
-                </listitem>
-                <listitem>
-                    <para>Custom fields can be linked to multiple
-                        projects.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>The sequence of displaying custom fields can be different
-                        per project.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Custom fields must be defined by users with access level
-                        ADMINISTRATOR.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Custom fields can be linked to projects by users with
-                        access level MANAGER or above (by default, this can be
-                        configurable).
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Number of custom fields is not restricted.</para>
-                </listitem>
-		<listitem>
-		    <para>Users can define filters that include custom fields.</para>
-		</listitem>
-		<listitem>
-		    <para>Custom fields can be included in View Issues, Print
-		    Issues, and CSV exports.</para>
-		</listitem>
-		<listitem>
-		    <para>Enumeration custom fields can have a set of static
-		    values or values that are calculated dynamically based on
-		    a custom function.</para>
-		</listitem>
-            </itemizedlist>
-        </para>
-        </section>
+			Following are some facts about the implementation of
+			custom fields in MantisBT:
+			<itemizedlist>
+				<listitem>
+					<para>Custom fields are defined system wide.</para>
+				</listitem>
+				<listitem>
+					<para>Custom fields can be linked to multiple
+						projects.
+					</para>
+				</listitem>
+				<listitem>
+					<para>The sequence of displaying custom fields can be different
+						per project.
+					</para>
+				</listitem>
+				<listitem>
+					<para>Custom fields must be defined by users with access level
+						ADMINISTRATOR.
+					</para>
+				</listitem>
+				<listitem>
+					<para>Custom fields can be linked to projects by users with
+						access level MANAGER or above (by default, this can be
+						configurable).
+					</para>
+				</listitem>
+				<listitem>
+					<para>Number of custom fields is not restricted.</para>
+				</listitem>
+				<listitem>
+					<para>Users can define filters that include custom fields.</para>
+				</listitem>
+				<listitem>
+					<para>Custom fields can be included in View Issues, Print
+					Issues, and CSV exports.</para>
+				</listitem>
+				<listitem>
+					<para>Enumeration custom fields can have a set of static
+					values or values that are calculated dynamically based on
+					a custom function.</para>
+				</listitem>
+			</itemizedlist>
+		</para>
+		</section>
 
 	<section id="admin.customize.customfields.definitions">
-	    <title>Custom Field Definition</title>
+		<title>Custom Field Definition</title>
 
-        <para>
-            The definition of a custom field includes the following logical
-            attributes:
+		<para>
+			The definition of a custom field includes the following logical
+			attributes:
 
-            <itemizedlist>
-                <listitem>
+			<itemizedlist>
+				<listitem>
 					<para>Caption variable name.
 						This value is supplied to the lang_get() API; it is
 						therefore mandatory to set this to a
@@ -158,209 +158,213 @@ $s_CODE = STRING;
 						(see <xref linkend="admin.customize.strings"/>),
 						then it will be displayed as-is.
 					</para></note>
-                </listitem>
-                <listitem>
-                    <para>Custom field type (string, numeric, float,
-		    enumeration, email, checkbox, radio, list, multi-selection list, date).
-                    </para>
-		    <para>Type 'string' is used for strings of up to 255 characters.</para>
-		    <para>Type 'numeric' is used for numerical integer values.</para>
-		    <para>Type 'float' is used for real (float / double) numbers.</para>
-		    <para>Type 'enumeration' is used when a user selects one entry from a list.  The user interface for such type is a combo-box.</para>
-		    <para>Type 'email' is used for storing email addresses.</para>
-		    <para>Type 'checkbox' is like enumeration but the list is shown as checkboxes and the user is allowed to tick more than one selection.  The default value and the possible value can contain multiple values like 'RED|YELLOW|BLUE' (without the single quote).</para>
-			<para>Type 'radio' is like enumeration but the list is shown as radio buttons and the user is allowed to tick on of the options.  The possible values can be 'RED|YELLOW|BLUE', where the default value can be 'YELLOW'.  Note that the default value can't contain multiple values.</para>
-		    <para>Type 'list' is like enumeration but the list is shown as a list box where the user is only allowed to select one option.  The possible values can be 'RED|YELLOW|BLUE', where the default value can be 'YELLOW'.  Note that the default value can't contain multiple values.</para>
-		    <para>Type 'multi-selection list' is like enumeration but the list is shown as a list box where the user is allowed to select multiple options.  The possible values can be 'RED|YELLOW|BLUE', where the default value can be 'RED|BLUE'.  Note that in this case the default value contains multiple values.</para>
-		    <para>Type 'date' is for date values.  The default value can be empty, or {tomorrow}, {yesterday}, {next week}, {last week}, {+3 days}, {-2 days}.</para>
-                </listitem>
-                <listitem>
-                    <para>Enumeration possible values (eg: RED|YELLOW|BLUE).
-                        Use the pipe ('|') character to separate possible values for an
-                        enumeration. One of the possible values can be an
-			empty string.  The set of possible values can also be
-			calculated at runtime.  For example, "=versions" would
-			automatically resolve into all the versions defined
-			for the current project.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Default value - see details above for a sample default value for each type.</para>
-                </listitem>
-                <listitem>
-                    <para>Minimum/maximum length for the custom field value (use 0
-                        to disable).  Note that these metrics are not really relevant to custom fields that are based on an enumeration of possible values.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Regular expression to use for validating user input (use <ulink url="http://www.php.net/manual/en/reference.pcre.pattern.syntax.php">PCRE syntax</ulink>).
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Read Access level: Minimum access level for users to be
-                        able to see the value of the custom field.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Write Access level: Minimum access level for users to be
-                        able to edit the value of the custom field.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Display when reporting issues? - If this custom
-		    field should be shown on the Report Issue page.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Display when updating issues? - If this custom
-		    field should be shown on the Update Issue page.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Display when resolving issues? - If this custom
-		    field should be shown when resolving an issue.  For
-		    example, a "root cause" custom field would make sense to
-		    set when resolving the issue.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Display when closing issues? - If this custom
-		    field should be shown when closing an issue.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Required on Report - If this custom
-		    field is a mandatory field on the Report Issue page.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Required on Update - If this custom
-		    field is a mandatory field on the Update Issue page.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Required on Resolve - If this custom
-		    field is a mandatory field when resolving an issue.
-                    </para>
-                </listitem>
-                <listitem>
-                    <para>Required on Close - If this custom
-		    field is a mandatory field when closing an issue.
-                    </para>
-                </listitem>
-            </itemizedlist>
-        </para>
+				</listitem>
+				<listitem>
+					<para>Custom field type (string, numeric, float,
+						enumeration, email, checkbox, radio, list, multi-selection list, date).
+					</para>
+					<para>Type 'string' is used for strings of up to 255 characters.</para>
+					<para>Type 'numeric' is used for numerical integer values.</para>
+					<para>Type 'float' is used for real (float / double) numbers.</para>
+					<para>Type 'enumeration' is used when a user selects one entry from a list.  The user interface for such type is a combo-box.</para>
+					<para>Type 'email' is used for storing email addresses.</para>
+					<para>Type 'checkbox' is like enumeration but the list is shown as checkboxes and the user is allowed to tick more than one selection.  The default value and the possible value can contain multiple values like 'RED|YELLOW|BLUE' (without the single quote).</para>
+					<para>Type 'radio' is like enumeration but the list is shown as radio buttons and the user is allowed to tick on of the options.  The possible values can be 'RED|YELLOW|BLUE', where the default value can be 'YELLOW'.  Note that the default value can't contain multiple values.</para>
+					<para>Type 'list' is like enumeration but the list is shown as a list box where the user is only allowed to select one option.  The possible values can be 'RED|YELLOW|BLUE', where the default value can be 'YELLOW'.  Note that the default value can't contain multiple values.</para>
+					<para>Type 'multi-selection list' is like enumeration but the list is shown as a list box where the user is allowed to select multiple options.  The possible values can be 'RED|YELLOW|BLUE', where the default value can be 'RED|BLUE'.  Note that in this case the default value contains multiple values.</para>
+					<para>Type 'date' is for date values.  The default value can be empty, or {tomorrow}, {yesterday}, {next week}, {last week}, {+3 days}, {-2 days}.</para>
+				</listitem>
+				<listitem>
+					<para>Enumeration possible values (eg: RED|YELLOW|BLUE).
+						Use the pipe ('|') character to separate possible values for an
+						enumeration. One of the possible values can be an
+						empty string.  The set of possible values can also be
+						calculated at runtime.  For example, "=versions" would
+						automatically resolve into all the versions defined
+						for the current project.
+					</para>
+				</listitem>
+				<listitem>
+					<para>Default value - see details above for a sample default value for each type.</para>
+				</listitem>
+				<listitem>
+					<para>Minimum/maximum length for the custom field value (use 0
+						to disable).  Note that these metrics are not really relevant to custom fields that are based on an enumeration of possible values.
+					</para>
+				</listitem>
+				<listitem>
+					<para>Regular expression to use for validating user input (use <ulink url="http://www.php.net/manual/en/reference.pcre.pattern.syntax.php">PCRE syntax</ulink>).
+					</para>
+				</listitem>
+				<listitem>
+					<para>Read Access level: Minimum access level for users to be
+						able to see the value of the custom field.
+					</para>
+				</listitem>
+				<listitem>
+					<para>Write Access level: Minimum access level for users to be
+						able to edit the value of the custom field.
+					</para>
+				</listitem>
+				<listitem>
+					<para>Display when reporting issues? - If this custom
+						field should be shown on the Report Issue page.
+					</para>
+				</listitem>
+				<listitem>
+					<para>Display when updating issues? - If this custom
+						field should be shown on the Update Issue page.
+					</para>
+				</listitem>
+				<listitem>
+					<para>Display when resolving issues? - If this custom
+						field should be shown when resolving an issue.  For
+						example, a "root cause" custom field would make sense to
+						set when resolving the issue.
+					</para>
+				</listitem>
+				<listitem>
+					<para>Display when closing issues? - If this custom
+						field should be shown when closing an issue.
+					</para>
+				</listitem>
+				<listitem>
+					<para>Required on Report - If this custom
+						field is a mandatory field on the Report Issue page.
+					</para>
+				</listitem>
+				<listitem>
+					<para>Required on Update - If this custom
+						field is a mandatory field on the Update Issue page.
+					</para>
+				</listitem>
+				<listitem>
+					<para>Required on Resolve - If this custom
+						field is a mandatory field when resolving an issue.
+					</para>
+				</listitem>
+				<listitem>
+					<para>Required on Close - If this custom
+						field is a mandatory field when closing an issue.
+					</para>
+				</listitem>
+			</itemizedlist>
+		</para>
 
-        <para>All custom fields are currently saved to a field of type
-        VARCHAR(255) in the database. However, in future releases, it is
-        possible to support custom fields of different types (eg: memo,
-        file).</para>
+		<para>All custom fields are currently saved to a field of type
+			VARCHAR(255) in the database. However, in future releases, it is
+			possible to support custom fields of different types (eg: memo,
+			file).
+		</para>
 
-        <para>
-            If the value of a custom field for a certain defect is not found,
-            the default value is assumed.
-        </para>
-    </section>
+		<para>
+			If the value of a custom field for a certain defect is not found,
+			the default value is assumed.
+		</para>
+	</section>
 
-    <section id="admin.customize.customfields.editing">
-        <title>Adding/Editing Custom Fields</title>
+	<section id="admin.customize.customfields.editing">
+		<title>Adding/Editing Custom Fields</title>
 
-            <para>
-                <itemizedlist>
-                    <listitem>
-                        <para>The logged in user needs $g_manage_custom_fields_threshold
-                            access level.
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>Select "Manage" from the main menu.</para>
-                    </listitem>
-                    <listitem>
-                        <para>Select "Manage Custom Fields" from the management
-                            menu.
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>In case of edit, click on the name of an existing
-			custom field to edit its information.
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>In case of adding a new one, enter the name of the
-			new custom field then click "New Custom Field".
-                        </para>
-                    </listitem>
-                </itemizedlist>
-            </para>
+			<para>
+				<itemizedlist>
+					<listitem>
+						<para>The logged in user needs $g_manage_custom_fields_threshold
+							access level.
+						</para>
+					</listitem>
+					<listitem>
+						<para>Select "Manage" from the main menu.
+						</para>
+					</listitem>
+					<listitem>
+						<para>Select "Manage Custom Fields" from the management menu.
+						</para>
+					</listitem>
+					<listitem>
+						<para>In case of edit, click on the name of an existing
+							custom field to edit its information.
+						</para>
+					</listitem>
+					<listitem>
+						<para>In case of adding a new one, enter the name of the
+							new custom field then click "New Custom Field".
+						</para>
+					</listitem>
+				</itemizedlist>
+			</para>
 
-	    <note><para>Added custom fields will not show up in any of the issues
-	    until the added custom field is linked to the appropriate
-	    projects.</para></note>
+		<note>
+			<para>Added custom fields will not show up in any of the issues
+				until the added custom field is linked to the appropriate
+				projects.
+			</para>
+		</note>
 	</section>
 
 	<section id="admin.customize.customfields.linking">
 		<title>Linking/Unlinking/Ordering Existing Custom Fields in Projects</title>
 
-            <para>
-                <itemizedlist>
-                    <listitem>
-                        <para>The logged in user needs to have access level that is
-                            greater than or equal to $g_custom_field_link_threshold and
-                            $g_manage_project_threshold.
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>Select "Manage" from the main menu.</para>
-                    </listitem>
-                    <listitem>
-                        <para>Select "Manage Projects".
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>Select the name of the project to manage.</para>
-                    </listitem>
-                    <listitem>
-                        <para>Scroll down to the "Custom Fields" box.</para>
-                    </listitem>
-                    <listitem>
-                        <para>Select the field to add from the list, then click "Add
-                            This Existing Custom Field".
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>To change the order of the custom fields, edit the
-                            "Sequence" value and click update. Custom fields with smaller
-                            values are displayed first.
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>To unlink a custom field, click on "Remove" link next to
-                            the field.
-                            Unlinking a custom field will not delete the values that are
-                            associated with the issues for this field. These values are only
-                            deleted if the custom field definition is removed (not unlinked!)
-                            from the database. This is useful if you decide to re-link the
-                            custom field. These values may also re-appear if issues are moved to
-                            another project which has this field linked.
-                        </para>
-                    </listitem>
-                </itemizedlist>
-            </para>
+			<para>
+				<itemizedlist>
+					<listitem>
+						<para>The logged in user needs to have access level that is
+							greater than or equal to $g_custom_field_link_threshold and
+							$g_manage_project_threshold.
+						</para>
+					</listitem>
+					<listitem>
+						<para>Select "Manage" from the main menu.</para>
+					</listitem>
+					<listitem>
+						<para>Select "Manage Projects".
+						</para>
+					</listitem>
+					<listitem>
+						<para>Select the name of the project to manage.</para>
+					</listitem>
+					<listitem>
+						<para>Scroll down to the "Custom Fields" box.</para>
+					</listitem>
+					<listitem>
+						<para>Select the field to add from the list, then click "Add
+							This Existing Custom Field".
+						</para>
+					</listitem>
+					<listitem>
+						<para>To change the order of the custom fields, edit the
+							"Sequence" value and click update. Custom fields with smaller
+							values are displayed first.
+						</para>
+					</listitem>
+					<listitem>
+						<para>To unlink a custom field, click on "Remove" link next to
+							the field.
+							Unlinking a custom field will not delete the values that are
+							associated with the issues for this field. These values are only
+							deleted if the custom field definition is removed (not unlinked!)
+							from the database. This is useful if you decide to re-link the
+							custom field. These values may also re-appear if issues are moved to
+							another project which has this field linked.
+						</para>
+					</listitem>
+				</itemizedlist>
+			</para>
 
-        <formalpara>
-            <title>Moving Issues</title>
-            <para>
-                When an issue is moved from one project to another, custom
-                fields that are not defined for the new project are not deleted.
-                These fields will re-appear with their correct values if the issue is
-                moved back to the original project, or if these custom fields are
-                linked to the new project.
-            </para>
-        </formalpara>
+		<formalpara>
+			<title>Moving Issues</title>
+			<para>
+				When an issue is moved from one project to another, custom
+				fields that are not defined for the new project are not deleted.
+				These fields will re-appear with their correct values if the issue is
+				moved back to the original project, or if these custom fields are
+				linked to the new project.
+			</para>
+		</formalpara>
 	</section>
 
- 	<section id="admin.customize.customfields.localize">
-	    <title>Localizing Custom Field Names</title>
+	<section id="admin.customize.customfields.localize">
+		<title>Localizing Custom Field Names</title>
 
 		<para>It is possible to localize the custom fields' labels.
 			This can be done as follows:
@@ -404,7 +408,8 @@ switch( $g_active_language ) {
 		break;
 }
 </programlisting>
-							</para></listitem>
+								</para>
+							</listitem>
 						</itemizedlist>
 					</para>
 				</listitem>
@@ -422,11 +427,11 @@ switch( $g_active_language ) {
 		</para></note>
 	</section>
 
-        <section id="admin.customize.customfields.defaults">
-            <title>Dynamic default values</title>
+		<section id="admin.customize.customfields.defaults">
+			<title>Dynamic default values</title>
 
-            <section id="admin.customize.customfields.defaults.date">
-                <title>Dynamic defaults for Date fields</title>
+			<section id="admin.customize.customfields.defaults.date">
+				<title>Dynamic defaults for Date fields</title>
 
 				<para>Custom fields of type date can be defaulted to
 					either specific or relative dates.
@@ -447,66 +452,76 @@ switch( $g_active_language ) {
 					<ulink url="http://www.php.net/strtotime">strtotime()</ulink>
 					function.
 				</para>
-            </section>
-        </section>
+			</section>
+		</section>
 
 	<section id="admin.customize.customfields.dynamic">
-	    <title>Dynamic values for Enumeration Custom Fields</title>
+		<title>Dynamic values for Enumeration Custom Fields</title>
 
-	    <para>As discussed earlier, one of the possible types of a custom
-	    field is "enumeration".  This type of custom field allows the user
-	    to select one value from a provided list of possible values.  The
-	    standard way of defining such custom fields is to provide a '|'
-	    separated list of possible values.  However, this approach has two
-	    limitations: the list is static, and the maximum length of the list
-	    must be no longer than 255 characters.  Hence, the need for the
-	    ability to construct the list of possible values dynamically.</para>
+		<para>As discussed earlier, one of the possible types of a custom
+			field is "enumeration".  This type of custom field allows the user
+			to select one value from a provided list of possible values.  The
+			standard way of defining such custom fields is to provide a '|'
+			separated list of possible values.  However, this approach has two
+			limitations: the list is static, and the maximum length of the list
+			must be no longer than 255 characters.  Hence, the need for the
+			ability to construct the list of possible values dynamically.
+		</para>
 
 
-            <section id="admin.customize.customfields.dynamic.default">
-	       <title>Dynamic possible values included by default</title>
+		<section id="admin.customize.customfields.dynamic.default">
+			<title>Dynamic possible values included by default</title>
 
-	    <para>MantisBT ships with some dynamic possible values, these
-	    include the following:
+			<para>MantisBT ships with some dynamic possible values, these
+				include the following:
 
-	    	<itemizedlist>
-		    <listitem><para>=categories - a list of categories defined
-		    in the current project (or the project to which the issue
-		    belongs).</para></listitem>
-		    <listitem><para>=versions - a list of all versions defined
-		    in the current project (or the project to which the issue
-		    belongs).</para></listitem>
-		    <listitem><para>=future_versions - a list of all versions that
-		    belong to the current project with
-		    released flag set to false.</para></listitem>
-		    <listitem><para>=released_versions - a list of all versions
-		    that belong to the current project with released flag set to
-		    true.</para></listitem>
-		</itemizedlist>
-	    </para>
+				<itemizedlist>
+					<listitem><para>=categories - a list of categories defined
+						in the current project (or the project to which the issue
+						belongs).
+					</para>
+					</listitem>
+					<listitem><para>=versions - a list of all versions defined
+						in the current project (or the project to which the issue
+						belongs).</para>
+					</listitem>
+					<listitem><para>=future_versions - a list of all versions that
+						belong to the current project with
+						released flag set to false.</para>
+					</listitem>
+					<listitem><para>=released_versions - a list of all versions
+						that belong to the current project with released flag set to
+						true.</para>
+					</listitem>
+				</itemizedlist>
+			</para>
 
-	    <note><para>The '=' before the name of the dynamic list of options is used
-	    to tell MantisBT that this is a dynamic list, rather than a static
-	    list with just one option.</para></note>
+			<note>
+				<para>The '=' before the name of the dynamic list of options is used
+					to tell MantisBT that this is a dynamic list, rather than a static
+					list with just one option.
+				</para>
+			</note>
 
-	    </section>
+		</section>
 
-	    <section id="admin.customize.customfields.dynamic.custom">
-	        <title>Defining Custom Dynamic Possible Values</title>
+		<section id="admin.customize.customfields.dynamic.custom">
+			<title>Defining Custom Dynamic Possible Values</title>
 
-		<para>If the user selects =versions, the actual custom function
-		that is executed is custom_function_*_enum_versions(). The reason
-		why the "enum_" is not included is to have a fixed prefix for all
-		custom functions used for this purpose and protect against users
-		using custom functions that were not intended for this purpose.
-		For example, you don't want the user to use
-		custom_function_*_issue_delete_notify() which may be overridden
-		by the web master to delete associated data in other
-		databases.</para>
+			<para>If the user selects =versions, the actual custom function
+				that is executed is custom_function_*_enum_versions(). The reason
+				why the "enum_" is not included is to have a fixed prefix for all
+				custom functions used for this purpose and protect against users
+				using custom functions that were not intended for this purpose.
+				For example, you don't want the user to use
+				custom_function_*_issue_delete_notify() which may be overridden
+				by the web master to delete associated data in other
+				databases.
+			</para>
 
-		<para>Following is a sample custom function that is used to
-		populate a field with the categories belonging to the currently
-		selected project:
+			<para>Following is a sample custom function that is used to
+				populate a field with the categories belonging to the currently
+				selected project:
 
 <programlisting># --------------------
 # Construct an enumeration for all categories for the current project.
@@ -525,24 +540,23 @@ function custom_function_override_enum_categories() {
 
     return $t_possible_values;
 }</programlisting>
-</para>
+			</para>
 
-<para>Notice the following:
+			<para>Notice the following:
+				<itemizedlist>
+					<listitem><para>The custom function doesn't take any
+					parameters.</para></listitem>
+					<listitem><para>The custom function returns the possible values in the
+					format (A|B|C).</para></listitem>
+					<listitem><para>The custom function uses the current
+					project.</para></listitem>
+					<listitem><para>The custom function builds on top of the already
+					existing APIs.</para></listitem>
+				</itemizedlist>
+			</para>
 
-<itemizedlist>
-	<listitem><para>The custom function doesn't take any
-	parameters.</para></listitem>
-	<listitem><para>The custom function returns the possible values in the
-	format (A|B|C).</para></listitem>
-   	<listitem><para>The custom function uses the current
-	project.</para></listitem>
-	<listitem><para>The custom function builds on top of the already
-	existing APIs.</para></listitem>
-</itemizedlist>
-</para>
-
-<para>To define your own function \u201c=mine\u201d, you will have to define it
-with the following signature:
+			<para>To define your own function &#8220;=mine&#8221;, you will have to define it
+				with the following signature:
 
 <programlisting>
 # --------------------
@@ -557,22 +571,24 @@ function custom_function_override_enum_mine() {
     return $t_possible_values;
 }
 </programlisting>
-</para>
+			</para>
 
-<para>Notice "override" in the function name. This is because this method is
-defined by the MantisBT administrator/webmaster and not part of the MantisBT source.
-It is OK to override a method that doesn't exist.</para>
+			<para>Notice "override" in the function name. This is because this method is
+				defined by the MantisBT administrator/webmaster and not part of the MantisBT source.
+				It is OK to override a method that doesn't exist.
+			</para>
 
-<para>As usual, when MantisBT is upgraded to future releases, the custom functions
-will not be overwritten. The difference between the "default" implementation and
-the "override" implementation is explained in more details in the custom
-functions section.</para>
+			<para>As usual, when MantisBT is upgraded to future releases, the custom functions
+				will not be overwritten. The difference between the "default" implementation and
+				the "override" implementation is explained in more details in the custom
+				functions section.
+			</para>
+
+		</section>
 
 	</section>
 
-        </section>
-
-    </section>
+	</section>
 
     <section id="admin.customize.enums">
         <title>Enumerations</title>

--- a/docbook/Admin_Guide/en-US/Customizing.xml
+++ b/docbook/Admin_Guide/en-US/Customizing.xml
@@ -160,19 +160,102 @@ $s_CODE = STRING;
 					</para></note>
 				</listitem>
 				<listitem>
-					<para>Custom field type (string, numeric, float,
-						enumeration, email, checkbox, radio, list, multi-selection list, date).
+					<para>Custom field type. Available types are defined as this table:
 					</para>
-					<para>Type 'string' is used for strings of up to 255 characters.</para>
-					<para>Type 'numeric' is used for numerical integer values.</para>
-					<para>Type 'float' is used for real (float / double) numbers.</para>
-					<para>Type 'enumeration' is used when a user selects one entry from a list.  The user interface for such type is a combo-box.</para>
-					<para>Type 'email' is used for storing email addresses.</para>
-					<para>Type 'checkbox' is like enumeration but the list is shown as checkboxes and the user is allowed to tick more than one selection.  The default value and the possible value can contain multiple values like 'RED|YELLOW|BLUE' (without the single quote).</para>
-					<para>Type 'radio' is like enumeration but the list is shown as radio buttons and the user is allowed to tick on of the options.  The possible values can be 'RED|YELLOW|BLUE', where the default value can be 'YELLOW'.  Note that the default value can't contain multiple values.</para>
-					<para>Type 'list' is like enumeration but the list is shown as a list box where the user is only allowed to select one option.  The possible values can be 'RED|YELLOW|BLUE', where the default value can be 'YELLOW'.  Note that the default value can't contain multiple values.</para>
-					<para>Type 'multi-selection list' is like enumeration but the list is shown as a list box where the user is allowed to select multiple options.  The possible values can be 'RED|YELLOW|BLUE', where the default value can be 'RED|BLUE'.  Note that in this case the default value contains multiple values.</para>
-					<para>Type 'date' is for date values.  The default value can be empty, or {tomorrow}, {yesterday}, {next week}, {last week}, {+3 days}, {-2 days}.</para>
+					<informaltable>
+						<tgroup cols="3">
+							<thead>
+								<row>
+									<entry>Type</entry>
+									<entry>Field Contents</entry>
+									<entry>Value Constraints</entry>
+								</row>
+							</thead>
+							<tbody>
+								<row>
+									<entry>String</entry>
+									<entry>text string up to 255 characters</entry>
+									<entry></entry>
+								</row>
+								<row>
+									<entry>Numeric</entry>
+									<entry>numerical integer value</entry>
+									<entry></entry>
+								</row>
+								<row>
+									<entry>Float</entry>
+									<entry>floating point number</entry>
+									<entry></entry>
+								</row>
+								<row>
+									<entry>Enumeration</entry>
+									<entry>one of a list of text strings</entry>
+									<entry>Enter the list of text strings separated by "|" (pipe
+										character) in the Possible Values field. The Default value should
+										match one of these strings as well. This will be displayed as a
+										dropdown menu.
+									</entry>
+								</row>
+								<row>
+									<entry>Email</entry>
+									<entry>an email address string up to 255 characters</entry>
+									<entry>When displayed, the value will also be encapsulated in a
+										mailto: reference.
+									</entry>
+								</row>
+								<row>
+									<entry>Checkbox</entry>
+									<entry>zero or more of a list of text strings</entry>
+									<entry>Enter the list of text strings separated by "|" (pipe
+										character) in the Possible Values field. The Default value should
+										match one of these strings as well. This will be displayed as a
+										list of text strings with a checkbox beside them.
+									</entry>
+								</row>
+								<row>
+									<entry>List</entry>
+									<entry>one of a list of text strings</entry>
+									<entry>Enter the list of text strings separated by "|" (pipe
+										character) in the Possible Values field. The Default value should
+										match one of these strings as well. This will be displayed as a
+										multi-line dropdown menu.
+									</entry>
+								</row>
+								<row>
+									<entry>Multiselection List</entry>
+									<entry>zero or more of a list of text strings</entry>
+									<entry>Enter the list of text strings separated by "|" (pipe
+										character) in the Possible Values field. Note that in this
+										case the default value contains multiple values. This will
+										be displayed as a multi-line dropdown menu.
+									</entry>
+								</row>
+								<row>
+									<entry>Date</entry>
+									<entry>text string defining a date</entry>
+									<entry>This is displayed as a set of dropdown menus for day, month,
+										and year. Default dates should be defined in yyyy-mm-dd format.
+										The default value can be empty, or {tomorrow}, {yesterday}, {next week},
+										{last week}, {+3 days}, {-2 days}.
+									</entry>
+								</row>
+								<row>
+									<entry>Radio</entry>
+									<entry>one of a list of radio buttons</entry>
+									<entry>Like a list, enter the list of text strings separated by "|" (pipe
+										character). This will be displayed as a row of radio buttons where only
+										one value is selectable.
+									</entry>
+								</row>
+								<row>
+									<entry>Textarea</entry>
+									<entry>text string of arbitrary length</entry>
+									<entry>Textarea is suitable for long texts that dont fit within the size of String type
+									</entry>
+								</row>
+							</tbody>
+						</tgroup>
+					</informaltable>
 				</listitem>
 				<listitem>
 					<para>Enumeration possible values (eg: RED|YELLOW|BLUE).
@@ -189,11 +272,19 @@ $s_CODE = STRING;
 				</listitem>
 				<listitem>
 					<para>Minimum/maximum length for the custom field value (use 0
-						to disable).  Note that these metrics are not really relevant to custom fields that are based on an enumeration of possible values.
+						to disable). Note that these metrics are not really relevant
+						to custom fields that are based on an enumeration of possible values.
+						On suitable types, fields are compared in length to be greater than or equal to
+						the minimum length, and less than or equal to the maximum length,
+						unless these values are 0 (if the values are 0, the check is skipped).
 					</para>
 				</listitem>
 				<listitem>
 					<para>Regular expression to use for validating user input (use <ulink url="http://www.php.net/manual/en/reference.pcre.pattern.syntax.php">PCRE syntax</ulink>).
+						Suitable field types are compared against the regular
+						expression. If the value matches the expression, then the value is
+						stored. For example, the expression "/^-?([0-9])*$/" can be used to
+						constrain an integer.
 					</para>
 				</listitem>
 				<listitem>
@@ -207,60 +298,70 @@ $s_CODE = STRING;
 					</para>
 				</listitem>
 				<listitem>
-					<para>Display when reporting issues? - If this custom
-						field should be shown on the Report Issue page.
+					<para>Displayed and Required parametrization:
 					</para>
-				</listitem>
-				<listitem>
-					<para>Display when updating issues? - If this custom
-						field should be shown on the Update Issue page.
-					</para>
-				</listitem>
-				<listitem>
-					<para>Display when resolving issues? - If this custom
-						field should be shown when resolving an issue.  For
-						example, a "root cause" custom field would make sense to
-						set when resolving the issue.
-					</para>
-				</listitem>
-				<listitem>
-					<para>Display when closing issues? - If this custom
-						field should be shown when closing an issue.
-					</para>
-				</listitem>
-				<listitem>
-					<para>Required on Report - If this custom
-						field is a mandatory field on the Report Issue page.
-					</para>
-				</listitem>
-				<listitem>
-					<para>Required on Update - If this custom
-						field is a mandatory field on the Update Issue page.
-					</para>
-				</listitem>
-				<listitem>
-					<para>Required on Resolve - If this custom
-						field is a mandatory field when resolving an issue.
-					</para>
-				</listitem>
-				<listitem>
-					<para>Required on Close - If this custom
-						field is a mandatory field when closing an issue.
-					</para>
+					<informaltable>
+						<tgroup cols="2">
+							<thead>
+								<row>
+									<entry>Entry</entry>
+									<entry>Meaning</entry>
+								</row>
+							</thead>
+							<tbody>
+								<row>
+									<entry>Display When Reporting Issues</entry>
+									<entry>If checked, the field will be shown on the report issues
+										displays
+									</entry>
+								</row>
+								<row>
+									<entry>Display When Updating Issues</entry>
+									<entry>If checked, the field will be shown on the update issue
+										and change status displays
+									</entry>
+								</row>
+								<row>
+									<entry>Display When Resolving Issues</entry>
+									<entry>If checked, the field will be shown on the update issue
+										displays and change status displays, if the new status is
+										resolved.
+									</entry>
+								</row>
+								<row>
+									<entry>Display When Closing Issues</entry>
+									<entry>If checked, the field will be shown on the update issue
+										displays and change status displays, if the new status is
+										closed.
+									</entry>
+								</row>
+								<row>
+									<entry>Required On Report</entry>
+									<entry>If checked, the field is mandatory on the Report Issue page.
+									</entry>
+								</row>
+								<row>
+									<entry>Required On Update</entry>
+									<entry>If checked, the field is mandatory on the Update Issue page.
+									</entry>
+								</row>
+								<row>
+									<entry>Required On Resolve</entry>
+									<entry>If checked, the field is mandatory when resolving an issue.
+									</entry>
+								</row>
+								<row>
+									<entry>Required On Close</entry>
+									<entry>If checked, the field is mandatory when closing an issue.
+									</entry>
+								</row>
+							</tbody>
+						</tgroup>
+					</informaltable>
 				</listitem>
 			</itemizedlist>
 		</para>
 
-		<para>All custom fields are currently saved to a field of type
-			VARCHAR(255) in the database. However, in future releases, it is
-			possible to support custom fields of different types (eg: memo,
-			file).
-		</para>
-
-		<para>
-			If the value of a custom field for a certain defect is not found,
-			the default value is assumed.
-		</para>
 	</section>
 
 	<section id="admin.customize.customfields.editing">

--- a/docbook/Admin_Guide/en-US/Page_Descriptions.xml
+++ b/docbook/Admin_Guide/en-US/Page_Descriptions.xml
@@ -417,22 +417,22 @@
             </para>
         </section>
 
-        <section id="admin.pages.manage.customfields">
-            <title>Manage Custom Fields</title>
+		<section id="admin.pages.manage.customfields">
+			<title>Manage Custom Fields</title>
 
-            <para>This page is the base point for managing custom fields. It
-                lists the custom fields defined in the system. There is also a
-                place to enter a new field name to create a new field.The "Edit"
-                links take you to a page where you can define the details of a
-                custom field. These include it's name, type, value, and display
-                information. On the edit page, the following information is defined
+			<para>This page is the base point for managing custom fields. It
+				lists the custom fields defined in the system. There is also a
+				place to enter a new field name to create a new field.The "Edit"
+				links take you to a page where you can define the details of a
+				custom field. These include it's name, type, value, and display
+				information. On the edit page, the following information is defined
                 to control the custom field:
                 <itemizedlist>
                     <listitem>
                         <para>name</para>
                     </listitem>
                     <listitem>
-                        <para>type. Possible values are listed below.</para>
+                        <para>type. The type of data defined by the custom field.</para>
                     </listitem>
                     <listitem>
                         <para>Value constraints (Possible values, default value,
@@ -446,183 +446,18 @@
                     </listitem>
                     <listitem>
                         <para>Display control (where the field will show up and must be
-                            filled in
+                            filled in)
                         </para>
                     </listitem>
                 </itemizedlist>
-            </para>
-            <para>
-                All fields are compared in length to be greater than or equal to
-                the minimum length, and less than or equal to the minimum length,
-                unless these values are 0. If the values are 0, the check is
-                skipped. All fields are also compared against the regular
-                expression. If the value matches the expression, then the value is
-                stored. For example, the expression "/^-?([0-9])*$/" can be used to
-                constrain an integer.The table below describes the field types and
-                the value constraints.
-            </para>
-            <informaltable>
-                <tgroup cols="3">
-                    <thead>
-                        <row>
-                            <entry>Type</entry>
-                            <entry>Field Contents</entry>
-                            <entry>Value Constraints</entry>
-                        </row>
-                    </thead>
-                    <tbody>
-                        <row>
-                            <entry>String</entry>
-                            <entry>text string up to 255 characters</entry>
-                            <entry></entry>
-                        </row>
-                        <row>
-                            <entry>Numeric</entry>
-                            <entry>an integer</entry>
-                            <entry></entry>
-                        </row>
-                        <row>
-                            <entry>Float</entry>
-                            <entry>a floating point number</entry>
-                            <entry></entry>
-                        </row>
-                        <row>
-                            <entry>Enumeration</entry>
-                            <entry>one of a list of text strings</entry>
-                            <entry>Enter the list of text strings separated by "|" (pipe
-                                character) in the Possible Values field. The Default value should
-                                match one of these strings as well. This will be displayed as a
-                                dropdown menu.
-                            </entry>
-                        </row>
-                        <row>
-                            <entry>Email</entry>
-                            <entry>an email address string up to 255 characters</entry>
-                            <entry>When displayed, the value will also be encapsulated in a
-                                mailto: reference.
-                            </entry>
-                        </row>
-                        <row>
-                            <entry>Checkbox</entry>
-                            <entry>zero or more of a list of text strings</entry>
-                            <entry>Enter the list of text strings separated by "|" (pipe
-                                character) in the Possible Values field. The Default value should
-                                match one of these strings as well. This will be displayed as a
-                                list of text strings with a checkbox beside them.
-                            </entry>
-                        </row>
-                        <row>
-                            <entry>List</entry>
-                            <entry>one of a list of text strings</entry>
-                            <entry>Enter the list of text strings separated by "|" (pipe
-                                character) in the Possible Values field. The Default value should
-                                match one of these strings as well. This will be displayed as a
-                                multi-line dropdown menu.
-                            </entry>
-                        </row>
-                        <row>
-                            <entry>Multiselection List</entry>
-                            <entry>zero or more of a list of text strings</entry>
-                            <entry>Enter the list of text strings separated by "|" (pipe
-                                character) in the Possible Values field. The Default value should
-                                match one of these strings as well. This will be displayed as a
-                                multi-line dropdown menu.
-                            </entry>
-                        </row>
-                        <row>
-                            <entry>Date</entry>
-                            <entry>text string defining a date</entry>
-                            <entry>This is displayed as a set of dropdown menus for day, month,
-                                and year. Defaults should be defined in yyyy-mm-dd format.
-                            </entry>
-                        </row>
-                    </tbody>
-                </tgroup>
-            </informaltable>
+			</para>
 
-            <para>The display entries are used as follows:
-            </para>
-            <informaltable>
-                <tgroup cols="2">
-                    <thead>
-                        <row>
-                            <entry>Entry</entry>
-                            <entry>Meaning</entry>
-                        </row>
-                    </thead>
-                    <tbody>
-                        <row>
-                            <entry>Display Only On Advanced Page</entry>
-                            <entry>If checked, the field will NOT be shown on the simple issue
-                                displays
-                            </entry>
-                        </row>
-                        <row>
-                            <entry>Display When Reporting Issues</entry>
-                            <entry>If checked, the field will be shown on the report issues
-                                displays
-                            </entry>
-                        </row>
-                        <row>
-                            <entry>Display When Updating Issues</entry>
-                            <entry>If checked, the field will NOT be shown on the update issue
-                                and change status displays
-                            </entry>
-                        </row>
-                        <row>
-                            <entry>Display When Resolving Issues</entry>
-                            <entry>If checked, the field will NOT be shown on the update issue
-                                displays and change status displays, if the new status is
-                                resolved.
-                            </entry>
-                        </row>
-                        <row>
-                            <entry>Display When Closing Issues</entry>
-                            <entry>If checked, the field will NOT be shown on the update issue
-                                displays and change status displays, if the new status is
-                                closed.
-                            </entry>
-                        </row>
-                        <row>
-                            <entry>Required On Report</entry>
-                            <entry>If checked, the field must be filled in on the issue
-                                reports.
-                            </entry>
-                        </row>
-                        <row>
-                            <entry>Required On Update</entry>
-                            <entry>If checked, the field must be filled in on the update issue
-                                and change status displays.
-                            </entry>
-                        </row>
-                        <row>
-                            <entry>Required On Resolve</entry>
-                            <entry>If checked, the field must be filled in on the update issue
-                                and change status displays, if the new status is resolved.
-                            </entry>
-                        </row>
-                        <row>
-                            <entry>Required On Close</entry>
-                            <entry>If checked, the field must be filled in on the update issue
-                                and change status displays, if the new status is closed.
-                            </entry>
-                        </row>
-                    </tbody>
-                </tgroup>
-            </informaltable>
+			<para>
+				See <xref linkend="admin.customize.customfields" /> for detailed
+				description for all attributes available for custom fields definition.
+			</para>
 
-            <para>Notes on Display
-                <itemizedlist>
-                    <listitem>
-                        <para>Be careful not to set both a required attribute and show
-                            only on advanced display. It may be possible to trigger a
-                            validation error that the user cannot recover from (i.e., field is
-                            not filled in).
-                        </para>
-                    </listitem>
-                </itemizedlist>
-            </para>
-        </section>
+		</section>
 
 
         <section id="admin.pages.manage.profiles">

--- a/manage_custom_field_edit_page.php
+++ b/manage_custom_field_edit_page.php
@@ -80,6 +80,11 @@ $t_definition = custom_field_get_definition( $f_field_id );
 				<span class="label-style"></span>
 			</div>
 			<div class="field-container">
+				<label for="custom-field-description"><span><?php echo lang_get( 'description' ) ?></span></label>
+				<span class="textarea"><textarea id="custom-field-description" name="description" cols="70" rows="2"><?php echo string_textarea( $t_definition['description'] ) ?></textarea></span>
+				<span class="label-style"></span>
+			</div>
+			<div class="field-container">
 				<label for="custom-field-type"><span><?php echo lang_get( 'custom_field_type' ) ?></span></label>
 				<span class="select">
 					<select id="custom-field-type" name="type">

--- a/manage_custom_field_update.php
+++ b/manage_custom_field_update.php
@@ -53,6 +53,7 @@ access_ensure_global_level( config_get( 'manage_custom_fields_threshold' ) );
 $f_field_id						= gpc_get_int( 'field_id' );
 $f_return						= strip_tags( gpc_get_string( 'return', 'manage_custom_field_page.php' ) );
 $t_values['name']				= gpc_get_string( 'name' );
+$t_values['description']		= gpc_get_string( 'description' );
 $t_values['type']				= gpc_get_int( 'type' );
 $t_values['possible_values']	= gpc_get_string( 'possible_values' );
 $t_values['default_value']		= gpc_get_string( 'default_value' );


### PR DESCRIPTION
Add description text attribute for custom field definition, and show this description on labels for form inputs.

![cf_description](https://cloud.githubusercontent.com/assets/14123811/14587756/c73b2628-04b8-11e6-8af9-e62dbd6364e8.png)

Fixes #03433
