### PR TITLE
Don't show empty EVENT_MENU_ISSUE menu items (target 1.3.x)

### DIFF
--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -271,7 +271,7 @@ foreach ( $t_links as $t_plugin => $t_hooks ) {
 					print_bracket_link( $t_href, $t_label );
 				}
 			}
-		} else {
+		} elseif( !empty( $t_hook ) ) {
 			print_bracket_link_prepared( $t_hook );
 		}
 	}


### PR DESCRIPTION
If the result of event call for EVENT_MENU_ISSUE is null, dont print
bracket with empty content.

Having null as returned value is valid.
For example: a plugin can hook to this event and return either an
actual item or an empty one, based in access level.

Fixes: #21407