### PR TITLE
Collapse cookie issues

### DIFF
--- a/core/collapse_api.php
+++ b/core/collapse_api.php
@@ -217,11 +217,15 @@ function collapse_cache_token() {
 			}
 		}
 
+		if( !$t_update ) {
+			$t_token = token_get( TOKEN_COLLAPSE );
+			$t_update = $t_token !== null;
+		}
 		if( $t_update ) {
-			$t_token = json_encode( $g_collapse_cache_token );
-			token_set( TOKEN_COLLAPSE, $t_token, TOKEN_EXPIRY_COLLAPSE );
+			$t_value = json_encode( $g_collapse_cache_token );
+			token_set( TOKEN_COLLAPSE, $t_value, TOKEN_EXPIRY_COLLAPSE );
 		} else {
-			token_touch( TOKEN_COLLAPSE );
+			token_touch( $t_token['id'] );
 		}
 
 		gpc_clear_cookie( 'MANTIS_collapse_settings' );

--- a/core/collapse_api.php
+++ b/core/collapse_api.php
@@ -209,7 +209,7 @@ function collapse_cache_token() {
 		$t_data = explode( '|', $t_cookie );
 
 		foreach( $t_data as $t_pair ) {
-			$t_pair = explode( ',', $t_pair );
+			$t_pair = explode( ':', $t_pair );
 
 			if( false !== $t_pair && count( $t_pair ) == 2 ) {
 				$g_collapse_cache_token[$t_pair[0]] = ( true == $t_pair[1] );

--- a/js/common.js
+++ b/js/common.js
@@ -389,9 +389,9 @@ function ToggleDiv( p_div ) {
 	}
 
 	if ( t_open_display == "none" ) {
-		t_cookie = t_cookie + "|" + p_div + ",1";
+		t_cookie = t_cookie + "|" + p_div + ":1";
 	} else {
-		t_cookie = t_cookie + "|" + p_div + ",0";
+		t_cookie = t_cookie + "|" + p_div + ":0";
 	}
 
 	SetCookie( "collapse_settings", t_cookie );


### PR DESCRIPTION
This PR addresses 2 related issues which I faced while testing [Cloud9 IDE](https://c9.io/).

- [#20822](https://www.mantisbt.org/bugs/view.php?id=20822): Collapsing/Expanding sections triggers error 2300 
- [#20824](https://www.mantisbt.org/bugs/view.php?id=20824): collapse_cache_token() always update token ID # 5 instead of the user's token