### PR TITLE
Fix config parsing issues and improve unit tests

### DIFF
--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -104,9 +104,9 @@ function print_config_value_as_string( $p_type, $p_value, $p_for_display = true 
 			echo (integer)$p_value;
 			return;
 		case CONFIG_TYPE_STRING:
-			$t_value = string_nl2br( string_html_specialchars( config_eval( $p_value ) ) );
+			$t_value = string_html_specialchars( config_eval( $p_value ) );
 			if( $p_for_display ) {
-				$t_value = '<p id="adm-config-value">\'' . $t_value . '\'</p>';
+				$t_value = '<p id="adm-config-value">\'' . string_nl2br( $t_value ) . '\'</p>';
 			}
 			echo $t_value;
 			return;

--- a/adm_config_set.php
+++ b/adm_config_set.php
@@ -90,7 +90,8 @@ if( !config_can_delete( $f_config_option ) ) {
 
 
 # For 'default', behavior is based on the global variable's type
-if( $f_type == CONFIG_TYPE_DEFAULT ) {
+# If value is empty, process as per default to ensure proper typecast
+if( $f_type == CONFIG_TYPE_DEFAULT || empty( $f_value ) ) {
 	$t_config_global_value = config_get_global( $f_config_option );
 	if( is_string( $t_config_global_value ) ) {
 		$t_type = CONFIG_TYPE_STRING;
@@ -108,13 +109,15 @@ if( $f_type == CONFIG_TYPE_DEFAULT ) {
 }
 
 # Parse the value
-if( $t_type == CONFIG_TYPE_STRING ) {
-	# Return strings as is
-	$t_value = $f_value;
-} else {
+# - Strings are returned as-is
+# - Empty values are typecast as appropriate
+$t_value = $f_value;
+if( $t_type != CONFIG_TYPE_STRING ) {
 	try {
-		$t_parser = new ConfigParser( $f_value );
-		$t_value = $t_parser->parse( ConfigParser::EXTRA_TOKENS_IGNORE );
+		if( !empty( $f_value ) ) {
+			$t_parser = new ConfigParser( $f_value );
+			$t_value = $t_parser->parse( ConfigParser::EXTRA_TOKENS_IGNORE );
+		}
 
 		switch( $t_type ) {
 			case CONFIG_TYPE_INT:

--- a/core/classes/ConfigParser.class.php
+++ b/core/classes/ConfigParser.class.php
@@ -27,7 +27,7 @@
  * Configuration Parser class
  *
  * Simple PHP code parser for scalar and array types
- * 
+ *
  * @package MantisBT
  * @subpackage classes
  *

--- a/core/classes/ConfigParser.class.php
+++ b/core/classes/ConfigParser.class.php
@@ -76,6 +76,8 @@ class ConfigParser
 			case T_STRING:
 			case T_LNUMBER:
 			case T_DNUMBER:
+			case '-':
+			case '+':
 				$t_result = $this->process_value();
 				break;
 

--- a/core/classes/Tokenizer.class.php
+++ b/core/classes/Tokenizer.class.php
@@ -44,15 +44,10 @@ class Tokenizer
 	 * Builds the token array from given code, discarding whitespace and
 	 * trailing semicolons
 	 * @param string $p_code PHP code to tokenize
-	 * @throws Exception if there are no tokens to process
 	 * @throws Exception if given code is not valid
 	 */
 	public function __construct( $p_code )
 	{
-		if( empty( $p_code ) ) {
-			throw new Exception( 'No more tokens' );
-		}
-
 		# Check syntax to make sure we get valid PHP code
 		# prepend 'return' statement to ensure the code is not actually executed
 		$t_code = 'return; ' . $p_code . ';';

--- a/core/classes/Tokenizer.class.php
+++ b/core/classes/Tokenizer.class.php
@@ -25,10 +25,10 @@
 
 /**
  * Tokenizer class
- * 
+ *
  * Uses PHP's internal token_get_all() function to parse a piece of code
  * into tokens
- * 
+ *
  * @package MantisBT
  * @subpackage classes
  */

--- a/core/classes/Tokenizer.class.php
+++ b/core/classes/Tokenizer.class.php
@@ -177,7 +177,7 @@ class Tokenizer
 				$p_value = token_name( $p_value );
 			}
 			throw new Exception(
-				'Invalid token: got "' . $this->value() . '", expected "$p_value"'
+				'Invalid token: got "' . $this->value() . '", expected "' . $p_value . '"'
 			);
 		}
 		$this->pop();

--- a/tests/Mantis/ConfigParserTest.php
+++ b/tests/Mantis/ConfigParserTest.php
@@ -205,8 +205,13 @@ class MantisConfigParserTest extends PHPUnit_Framework_TestCase {
 			'Integer Zero' => array( '0', PHPUnit_Type::TYPE_INT ),
 			'Integer One' => array( '1', PHPUnit_Type::TYPE_INT ),
 			'Integer with whitespace' => array( " 1\n", PHPUnit_Type::TYPE_INT ),
-
+			'Integer negative' => array( '-1', PHPUnit_Type::TYPE_INT ),
+			'Integer positive' => array( '+1', PHPUnit_Type::TYPE_INT ),
+	
 			'Float' => array( '1.1', PHPUnit_Type::TYPE_FLOAT ),
+			'Float negative' => array( '-1.1', PHPUnit_Type::TYPE_FLOAT ),
+			'Float positive' => array( '+1.1', PHPUnit_Type::TYPE_FLOAT ),
+			'Float scientific' => array( '1.2e3', PHPUnit_Type::TYPE_FLOAT ),
 
 			'String empty double-quote' => array( '""', PHPUnit_Type::TYPE_STRING ),
 			'String empty single-quote' => array( "''", PHPUnit_Type::TYPE_STRING ),

--- a/tests/Mantis/ConfigParserTest.php
+++ b/tests/Mantis/ConfigParserTest.php
@@ -47,11 +47,6 @@ use PHPUnit_Framework_Constraint_IsType as PHPUnit_Type;
 class MantisConfigParserTest extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * @var array List of test cases for scalar types
-	 */
-	private $cases_scalar = array();
-
-	/**
 	 * @var array List of test cases for arrays
 	 */
 	private $cases_array = array();
@@ -59,10 +54,9 @@ class MantisConfigParserTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * MantisConfigParserTest constructor.
 	 */
-	public function __construct() {
-		parent::__construct();
+	public function __construct( $name = null, array $data = [], $dataName = '' ) {
+		parent::__construct( $name, $data, $dataName );
 
-		$this->initScalarTestCases();
 		$this->initArrayTestCases();
 	}
 
@@ -82,19 +76,21 @@ class MantisConfigParserTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * Test a list of strings representing scalar values, making sure
 	 * the value and the type match
+	 * @dataProvider providerScalarTypes
+	 *
+	 * @param string $p_string The string to parse
+	 * @param string $p_type   Expected type (PHPUnit_Type::TYPE_xxx constant)
 	 *
 	 * @throws Exception
 	 */
-	public function testScalarTypes() {
-		foreach( $this->cases_scalar as $t_string => $t_expected_type ) {
-			$t_reference_result = eval( 'return ' . $t_string . ';' );
+	public function testScalarTypes( $p_string, $p_type ) {
+		$t_reference_result = eval( 'return ' . $p_string . ';' );
 
-			$t_parser = new ConfigParser( $t_string );
-			$t_parsed_result = $t_parser->parse();
+		$t_parser = new ConfigParser( $p_string );
+		$t_parsed_result = $t_parser->parse();
 
-			$this->assertInternalType( $t_expected_type, $t_parsed_result );
-			$this->assertEquals( $t_parsed_result, $t_reference_result, $this->errorMessage( $t_string ) );
-		}
+		$this->assertInternalType( $p_type, $t_parsed_result );
+		$this->assertEquals( $t_parsed_result, $t_reference_result, $this->errorMessage( $p_string ) );
 	}
 
 	/**
@@ -213,48 +209,38 @@ class MantisConfigParserTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Adds a new scalar test case to the list
-	 *
-	 * @param string $p_string Value to check
-	 * @param string $p_type   Expected type
+	 * Data provider for Scalar types test cases.
+	 * Test case structure:
+	 *   <test case> => array( <string to test>, <expected type> )
+	 * @return array
 	 */
-	private function addScalarCase( $p_string, $p_type ) {
-		$this->cases_scalar[$p_string] = $p_type;
-	}
+	public function providerScalarTypes() {
+		return array(
+			'Integer Zero' => array( '0', PHPUnit_Type::TYPE_INT ),
+			'Integer One' => array( '1', PHPUnit_Type::TYPE_INT ),
+			'Integer with whitespace' => array( " 1\n", PHPUnit_Type::TYPE_INT ),
 
-	/**
-	 * Initialize the Scalar type test cases
-	 */
-	private function initScalarTestCases() {
-		# Integer
-		$this->addScalarCase( '0', PHPUnit_Type::TYPE_INT );
-		$this->addScalarCase( '1', PHPUnit_Type::TYPE_INT );
-		$this->addScalarCase( " 1\n", PHPUnit_Type::TYPE_INT );
+			'Float' => array( '1.1', PHPUnit_Type::TYPE_FLOAT ),
 
-		# Float
-		$this->addScalarCase( '1.1', PHPUnit_Type::TYPE_FLOAT );
-
-		# String
-		$this->addScalarCase( '""', PHPUnit_Type::TYPE_STRING );
-		$this->addScalarCase( "''", PHPUnit_Type::TYPE_STRING );
-		$this->addScalarCase( '" "', PHPUnit_Type::TYPE_STRING );
-		$this->addScalarCase( '"1"', PHPUnit_Type::TYPE_STRING );
-		$this->addScalarCase( "'1'", PHPUnit_Type::TYPE_STRING );
-
-		# Built-in string literals
-		$this->addScalarCase( 'null', PHPUnit_Type::TYPE_NULL );
-		$this->addScalarCase( 'false', PHPUnit_Type::TYPE_BOOL );
-		$this->addScalarCase( 'true', PHPUnit_Type::TYPE_BOOL );
-
-		# Constants
-		$this->addScalarCase( 'VERSION_ALL', PHPUnit_Type::TYPE_NULL );         # null
-		$this->addScalarCase( 'VERSION_FUTURE', PHPUnit_Type::TYPE_BOOL );      # false
-		$this->addScalarCase( 'VERSION_RELEASED', PHPUnit_Type::TYPE_BOOL );    # true
-		$this->addScalarCase( 'OFF', PHPUnit_Type::TYPE_INT );                  # 0
-		$this->addScalarCase( 'DEVELOPER', PHPUnit_Type::TYPE_INT );            # int
-		$this->addScalarCase( " DEVELOPER\n", PHPUnit_Type::TYPE_INT );
-		$this->addScalarCase( 'MANTIS_VERSION', PHPUnit_Type::TYPE_STRING );    #string
-		$this->addScalarCase( " MANTIS_VERSION\n", PHPUnit_Type::TYPE_STRING );
+			'String empty double-quote' => array( '""', PHPUnit_Type::TYPE_STRING ),
+			'String empty single-quote' => array( "''", PHPUnit_Type::TYPE_STRING ),
+			'String whitespace' => array( '" "', PHPUnit_Type::TYPE_STRING ),
+			'String number double-quote' => array( '"1"', PHPUnit_Type::TYPE_STRING ),
+			'String number single-quote' => array( "'1'", PHPUnit_Type::TYPE_STRING ),
+	
+			'Built-in string literal null' => array( 'null', PHPUnit_Type::TYPE_NULL ),
+			'Built-in string literal false' => array( 'false', PHPUnit_Type::TYPE_BOOL ),
+			'Built-in string literal true' => array( 'true', PHPUnit_Type::TYPE_BOOL ),
+	
+			'Constant = null' => array( 'VERSION_ALL', PHPUnit_Type::TYPE_NULL ),
+			'Constant = false' => array( 'VERSION_FUTURE', PHPUnit_Type::TYPE_BOOL ),
+			'Constant = true' => array( 'VERSION_RELEASED', PHPUnit_Type::TYPE_BOOL ),
+			'Constant = 0' => array( 'OFF', PHPUnit_Type::TYPE_INT ),
+			'Constant integer' => array( 'DEVELOPER', PHPUnit_Type::TYPE_INT ),
+			'Constant integer with whitespace' => array( " DEVELOPER\n", PHPUnit_Type::TYPE_INT ),
+			'Constant string' => array( 'MANTIS_VERSION', PHPUnit_Type::TYPE_STRING ),
+			'Constant string with whitespace' => array( " MANTIS_VERSION\n", PHPUnit_Type::TYPE_STRING ),
+		);
 	}
 
 	/**

--- a/tests/Mantis/ConfigParserTest.php
+++ b/tests/Mantis/ConfigParserTest.php
@@ -67,6 +67,19 @@ class MantisConfigParserTest extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * Test with empty string or null
+	 *
+	 * @throws Exception
+	 */
+	public function testNoTokens() {
+		$this->setExpectedException( 'Exception', 'No more tokens' );
+		$t_parser = new ConfigParser( '' );
+		$t_parser->parse();
+		$t_parser = new ConfigParser( null );
+		$t_parser->parse();
+	}
+
+	/**
 	 * Test a list of strings representing scalar values, making sure
 	 * the value and the type match
 	 *

--- a/tests/Mantis/ConfigParserTest.php
+++ b/tests/Mantis/ConfigParserTest.php
@@ -227,6 +227,7 @@ class MantisConfigParserTest extends PHPUnit_Framework_TestCase {
 	 */
 	private function initScalarTestCases() {
 		# Integer
+		$this->addScalarCase( '0', PHPUnit_Type::TYPE_INT );
 		$this->addScalarCase( '1', PHPUnit_Type::TYPE_INT );
 		$this->addScalarCase( " 1\n", PHPUnit_Type::TYPE_INT );
 
@@ -234,6 +235,9 @@ class MantisConfigParserTest extends PHPUnit_Framework_TestCase {
 		$this->addScalarCase( '1.1', PHPUnit_Type::TYPE_FLOAT );
 
 		# String
+		$this->addScalarCase( '""', PHPUnit_Type::TYPE_STRING );
+		$this->addScalarCase( "''", PHPUnit_Type::TYPE_STRING );
+		$this->addScalarCase( '" "', PHPUnit_Type::TYPE_STRING );
 		$this->addScalarCase( '"1"', PHPUnit_Type::TYPE_STRING );
 		$this->addScalarCase( "'1'", PHPUnit_Type::TYPE_STRING );
 

--- a/tests/Mantis/ConfigParserTest.php
+++ b/tests/Mantis/ConfigParserTest.php
@@ -189,7 +189,7 @@ class MantisConfigParserTest extends PHPUnit_Framework_TestCase {
 			. $p_text . "\n"
 			. "<<<------------------------\n";
 	}
-	
+
 	/**
 	 * Adds a new test case to the list
 	 *
@@ -239,7 +239,7 @@ class MantisConfigParserTest extends PHPUnit_Framework_TestCase {
 		$this->addScalarCase( 'MANTIS_VERSION', PHPUnit_Type::TYPE_STRING );    #string
 		$this->addScalarCase( " MANTIS_VERSION\n", PHPUnit_Type::TYPE_STRING );
 	}
-	
+
 	/**
 	 * Initialize the array test cases list
 	 */


### PR DESCRIPTION
Covers the following points

- fixed regressions introduced by the config parser ([21124](https://www.mantisbt.org/bugs/view.php?id=21124))
  - *No more tokens* exception with empty values (`''`, `0`, etc)
  - *Unexpected token "-"* exception with negative numbers (and the same with "+")
- fixed config value corruption when editing a value containing newlines [21136](https://www.mantisbt.org/bugs/view.php?id=21136)
- improved handling of empty values
- added new unit test cases
- improved and simplified unit tests through use of data providers
