### PR TITLE
move "auto_set_status_to_assigned" logic into bug_api

### DIFF
--- a/bug_actiongroup.php
+++ b/bug_actiongroup.php
@@ -151,11 +151,7 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			break;
 		case 'ASSIGN':
 			$f_assign = gpc_get_int( 'assign' );
-			if( ON == config_get( 'auto_set_status_to_assigned' ) ) {
-				$t_assign_status = config_get( 'bug_assigned_status' );
-			} else {
-				$t_assign_status = $t_status;
-			}
+			$t_assign_status = bug_get_status_for_assign( $t_bug->handler_id, $f_assign, $t_status );
 			# check that new handler has rights to handle the issue, and
 			#  that current user has rights to assign the issue
 			$t_threshold = access_get_status_threshold( $t_assign_status, $t_bug->project_id );

--- a/bug_update.php
+++ b/bug_update.php
@@ -373,14 +373,7 @@ if( $t_bug_note->note &&
 }
 
 # Handle automatic assignment of issues.
-if( $t_existing_bug->handler_id == NO_USER &&
-	$t_updated_bug->handler_id != NO_USER &&
-	$t_updated_bug->status == $t_existing_bug->status &&
-	$t_updated_bug->status < config_get( 'bug_assigned_status' ) &&
-	config_get( 'auto_set_status_to_assigned' )
-) {
-	$t_updated_bug->status = config_get( 'bug_assigned_status' );
-}
+$t_updated_bug->status = bug_get_status_for_assign( $t_existing_bug->handler_id, $t_updated_bug->handler_id, $t_existing_bug->status, $t_updated_bug->status );
 
 # Allow a custom function to validate the proposed bug updates. Note that
 # custom functions are being deprecated in MantisBT. You should migrate to

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -513,11 +513,7 @@ class BugData {
 		}
 
 		# Check if bug was pre-assigned or auto-assigned.
-		if( ( $this->handler_id != 0 ) && ( $this->status == $t_starting_status ) && ( ON == config_get( 'auto_set_status_to_assigned' ) ) ) {
-			$t_status = config_get( 'bug_assigned_status' );
-		} else {
-			$t_status = $this->status;
-		}
+		$t_status = bug_get_status_for_assign( NO_USER, $this->handler_id, $this->status);
 
 		# Insert the rest of the data
 		db_param_push();
@@ -1723,11 +1719,7 @@ function bug_assign( $p_bug_id, $p_user_id, $p_bugnote_text = '', $p_bugnote_pri
 	$h_status = bug_get_field( $p_bug_id, 'status' );
 	$h_handler_id = bug_get_field( $p_bug_id, 'handler_id' );
 
-	if( ( ON == config_get( 'auto_set_status_to_assigned' ) ) && ( NO_USER != $p_user_id ) ) {
-		$t_ass_val = config_get( 'bug_assigned_status' );
-	} else {
-		$t_ass_val = $h_status;
-	}
+	$t_ass_val = bug_get_status_for_assign( $h_handler_id, $p_user_id, $h_status );
 
 	if( ( $t_ass_val != $h_status ) || ( $p_user_id != $h_handler_id ) ) {
 
@@ -2061,4 +2053,33 @@ function bug_format_id( $p_bug_id ) {
 	$t_string = sprintf( '%0' . (int)$t_padding . 'd', $p_bug_id );
 
 	return event_signal( 'EVENT_DISPLAY_BUG_ID', $t_string, array( $p_bug_id ) );
+}
+
+/**
+ * Returns the resulting status for a bug after an assignment action is performed.
+ * If the option "auto_set_status_to_assigned" is enabled, the resulting status
+ * is calculated based on current handler and status , and requested modifications.
+ * @param integer $p_current_handler	Current handler user id
+ * @param integer $p_new_handler		New handler user id
+ * @param integer $p_current_status		Current bug status
+ * @param integer $p_new_status			New bug status (as being part of a status change combined action)
+ * @return integer		Calculated status after assignment
+ */
+function bug_get_status_for_assign( $p_current_handler, $p_new_handler, $p_current_status, $p_new_status = null ) {
+	if( null === $p_new_status ) {
+		$p_new_status = $p_current_status;
+	}
+	if( config_get( 'auto_set_status_to_assigned' ) ) {
+		$t_assigned_status = config_get( 'bug_assigned_status' );
+
+		if(		$p_current_handler == NO_USER &&
+				$p_new_handler != NO_USER &&
+				$p_new_status == $p_current_status &&
+				$p_new_status < $t_assigned_status &&
+				bug_check_workflow( $p_current_status, $t_assigned_status ) ) {
+
+			return $t_assigned_status;
+		}
+	}
+	return $p_new_status;
 }

--- a/core/bug_group_action_api.php
+++ b/core/bug_group_action_api.php
@@ -202,12 +202,7 @@ function bug_group_action_get_commands( array $p_project_ids = null ) {
 
 		if( !isset( $t_commands['ASSIGN'] ) &&
 			access_has_project_level( config_get( 'update_bug_assign_threshold', null, null, $t_project_id ), $t_project_id ) ) {
-			if( ON == config_get( 'auto_set_status_to_assigned', null, null, $t_project_id ) &&
-				access_has_project_level( access_get_status_threshold( config_get( 'bug_assigned_status', null, null, $t_project_id ), $t_project_id ), $t_project_id ) ) {
-				$t_commands['ASSIGN'] = lang_get( 'actiongroup_menu_assign' );
-			} else {
-				$t_commands['ASSIGN'] = lang_get( 'actiongroup_menu_assign' );
-			}
+			$t_commands['ASSIGN'] = lang_get( 'actiongroup_menu_assign' );
 		}
 
 		if( !isset( $t_commands['CLOSE'] ) &&

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1622,12 +1622,6 @@ function html_button_bug_change_status( BugData $p_bug ) {
  */
 function html_button_bug_assign_to( BugData $p_bug ) {
 	# make sure status is allowed of assign would cause auto-set-status
-	# workflow implementation
-	if( ON == config_get( 'auto_set_status_to_assigned' )
-		&& !bug_check_workflow( $p_bug->status, config_get( 'bug_assigned_status' ) )
-	) {
-		return;
-	}
 
 	# make sure current user has access to modify bugs.
 	if( !access_has_bug_level( config_get( 'update_bug_assign_threshold', config_get( 'update_bug_threshold' ) ), $p_bug->id ) ) {


### PR DESCRIPTION
Create a bug api function to evaluate the resulting status after an
assignment action. This function account for the option
"auto_set_status_to_assigned", current handler and status, and requested
new handler and status.

The behaviour of assignments, when this option is enabled, is slightly
modified:
Previously, inconcistent logic allowed to transition a bug into assigned
status by changing handler user, even if the transition is not allowed
by workflow configuration.
Additionally, the assign action was not available to the user if the
assigned status is not reachable by workflow, even when the assign
action would not result in a status change.

Now, the assign action is always available (if allowed by permissions),
and the status change is performed only if the conditions are met,
otherwise, the handler change is always performed.

The conditions needed for automatic change to 'bug_assigned_status' are:
- current handler is empty
- new handler is not empty
- status is not already part of the bug modification
- current status is lower than 'bug_assigned_status'
- 'bug_assigned_status' is reachable by workflow

Fixes #21203