### PR TITLE
Fix error when category default handler is deleted

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -504,7 +504,7 @@ class BugData {
 			$t_result = db_query( $t_query, array( $this->category_id ) );
 			$t_handler = db_result( $t_result );
 
-			if( $t_handler !== false ) {
+			if( $t_handler !== false && user_exists( $t_handler ) ) {
 				$this->handler_id = $t_handler;
 			}
 		}

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -297,7 +297,7 @@ function print_user_option_list( $p_user_id, $p_project_id = null, $p_access = A
 		$p_user_id != NO_USER &&
 		!array_key_exists( $p_user_id, $t_users )
 	) {
-		$t_row = user_get_row( $p_user_id );
+		$t_row = user_cache_row( $p_user_id, /* trigger_error */ false );
 		if( $t_row === false ) {
 			# User doesn't exist - create a dummy record for display purposes
 			$t_name = user_get_name( $p_user_id );


### PR DESCRIPTION
- Fix the error in edit category page.
- Don't assign to default handler on reporting an issue unless user exists.

Fixes #20867