### PR TITLE
Use matching label for max custom field length

### DIFF
--- a/manage_custom_field_edit_page.php
+++ b/manage_custom_field_edit_page.php
@@ -171,7 +171,7 @@ $t_definition = custom_field_get_definition( $f_field_id );
     </tr>
     <tr>
         <td class="category">
-            <?php echo lang_get( 'custom_field_length_min' ) ?>
+            <?php echo lang_get( 'custom_field_length_max' ) ?>
         </td>
         <td>
             <input type="text" id="custom-field-length-max" name="length_max" class="input-sm" size="32" maxlength="64" value="<?php echo $t_definition['length_max'] ?>" />


### PR DESCRIPTION
Fixes #20182

<img width="620" alt="screen shot 2016-07-10 at 12 49 13 am" src="https://cloud.githubusercontent.com/assets/1354889/16712302/33ba5632-4638-11e6-9afd-6ae20c5055cc.png">
