### PR TITLE
Let Timeline handle non-existing bugs

### DIFF
--- a/core/history_api.php
+++ b/core/history_api.php
@@ -240,6 +240,11 @@ function history_get_event_from_row( $p_result, $p_user_id = null, $p_check_acce
 	while ( $t_row = db_fetch_array( $p_result ) ) {
 		extract( $t_row, EXTR_PREFIX_ALL, 'v' );
 
+		# Ignore entries related to non-existing bugs (see #20727)
+		if( !bug_exists( $v_bug_id ) ) {
+			continue;
+		}
+
 		# Make sure the entry belongs to current project.
 		if ( $t_project_id != ALL_PROJECTS && $t_project_id != bug_get_field( $v_bug_id, 'project_id' ) ) {
 			continue;

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -226,7 +226,7 @@ function history_get_range_result( $p_bug_id = null, $p_start_time = null, $p_en
 
 /**
  * Gets the next accessible history event for current user and specified db result.
- * @param  string  $p_result      The database result.
+ * @param  object  $p_result      The database result.
  * @param  integer $p_user_id     The user id or null for logged in user.
  * @param  boolean $p_check_access_to_issue true: check that user has access to bugs,
  *                                          false otherwise.


### PR DESCRIPTION
If an history entry refers to a bug that does not exist in the database, history_get_event_from_row() throws application error 1100.

Even though it is not a normal situation to find orphan records in the history table, the overhead of verifying a bug's existence at the beginning of the loop is negligible, so it doesn't hurt to add the extra bug_exists() check.

Fixes [#20727](https://www.mantisbt.org/bugs/view.php?id=20727)