### PR TITLE
Enhance access level display

### DIFF
--- a/bugnote_view_inc.php
+++ b/bugnote_view_inc.php
@@ -168,10 +168,7 @@ $t_num_notes = count( $t_bugnotes );
 		<span class="small access-level"><?php
 			if( user_exists( $t_bugnote->reporter_id ) ) {
 				$t_access_level = access_get_project_level( null, (int)$t_bugnote->reporter_id );
-				# Only display access level when higher than 0 (ANYBODY)
-				if( $t_access_level > ANYBODY ) {
-					echo '(', get_enum_element( 'access_levels', $t_access_level ), ')';
-				}
+				echo '(', access_level_get_string( $t_access_level ), ')';
 			}
 		?></span>
 		</span>

--- a/core/access_api.php
+++ b/core/access_api.php
@@ -695,3 +695,17 @@ function access_get_status_threshold( $p_status, $p_project_id = ALL_PROJECTS ) 
 		}
 	}
 }
+
+/**
+ * Given a access level, return the appropriate string for it
+ * @param integer $p_access_level
+ * @return string
+ */
+function access_level_get_string( $p_access_level ) {
+	if( $p_access_level > ANYBODY ) {
+		$t_access_level_string = get_enum_element( 'access_levels', $p_access_level );
+	} else {
+		$t_access_level_string = lang_get( 'no_access' );
+	}
+	return $t_access_level_string;
+}

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -1570,12 +1570,12 @@ function email_format_bug_message( array $p_visible_bug_data ) {
 
 		if( user_exists( $t_bugnote->reporter_id ) ) {
 			$t_access_level = access_get_project_level( $p_visible_bug_data['email_project_id'], $t_bugnote->reporter_id );
-			$t_access_level_string = ' (' . get_enum_element( 'access_levels', $t_access_level ) . ') - ';
+			$t_access_level_string = ' (' . access_level_get_string( $t_access_level ) . ')';
 		} else {
 			$t_access_level_string = '';
 		}
 
-		$t_string = ' (' . $t_formatted_bugnote_id . ') ' . user_get_name( $t_bugnote->reporter_id ) . $t_access_level_string . $t_last_modified . "\n" . $t_time_tracking . ' ' . $t_bugnote_link;
+		$t_string = ' (' . $t_formatted_bugnote_id . ') ' . user_get_name( $t_bugnote->reporter_id ) . $t_access_level_string . ' - ' . $t_last_modified . "\n" . $t_time_tracking . ' ' . $t_bugnote_link;
 
 		$t_message .= $t_email_separator2 . " \n";
 		$t_message .= $t_string . " \n";

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -256,6 +256,7 @@ $s_issue_status_percentage = 'Issue Status Percentage';
 
 # Enum Strings
 $s_access_levels_enum_string = '10:viewer,25:reporter,40:updater,55:developer,70:manager,90:administrator';
+$s_no_access = 'no access';
 $s_project_status_enum_string = '10:development,30:release,50:stable,70:obsolete';
 $s_project_view_state_enum_string = '10:public,50:private';
 $s_view_state_enum_string = '10:public,50:private';


### PR DESCRIPTION
Prior to this, the access level display in bugnotes was (@0@) if the
user who added the note did not have access to the project. This
situation can happen when an issue is moved to a private project, or
when a user's rights to a private project are revoked.
This is similar to the fix for #11923, but
- affects also email notification
- displays "no access" for existing users instead of displaying nothing

Fixes #20897