### PR TITLE
Bump the required MantisCore version in bundled plugins

### DIFF
--- a/plugins/Gravatar/Gravatar.php
+++ b/plugins/Gravatar/Gravatar.php
@@ -68,7 +68,7 @@ class GravatarPlugin extends MantisPlugin {
 
 		$this->version = '1.0';
 		$this->requires = array(
-			'MantisCore' => '1.3.0',
+			'MantisCore' => '2.0.0',
 		);
 
 		$this->author = 'Victor Boctor';

--- a/plugins/MantisCoreFormatting/MantisCoreFormatting.php
+++ b/plugins/MantisCoreFormatting/MantisCoreFormatting.php
@@ -35,7 +35,7 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 
 		$this->version = '1.3.0';
 		$this->requires = array(
-			'MantisCore' => '1.3.0',
+			'MantisCore' => '2.0.0',
 		);
 
 		$this->author = 'MantisBT Team';

--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -34,7 +34,7 @@ class MantisGraphPlugin extends MantisPlugin  {
 
 		$this->version = '1.3.0';
 		$this->requires = array(
-			'MantisCore' => '1.3.0',
+			'MantisCore' => '2.0.0',
 		);
 
 		$this->author = 'MantisBT Team';

--- a/plugins/XmlImportExport/XmlImportExport.php
+++ b/plugins/XmlImportExport/XmlImportExport.php
@@ -38,7 +38,7 @@ class XmlImportExportPlugin extends MantisPlugin {
 
 		$this->version = '1.3.0';
 		$this->requires = array(
-			'MantisCore' => '1.3.0',
+			'MantisCore' => '2.0.0',
 		);
 
 		$this->author = 'MantisBT Team';


### PR DESCRIPTION
This fix is needed for plugins to function properly with 2.0.0

Please note that we may need to followup with another PR once the plugin and MantisCore versions are finalized.