### PR TITLE
Support $g_debug_email being set to OFF

### DIFF
--- a/docbook/Admin_Guide/en-US/config/logging.xml
+++ b/docbook/Admin_Guide/en-US/config/logging.xml
@@ -31,12 +31,12 @@
 			<term>$g_debug_email</term>
 			<listitem>
 				<para>Used for debugging e-mail notifications.
-					When it is OFF, the emails are sent normally.
+					When it is '', the emails are sent normally.
 					If set to an e-mail address, all messages are sent
 					to it, with the original recipients (To, Cc, Bcc)
 					included in the message body.
 				</para>
-				<para>Default is OFF.</para>
+				<para>Default is ''.</para>
 			</listitem>
 		</varlistentry>
 


### PR DESCRIPTION
For backward compatibility support this config option set to OFF.   Also update the documentation of the configuration option to reflect that '' is the new way of reflecting that debug emails are off.