### PR TITLE
Remove leftover php closing bracket from priority graph page

### DIFF
--- a/plugins/MantisGraph/pages/priority_graph.php
+++ b/plugins/MantisGraph/pages/priority_graph.php
@@ -58,7 +58,6 @@ $t_metrics = create_bug_enum_summary( lang_get( 'priority_enum_string' ), 'prior
 <div class="col-md-6 col-xs-12">
 <?php graph_pie( $t_metrics, plugin_lang_get( 'by_priority_pct' ) ); ?>
 </div>
-?>
 
 </div>
 </div>


### PR DESCRIPTION
Minor fix. Remove "?>" from priority graph page. See image
<img width="348" alt="screen shot 2016-07-09 at 6 50 01 pm" src="https://cloud.githubusercontent.com/assets/1354889/16711246/00e4adca-4606-11e6-8914-c4be0b33ee19.png">
