### PR TITLE
Fix plugin and config custom main menu options in modern ui

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -3498,14 +3498,28 @@ $g_custom_field_edit_after_create = ON;
 
 /**
  * Add custom options to the main menu.  For example:
+ *
  * $g_main_menu_custom_options = array(
- *     array( "My Link",  MANAGER,       'my_link.php' ),
- *     array( "My Link2", ADMINISTRATOR, 'my_link2.php' )
+ *     array( 
+ *         'title'        => 'My Link',
+ *         'access_level' => MANAGER,
+ *         'url'          => 'my_link.php',
+ *         'icon'         => 'fa-plug'
+ *     ),
+ *     array( 
+ *         'title'        => 'My Link2',
+ *         'access_level' => ADMINISTRATOR,
+ *         'url'          => 'my_link2.php',
+ *         'icon'         => 'fa-plug'
+ *     )
  * );
  *
- * Note that if the caption is found in custom_strings_inc.php, then it will be
- * replaced by the translated string.  Options will only be added to the menu
+ * Note that if the caption is a localized string name (in strings_english.txt or custom_strings_inc.php),
+ * then it will be replaced by the translated string.  Options will only be added to the menu
  * if the current logged in user has the appropriate access level.
+ *
+ * Use icons from http://fontawesome.io/icons/ - Add "fa-" prefix to icon name.
+ *
  * @global array $g_main_menu_custom_options
  */
 $g_main_menu_custom_options = array();

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -3514,9 +3514,13 @@ $g_custom_field_edit_after_create = ON;
  *     )
  * );
  *
- * Note that if the caption is a localized string name (in strings_english.txt or custom_strings_inc.php),
- * then it will be replaced by the translated string.  Options will only be added to the menu
- * if the current logged in user has the appropriate access level.
+ * Note that if the caption is a localized string name (in strings_english.txt
+ * or custom_strings_inc.php), then it will be replaced by the translated
+ * string.  Options will only be added to the menu if the current logged in
+ * user has the appropriate access level.
+ *
+ * Access level is an optional field, and no check will be done if it is not set.
+ * Icon is an optional field, and 'fa-plug' will be used if it is not set.
  *
  * Use icons from http://fontawesome.io/icons/ - Add "fa-" prefix to icon name.
  *

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -416,27 +416,6 @@ function html_end() {
 }
 
 /**
- * Prepare an array of additional menu options from a configuration variable
- * @param string $p_config Configuration variable name.
- * @return array
- */
-function prepare_custom_menu_options( $p_config ) {
-	$t_custom_menu_options = config_get( $p_config );
-	$t_options = array();
-
-	foreach( $t_custom_menu_options as $t_custom_option ) {
-		$t_access_level = $t_custom_option[1];
-		if( access_has_project_level( $t_access_level ) ) {
-			$t_caption = string_html_specialchars( lang_get_defaulted( $t_custom_option[0] ) );
-			$t_link = string_attribute( $t_custom_option[2] );
-			$t_options[] = '<a href="' . $t_link . '">' . $t_caption . '</a>';
-		}
-	}
-
-	return $t_options;
-}
-
-/**
  * Print the menu bar with a list of projects to which the user has access
  * @return void
  */

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -823,11 +823,17 @@ function layout_config_menu_options_for_sidebar( $p_active_sidebar_page ) {
 	$t_custom_options = config_get( 'main_menu_custom_options' );
 
 	foreach( $t_custom_options as $t_custom_option ) {
-		$t_menu_option = array();
-		$t_menu_option['title'] = $t_custom_option[0];
-		$t_menu_option['access_level'] = $t_custom_option[1];
-		$t_menu_option['icon'] = 'fa-plug';
-		$t_menu_option['url'] = $t_custom_option[2];
+		if( isset( $t_custom_option['url'] ) ) {
+			$t_menu_option = $t_custom_option;
+		} else {
+			# Support < 2.0.0 custom menu options config format
+			$t_menu_option = array();
+			$t_menu_option['title'] = $t_custom_option[0];
+			$t_menu_option['access_level'] = $t_custom_option[1];
+			$t_menu_option['icon'] = 'fa-plug';
+			$t_menu_option['url'] = $t_custom_option[2];
+		}
+
 		$t_menu_options[] = $t_menu_option;
 	}
 

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -715,17 +715,7 @@ function layout_print_sidebar( $p_active_sidebar_page = null ) {
 
 		# Plugin / Event added options
 		$t_event_menu_options = event_signal( 'EVENT_MENU_MAIN_FRONT' );
-		foreach( $t_event_menu_options as $t_plugin => $t_plugin_menu_options ) {
-			foreach( $t_plugin_menu_options as $t_callback => $t_callback_menu_options ) {
-				if( is_array( $t_callback_menu_options ) ) {
-					$t_menu_options = array_merge( $t_menu_options, $t_callback_menu_options );
-				} else {
-					if( !is_null( $t_callback_menu_options ) ) {
-						$t_menu_options[] = $t_callback_menu_options;
-					}
-				}
-			}
-		}
+		layout_plugin_menu_options_for_sidebar( $t_event_menu_options, $p_active_sidebar_page );
 
 		# My View
 		layout_sidebar_menu( 'my_view_page.php', 'my_view_link', 'fa-dashboard', $p_active_sidebar_page );
@@ -766,17 +756,7 @@ function layout_print_sidebar( $p_active_sidebar_page = null ) {
 
 		# Plugin / Event added options
 		$t_event_menu_options = event_signal( 'EVENT_MENU_MAIN' );
-		foreach( $t_event_menu_options as $t_plugin => $t_plugin_menu_options ) {
-			foreach( $t_plugin_menu_options as $t_callback => $t_callback_menu_options ) {
-				if( is_array( $t_callback_menu_options ) ) {
-					$t_menu_options = array_merge( $t_menu_options, $t_callback_menu_options );
-				} else {
-					if( !is_null( $t_callback_menu_options ) ) {
-						$t_menu_options[] = $t_callback_menu_options;
-					}
-				}
-			}
-		}
+		layout_plugin_menu_options_for_sidebar( $t_event_menu_options, $p_active_sidebar_page );
 
 		# Manage Users (admins) or Manage Project (managers) or Manage Custom Fields
 		if( access_has_global_level( config_get( 'manage_site_threshold' ) ) ) {
@@ -813,6 +793,37 @@ function layout_print_sidebar( $p_active_sidebar_page = null ) {
 }
 
 /**
+ * Process plugin menu options for sidebar
+ * @param array $p_plugin_event_response The response from the plugin event signal.
+ * @param string $p_active_sidebar_page The active page on the sidebar.
+ * @return void
+ */
+function layout_plugin_menu_options_for_sidebar( $p_plugin_event_response, $p_active_sidebar_page ) {
+	$t_menu_options = array();
+
+	foreach( $p_plugin_event_response as $t_plugin => $t_plugin_menu_options ) {
+		foreach( $t_plugin_menu_options as $t_callback => $t_callback_menu_options ) {
+			if( is_array( $t_callback_menu_options ) ) {
+				$t_menu_options = array_merge( $t_menu_options, $t_callback_menu_options );
+			} else {
+				if( !is_null( $t_callback_menu_options ) ) {
+					$t_menu_options[] = $t_callback_menu_options;
+				}
+			}
+		}
+	}
+
+	foreach( $t_menu_options as $t_menu_option ) {
+		$t_icon = isset( $t_menu_option['icon'] ) ? $t_menu_option['icon'] : 'fa-plug';
+		if( !isset( $t_menu_option['url'] ) || !isset( $t_menu_option['title'] ) ) {
+			continue;
+		}
+
+		layout_sidebar_menu( $t_menu_option['url'], $t_menu_option['title'], $t_icon, $p_active_sidebar_page );	
+	}
+}
+
+/**
  * Print sidebar opening elements
  * @return null
  */
@@ -843,7 +854,7 @@ function layout_sidebar_menu( $p_page, $p_title, $p_icon, $p_active_sidebar_page
 	}
 	echo '<a href="' . helper_mantis_url( $p_page ) . '">' . "\n";
 	echo '<i class="menu-icon fa ' . $p_icon . '"></i> ' . "\n";
-	echo '<span class="menu-text"> ' . lang_get( $p_title ) . ' </span>' . "\n";
+	echo '<span class="menu-text"> ' . lang_get_defaulted( $p_title ) . ' </span>' . "\n";
 	echo '</a>' . "\n";
 	echo '<b class="arrow"></b>' . "\n";
 	echo '</li>' . "\n";

--- a/docbook/Admin_Guide/en-US/config/html.xml
+++ b/docbook/Admin_Guide/en-US/config/html.xml
@@ -155,6 +155,10 @@ $g_main_menu_custom_options = array(
 					Use icons from <ulink url="http://fontawesome.io/icons/">Font Awesome</ulink>.
 					Add "fa-" prefix to icon name.
 				</para>
+				<para>
+					Access level is an optional field, and no check will be done if it is not set.
+					Icon is an optional field, and 'fa-plug' will be used if it is not set.
+				</para>
 			</listitem>
 		</varlistentry>
 	</variablelist>

--- a/docbook/Admin_Guide/en-US/config/html.xml
+++ b/docbook/Admin_Guide/en-US/config/html.xml
@@ -129,8 +129,18 @@
 					the link to be executed. For example:
 <programlisting>
 $g_main_menu_custom_options = array(
-	array( 'My Link', MANAGER, 'my_link.php' ),
-	array( 'My Link2', ADMINISTRATOR, 'my_link2.php' ),
+    array( 
+        'title'        =&gt; 'My Link',
+        'access_level' =&gt; MANAGER,
+        'url'          =&gt; 'my_link.php',
+        'icon'         =&gt; 'fa-plug'
+    ),
+    array( 
+        'title'        =&gt; 'My Link2',
+        'access_level' =&gt; ADMINISTRATOR,
+        'url'          =&gt; 'my_link2.php',
+        'icon'         =&gt; 'fa-plug'
+    )
 );
 </programlisting>
 					Note that if the caption is found in the
@@ -140,6 +150,10 @@ $g_main_menu_custom_options = array(
 					string. Options will only be added to the menu if
 					the current logged in user has the appropriate
 					access level.
+				</para>
+				<para>
+					Use icons from <ulink url="http://fontawesome.io/icons/">Font Awesome</ulink>.
+					Add "fa-" prefix to icon name.
 				</para>
 			</listitem>
 		</varlistentry>

--- a/docbook/Developers_Guide/en-US/Events_Reference_Output.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference_Output.xml
@@ -230,16 +230,16 @@
 			<title>EVENT_MENU_MAIN (Default)</title>
 			<blockquote>
 				<para>
-					This event gives plugins the opportunity to add new links to the main menu at
-					the top (or bottom) of every page in MantisBT.  New links will be added after the
-					'Docs' link, and before the 'Manage' link.  Hooked events may return multiple
-					links, in which case each link in the array will be automatically separated
-					with the '|' symbol as usual.
+					This event gives plugins the opportunity to add new menu options to main menu.
+					New links will be added AFTER the standard menu options.
+					Hooked events may return an array of menu options.
+					Each array entry will contain an associate array with keys 'title', 'url',
+					'access_level', and 'icon' (e.g. fa-pencil from <ulink url="http://fontawesome.io/icons/">Font Awesome</ulink>).
 				</para>
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>&lt;Array&gt;: List of HTML links for the main menu.</para></listitem>
+					<listitem><para>&lt;Array&gt;: Array of menu options, each is an array of properties.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -248,16 +248,16 @@
 			<title>EVENT_MENU_MAIN_FRONT (Default)</title>
 			<blockquote>
 				<para>
-					This event gives plugins the opportunity to add new links to the main menu at
-					the top (or bottom) of every page in MantisBT.  New links will be added after the
-					'Main' link, and before the 'My View' link.  Hooked events may return multiple
-					links, in which case each link in the array will be automatically separated
-					with the '|' symbol as usual.
+					This event gives plugins the opportunity to add new menu options to main menu.
+					New links will be added BEFORE the standard menu options.
+					Hooked events may return an array of menu options.
+					Each array entry will contain an associate array with keys 'title', 'url',
+					'access_level', and 'icon' (e.g. fa-pencil from <ulink url="http://fontawesome.io/icons/">Font Awesome</ulink>).
 				</para>
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>&lt;Array&gt;: List of HTML links for the main menu.</para></listitem>
+					<listitem><para>&lt;Array&gt;: Array of menu options, each is an array of properties.</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>

--- a/docbook/Developers_Guide/en-US/Events_Reference_Output.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference_Output.xml
@@ -230,16 +230,34 @@
 			<title>EVENT_MENU_MAIN (Default)</title>
 			<blockquote>
 				<para>
-					This event gives plugins the opportunity to add new menu options to main menu.
+					This event gives plugins the opportunity to add new menu options to the main menu.
 					New links will be added AFTER the standard menu options.
-					Hooked events may return an array of menu options.
-					Each array entry will contain an associate array with keys 'title', 'url',
-					'access_level', and 'icon' (e.g. fa-pencil from <ulink url="http://fontawesome.io/icons/">Font Awesome</ulink>).
 				</para>
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>&lt;Array&gt;: Array of menu options, each is an array of properties.</para></listitem>
+					<listitem>
+						<para>&lt;Array&gt;: Hooked events may return an array of menu options.
+					Each array entry will contain an associate array with keys 'title', 'url',
+					'access_level', and 'icon' (e.g. fa-pencil from <ulink url="http://fontawesome.io/icons/">Font Awesome</ulink>).
+						</para>
+						<programlisting>
+							return array(
+							    array( 
+									'title' =&gt; 'My Link',
+									'access_level' =&gt; DEVELOPER,
+									'url' =&gt; 'my_link.php',
+									'icon' =&gt; 'fa-random'
+								),
+								array(
+									'title' =&gt; 'My Link2',
+									'access_level' =&gt; DEVELOPER,
+									'url' =&gt; 'my_link2.php',
+									'icon' =&gt; 'fa-shield'
+								)
+							);
+						</programlisting>
+					</listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>
@@ -250,14 +268,32 @@
 				<para>
 					This event gives plugins the opportunity to add new menu options to main menu.
 					New links will be added BEFORE the standard menu options.
-					Hooked events may return an array of menu options.
-					Each array entry will contain an associate array with keys 'title', 'url',
-					'access_level', and 'icon' (e.g. fa-pencil from <ulink url="http://fontawesome.io/icons/">Font Awesome</ulink>).
 				</para>
 
 				<itemizedlist>
 					<title>Return Value</title>
-					<listitem><para>&lt;Array&gt;: Array of menu options, each is an array of properties.</para></listitem>
+					<listitem>
+						<para>&lt;Array&gt;: Hooked events may return an array of menu options.
+					Each array entry will contain an associate array with keys 'title', 'url',
+					'access_level', and 'icon' (e.g. fa-pencil from <ulink url="http://fontawesome.io/icons/">Font Awesome</ulink>).
+						</para>
+						<programlisting>
+							return array(
+							    array( 
+									'title' =&gt; 'My Link',
+									'access_level' =&gt; DEVELOPER,
+									'url' =&gt; 'my_link.php',
+									'icon' =&gt; 'fa-random'
+								),
+								array(
+									'title' =&gt; 'My Link2',
+									'access_level' =&gt; DEVELOPER,
+									'url' =&gt; 'my_link2.php',
+									'icon' =&gt; 'fa-shield'
+								)
+							);
+						</programlisting>
+					</listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>


### PR DESCRIPTION
- Fixed support for plugin custom main menu options and added icon support.
- Fixed support for config custom main menu options and added icon support.
- Use a consistent format for config and plugin custom main menu options.
- Update documentation for both features.
- Plugin custom options are added at the beginning or end.
- Config custom options are added at the end and after plugin custom options.

Fixes #21397, #21414