### PR TITLE
Do not enforce related thresholds when sponsorship is OFF

### DIFF
--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -109,10 +109,8 @@ $f_handler_id = gpc_get_int( 'handler_id', $t_bug->handler_id );
 if( config_get( 'bug_assigned_status' ) == $f_new_status ) {
 	$t_bug_sponsored = config_get( 'enable_sponsorship' )
 		&& sponsorship_get_amount( sponsorship_get_all_ids( $f_bug_id ) ) > 0;
-	if( $t_bug_sponsored ) {
-		if( !access_has_bug_level( config_get( 'assign_sponsored_bugs_threshold' ), $f_bug_id ) ) {
-			trigger_error( ERROR_SPONSORSHIP_ASSIGNER_ACCESS_LEVEL_TOO_LOW, ERROR );
-		}
+	if( $t_bug_sponsored && !access_has_bug_level( config_get( 'assign_sponsored_bugs_threshold' ), $f_bug_id ) ) {
+		trigger_error( ERROR_SPONSORSHIP_ASSIGNER_ACCESS_LEVEL_TOO_LOW, ERROR );
 	}
 
 	if( $f_handler_id != NO_USER ) {
@@ -120,10 +118,8 @@ if( config_get( 'bug_assigned_status' ) == $f_new_status ) {
 			trigger_error( ERROR_HANDLER_ACCESS_TOO_LOW, ERROR );
 		}
 
-		if( $t_bug_sponsored ) {
-			if( !access_has_bug_level( config_get( 'handle_sponsored_bugs_threshold' ), $f_bug_id, $f_handler_id ) ) {
-				trigger_error( ERROR_SPONSORSHIP_HANDLER_ACCESS_LEVEL_TOO_LOW, ERROR );
-			}
+		if( $t_bug_sponsored && !access_has_bug_level( config_get( 'handle_sponsored_bugs_threshold' ), $f_bug_id, $f_handler_id ) ) {
+			trigger_error( ERROR_SPONSORSHIP_HANDLER_ACCESS_LEVEL_TOO_LOW, ERROR );
 		}
 	}
 }

--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -107,7 +107,8 @@ if( $t_can_update_due_date ) {
 $f_handler_id = gpc_get_int( 'handler_id', $t_bug->handler_id );
 
 if( config_get( 'bug_assigned_status' ) == $f_new_status ) {
-	$t_bug_sponsored = sponsorship_get_amount( sponsorship_get_all_ids( $f_bug_id ) ) > 0;
+	$t_bug_sponsored = config_get( 'enable_sponsorship' )
+		&& sponsorship_get_amount( sponsorship_get_all_ids( $f_bug_id ) ) > 0;
 	if( $t_bug_sponsored ) {
 		if( !access_has_bug_level( config_get( 'assign_sponsored_bugs_threshold' ), $f_bug_id ) ) {
 			trigger_error( ERROR_SPONSORSHIP_ASSIGNER_ACCESS_LEVEL_TOO_LOW, ERROR );

--- a/bug_update.php
+++ b/bug_update.php
@@ -205,8 +205,9 @@ if( $t_existing_bug->status != $t_updated_bug->status ) {
 }
 
 # Validate any change to the handler of an issue.
-$t_issue_is_sponsored = sponsorship_get_amount( sponsorship_get_all_ids( $f_bug_id ) ) > 0;
 if( $t_existing_bug->handler_id != $t_updated_bug->handler_id ) {
+	$t_issue_is_sponsored = config_get( 'enable_sponsorship' )
+		&& sponsorship_get_amount( sponsorship_get_all_ids( $f_bug_id ) ) > 0;
 	access_ensure_bug_level( config_get( 'update_bug_assign_threshold' ), $f_bug_id );
 	if( $t_issue_is_sponsored && !access_has_bug_level( config_get( 'handle_sponsored_bugs_threshold' ), $f_bug_id ) ) {
 		trigger_error( ERROR_SPONSORSHIP_HANDLER_ACCESS_LEVEL_TOO_LOW, ERROR );


### PR DESCRIPTION
When $g_enable_sponsorship = OFF, we should not enforce related
thresholds ($g_handle_sponsored_bugs_threshold and
$g_assign_sponsored_bugs_threshold) when updating issues.

Fixes [#21030](https://www.mantisbt.org/bugs/view.php?id=21030)