### PR TITLE
Replace UTF-8 4bytes chars by '�' (U+FFFD) on MySQL

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -318,11 +318,21 @@ class BugData {
 				}
 				break;
 			case 'summary':
+				# MySQL 4-bytes UTF-8 chars workaround #21101
+				$p_value = db_mysql_fix_utf8( $p_value );
+				# Fall through
 			case 'build':
 				if ( !$this->loading ) {
 					$p_value = trim( $p_value );
 				}
 				break;
+			case 'description':
+			case 'steps_to_reproduce':
+			case 'additional_information':
+				# MySQL 4-bytes UTF-8 chars workaround #21101
+				$p_value = db_mysql_fix_utf8( $p_value );
+				break;
+
 		}
 		$this->$p_name = $p_value;
 	}

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -215,6 +215,9 @@ function bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking = '0:00', $p_
 	# Event integration
 	$t_bugnote_text = event_signal( 'EVENT_BUGNOTE_DATA', $p_bugnote_text, $c_bug_id );
 
+	# MySQL 4-bytes UTF-8 chars workaround #21101
+	$t_bugnote_text = db_mysql_fix_utf8( $t_bugnote_text );
+
 	# insert bugnote text
 	db_param_push();
 	$t_query = 'INSERT INTO {bugnote_text} ( note ) VALUES ( ' . db_param() . ' )';
@@ -622,6 +625,9 @@ function bugnote_set_text( $p_bugnote_id, $p_bugnote_text ) {
 	if( $t_old_text == $p_bugnote_text ) {
 		return true;
 	}
+	# MySQL 4-bytes UTF-8 chars workaround #21101
+	$p_bugnote_text = db_mysql_fix_utf8( $p_bugnote_text );
+
 
 	$t_bug_id = bugnote_get_field( $p_bugnote_id, 'bug_id' );
 	$t_bugnote_text_id = bugnote_get_field( $p_bugnote_id, 'bugnote_text_id' );

--- a/core/cfdefs/cfdef_standard.php
+++ b/core/cfdefs/cfdef_standard.php
@@ -27,7 +27,8 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_STRING] = array (
 	'#display_length_max' => true,
 	'#display_default_value' => true,
 	'#function_return_distinct_values' => null,
-	'#function_value_to_database' => null,
+	# MySQL 4-bytes UTF-8 chars workaround #21101
+	'#function_value_to_database' => 'db_mysql_fix_utf8',
 	'#function_database_to_value' => null,
 	'#function_print_input' => 'cfdef_input_textbox',
 	'#function_string_value' => null,
@@ -41,7 +42,8 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_TEXTAREA] = array (
 	'#display_length_max' => true,
 	'#display_default_value' => true,
 	'#function_return_distinct_values' => null,
-	'#function_value_to_database' => null,
+	# MySQL 4-bytes UTF-8 chars workaround #21101
+	'#function_value_to_database' => 'db_mysql_fix_utf8',
 	'#function_database_to_value' => null,
 	'#function_print_input' => 'cfdef_input_textarea',
 	'#function_string_value' => null,

--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -1202,6 +1202,7 @@ function custom_field_set_value( $p_field_id, $p_bug_id, $p_value, $p_log_insert
 	$t_type = custom_field_get_field( $p_field_id, 'type' );
 
 	$t_value_field = ( $t_type == CUSTOM_FIELD_TYPE_TEXTAREA ) ? 'text' : 'value';
+	$t_value = custom_field_value_to_database( $p_value, $t_type );
 
 	# Determine whether an existing value needs to be updated or a new value inserted
 	db_param_push();
@@ -1218,13 +1219,13 @@ function custom_field_set_value( $p_field_id, $p_bug_id, $p_value, $p_log_insert
 					  WHERE field_id=' . db_param() . ' AND
 					  		bug_id=' . db_param();
 		$t_params = array(
-			custom_field_value_to_database( $p_value, $t_type ),
+			$t_value,
 			(int)$p_field_id,
 			(int)$p_bug_id,
 		);
 		db_query( $t_query, $t_params );
 
-		history_log_event_direct( $p_bug_id, $t_name, custom_field_database_to_value( $t_row[$t_value_field], $t_type ), $p_value );
+		history_log_event_direct( $p_bug_id, $t_name, custom_field_database_to_value( $t_row[$t_value_field], $t_type ), $t_value );
 	} else {
 		db_param_push();
 		$t_query = 'INSERT INTO {custom_field_string}
@@ -1234,12 +1235,12 @@ function custom_field_set_value( $p_field_id, $p_bug_id, $p_value, $p_log_insert
 		$t_params = array(
 			(int)$p_field_id,
 			(int)$p_bug_id,
-			custom_field_value_to_database( $p_value, $t_type ),
+			$t_value,
 		);
 		db_query( $t_query, $t_params );
 		# Don't log history events for new bug reports or on other special occasions
 		if( $p_log_insert ) {
-			history_log_event_direct( $p_bug_id, $t_name, '', $p_value );
+			history_log_event_direct( $p_bug_id, $t_name, '', $t_value );
 		}
 	}
 

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -1293,3 +1293,24 @@ function db_oracle_adapt_query_syntax( $p_query, array &$p_arr_parms = null ) {
 	$p_query = db_oracle_order_binds_sequentially( $p_query );
 	return $p_query;
 }
+
+/**
+ * Replace 4-byte UTF-8 chars
+ * This is a workaround to avoid data getting truncated on MySQL databases
+ * using native utf8 encoding, which only supports 3 bytes chars (see #20431)
+ * @param string $p_string
+ * @return string
+ */
+function db_mysql_fix_utf8( $p_string ) {
+	if( !db_is_mysql() ) {
+		return $p_string;
+	}
+	return preg_replace(
+		# 4-byte UTF8 chars always start with bytes 0xF0-0xF7 (0b11110xxx)
+		'/[\xF0-\xF7].../s',
+		# replace with U+FFFD to avoid potential Unicode XSS attacks,
+		# see http://unicode.org/reports/tr36/#Deletion_of_Noncharacters
+		"\xEF\xBF\xBD",
+		$p_string
+	);
+}


### PR DESCRIPTION
Workaround applied to the following fields:

- bug.summary
- bug.description
- bug.steps_to_reproduce
- bug.additional_information
- bugnote.text
- custom fields with type *string* and *text area*

Let me know if you think other fields need to be fixed as well.

Fixes [#21101](https://www.mantisbt.org/bugs/view.php?id=21101)