### PR TITLE
Only cache visible plugin columns

### DIFF
--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -207,14 +207,20 @@ function column_is_plugin_column( $p_column ) {
 /**
  * Allow plugin columns to pre-cache data for a set of issues
  * rather than requiring repeated queries for each issue.
+ * If the user columns parameter is provided, only plugin columns that are
+ * contained in that column set will be cached.
  * @param array $p_bugs Array of BugData objects.
+ * @param array $p_selected_columns Array of columns the user is visualizing
  * @return void
  */
-function columns_plugin_cache_issue_data( array $p_bugs ) {
+function columns_plugin_cache_issue_data( array $p_bugs, array $p_selected_columns = null ) {
 	$t_columns = columns_get_plugin_columns();
+	$t_all = ( null === $p_selected_columns );
 
-	foreach( $t_columns as $t_column_object ) {
-		$t_column_object->cache( $p_bugs );
+	foreach( $t_columns as $t_name => $t_column_object ) {
+		if( $t_all || in_array( $t_name, $p_selected_columns  ) ) {
+			$t_column_object->cache( $p_bugs );
+		}
 	}
 }
 

--- a/csv_export.php
+++ b/csv_export.php
@@ -63,13 +63,13 @@ if( $t_rows === false ) {
 	print_header_redirect( 'view_all_set.php?type=0' );
 }
 
-# pre-cache custom column data
-columns_plugin_cache_issue_data( $t_rows );
-
-csv_start( csv_get_default_filename() );
-
 # Get columns to be exported
 $t_columns = csv_get_columns();
+
+# pre-cache custom column data
+columns_plugin_cache_issue_data( $t_rows, $t_columns );
+
+csv_start( csv_get_default_filename() );
 
 # export the titles
 $t_first_column = true;

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -87,7 +87,7 @@ $t_columns = excel_get_columns();
 
 do {
 	# pre-cache custom column data
-	columns_plugin_cache_issue_data( $t_result );
+	columns_plugin_cache_issue_data( $t_result, $t_columns );
 
 	foreach( $t_result as $t_row ) {
 		if( is_blank( $f_export ) || in_array( $t_row->id, $f_bug_arr ) ) {

--- a/print_all_bug_page.php
+++ b/print_all_bug_page.php
@@ -100,7 +100,7 @@ $t_result = filter_get_bug_rows( $f_page_number, $t_per_page, $t_page_count, $t_
 $t_row_count = count( $t_result );
 
 # pre-cache custom column data
-columns_plugin_cache_issue_data( $t_result );
+columns_plugin_cache_issue_data( $t_result, $t_columns );
 
 # for export
 $t_show_flag = gpc_get_int( 'show_flag', 0 );

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -175,7 +175,7 @@ function write_bug_rows( array $p_rows ) {
 	$t_in_stickies = ( $g_filter && ( 'on' == $g_filter[FILTER_PROPERTY_STICKY] ) );
 
 	# pre-cache custom column data
-	columns_plugin_cache_issue_data( $p_rows );
+	columns_plugin_cache_issue_data( $p_rows, $g_columns );
 
 	# -- Loop over bug rows --
 


### PR DESCRIPTION
On issues view/prin/export, a call is made to all MantisColumn plugin objects to
cache the list of issues. This call is now done only for those columns
that are part of the user column selection

Fixes: #0020854