### PR TITLE
Fix core plugin versions

### DIFF
--- a/plugins/Gravatar/Gravatar.php
+++ b/plugins/Gravatar/Gravatar.php
@@ -68,7 +68,7 @@ class GravatarPlugin extends MantisPlugin {
 
 		$this->version = '1.0';
 		$this->requires = array(
-			'MantisCore' => '1.3.0',
+			'MantisCore' => '2.0.0',
 		);
 
 		$this->author = 'Victor Boctor';

--- a/plugins/Gravatar/Gravatar.php
+++ b/plugins/Gravatar/Gravatar.php
@@ -66,7 +66,7 @@ class GravatarPlugin extends MantisPlugin {
 		$this->description = lang_get( 'description' );
 		$this->page = '';
 
-		$this->version = '1.0';
+		$this->version = MANTIS_VERSION;
 		$this->requires = array(
 			'MantisCore' => '2.0.0',
 		);

--- a/plugins/MantisCoreFormatting/MantisCoreFormatting.php
+++ b/plugins/MantisCoreFormatting/MantisCoreFormatting.php
@@ -33,7 +33,7 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 		$this->description = lang_get( 'plugin_format_description' );
 		$this->page = 'config';
 
-		$this->version = '1.3.0';
+		$this->version = MANTIS_VERSION;
 		$this->requires = array(
 			'MantisCore' => '2.0.0',
 		);

--- a/plugins/MantisCoreFormatting/MantisCoreFormatting.php
+++ b/plugins/MantisCoreFormatting/MantisCoreFormatting.php
@@ -35,7 +35,7 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 
 		$this->version = '1.3.0';
 		$this->requires = array(
-			'MantisCore' => '1.3.0',
+			'MantisCore' => '2.0.0',
 		);
 
 		$this->author = 'MantisBT Team';

--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -32,7 +32,7 @@ class MantisGraphPlugin extends MantisPlugin  {
 		$this->description = lang_get( 'plugin_graph_description' );
 		$this->page = 'config';
 
-		$this->version = '1.3.0';
+		$this->version = MANTIS_VERSION;
 		$this->requires = array(
 			'MantisCore' => '2.0.0',
 		);

--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -34,7 +34,7 @@ class MantisGraphPlugin extends MantisPlugin  {
 
 		$this->version = '1.3.0';
 		$this->requires = array(
-			'MantisCore' => '1.3.0',
+			'MantisCore' => '2.0.0',
 		);
 
 		$this->author = 'MantisBT Team';

--- a/plugins/XmlImportExport/XmlImportExport.php
+++ b/plugins/XmlImportExport/XmlImportExport.php
@@ -38,7 +38,7 @@ class XmlImportExportPlugin extends MantisPlugin {
 
 		$this->version = '1.3.0';
 		$this->requires = array(
-			'MantisCore' => '1.3.0',
+			'MantisCore' => '2.0.0',
 		);
 
 		$this->author = 'MantisBT Team';

--- a/plugins/XmlImportExport/XmlImportExport.php
+++ b/plugins/XmlImportExport/XmlImportExport.php
@@ -36,7 +36,7 @@ class XmlImportExportPlugin extends MantisPlugin {
 		$this->description = plugin_lang_get( 'description' );
 		$this->page = "config_page";
 
-		$this->version = '1.3.0';
+		$this->version = MANTIS_VERSION;
 		$this->requires = array(
 			'MantisCore' => '2.0.0',
 		);


### PR DESCRIPTION
Update core plugins as follows:
- Support/require MantisCore 2.0.0.
- Use MANTIS_VERSION for core plugin versions.

I've noticed that plugins used to require 1.3.0 and now 2.0.0 and that matches pre-releases of such release numbers.  We can look at that later and see if we want to keep this behavior or change it.