### PR TITLE
Add email notifications for users assigned to categories

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -445,6 +445,7 @@ $g_enable_email_notification	= ON;
  *       'handler': the handler of the bug
  *       'monitor': users who are monitoring a bug
  *      'bugnotes': users who have added a bugnote to the bug
+ *      'category': category owners
  *      'explicit': users who are explicitly specified by the code based on the
  *                  action (e.g. user added to monitor list).
  * 'threshold_max': all users with access <= max
@@ -486,6 +487,7 @@ $g_default_notify_flags = array(
 	'handler'       => ON,
 	'monitor'       => ON,
 	'bugnotes'      => ON,
+	'category'      => OFF,
 	'explicit'      => ON,
 	'threshold_min' => NOBODY,
 	'threshold_max' => NOBODY

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -308,6 +308,20 @@ function email_collect_recipients( $p_bug_id, $p_notify_type, array $p_extra_use
 		}
 	}
 
+	# add Category Owner
+	if( ON == email_notify_flag( $p_notify_type, 'category' ) ) {
+		$t_category_id = bug_get_field( $p_bug_id, 'category_id' );
+
+		if( $t_category_id > 0 ) {
+			$t_category_assigned_to = category_get_field( $t_category_id, 'user_id' );
+
+			if( $t_category_assigned_to > 0 ) {
+				$t_recipients[$t_category_assigned_to] = true;
+				log_event( LOG_EMAIL_RECIPIENT, sprintf( 'Issue = #%d, add Category Owner = @U%d', $p_bug_id, $t_category_assigned_to ) );
+			}
+		}
+	}
+
 	# add users who contributed bugnotes
 	$t_bugnote_id = bugnote_get_latest_id( $p_bug_id );
 	$t_bugnote_date = bugnote_get_field( $t_bugnote_id, 'last_modified' );

--- a/docbook/Admin_Guide/en-US/Customizing.xml
+++ b/docbook/Admin_Guide/en-US/Customizing.xml
@@ -791,6 +791,7 @@ $g_default_notify_flags = array(
 	'handler'       => ON,
 	'monitor'       => ON,
 	'bugnotes'      => ON,
+	'category'      => OFF,
 	'threshold_min' => NOBODY,
 	'threshold_max' => NOBODY
 );

--- a/docbook/Admin_Guide/en-US/config/email.xml
+++ b/docbook/Admin_Guide/en-US/config/email.xml
@@ -67,6 +67,7 @@ $g_default_notify_flags = array(
 	'handler'       =&gt; ON,
 	'monitor'       =&gt; ON,
 	'bugnotes'      =&gt; ON,
+	'category'      =&gt; OFF,
 	'explicit'      =&gt; ON,
 	'threshold_min' =&gt; NOBODY,
 	'threshold_max' =&gt; NOBODY

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -775,6 +775,7 @@ $s_colour_global = 'All Project settings override default configuration.';
 $s_issue_reporter = 'User who reported the issue';
 $s_issue_handler = 'User who is handling the issue';
 $s_users_added_bugnote = 'Users who added Issue Notes';
+$s_category_assigned_to = 'Category Owner';
 $s_change_configuration = 'Update Configuration';
 $s_message = 'Message';
 $s_default_notify = 'Setting default notification flags to';

--- a/manage_config_email_page.php
+++ b/manage_config_email_page.php
@@ -221,6 +221,7 @@ function get_section_begin_for_email( $p_section_name ) {
 	echo '      <th class="form-title" style="text-align:center" rowspan="2">&#160;' . lang_get( 'issue_handler' ) . '&#160;</th>' . "\n";
 	echo '      <th class="form-title" style="text-align:center" rowspan="2">&#160;' . lang_get( 'users_monitoring_bug' ) . '&#160;</th>' . "\n";
 	echo '      <th class="form-title" style="text-align:center" rowspan="2">&#160;' . lang_get( 'users_added_bugnote' ) . '&#160;</th>' . "\n";
+	echo '      <th class="form-title" style="text-align:center" rowspan="2">&#160;' . lang_get( 'category_assigned_to' ) . '&#160;</th>' . "\n";
 	echo '      <th class="form-title" style="text-align:center" colspan="' . count( $t_access_levels ) . '">&#160;' . lang_get( 'access_levels' ) . '&#160;</th>' . "\n";
 	echo '    </tr><tr class="row-category2">' . "\n";
 
@@ -248,6 +249,7 @@ function get_capability_row_for_email( $p_caption, $p_message_type ) {
 	echo '  <td' . color_notify_flag( $p_message_type, 'handler' ) . '>' . show_notify_flag( $p_message_type, 'handler' ) . '</td>' . "\n";
 	echo '  <td' . color_notify_flag( $p_message_type, 'monitor' ) . '>' . show_notify_flag( $p_message_type, 'monitor' ) . '</td>' . "\n";
 	echo '  <td' . color_notify_flag( $p_message_type, 'bugnotes' ) . '>' . show_notify_flag( $p_message_type, 'bugnotes' ) . '</td>' . "\n";
+	echo '  <td' . color_notify_flag( $p_message_type, 'category' ) . '>' . show_notify_flag( $p_message_type, 'category' ) . '</td>' . "\n";
 
 	foreach( $t_access_levels as $t_access_level ) {
 		echo '  <td' . color_threshold_flag( $t_access_level, $p_message_type ) . '>' . show_notify_threshold( $t_access_level, $p_message_type ) . '</td>' . "\n";

--- a/manage_config_email_set.php
+++ b/manage_config_email_set.php
@@ -71,7 +71,7 @@ $t_can_change_defaults = $t_access >= config_get_access( 'default_notify_flags' 
 
 # build a list of the possible actions and flags
 $t_valid_actions = email_get_actions();
-$t_valid_flags = array( 'reporter', 'handler', 'monitor' , 'bugnotes' );
+$t_valid_flags = array( 'reporter', 'handler', 'monitor' , 'bugnotes', 'category' );
 
 # initialize the thresholds
 foreach( $t_valid_actions as $t_action ) {


### PR DESCRIPTION
Users who are assigned to categories can now receive email notifications.
It's configurable on [ E-mail Notifications ] page per-project.

A common use case:
 - A user was assigned to some category;
 - When new issue is submitted to this category and "Assigned To" field is empty, this issue is assigned to Category Owner (hence he receives a notification);
 - If then we re-assign issue to other man, the Category Owner will no longer receive notifications.

This patch makes it possible to receive notifications by Category Owners in this case as well.

See also: https://www.mantisbt.org/forums/viewtopic.php?f=3&t=22917