### PR TITLE
Only prepend 'css/' when given a filename without path

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -388,7 +388,11 @@ function html_css() {
  * @return void
  */
 function html_css_link( $p_filename ) {
-	echo "\t", '<link rel="stylesheet" type="text/css" href="', string_sanitize_url( helper_mantis_url( 'css/' . $p_filename ), true ), '" />' . "\n";
+	# If no path is specified, look for CSS files in default directory
+	if( $p_filename == basename( $p_filename ) ) {
+		$p_filename = 'css/' . $p_filename;
+	}
+	echo "\t", '<link rel="stylesheet" type="text/css" href="', string_sanitize_url( helper_mantis_url( $p_filename ), true ), '" />' . "\n";
 }
 
 


### PR DESCRIPTION
Commit 1819bbdf8c2d629798fa48537f9bb167e8d33005 introduced new
html_css_link() function to include CSS files, but made the assumption
that these would always be in the css/ directory.

This lets the admin specify $g_css_include_file with a path, allowing
them to store custom CSS in a different location within the MantisBT
root.

Fixes [#21194](https://www.mantisbt.org/bugs/view.php?id=21194)