### PR TITLE
Don't cache users in project_get_all_user_rows()

### DIFF
--- a/core/email_api.php
+++ b/core/email_api.php
@@ -558,6 +558,9 @@ function email_notify_new_account( $p_username, $p_email ) {
 
 	$t_threshold_min = config_get( 'notify_new_user_created_threshold_min' );
 	$t_threshold_users = project_get_all_user_rows( ALL_PROJECTS, $t_threshold_min );
+	$t_user_ids= array_keys( $t_threshold_users );
+	user_cache_array_rows( $t_user_ids );
+	user_pref_cache_array_rows( $t_user_ids );
 
 	foreach( $t_threshold_users as $t_user ) {
 		lang_push( user_pref_get_language( $t_user['id'] ) );

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -705,8 +705,6 @@ function project_get_all_user_rows( $p_project_id = ALL_PROJECTS, $p_access_leve
 		}
 	}
 
-	user_cache_array_rows( array_keys( $t_users ) );
-
 	return $t_users;
 }
 

--- a/core/user_pref_api.php
+++ b/core/user_pref_api.php
@@ -288,9 +288,8 @@ $g_cache_current_user_pref = array();
 
 /**
  * Cache a user preferences row if necessary and return the cached copy
- *  If the third parameter is true (default), trigger an error
- *  if the preferences can't be found.  If the second parameter is
- *  false, return false if the preferences can't be found.
+ *  If $p_trigger_errors is true (default), trigger an error if the preferences can't be found.
+ *  If $p_trigger_errors is false, return false if the preferences can't be found.
  *
  * @param integer $p_user_id        A valid user identifier.
  * @param integer $p_project_id     A valid project identifier.
@@ -300,30 +299,14 @@ $g_cache_current_user_pref = array();
 function user_pref_cache_row( $p_user_id, $p_project_id = ALL_PROJECTS, $p_trigger_errors = true ) {
 	global $g_cache_user_pref;
 
-	if( isset( $g_cache_user_pref[(int)$p_user_id][(int)$p_project_id] ) ) {
-		return $g_cache_user_pref[(int)$p_user_id][(int)$p_project_id];
+	if( !isset( $g_cache_user_pref[(int)$p_user_id][(int)$p_project_id] ) ) {
+		user_pref_cache_array_rows( array( $p_user_id ), $p_project_id );
 	}
 
-	$t_query = 'SELECT * FROM {user_pref} WHERE user_id=' . db_param() . ' AND project_id=' . db_param();
-	$t_result = db_query( $t_query, array( (int)$p_user_id, (int)$p_project_id ) );
-
-	$t_row = db_fetch_array( $t_result );
-
-	if( !$t_row ) {
-		if( $p_trigger_errors ) {
-			trigger_error( ERROR_USER_PREFS_NOT_FOUND, ERROR );
-		} else {
-			$g_cache_user_pref[(int)$p_user_id][(int)$p_project_id] = false;
-			return false;
-		}
+	$t_row = $g_cache_user_pref[(int)$p_user_id][(int)$p_project_id];
+	if( false === $t_row && $p_trigger_errors ) {
+		trigger_error( ERROR_USER_PREFS_NOT_FOUND, ERROR );
 	}
-
-	if( !isset( $g_cache_user_pref[(int)$p_user_id] ) ) {
-		$g_cache_user_pref[(int)$p_user_id] = array();
-	}
-
-	$g_cache_user_pref[(int)$p_user_id][(int)$p_project_id] = $t_row;
-
 	return $t_row;
 }
 


### PR DESCRIPTION
Adjustments to user rows cache in project_get_all_user_rows()
Bypassing cache when it's not actually needed, helps with the performance issues in #17577
With this fix I'm experiencing about 30~40% improvement in response time.


