### PR TITLE
Ability to specify Timeout for SMTP connection

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -656,6 +656,13 @@ $g_smtp_connection_mode = '';
 $g_smtp_port = 25;
 
 /**
+ * Default SMTP timeout in seconds
+ * In case of SMTP errors, try raising to higher value first (e.g. 60 seconds)
+ * @global integer $g_smtp_timeout
+ */
+$g_smtp_timeout = 10;
+
+/**
  * It is recommended to use a cronjob or a scheduler task to send emails. The
  * cronjob should typically run every 5 minutes.  If no cronjob is used,then
  * user will have to wait for emails to be sent after performing an action

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -1139,6 +1139,7 @@ function email_send( EmailData $p_email_data ) {
 	$t_mail->FromName = config_get( 'from_name' );
 	$t_mail->AddCustomHeader( 'Auto-Submitted:auto-generated' );
 	$t_mail->AddCustomHeader( 'X-Auto-Response-Suppress: All' );
+	$t_mail->Timeout = config_get( 'smtp_timeout' );
 
 	# Setup new line and encoding to avoid extra new lines with some smtp gateways like sendgrid.net
 	$t_mail->LE         = "\r\n";


### PR DESCRIPTION
Solves a problem with slower SMTP servers, when the message is actually sent, but phpmailer reports `"SMTP Error: Data not accepted."` when timeout occurs before SMTP response, causing `send_emails.php` script to end send-out with error and keep the e-mail for subsequent delivery - causing almost infinite number of delivered e-mails when send-out script is cron scheduled.