### PR TITLE
Add "new status" to EVENT_UPDATE_BUG_STATUS_FORM

### DIFF
--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -330,7 +330,7 @@ print_recently_visited();
 		}
 	}
 
-	event_signal( 'EVENT_UPDATE_BUG_STATUS_FORM', array( $f_bug_id ) );
+	event_signal( 'EVENT_UPDATE_BUG_STATUS_FORM', array( $f_bug_id, $f_new_status ) );
 
 	if( $f_change_type == BUG_UPDATE_TYPE_REOPEN ) {
 ?>

--- a/docbook/Developers_Guide/en-US/Events_Reference_Bug.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference_Bug.xml
@@ -197,6 +197,7 @@
 				<itemizedlist>
 					<title>Parameters</title>
 					<listitem><para>&lt;Integer&gt;: Bug ID</para></listitem>
+					<listitem><para>&lt;Integer&gt;: New Status</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>


### PR DESCRIPTION
Add parameter to EVENT_UPDATE_BUG_STATUS_FORM, to include the new
status.

Fixes: #17923

Can be cleanly picked into master
