### PR TITLE
Fix footer layout for users without 'Save Filter' privileges 

### DIFF
--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -3496,12 +3496,11 @@ function filter_draw_selection_area2( $p_page_number, $p_for_screen = true, $p_e
 
 	echo '</form></div>';
 	echo '<div class="btn-toolbar pull-right">';
+	echo '<div class="btn-group">';
 
 	$t_stored_queries_arr = filter_db_get_available_queries();
-
+	
 	if( access_has_project_level( config_get( 'stored_query_create_threshold' ) ) ) { ?>
-	<div class="btn-group">
-
 		<form class="form-inline pull-left" method="post" name="save_query" action="query_store_page.php">
 			<?php # CSRF protection not required here - form does not result in modifications ?>
 			<input type="submit" name="save_query_button" class="btn btn-primary btn-white btn-sm btn-round"


### PR DESCRIPTION
Relocate opening div outside of the conditional statement to match closing div

Fixes #20240