### PR TITLE
Move Bug update events into BugData

### DIFF
--- a/bug_actiongroup.php
+++ b/bug_actiongroup.php
@@ -218,7 +218,7 @@ foreach( $f_bug_arr as $t_bug_id ) {
 						$t_bugdata->add_update_callback( $add_bugnote_func, array( $t_bugnote_params ) );
 						}
 
-					$t_bugdata->update( false, true );
+					$t_bugdata->update( /* update extended */ false, /* bypass mail */ true );
 
 					if( is_blank( $f_bug_notetext ) ) {
 						# If there is a note, bugnote add, send email notification for new note
@@ -306,7 +306,7 @@ foreach( $f_bug_arr as $t_bug_id ) {
 				if( access_has_bug_level( config_get( 'due_date_update_threshold' ), $t_bug_id ) ) {
 					$t_bugdata = bug_get( $t_bug_id );
 					$t_bugdata->due_date = $t_due_date;
-					$t_bugdata->update( false, true );
+					$t_bugdata->update( /* update extended */ false, /* bypass mail */ true );
 				} else {
 					$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_access' );
 				}
@@ -331,7 +331,7 @@ foreach( $f_bug_arr as $t_bug_id ) {
 				# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
 				$t_bugdata = bug_get( $t_bug_id );
 				$t_bugdata->sticky = intval( !$f_sticky );
-				$t_bugdata->update( false, true );
+				$t_bugdata->update( /* update extended */ false, /* bypass mail */ true );
 				helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 			} else {
 				$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_access' );

--- a/bug_actiongroup.php
+++ b/bug_actiongroup.php
@@ -192,8 +192,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( config_get( 'update_bug_threshold' ), $t_bug_id ) ) {
 				$f_priority = gpc_get_int( 'priority' );
 				# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-				bug_set_field( $t_bug_id, 'priority', $f_priority );
-				email_bug_updated( $t_bug_id );
+				$t_bugdata = bug_get( $t_bug_id );
+				$t_bugdata->priority = $f_priority;
+				$t_bugdata->update();
 				helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 			} else {
 				$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_access' );
@@ -204,14 +205,24 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( access_get_status_threshold( $f_status, $t_bug->project_id ), $t_bug_id ) ) {
 				if( true == bug_check_workflow( $t_status, $f_status ) ) {
 					# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-					bug_set_field( $t_bug_id, 'status', $f_status );
+					$t_bugdata = bug_get( $t_bug_id );
+					$t_bugdata->status = $f_status;
 
 					# Add bugnote if supplied
 					if( !is_blank( $f_bug_notetext ) ) {
-						$t_bugnote_id = bugnote_add( $t_bug_id, $f_bug_notetext, null, $f_bug_noteprivate );
-						bugnote_process_mentions( $t_bug_id, $t_bugnote_id, $f_bug_notetext );
-						# No need to call email_generic(), bugnote_add() does it
-					} else {
+						$add_bugnote_func = function( array $p_bugnote_params ) {
+							$t_bugnote_id = call_user_func_array( 'bugnote_add', $p_bugnote_params );
+							bugnote_process_mentions( $p_bugnote_params[0], $t_bugnote_id, $p_bugnote_params[1] );
+						};
+						$t_bugnote_params = array( $t_bug_id, $f_bug_notetext, null, $f_bug_noteprivate );
+						$t_bugdata->add_update_callback( $add_bugnote_func, array( $t_bugnote_params ) );
+						}
+
+					$t_bugdata->update( false, true );
+
+					if( is_blank( $f_bug_notetext ) ) {
+						# If there is a note, bugnote add, send email notification for new note
+						# if not, notify generic update.
 						email_bug_updated( $t_bug_id );
 					}
 
@@ -228,8 +239,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( config_get( 'update_bug_threshold' ), $t_bug_id ) ) {
 				if( category_exists( $f_category_id ) ) {
 					# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-					bug_set_field( $t_bug_id, 'category_id', $f_category_id );
-					email_bug_updated( $t_bug_id );
+					$t_bugdata = bug_get( $t_bug_id );
+					$t_bugdata->category_id = $f_category_id;
+					$t_bugdata->update();
 					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 				} else {
 					$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_category' );
@@ -243,8 +255,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( config_get( 'update_bug_threshold' ), $t_bug_id ) ) {
 				if( $f_product_version === '' || version_get_id( $f_product_version, $t_bug->project_id ) !== false ) {
 					/** @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) ); */
-					bug_set_field( $t_bug_id, 'version', $f_product_version );
-					email_bug_updated( $t_bug_id );
+					$t_bugdata = bug_get( $t_bug_id );
+					$t_bugdata->version = $f_product_version;
+					$t_bugdata->update();
 					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 				} else {
 					$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_version' );
@@ -258,8 +271,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( config_get( 'update_bug_threshold' ), $t_bug_id ) ) {
 				if( $f_fixed_in_version === '' || version_get_id( $f_fixed_in_version, $t_bug->project_id ) !== false ) {
 					# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-					bug_set_field( $t_bug_id, 'fixed_in_version', $f_fixed_in_version );
-					email_bug_updated( $t_bug_id );
+					$t_bugdata = bug_get( $t_bug_id );
+					$t_bugdata->fixed_in_version = $f_fixed_in_version;
+					$t_bugdata->update();
 					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 					} else {
 						$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_version' );
@@ -273,8 +287,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( config_get( 'roadmap_update_threshold' ), $t_bug_id ) ) {
 				if( $f_target_version === '' || version_get_id( $f_target_version, $t_bug->project_id ) !== false ) {
 					# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-					bug_set_field( $t_bug_id, 'target_version', $f_target_version );
-					email_bug_updated( $t_bug_id );
+					$t_bugdata = bug_get( $t_bug_id );
+					$t_bugdata->target_version = $f_target_version;
+					$t_bugdata->update();
 					helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 				} else {
 					$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_version' );
@@ -289,7 +304,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 				$t_due_date = date_strtotime( $t_due_date );
 
 				if( access_has_bug_level( config_get( 'due_date_update_threshold' ), $t_bug_id ) ) {
-					bug_set_field( $t_bug_id, 'due_date', $t_due_date );
+					$t_bugdata = bug_get( $t_bug_id );
+					$t_bugdata->due_date = $t_due_date;
+					$t_bugdata->update( false, true );
 				} else {
 					$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_access' );
 				}
@@ -299,8 +316,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 			if( access_has_bug_level( config_get( 'change_view_status_threshold' ), $t_bug_id ) ) {
 				$f_view_status = gpc_get_int( 'view_status' );
 				# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-				bug_set_field( $t_bug_id, 'view_state', $f_view_status );
-				email_bug_updated( $t_bug_id );
+				$t_bugdata = bug_get( $t_bug_id );
+				$t_bugdata->view_state = $f_view_status;
+				$t_bugdata->update();
 				helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 			} else {
 				$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_access' );
@@ -311,7 +329,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 				$f_sticky = bug_get_field( $t_bug_id, 'sticky' );
 				# The new value is the inverted old value
 				# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
-				bug_set_field( $t_bug_id, 'sticky', intval( !$f_sticky ) );
+				$t_bugdata = bug_get( $t_bug_id );
+				$t_bugdata->sticky = intval( !$f_sticky );
+				$t_bugdata->update( false, true );
 				helper_call_custom_function( 'issue_update_notify', array( $t_bug_id ) );
 			} else {
 				$t_failed_ids[$t_bug_id] = lang_get( 'bug_actiongroup_access' );

--- a/bug_actiongroup_update_product_build_inc.php
+++ b/bug_actiongroup_update_product_build_inc.php
@@ -109,6 +109,6 @@ function action_update_product_build_process( $p_bug_id ) {
 	$t_build = gpc_get_string( 'build' );
 	$t_bugdata = bug_get( $p_bug_id );
 	$t_bugdata->build = $t_build;
-	$t_bugdata->update( false, true );
+	$t_bugdata->update( /* update extended */ false, /* bypass mail */ true );
 	return null;
 }

--- a/bug_actiongroup_update_product_build_inc.php
+++ b/bug_actiongroup_update_product_build_inc.php
@@ -107,7 +107,8 @@ function action_update_product_build_validate( $p_bug_id ) {
  */
 function action_update_product_build_process( $p_bug_id ) {
 	$t_build = gpc_get_string( 'build' );
-
-	bug_set_field( $p_bug_id, 'build', $t_build );
+	$t_bugdata = bug_get( $p_bug_id );
+	$t_bugdata->build = $t_build;
+	$t_bugdata->update( false, true );
 	return null;
 }

--- a/bug_actiongroup_update_severity_inc.php
+++ b/bug_actiongroup_update_severity_inc.php
@@ -100,6 +100,8 @@ function action_update_severity_validate( $p_bug_id ) {
  */
 function action_update_severity_process( $p_bug_id ) {
 	$f_severity = gpc_get_string( 'severity' );
-	bug_set_field( $p_bug_id, 'severity', $f_severity );
+	$t_bugdata = bug_get( $p_bug_id );
+	$t_bugdata->severity = $f_severity;
+	$t_bugdata->update( false, true );
 	return null;
 }

--- a/bug_actiongroup_update_severity_inc.php
+++ b/bug_actiongroup_update_severity_inc.php
@@ -102,6 +102,6 @@ function action_update_severity_process( $p_bug_id ) {
 	$f_severity = gpc_get_string( 'severity' );
 	$t_bugdata = bug_get( $p_bug_id );
 	$t_bugdata->severity = $f_severity;
-	$t_bugdata->update( false, true );
+	$t_bugdata->update( /* update extended */ false, /* bypass mail */ true );
 	return null;
 }

--- a/bug_report.php
+++ b/bug_report.php
@@ -171,6 +171,7 @@ helper_call_custom_function( 'issue_create_validate', array( $t_bug_data ) );
 
 # Validate the custom fields before adding the bug.
 $t_related_custom_field_ids = custom_field_get_linked_ids( $t_bug_data->project_id );
+$t_custom_fields_to_set = array();
 foreach( $t_related_custom_field_ids as $t_id ) {
 	$t_def = custom_field_get_definition( $t_id );
 
@@ -182,9 +183,15 @@ foreach( $t_related_custom_field_ids as $t_id ) {
 		trigger_error( ERROR_EMPTY_FIELD, ERROR );
 	}
 
-	if( !custom_field_validate( $t_id, gpc_get_custom_field( 'custom_field_' . $t_id, $t_def['type'], null ) ) ) {
+	$t_new_custom_field_value = gpc_get_custom_field( 'custom_field_' . $t_id, $t_def['type'], $t_def['default_value'] );
+	if( !custom_field_validate( $t_id, $t_new_custom_field_value ) ) {
 		error_parameters( lang_get_defaulted( custom_field_get_field( $t_id, 'name' ) ) );
 		trigger_error( ERROR_CUSTOM_FIELD_INVALID_VALUE, ERROR );
+	}
+
+	# Only set custom field value if user has write access
+	if( custom_field_has_write_access_to_project( $t_id, $t_bug_data->project_id ) ) {
+		$t_custom_fields_to_set[] = array( 'id' => $t_id, 'value' => $t_new_custom_field_value );
 	}
 }
 
@@ -193,91 +200,103 @@ if( $t_bug_data->handler_id == NO_USER && $t_bug_data->status >= config_get( 'bu
 	$t_bug_data->handler_id = auth_get_current_user_id();
 }
 
-# Create the bug
-$t_bug_id = $t_bug_data->create();
-$t_bug_data->process_mentions();
+# set up post-update callbacks
+# operations are defined as closures that receive a BugData object as parameter
+# at that point, when the function is called, the bug_id will be defined
 
-# Mark the added issue as visited so that it appears on the last visited list.
-last_visited_issue( $t_bug_id );
+# Handle custom field submission
+if( !empty( $t_custom_fields_to_set ) ) {
+	$t_callback_set_cf = function( BugData $p_bug, array $p_cf_values_array ) {
+		$t_bug_id = $p_bug->id;
+		foreach( $p_cf_values_array as $t_cf_input ) {
+			$t_id = $t_cf_input['id'];
+			$t_value = $t_cf_input['value'];
+			$t_def = custom_field_get_definition( $t_id );
+			if( !custom_field_set_value( $t_id, $t_bug_id, $t_value, false ) ) {
+				error_parameters( lang_get_defaulted( custom_field_get_field( $t_id, 'name' ) ) );
+				trigger_error( ERROR_CUSTOM_FIELD_INVALID_VALUE, ERROR );
+			}
+		}
+	};
+	$t_bug_data->add_update_callback( $t_callback_set_cf, array( $t_bug_data, $t_custom_fields_to_set ) );
+}
 
 # Handle the file upload
 if( $f_files !== null ) {
 	if( !file_allow_bug_upload( $t_bug_id ) ) {
 		access_denied();
 	}
-
-	file_process_posted_files_for_bug( $t_bug_id, $f_files );
+	$t_callback_file_upload = function( BugData $p_bug, $p_files ) {
+		file_process_posted_files_for_bug( $p_bug->id, $p_files );
+	};
+	$t_bug_data->add_update_callback( $t_callback_file_upload, array( $t_bug_data, $f_files ) );
 }
 
-# Handle custom field submission
-foreach( $t_related_custom_field_ids as $t_id ) {
-	# Do not set custom field value if user has no write access
-	if( !custom_field_has_write_access( $t_id, $t_bug_id ) ) {
-		continue;
-	}
-
-	$t_def = custom_field_get_definition( $t_id );
-	if( !custom_field_set_value( $t_id, $t_bug_id, gpc_get_custom_field( 'custom_field_' . $t_id, $t_def['type'], $t_def['default_value'] ), false ) ) {
-		error_parameters( lang_get_defaulted( custom_field_get_field( $t_id, 'name' ) ) );
-		trigger_error( ERROR_CUSTOM_FIELD_INVALID_VALUE, ERROR );
-	}
-}
-
+# Handle bug clone and relations
 if( $f_master_bug_id > 0 ) {
-	# it's a child generation... let's create the relationship and add some lines in the history
+	# For a child generation add some lines in the history
+	$t_callback_child_generation = function( BugData $p_bug, $p_master_bug_id ) {
+		# update master bug last updated
+		bug_update_date( $p_master_bug_id );
+		# Add log line to record the cloning action
+		history_log_event_special( $p_bug->id, BUG_CREATED_FROM, '', $p_master_bug_id );
+		history_log_event_special( $p_master_bug_id, BUG_CLONED_TO, '', $p_bug->id );
+	};
+	$t_bug_data->add_update_callback( $t_callback_child_generation, array( $t_bug_data, $f_master_bug_id ) );
 
-	# update master bug last updated
-	bug_update_date( $f_master_bug_id );
-
-	# Add log line to record the cloning action
-	history_log_event_special( $t_bug_id, BUG_CREATED_FROM, '', $f_master_bug_id );
-	history_log_event_special( $f_master_bug_id, BUG_CLONED_TO, '', $t_bug_id );
-
+	# create relationships
 	if( $f_rel_type > BUG_REL_ANY ) {
-		# Add the relationship
-		relationship_add( $t_bug_id, $f_master_bug_id, $f_rel_type );
-
-		# Add log line to the history (both issues)
-		history_log_event_special( $f_master_bug_id, BUG_ADD_RELATIONSHIP, relationship_get_complementary_type( $f_rel_type ), $t_bug_id );
-		history_log_event_special( $t_bug_id, BUG_ADD_RELATIONSHIP, $f_rel_type, $f_master_bug_id );
-
-		# Send the email notification
-		email_relationship_added( $f_master_bug_id, $t_bug_id, relationship_get_complementary_type( $f_rel_type ) );
-
-		# update relationship target bug last updated
-		bug_update_date( $t_bug_id );
+		$t_callback_relations = function( BugData $p_bug, $p_master_bug_id, $p_rel_type ) {
+			# Add the relationship
+			relationship_add( $p_bug->id, $p_master_bug_id, $p_rel_type );
+			# Add log line to the history (both issues)
+			history_log_event_special( $p_master_bug_id, BUG_ADD_RELATIONSHIP, relationship_get_complementary_type( $p_rel_type ), $p_bug->id );
+			history_log_event_special( $p_bug->id, BUG_ADD_RELATIONSHIP, $p_rel_type, $p_master_bug_id );
+			# Send the email notification
+			email_relationship_added( $p_master_bug_id, $p_bug->id, relationship_get_complementary_type( $p_rel_type ) );
+		};
+		$t_bug_data->add_update_callback( $t_callback_relations, array( $t_bug_data, $f_master_bug_id, $f_rel_type ) );
 	}
 
 	# copy notes from parent
 	if( $f_copy_notes_from_parent ) {
-
-		$t_parent_bugnotes = bugnote_get_all_bugnotes( $f_master_bug_id );
-
-		foreach ( $t_parent_bugnotes as $t_parent_bugnote ) {
-			$t_private = $t_parent_bugnote->view_state == VS_PRIVATE;
-
-			bugnote_add(
-				$t_bug_id,
-				$t_parent_bugnote->note,
-				$t_parent_bugnote->time_tracking,
-				$t_private,
-				$t_parent_bugnote->note_type,
-				$t_parent_bugnote->note_attr,
-				$t_parent_bugnote->reporter_id,
-				false,
-				0,
-				0,
-				false );
-
-			# Note: we won't trigger mentions in the clone scenario.
-		}
+		$t_callback_copy_notes = function( BugData $p_bug, $p_master_bug_id ) {
+			$t_parent_bugnotes = bugnote_get_all_bugnotes( $p_master_bug_id );
+			foreach ( $t_parent_bugnotes as $t_parent_bugnote ) {
+				$t_private = $t_parent_bugnote->view_state == VS_PRIVATE;
+				bugnote_add(
+					$p_bug->id,
+					$t_parent_bugnote->note,
+					$t_parent_bugnote->time_tracking,
+					$t_private,
+					$t_parent_bugnote->note_type,
+					$t_parent_bugnote->note_attr,
+					$t_parent_bugnote->reporter_id,
+					false,
+					0,
+					0,
+					false );
+				# Note: we won't trigger mentions in the clone scenario.
+			}
+		};
+		$t_bug_data->add_update_callback( $t_callback_copy_notes, array( $t_bug_data, $f_master_bug_id ) );
 	}
 
 	# copy attachments from parent
 	if( $f_copy_attachments_from_parent ) {
-		file_copy_attachments( $f_master_bug_id, $t_bug_id );
+		$t_callback_copy_attachments = function( BugData $p_bug, $p_master_bug_id ) {
+			file_copy_attachments( $p_master_bug_id, $p_bug->id );
+		};
+		$t_bug_data->add_update_callback( $t_callback_copy_attachments, array( $t_bug_data, $f_master_bug_id ) );
 	}
 }
+
+# Create the bug
+$t_bug_id = $t_bug_data->create();
+$t_bug_data->process_mentions();
+
+# Mark the added issue as visited so that it appears on the last visited list.
+last_visited_issue( $t_bug_id );
 
 helper_call_custom_function( 'issue_create_notify', array( $t_bug_id ) );
 

--- a/bug_report.php
+++ b/bug_report.php
@@ -188,9 +188,6 @@ foreach( $t_related_custom_field_ids as $t_id ) {
 	}
 }
 
-# Allow plugins to pre-process bug data
-$t_bug_data = event_signal( 'EVENT_REPORT_BUG_DATA', $t_bug_data );
-
 # Ensure that resolved bugs have a handler
 if( $t_bug_data->handler_id == NO_USER && $t_bug_data->status >= config_get( 'bug_resolved_status_threshold' ) ) {
 	$t_bug_data->handler_id = auth_get_current_user_id();
@@ -283,9 +280,6 @@ if( $f_master_bug_id > 0 ) {
 }
 
 helper_call_custom_function( 'issue_create_notify', array( $t_bug_id ) );
-
-# Allow plugins to post-process bug data with the new bug ID
-event_signal( 'EVENT_REPORT_BUG', array( $t_bug_data, $t_bug_id ) );
 
 email_bug_added( $t_bug_id );
 

--- a/bug_stick.php
+++ b/bug_stick.php
@@ -55,7 +55,9 @@ if( $t_bug->project_id != helper_get_current_project() ) {
 
 access_ensure_bug_level( config_get( 'set_bug_sticky_threshold' ), $f_bug_id );
 
-bug_set_field( $f_bug_id, 'sticky', 'stick' == $f_action );
+$t_bugdata = bug_get( $p_bug_id );
+$t_bugdata->sticky = ( 'stick' == $f_action );
+$t_bugdata->update();
 
 form_security_purge( 'bug_stick' );
 

--- a/bug_update.php
+++ b/bug_update.php
@@ -419,13 +419,10 @@ if( $t_updated_bug->duplicate_id != 0 ) {
 }
 
 # Commit the bug updates to the database.
-$t_text_field_update_required = ( $t_existing_bug->description != $t_updated_bug->description ) ||
-								( $t_existing_bug->additional_information != $t_updated_bug->additional_information ) ||
-								( $t_existing_bug->steps_to_reproduce != $t_updated_bug->steps_to_reproduce );
-$t_updated_bug->update( $t_text_field_update_required, true );
-
-
-
+$t_text_field_update_required = ( $t_existing_bug->description != $t_updated_bug->description )
+		|| ( $t_existing_bug->additional_information != $t_updated_bug->additional_information )
+		|| ( $t_existing_bug->steps_to_reproduce != $t_updated_bug->steps_to_reproduce );
+$t_updated_bug->update( /* update extended */ $t_text_field_update_required, /* bypass mail */ true );
 
 # Allow a custom function to respond to the modifications made to the bug. Note
 # that custom functions are being deprecated in MantisBT. You should migrate to

--- a/bug_update.php
+++ b/bug_update.php
@@ -380,8 +380,43 @@ $t_updated_bug->status = bug_get_status_for_assign( $t_existing_bug->handler_id,
 # the new plugin system instead.
 helper_call_custom_function( 'issue_update_validate', array( $f_bug_id, $t_updated_bug, $t_bug_note->note ) );
 
-# Allow plugins to validate/modify the update prior to it being committed.
-$t_updated_bug = event_signal( 'EVENT_UPDATE_BUG_DATA', $t_updated_bug, $t_existing_bug );
+# set up post-update callbacks
+
+# Update custom field values.
+foreach ( $t_custom_fields_to_set as $t_custom_field_to_set ) {
+	$t_updated_bug->add_update_callback( 'custom_field_set_value', array( $t_custom_field_to_set['id'], $f_bug_id, $t_custom_field_to_set['value'] ) );
+}
+
+# Add a bug note if there is one.
+if( $t_bug_note->note || helper_duration_to_minutes( $t_bug_note->time_tracking ) > 0 ) {
+
+	$add_bugnote_func = function( array $p_bugnote_params ) {
+		$t_bugnote_id = call_user_func_array( 'bugnote_add', $p_bugnote_params );
+		bugnote_process_mentions( $p_bugnote_params[0], $t_bugnote_id, $p_bugnote_params[1] );
+	};
+	$t_bugnote_params = array( $f_bug_id, $t_bug_note->note, $t_bug_note->time_tracking, $t_bug_note->view_state == VS_PRIVATE, BUGNOTE, '', null, false );
+	$t_updated_bug->add_update_callback( $add_bugnote_func, array( $t_bugnote_params ) );
+}
+
+# Add a duplicate relationship if requested.
+# @TODO move this logic into BugData
+if( $t_updated_bug->duplicate_id != 0 ) {
+
+	$add_relatioship_func = function( $p_bug_data ) {
+		relationship_add( $p_bug_data->id, $p_bug_data->duplicate_id, BUG_DUPLICATE );
+		history_log_event_special( $p_bug_data->id, BUG_ADD_RELATIONSHIP, BUG_DUPLICATE, $p_bug_data->duplicate_id );
+		history_log_event_special( $p_bug_data->duplicate_id, BUG_ADD_RELATIONSHIP, BUG_HAS_DUPLICATE, $p_bug_data->id );
+		if( user_exists( $p_bug_data->reporter_id ) ) {
+			bug_monitor( $p_bug_data->id, $p_bug_data->reporter_id );
+		}
+		if( user_exists( $p_bug_data->handler_id ) ) {
+			bug_monitor( $p_bug_data->id, $p_bug_data->handler_id );
+		}
+		bug_monitor_copy( $p_bug_data->id, $p_bug_data->duplicate_id );
+	};
+
+	$t_updated_bug->add_update_callback( $add_relatioship_func, array( $t_updated_bug ) );
+}
 
 # Commit the bug updates to the database.
 $t_text_field_update_required = ( $t_existing_bug->description != $t_updated_bug->description ) ||
@@ -389,32 +424,8 @@ $t_text_field_update_required = ( $t_existing_bug->description != $t_updated_bug
 								( $t_existing_bug->steps_to_reproduce != $t_updated_bug->steps_to_reproduce );
 $t_updated_bug->update( $t_text_field_update_required, true );
 
-# Update custom field values.
-foreach ( $t_custom_fields_to_set as $t_custom_field_to_set ) {
-	custom_field_set_value( $t_custom_field_to_set['id'], $f_bug_id, $t_custom_field_to_set['value'] );
-}
 
-# Add a bug note if there is one.
-if( $t_bug_note->note || helper_duration_to_minutes( $t_bug_note->time_tracking ) > 0 ) {
-	$t_bugnote_id = bugnote_add( $f_bug_id, $t_bug_note->note, $t_bug_note->time_tracking, $t_bug_note->view_state == VS_PRIVATE, 0, '', null, false );
-	bugnote_process_mentions( $f_bug_id, $t_bugnote_id, $t_bug_note->note );
-}
 
-# Add a duplicate relationship if requested.
-if( $t_updated_bug->duplicate_id != 0 ) {
-	relationship_add( $f_bug_id, $t_updated_bug->duplicate_id, BUG_DUPLICATE );
-	history_log_event_special( $f_bug_id, BUG_ADD_RELATIONSHIP, BUG_DUPLICATE, $t_updated_bug->duplicate_id );
-	history_log_event_special( $t_updated_bug->duplicate_id, BUG_ADD_RELATIONSHIP, BUG_HAS_DUPLICATE, $f_bug_id );
-	if( user_exists( $t_existing_bug->reporter_id ) ) {
-		bug_monitor( $f_bug_id, $t_existing_bug->reporter_id );
-	}
-	if( user_exists( $t_existing_bug->handler_id ) ) {
-		bug_monitor( $f_bug_id, $t_existing_bug->handler_id );
-	}
-	bug_monitor_copy( $f_bug_id, $t_updated_bug->duplicate_id );
-}
-
-event_signal( 'EVENT_UPDATE_BUG', array( $t_existing_bug, $t_updated_bug ) );
 
 # Allow a custom function to respond to the modifications made to the bug. Note
 # that custom functions are being deprecated in MantisBT. You should migrate to

--- a/bugnote_add.php
+++ b/bugnote_add.php
@@ -107,10 +107,11 @@ if( config_get( 'reassign_on_feedback' ) &&
 	 $t_bug->handler_id !== auth_get_current_user_id() &&
 	 $t_bug->reporter_id === auth_get_current_user_id() ) {
 	if( $t_bug->handler_id !== NO_USER ) {
-		bug_set_field( $t_bug->id, 'status', config_get( 'bug_assigned_status' ) );
+		$t_bug->status = config_get( 'bug_assigned_status' );
 	} else {
-		bug_set_field( $t_bug->id, 'status', config_get( 'bug_submit_status' ) );
+		$t_bug->status = config_get( 'bug_submit_status' );
 	}
+	$t_bug->update( false, true );
 }
 
 form_security_purge( 'bugnote_add' );

--- a/bugnote_add.php
+++ b/bugnote_add.php
@@ -111,7 +111,7 @@ if( config_get( 'reassign_on_feedback' ) &&
 	} else {
 		$t_bug->status = config_get( 'bug_submit_status' );
 	}
-	$t_bug->update( false, true );
+	$t_bug->update( /* update extended */ false, /* bypass mail */ true );
 }
 
 form_security_purge( 'bugnote_add' );

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -254,6 +254,12 @@ class BugData {
 	private $loading = false;
 
 	/**
+	 * an array of tuples: ( 'func' => callable, 'params' => array )
+	 * to be used as callbacks on the update process
+	 */
+	private $update_callbacks = array();
+
+	/**
 	 * return number of file attachment's linked to current bug
 	 * @return integer
 	 */
@@ -781,7 +787,23 @@ class BugData {
 			email_bug_updated( $c_bug_id );
 		}
 
+		# Execute all registered update callbacks
+		while( !empty( $this->update_callbacks ) ) {
+			$t_callback = array_shift( $this->update_callbacks );
+			call_user_func_array( $t_callback['func'], $t_callback['params'] );
+		}
+
 		return true;
+	}
+
+	function add_update_callback( callable $p_callable, array $p_params = null ) {
+		if( null === $p_params ) {
+			$p_params = array();
+		}
+		$t_callback = array();
+		$t_callback['func'] = $p_callable;
+		$t_callback['params'] = $p_params;
+		$this->update_callbacks[] = $t_callback;
 	}
 }
 

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -627,7 +627,6 @@ class BugData {
      * @access public
 	 */
 	function update( $p_update_extended = false, $p_bypass_mail = false ) {
-		self::validate( $p_update_extended );
 
 		if( is_blank( $this->due_date ) ) {
 			$this->due_date = date_get_null();
@@ -639,6 +638,8 @@ class BugData {
 		# @TODO This event is better defined as EVENT_TYPE_EXECUTE to avoid that situation
 		$t_updated_data = event_signal( 'EVENT_UPDATE_BUG_DATA', $this, $t_old_data );
 		$c_bug_id = $t_updated_data->id;
+
+		$t_updated_data->validate( $p_update_extended );
 
 		# Update all fields
 		# Ignore date_submitted and last_updated since they are pulled out

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -637,6 +637,8 @@ class BugData {
 
 		$t_old_data = bug_get( $this->id, true );
 
+		event_signal( 'EVENT_UPDATE_BUG_DATA', $this, $t_old_data );
+
 		# Update all fields
 		# Ignore date_submitted and last_updated since they are pulled out
 		#  as unix timestamps which could confuse the history log and they
@@ -792,6 +794,8 @@ class BugData {
 			$t_callback = array_shift( $this->update_callbacks );
 			call_user_func_array( $t_callback['func'], $t_callback['params'] );
 		}
+
+		event_signal( 'EVENT_UPDATE_BUG', array( $t_old_data, $this ) );
 
 		return true;
 	}

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -774,19 +774,15 @@ class BugData {
 			# If handler changes, send out owner change email
 			if( $t_old_data->handler_id != $this->handler_id ) {
 				email_owner_changed( $c_bug_id, $t_old_data->handler_id, $this->handler_id );
-				return true;
-			}
-
-			# status changed
-			if( $t_old_data->status != $this->status ) {
+			} elseif( $t_old_data->status != $this->status ) {
+				# status changed
 				$t_status = MantisEnum::getLabel( config_get( 'status_enum_string' ), $this->status );
 				$t_status = str_replace( ' ', '_', $t_status );
 				email_bug_status_changed( $c_bug_id, $t_status );
-				return true;
+			} else {
+				# @todo handle priority change if it requires special handling
+				email_bug_updated( $c_bug_id );
 			}
-
-			# @todo handle priority change if it requires special handling
-			email_bug_updated( $c_bug_id );
 		}
 
 		# Execute all registered update callbacks

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -629,15 +629,16 @@ class BugData {
 	function update( $p_update_extended = false, $p_bypass_mail = false ) {
 		self::validate( $p_update_extended );
 
-		$c_bug_id = $this->id;
-
 		if( is_blank( $this->due_date ) ) {
 			$this->due_date = date_get_null();
 		}
 
 		$t_old_data = bug_get( $this->id, true );
 
-		event_signal( 'EVENT_UPDATE_BUG_DATA', $this, $t_old_data );
+		# From this point, use returned object from event in case the object refenced is not $this
+		# @TODO This event is better defined as EVENT_TYPE_EXECUTE to avoid that situation
+		$t_updated_data = event_signal( 'EVENT_UPDATE_BUG_DATA', $this, $t_old_data );
+		$c_bug_id = $t_updated_data->id;
 
 		# Update all fields
 		# Ignore date_submitted and last_updated since they are pulled out
@@ -657,21 +658,21 @@ class BugData {
 						build=' . db_param() . ', fixed_in_version=' . db_param() . ',';
 
 		$t_fields = array(
-			$this->project_id, $this->reporter_id,
-			$this->handler_id, $this->duplicate_id,
-			$this->priority, $this->severity,
-			$this->reproducibility, $this->status,
-			$this->resolution, $this->projection,
-			$this->category_id, $this->eta,
-			$this->os, $this->os_build,
-			$this->platform, $this->version,
-			$this->build, $this->fixed_in_version,
+			$t_updated_data->project_id, $t_updated_data->reporter_id,
+			$t_updated_data->handler_id, $t_updated_data->duplicate_id,
+			$t_updated_data->priority, $t_updated_data->severity,
+			$t_updated_data->reproducibility, $t_updated_data->status,
+			$t_updated_data->resolution, $t_updated_data->projection,
+			$t_updated_data->category_id, $t_updated_data->eta,
+			$t_updated_data->os, $t_updated_data->os_build,
+			$t_updated_data->platform, $t_updated_data->version,
+			$t_updated_data->build, $t_updated_data->fixed_in_version,
 		);
 		$t_roadmap_updated = false;
 		if( access_has_project_level( config_get( 'roadmap_update_threshold' ) ) ) {
 			$t_query .= '
 						target_version=' . db_param() . ',';
-			$t_fields[] = $this->target_version;
+			$t_fields[] = $t_updated_data->target_version;
 			$t_roadmap_updated = true;
 		}
 
@@ -682,44 +683,44 @@ class BugData {
 						sticky=' . db_param() . ',
 						due_date=' . db_param() . '
 					WHERE id=' . db_param();
-		$t_fields[] = $this->view_state;
-		$t_fields[] = $this->summary;
-		$t_fields[] = $this->sponsorship_total;
-		$t_fields[] = (bool)$this->sticky;
-		$t_fields[] = $this->due_date;
-		$t_fields[] = $this->id;
+		$t_fields[] = $t_updated_data->view_state;
+		$t_fields[] = $t_updated_data->summary;
+		$t_fields[] = $t_updated_data->sponsorship_total;
+		$t_fields[] = (bool)$t_updated_data->sticky;
+		$t_fields[] = $t_updated_data->due_date;
+		$t_fields[] = $t_updated_data->id;
 
 		db_query( $t_query, $t_fields );
 
-		bug_clear_cache( $this->id );
+		bug_clear_cache( $t_updated_data->id );
 
 		# log changes
-		history_log_event_direct( $c_bug_id, 'project_id', $t_old_data->project_id, $this->project_id );
-		history_log_event_direct( $c_bug_id, 'reporter_id', $t_old_data->reporter_id, $this->reporter_id );
-		history_log_event_direct( $c_bug_id, 'handler_id', $t_old_data->handler_id, $this->handler_id );
-		history_log_event_direct( $c_bug_id, 'priority', $t_old_data->priority, $this->priority );
-		history_log_event_direct( $c_bug_id, 'severity', $t_old_data->severity, $this->severity );
-		history_log_event_direct( $c_bug_id, 'reproducibility', $t_old_data->reproducibility, $this->reproducibility );
-		history_log_event_direct( $c_bug_id, 'status', $t_old_data->status, $this->status );
-		history_log_event_direct( $c_bug_id, 'resolution', $t_old_data->resolution, $this->resolution );
-		history_log_event_direct( $c_bug_id, 'projection', $t_old_data->projection, $this->projection );
-		history_log_event_direct( $c_bug_id, 'category', category_full_name( $t_old_data->category_id, false ), category_full_name( $this->category_id, false ) );
-		history_log_event_direct( $c_bug_id, 'eta', $t_old_data->eta, $this->eta );
-		history_log_event_direct( $c_bug_id, 'os', $t_old_data->os, $this->os );
-		history_log_event_direct( $c_bug_id, 'os_build', $t_old_data->os_build, $this->os_build );
-		history_log_event_direct( $c_bug_id, 'platform', $t_old_data->platform, $this->platform );
-		history_log_event_direct( $c_bug_id, 'version', $t_old_data->version, $this->version );
-		history_log_event_direct( $c_bug_id, 'build', $t_old_data->build, $this->build );
-		history_log_event_direct( $c_bug_id, 'fixed_in_version', $t_old_data->fixed_in_version, $this->fixed_in_version );
+		history_log_event_direct( $c_bug_id, 'project_id', $t_old_data->project_id, $t_updated_data->project_id );
+		history_log_event_direct( $c_bug_id, 'reporter_id', $t_old_data->reporter_id, $t_updated_data->reporter_id );
+		history_log_event_direct( $c_bug_id, 'handler_id', $t_old_data->handler_id, $t_updated_data->handler_id );
+		history_log_event_direct( $c_bug_id, 'priority', $t_old_data->priority, $t_updated_data->priority );
+		history_log_event_direct( $c_bug_id, 'severity', $t_old_data->severity, $t_updated_data->severity );
+		history_log_event_direct( $c_bug_id, 'reproducibility', $t_old_data->reproducibility, $t_updated_data->reproducibility );
+		history_log_event_direct( $c_bug_id, 'status', $t_old_data->status, $t_updated_data->status );
+		history_log_event_direct( $c_bug_id, 'resolution', $t_old_data->resolution, $t_updated_data->resolution );
+		history_log_event_direct( $c_bug_id, 'projection', $t_old_data->projection, $t_updated_data->projection );
+		history_log_event_direct( $c_bug_id, 'category', category_full_name( $t_old_data->category_id, false ), category_full_name( $t_updated_data->category_id, false ) );
+		history_log_event_direct( $c_bug_id, 'eta', $t_old_data->eta, $t_updated_data->eta );
+		history_log_event_direct( $c_bug_id, 'os', $t_old_data->os, $t_updated_data->os );
+		history_log_event_direct( $c_bug_id, 'os_build', $t_old_data->os_build, $t_updated_data->os_build );
+		history_log_event_direct( $c_bug_id, 'platform', $t_old_data->platform, $t_updated_data->platform );
+		history_log_event_direct( $c_bug_id, 'version', $t_old_data->version, $t_updated_data->version );
+		history_log_event_direct( $c_bug_id, 'build', $t_old_data->build, $t_updated_data->build );
+		history_log_event_direct( $c_bug_id, 'fixed_in_version', $t_old_data->fixed_in_version, $t_updated_data->fixed_in_version );
 		if( $t_roadmap_updated ) {
-			history_log_event_direct( $c_bug_id, 'target_version', $t_old_data->target_version, $this->target_version );
+			history_log_event_direct( $c_bug_id, 'target_version', $t_old_data->target_version, $t_updated_data->target_version );
 		}
-		history_log_event_direct( $c_bug_id, 'view_state', $t_old_data->view_state, $this->view_state );
-		history_log_event_direct( $c_bug_id, 'summary', $t_old_data->summary, $this->summary );
-		history_log_event_direct( $c_bug_id, 'sponsorship_total', $t_old_data->sponsorship_total, $this->sponsorship_total );
-		history_log_event_direct( $c_bug_id, 'sticky', $t_old_data->sticky, $this->sticky );
+		history_log_event_direct( $c_bug_id, 'view_state', $t_old_data->view_state, $t_updated_data->view_state );
+		history_log_event_direct( $c_bug_id, 'summary', $t_old_data->summary, $t_updated_data->summary );
+		history_log_event_direct( $c_bug_id, 'sponsorship_total', $t_old_data->sponsorship_total, $t_updated_data->sponsorship_total );
+		history_log_event_direct( $c_bug_id, 'sticky', $t_old_data->sticky, $t_updated_data->sticky );
 
-		history_log_event_direct( $c_bug_id, 'due_date', ( $t_old_data->due_date != date_get_null() ) ? $t_old_data->due_date : null, ( $this->due_date != date_get_null() ) ? $this->due_date : null );
+		history_log_event_direct( $c_bug_id, 'due_date', ( $t_old_data->due_date != date_get_null() ) ? $t_old_data->due_date : null, ( $t_updated_data->due_date != date_get_null() ) ? $t_updated_data->due_date : null );
 
 		# Update extended info if requested
 		if( $p_update_extended ) {
@@ -732,36 +733,36 @@ class BugData {
 								additional_information=' . db_param() . '
 							WHERE id=' . db_param();
 			db_query( $t_query, array(
-				$this->description,
-				$this->steps_to_reproduce,
-				$this->additional_information,
+				$t_updated_data->description,
+				$t_updated_data->steps_to_reproduce,
+				$t_updated_data->additional_information,
 				$t_bug_text_id ) );
 
 			bug_text_clear_cache( $c_bug_id );
 
 			$t_current_user = auth_get_current_user_id();
 
-			if( $t_old_data->description != $this->description ) {
+			if( $t_old_data->description != $t_updated_data->description ) {
 				if( bug_revision_count( $c_bug_id, REV_DESCRIPTION ) < 1 ) {
 					bug_revision_add( $c_bug_id, $t_old_data->reporter_id, REV_DESCRIPTION, $t_old_data->description, 0, $t_old_data->date_submitted );
 				}
-				$t_revision_id = bug_revision_add( $c_bug_id, $t_current_user, REV_DESCRIPTION, $this->description );
+				$t_revision_id = bug_revision_add( $c_bug_id, $t_current_user, REV_DESCRIPTION, $t_updated_data->description );
 				history_log_event_special( $c_bug_id, DESCRIPTION_UPDATED, $t_revision_id );
 			}
 
-			if( $t_old_data->steps_to_reproduce != $this->steps_to_reproduce ) {
+			if( $t_old_data->steps_to_reproduce != $t_updated_data->steps_to_reproduce ) {
 				if( bug_revision_count( $c_bug_id, REV_STEPS_TO_REPRODUCE ) < 1 ) {
 					bug_revision_add( $c_bug_id, $t_old_data->reporter_id, REV_STEPS_TO_REPRODUCE, $t_old_data->steps_to_reproduce, 0, $t_old_data->date_submitted );
 				}
-				$t_revision_id = bug_revision_add( $c_bug_id, $t_current_user, REV_STEPS_TO_REPRODUCE, $this->steps_to_reproduce );
+				$t_revision_id = bug_revision_add( $c_bug_id, $t_current_user, REV_STEPS_TO_REPRODUCE, $t_updated_data->steps_to_reproduce );
 				history_log_event_special( $c_bug_id, STEP_TO_REPRODUCE_UPDATED, $t_revision_id );
 			}
 
-			if( $t_old_data->additional_information != $this->additional_information ) {
+			if( $t_old_data->additional_information != $t_updated_data->additional_information ) {
 				if( bug_revision_count( $c_bug_id, REV_ADDITIONAL_INFO ) < 1 ) {
 					bug_revision_add( $c_bug_id, $t_old_data->reporter_id, REV_ADDITIONAL_INFO, $t_old_data->additional_information, 0, $t_old_data->date_submitted );
 				}
-				$t_revision_id = bug_revision_add( $c_bug_id, $t_current_user, REV_ADDITIONAL_INFO, $this->additional_information );
+				$t_revision_id = bug_revision_add( $c_bug_id, $t_current_user, REV_ADDITIONAL_INFO, $t_updated_data->additional_information );
 				history_log_event_special( $c_bug_id, ADDITIONAL_INFO_UPDATED, $t_revision_id );
 			}
 		}
@@ -772,11 +773,11 @@ class BugData {
 		# allow bypass if user is sending mail separately
 		if( false == $p_bypass_mail ) {
 			# If handler changes, send out owner change email
-			if( $t_old_data->handler_id != $this->handler_id ) {
-				email_owner_changed( $c_bug_id, $t_old_data->handler_id, $this->handler_id );
-			} elseif( $t_old_data->status != $this->status ) {
+			if( $t_old_data->handler_id != $t_updated_data->handler_id ) {
+				email_owner_changed( $c_bug_id, $t_old_data->handler_id, $t_updated_data->handler_id );
+			} elseif( $t_old_data->status != $t_updated_data->status ) {
 				# status changed
-				$t_status = MantisEnum::getLabel( config_get( 'status_enum_string' ), $this->status );
+				$t_status = MantisEnum::getLabel( config_get( 'status_enum_string' ), $t_updated_data->status );
 				$t_status = str_replace( ' ', '_', $t_status );
 				email_bug_status_changed( $c_bug_id, $t_status );
 			} else {
@@ -786,12 +787,12 @@ class BugData {
 		}
 
 		# Execute all registered update callbacks
-		while( !empty( $this->update_callbacks ) ) {
-			$t_callback = array_shift( $this->update_callbacks );
+		while( !empty( $t_updated_data->update_callbacks ) ) {
+			$t_callback = array_shift( $t_updated_data->update_callbacks );
 			call_user_func_array( $t_callback['func'], $t_callback['params'] );
 		}
 
-		event_signal( 'EVENT_UPDATE_BUG', array( $t_old_data, $this ) );
+		event_signal( 'EVENT_UPDATE_BUG', array( $t_old_data, $t_updated_data ) );
 
 		return true;
 	}

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1751,37 +1751,33 @@ function bug_assign( $p_bug_id, $p_user_id, $p_bugnote_text = '', $p_bugnote_pri
 	if( ( $p_user_id != NO_USER ) && !access_has_bug_level( config_get( 'handle_bug_threshold' ), $p_bug_id, $p_user_id ) ) {
 		trigger_error( ERROR_USER_DOES_NOT_HAVE_REQ_ACCESS );
 	}
+	$t_bugdata = bug_get( $p_bug_id );
+	$t_original_handler_id = $t_bugdata->handler_id;
+	$t_original_status = $t_bugdata->status;
+	$t_bugdata->handler_id = $p_user_id;
 
-	# extract current information into history variables
-	$h_status = bug_get_field( $p_bug_id, 'status' );
-	$h_handler_id = bug_get_field( $p_bug_id, 'handler_id' );
+	$t_assigned_status = bug_get_status_for_assign( $t_original_handler_id, $t_bugdata->handler_id, $t_original_status );
+	$t_bugdata->status = $t_assigned_status;
 
-	$t_ass_val = bug_get_status_for_assign( $h_handler_id, $p_user_id, $h_status );
+	# callback for history logging:
+	$t_bugdata->add_update_callback( 'history_log_event_direct', array( $t_bugdata->id, 'status', $t_original_status, $t_bugdata->status ) );
+	$t_bugdata->add_update_callback( 'history_log_event_direct', array( $t_bugdata->id, 'handler_id', $t_original_handler_id, $t_bugdata->handler_id ) );
 
-	if( ( $t_ass_val != $h_status ) || ( $p_user_id != $h_handler_id ) ) {
+	# callback for note add
+	if( !empty($p_bugnote_text) ) {
+		$add_bugnote_func = function( array $p_bugnote_params ) {
+			$t_bugnote_id = call_user_func_array( 'bugnote_add', $p_bugnote_params );
+			bugnote_process_mentions( $p_bugnote_params[0], $t_bugnote_id, $p_bugnote_params[1] );
+		};
+		$t_bugnote_params = array( $t_bugdata->id, $p_bugnote_text, 0, $p_bugnote_private, BUGNOTE, '', null, false );
+		$t_bugdata->add_update_callback( $add_bugnote_func, array( $t_bugnote_params ) );
+	}
 
-		# get user id
-		db_param_push();
-		$t_query = 'UPDATE {bug}
-					  SET handler_id=' . db_param() . ', status=' . db_param() . '
-					  WHERE id=' . db_param();
-		db_query( $t_query, array( $p_user_id, $t_ass_val, $p_bug_id ) );
+	$t_bugdata->update( false, true );
 
-		# log changes
-		history_log_event_direct( $p_bug_id, 'status', $h_status, $t_ass_val );
-		history_log_event_direct( $p_bug_id, 'handler_id', $h_handler_id, $p_user_id );
-
-		# Add bugnote if supplied ignore false return
-		$t_bugnote_id = bugnote_add( $p_bug_id, $p_bugnote_text, 0, $p_bugnote_private, 0, '', null, false );
-		bugnote_process_mentions( $p_bug_id, $t_bugnote_id, $p_bugnote_text );
-
-		# updated the last_updated date
-		bug_update_date( $p_bug_id );
-
-		bug_clear_cache( $p_bug_id );
-
+	if( $t_original_handler_id != $t_bugdata->handler_id) {
 		# Send email for change of handler
-		email_owner_changed( $p_bug_id, $h_handler_id, $p_user_id );
+		email_owner_changed( $t_bugdata->id, $t_original_handler_id, $t_bugdata->handler_id );
 	}
 
 	return true;

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1846,69 +1846,85 @@ function bug_resolve( $p_bug_id, $p_resolution, $p_fixed_in_version = '', $p_bug
 	$c_resolution = (int)$p_resolution;
 	$p_bugnote_text = trim( $p_bugnote_text );
 
-	# Add bugnote if supplied
-	# Moved bugnote_add before bug_set_field calls in case time_tracking_no_note is off.
-	# Error condition stopped execution but status had already been changed
-	$t_bugnote_id = bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking, $p_bugnote_private, 0, '', null, false );
-	bugnote_process_mentions( $p_bug_id, $t_bugnote_id, $p_bugnote_text );
+	# @TODO
+	# If time tracking is enabled, this code is executed outside of BugData validation.
+	# These time tracking dependencies should be removed
+	$t_time_tracking_enabled = config_get( 'time_tracking_enabled' );
+	if( ON == $t_time_tracking_enabled ) {
+		# Add bugnote if supplied
+		# Moved bugnote_add before bug_set_field calls in case time_tracking_no_note is off.
+		# Error condition stopped execution but status had already been changed
+		$t_bugnote_id = bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking, $p_bugnote_private, BUGNOTE, '', null, false );
+		bugnote_process_mentions( $p_bug_id, $t_bugnote_id, $p_bugnote_text );
+	}
+
+	$t_bugdata = bug_get( $p_bug_id );
+
+	$t_bugdata->status = config_get( 'bug_resolved_status_threshold' );
+	$t_bugdata->fixed_in_version = $p_fixed_in_version;
+	$t_bugdata->resolution = $c_resolution;
+
+	$t_old_handler_id = $t_bugdata->handler_id;
+	# only set handler if specified explicitly or if bug was not assigned to a handler
+	if( null == $p_handler_id ) {
+		if( $t_bugdata->handler_id == 0 ) {
+			$t_bugdata->handler_id = auth_get_current_user_id();
+		}
+	} else {
+		$t_bugdata->handler_id = $p_handler_id;
+	}
+
+	# If time tracking is disabled, the bug note is added as a callback after validation
+	# This is the proper way.
+	if( OFF == $t_time_tracking_enabled ) {
+		$add_bugnote_func = function( array $p_bugnote_params ) {
+			$t_bugnote_id = call_user_func_array( 'bugnote_add', $p_bugnote_params );
+			bugnote_process_mentions( $p_bugnote_params[0], $t_bugnote_id, $p_bugnote_params[1] );
+		};
+		$t_bugnote_params = array( $p_bug_id, $p_bugnote_text, $p_time_tracking, $p_bugnote_private, BUGNOTE, '', null, false );
+		$t_bugdata->add_update_callback( $add_bugnote_func, array( $t_bugnote_params ) );
+	}
 
 	$t_duplicate = !is_blank( $p_duplicate_id ) && ( $p_duplicate_id != 0 );
 	if( $t_duplicate ) {
 		if( $p_bug_id == $p_duplicate_id ) {
 			trigger_error( ERROR_BUG_DUPLICATE_SELF, ERROR );
-
 			# never returns
 		}
-
 		# the related bug exists...
 		bug_ensure_exists( $p_duplicate_id );
+		$t_bugdata->duplicate_id = $p_duplicate_id;
+
+		# create callbacks for duplicate bug actions:
 
 		# check if there is other relationship between the bugs...
 		$t_id_relationship = relationship_same_type_exists( $p_bug_id, $p_duplicate_id, BUG_DUPLICATE );
 
-		 if( $t_id_relationship > 0 ) {
+		if( $t_id_relationship > 0 ) {
 			# Update the relationship
-			relationship_update( $t_id_relationship, $p_bug_id, $p_duplicate_id, BUG_DUPLICATE );
-
+			$t_bugdata->add_update_callback( 'relationship_update', array( $t_id_relationship, $p_bug_id, $p_duplicate_id, BUG_DUPLICATE ) );
 			# Add log line to the history (both bugs)
-			history_log_event_special( $p_bug_id, BUG_REPLACE_RELATIONSHIP, BUG_DUPLICATE, $p_duplicate_id );
-			history_log_event_special( $p_duplicate_id, BUG_REPLACE_RELATIONSHIP, BUG_HAS_DUPLICATE, $p_bug_id );
+			$t_bugdata->add_update_callback( 'history_log_event_special', array( $p_bug_id, BUG_REPLACE_RELATIONSHIP, BUG_DUPLICATE, $p_duplicate_id ) );
+			$t_bugdata->add_update_callback( 'history_log_event_special', array( $p_duplicate_id, BUG_REPLACE_RELATIONSHIP, BUG_HAS_DUPLICATE, $p_bug_id ) );
 		} else if( $t_id_relationship != -1 ) {
 			# Add the new relationship
-			relationship_add( $p_bug_id, $p_duplicate_id, BUG_DUPLICATE );
-
+			$t_bugdata->add_update_callback( 'relationship_add', array( $p_bug_id, $p_duplicate_id, BUG_DUPLICATE ) );
 			# Add log line to the history (both bugs)
-			history_log_event_special( $p_bug_id, BUG_ADD_RELATIONSHIP, BUG_DUPLICATE, $p_duplicate_id );
-			history_log_event_special( $p_duplicate_id, BUG_ADD_RELATIONSHIP, BUG_HAS_DUPLICATE, $p_bug_id );
+			$t_bugdata->add_update_callback( 'history_log_event_special', array( $p_bug_id, BUG_ADD_RELATIONSHIP, BUG_DUPLICATE, $p_duplicate_id ) );
+			$t_bugdata->add_update_callback( 'history_log_event_special', array( $p_duplicate_id, BUG_ADD_RELATIONSHIP, BUG_HAS_DUPLICATE, $p_bug_id ) );
 		} # else relationship is -1 - same type exists, do nothing
 
 		# Copy list of users monitoring the duplicate bug to the original bug
-		$t_old_reporter_id = bug_get_field( $p_bug_id, 'reporter_id' );
-		$t_old_handler_id = bug_get_field( $p_bug_id, 'handler_id' );
-		if( user_exists( $t_old_reporter_id ) ) {
-			bug_monitor( $p_duplicate_id, $t_old_reporter_id );
+		if( user_exists( $t_bugdata->reporter_id ) ) {
+			$t_bugdata->add_update_callback( 'bug_monitor', array( $p_duplicate_id, $t_bugdata->reporter_id ) );
 		}
 		if( user_exists( $t_old_handler_id ) ) {
-			bug_monitor( $p_duplicate_id, $t_old_handler_id );
+			$t_bugdata->add_update_callback( 'bug_monitor', array( $p_duplicate_id, $t_old_handler_id ) );
 		}
-		bug_monitor_copy( $p_bug_id, $p_duplicate_id );
-
-		bug_set_field( $p_bug_id, 'duplicate_id', (int)$p_duplicate_id );
+		$t_bugdata->add_update_callback( 'bug_monitor_copy', array( $p_bug_id, $p_duplicate_id ) );
 	}
 
-	bug_set_field( $p_bug_id, 'status', config_get( 'bug_resolved_status_threshold' ) );
-	bug_set_field( $p_bug_id, 'fixed_in_version', $p_fixed_in_version );
-	bug_set_field( $p_bug_id, 'resolution', $c_resolution );
-
-	# only set handler if specified explicitly or if bug was not assigned to a handler
-	if( null == $p_handler_id ) {
-		if( bug_get_field( $p_bug_id, 'handler_id' ) == 0 ) {
-			$p_handler_id = auth_get_current_user_id();
-			bug_set_field( $p_bug_id, 'handler_id', $p_handler_id );
-		}
-	} else {
-		bug_set_field( $p_bug_id, 'handler_id', $p_handler_id );
-	}
+	$t_bugdata->update( false, true );
 
 	email_resolved( $p_bug_id );
 	email_relationship_child_resolved( $p_bug_id );

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -800,6 +800,11 @@ class BugData {
 		return true;
 	}
 
+	/**
+	 * Add a callable item to the callback queue, which is executed after BugData update.
+	 * @param callable	A callable item, in any form of the PHP Callable interface
+	 * @param array $p_params	Params to be used with the callable item
+	 */
 	function add_update_callback( callable $p_callable, array $p_params = null ) {
 		if( null === $p_params ) {
 			$p_params = array();
@@ -1343,7 +1348,7 @@ function bug_move( $p_bug_id, $p_target_project_id ) {
 	$t_bugdata->add_update_callback( file_move_bug_attachments, array( $t_bugdata->id, $t_bugdata->project_id ) );
 
 	# @TODO email is bypassed, add a notification for MOVE
-	$t_bugdata->update( false, true );
+	$t_bugdata->update( /* update extended */ false, /* bypass mail */ true );
 }
 
 /**
@@ -1773,7 +1778,7 @@ function bug_assign( $p_bug_id, $p_user_id, $p_bugnote_text = '', $p_bugnote_pri
 		$t_bugdata->add_update_callback( $add_bugnote_func, array( $t_bugnote_params ) );
 	}
 
-	$t_bugdata->update( false, true );
+	$t_bugdata->update( /* update extended */ false, /* bypass mail */ true );
 
 	if( $t_original_handler_id != $t_bugdata->handler_id) {
 		# Send email for change of handler
@@ -1821,7 +1826,7 @@ function bug_close( $p_bug_id, $p_bugnote_text = '', $p_bugnote_private = false,
 		$t_bugdata->add_update_callback( $add_bugnote_func, array( $t_bugnote_params ) );
 	}
 
-	$t_bugdata->update( false, true );
+	$t_bugdata->update( /* update extended */ false, /* bypass mail */ true );
 
 	email_close( $p_bug_id );
 	email_relationship_child_closed( $p_bug_id );
@@ -1924,7 +1929,7 @@ function bug_resolve( $p_bug_id, $p_resolution, $p_fixed_in_version = '', $p_bug
 		$t_bugdata->add_update_callback( 'bug_monitor_copy', array( $p_bug_id, $p_duplicate_id ) );
 	}
 
-	$t_bugdata->update( false, true );
+	$t_bugdata->update( /* update extended */ false, /* bypass mail */ true );
 
 	email_resolved( $p_bug_id );
 	email_relationship_child_resolved( $p_bug_id );
@@ -1975,7 +1980,7 @@ function bug_reopen( $p_bug_id, $p_bugnote_text = '', $p_time_tracking = '0:00',
 
 	$t_bugdata->status = config_get( 'bug_reopen_status' );
 	$t_bugdata->resolution = config_get( 'bug_reopen_resolution' );
-	$t_bugdata->update( false, true );
+	$t_bugdata->update( /* update extended */ false, /* bypass mail */ true );
 
 	email_bug_reopened( $p_bug_id );
 

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1795,13 +1795,33 @@ function bug_assign( $p_bug_id, $p_user_id, $p_bugnote_text = '', $p_bugnote_pri
 function bug_close( $p_bug_id, $p_bugnote_text = '', $p_bugnote_private = false, $p_time_tracking = '0:00' ) {
 	$p_bugnote_text = trim( $p_bugnote_text );
 
-	# Add bugnote if supplied ignore a false return
-	# Moved bugnote_add before bug_set_field calls in case time_tracking_no_note is off.
-	# Error condition stopped execution but status had already been changed
-	$t_bugnote_id = bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking, $p_bugnote_private, 0, '', null, false );
-	bugnote_process_mentions( $p_bug_id, $t_bugnote_id, $p_bugnote_text );
+	# @TODO
+	# If time tracking is enabled, this code is executed outside of BugData validation.
+	# These time tracking dependencies should be removed
+	$t_time_tracking_enabled = config_get( 'time_tracking_enabled' );
+	if( ON == $t_time_tracking_enabled ) {
+		# Add bugnote if supplied ignore a false return
+		# Moved bugnote_add before bug_set_field calls in case time_tracking_no_note is off.
+		# Error condition stopped execution but status had already been changed
+		$t_bugnote_id = bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking, $p_bugnote_private, BUGNOTE, '', null, false );
+		bugnote_process_mentions( $p_bug_id, $t_bugnote_id, $p_bugnote_text );
+	}
 
-	bug_set_field( $p_bug_id, 'status', config_get( 'bug_closed_status_threshold' ) );
+	$t_bugdata = bug_get( $p_bug_id );
+	$t_bugdata->status = config_get( 'bug_closed_status_threshold' );
+
+	# If time tracking is disabled, the bug note is added as a callback after validation
+	# This is the proper way.
+	if( OFF == $t_time_tracking_enabled ) {
+		$add_bugnote_func = function( array $p_bugnote_params ) {
+			$t_bugnote_id = call_user_func_array( 'bugnote_add', $p_bugnote_params );
+			bugnote_process_mentions( $p_bugnote_params[0], $t_bugnote_id, $p_bugnote_params[1] );
+		};
+		$t_bugnote_params = array( $t_bugdata->id, $p_bugnote_text, $p_time_tracking, $p_bugnote_private, BUGNOTE, '', null, false );
+		$t_bugdata->add_update_callback( $add_bugnote_func, array( $t_bugnote_params ) );
+	}
+
+	$t_bugdata->update( false, true );
 
 	email_close( $p_bug_id );
 	email_relationship_child_closed( $p_bug_id );

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1311,20 +1311,15 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
  * @access public
  */
 function bug_move( $p_bug_id, $p_target_project_id ) {
-	# Attempt to move disk based attachments to new project file directory.
-	file_move_bug_attachments( $p_bug_id, $p_target_project_id );
-
-	# Move the issue to the new project.
-	bug_set_field( $p_bug_id, 'project_id', $p_target_project_id );
-
-	# Update the category if needed
-	$t_category_id = bug_get_field( $p_bug_id, 'category_id' );
+	$t_bugdata = bug_get( $p_bug_id );
+	$t_bugdata->project_id = $p_target_project_id;
+	$t_category_id = $t_bugdata->category_id;
 
 	# Bug has no category
 	if( $t_category_id == 0 ) {
 		# Category is required in target project, set it to default
 		if( ON != config_get( 'allow_no_category', null, null, $p_target_project_id ) ) {
-			bug_set_field( $p_bug_id, 'category_id', config_get( 'default_category_for_moves', null, null, $p_target_project_id ) );
+			$t_bugdata->category_id = config_get( 'default_category_for_moves', null, null, $p_target_project_id );
 		}
 	} else {
 		# Check if the category is global, and if not attempt mapping it to the new project
@@ -1340,9 +1335,15 @@ function bug_move( $p_bug_id, $p_target_project_id ) {
 				# Use target project's default category for moves, since there is no match by name.
 				$t_target_project_category_id = config_get( 'default_category_for_moves', null, null, $p_target_project_id );
 			}
-			bug_set_field( $p_bug_id, 'category_id', $t_target_project_category_id );
+			$t_bugdata->category_id = $t_target_project_category_id;
 		}
 	}
+
+	# Attempt to move disk based attachments to new project file directory.
+	$t_bugdata->add_update_callback( file_move_bug_attachments, array( $t_bugdata->id, $t_bugdata->project_id ) );
+
+	# @TODO email is bypassed, add a notification for MOVE
+	$t_bugdata->update( false, true );
 }
 
 /**

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1948,14 +1948,34 @@ function bug_resolve( $p_bug_id, $p_resolution, $p_fixed_in_version = '', $p_bug
 function bug_reopen( $p_bug_id, $p_bugnote_text = '', $p_time_tracking = '0:00', $p_bugnote_private = false ) {
 	$p_bugnote_text = trim( $p_bugnote_text );
 
-	# Add bugnote if supplied
-	# Moved bugnote_add before bug_set_field calls in case time_tracking_no_note is off.
-	# Error condition stopped execution but status had already been changed
-	$t_bugnote_id = bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking, $p_bugnote_private, 0, '', null, false );
-	bugnote_process_mentions( $p_bug_id, $t_bugnote_id, $p_bugnote_text );
+	# @TODO
+	# If time tracking is enabled, this code is executed outside of BugData validation.
+	# These time tracking dependencies should be removed
+	$t_time_tracking_enabled = config_get( 'time_tracking_enabled' );
+	if( ON == $t_time_tracking_enabled ) {
+		# Add bugnote if supplied ignore a false return
+		# Moved bugnote_add before bug_set_field calls in case time_tracking_no_note is off.
+		# Error condition stopped execution but status had already been changed
+		$t_bugnote_id = bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking, $p_bugnote_private, BUGNOTE, '', null, false );
+		bugnote_process_mentions( $p_bug_id, $t_bugnote_id, $p_bugnote_text );
+	}
 
-	bug_set_field( $p_bug_id, 'status', config_get( 'bug_reopen_status' ) );
-	bug_set_field( $p_bug_id, 'resolution', config_get( 'bug_reopen_resolution' ) );
+	$t_bugdata = bug_get( $p_bug_id );
+
+	# If time tracking is disabled, the bug note is added as a callback after validation
+	# This is the proper way.
+	if( OFF == $t_time_tracking_enabled ) {
+		$add_bugnote_func = function( array $p_bugnote_params ) {
+			$t_bugnote_id = call_user_func_array( 'bugnote_add', $p_bugnote_params );
+			bugnote_process_mentions( $p_bugnote_params[0], $t_bugnote_id, $p_bugnote_params[1] );
+		};
+		$t_bugnote_params = array( $p_bug_id, $p_bugnote_text, $p_time_tracking, $p_bugnote_private, BUGNOTE, '', null, false );
+		$t_bugdata->add_update_callback( $add_bugnote_func, array( $t_bugnote_params ) );
+	}
+
+	$t_bugdata->status = config_get( 'bug_reopen_status' );
+	$t_bugdata->resolution = config_get( 'bug_reopen_resolution' );
+	$t_bugdata->update( false, true );
 
 	email_bug_reopened( $p_bug_id );
 

--- a/core/sponsorship_api.php
+++ b/core/sponsorship_api.php
@@ -292,8 +292,9 @@ function sponsorship_format_amount( $p_amount ) {
  */
 function sponsorship_update_bug( $p_bug_id ) {
 	$t_total_amount = sponsorship_get_amount( sponsorship_get_all_ids( $p_bug_id ) );
-	bug_set_field( $p_bug_id, 'sponsorship_total', $t_total_amount );
-	bug_update_date( $p_bug_id );
+	$t_bugdata = bug_get( $p_bug_id );
+	$t_bugdata->sponsorship_total = $t_total_amount;
+	$t_bugdata->update();
 }
 
 /**


### PR DESCRIPTION
(updated PR from #720, targeting current master, and finishing what was left)

EVENT_UPDATE_BUG_DATA and EVENT_UPDATE_BUG
are now triggered in the BugData update function, as suggested in #0020577
A callback queue is created in BugData to be able to perform post-update operations.

Fixes: #20577

 summary of this work:
- EVENT_UPDATE_BUG_DATA and EVENT_UPDATE_BUG should be triggered inside the BugData update method
- All bug modifications should be done through the BugData object. That would guarantee the consistency of the application for core, plugins, and soap, operations. (We'll still keep some direct table updates for some specific core code, that should be under control)

The problem with this approach is that other modifications beside the main bug table may exist (eg: adding notes). These operations have to be done:
- After EVENT_UPDATE_BUG_DATA, because this event can be used for validation to stop the update operation. 
- before EVENT_UPDATE_BUG, because this event should indicate finalization of the update, including all related tasks.
  Since the BugData->update() is an atomic call, the method proposed is to include a callback queue that stores the operations to be performed after "validation" and before "finalization".

A clear example of this is updating custom fields.
Previously, CFs are not updated by the BugData operation, and the changes has to be performed by the caller.
If you update _before_, then if a plugin stops the update (due to some failed validation), the fields are already changed. If you update _after_, a plugin that listens to bug update event dont know the new CF values, since at that moment they are not still committed.
By adding the CF update as post-update callbacks, it is performed after BugData changes are saved, and before the finalization event is triggered, so plugins listening to EVENT_UPDATE_BUG can see the updated custom fields.
