### PR TITLE
Fix checking of limit_reporters and report_bug_threshold

### DIFF
--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -285,7 +285,7 @@ if( $t_show_reporter ) {
 		# Do not allow the bug's reporter to edit the Reporter field
 		# when limit_reporters is ON
 		if( ON == config_get( 'limit_reporters' )
-		&&  !access_has_project_level( config_get( 'report_bug_threshold', null, null, $t_bug->project_id ) + 1, $t_bug->project_id )
+		&&  !access_has_project_level( access_threshold_min_level( config_get( 'report_bug_threshold', null, null, $t_bug->project_id ) ) + 1, $t_bug->project_id )
 		) {
 			echo string_attribute( user_get_name( $t_bug->reporter_id ) );
 		} else {

--- a/changelog_page.php
+++ b/changelog_page.php
@@ -180,9 +180,6 @@ foreach( $t_project_ids as $t_project_id ) {
 	$t_project_name = project_get_field( $t_project_id, 'name' );
 	$t_can_view_private = access_has_project_level( config_get( 'private_bug_threshold' ), $t_project_id );
 
-	$t_limit_reporters = config_get( 'limit_reporters' );
-	$t_user_access_level_is_reporter = ( config_get( 'report_bug_threshold', null, null, $t_project_id ) == access_get_project_level( $t_project_id ) );
-
 	$t_resolved = config_get( 'bug_resolved_status_threshold' );
 
 	# grab version info for later use
@@ -192,6 +189,10 @@ foreach( $t_project_ids as $t_project_id ) {
 	category_get_all_rows( $t_project_id );
 
 	$t_project_header_printed = false;
+
+	$t_limit_reporters = config_get( 'limit_reporters' );
+	$t_report_bug_threshold = config_get( 'report_bug_threshold', null, null, $t_project_id );
+	$t_access_limit_reporters_applies = !access_has_project_level( access_threshold_min_level( $t_report_bug_threshold ) + 1, $t_project_id );
 
 	foreach( $t_version_rows as $t_version_row ) {
 		$t_version_header_printed = false;
@@ -232,8 +233,9 @@ foreach( $t_project_ids as $t_project_id ) {
 
 			# check limit_Reporter (Issue #4770)
 			# reporters can view just issues they reported
-			if( ON === $t_limit_reporters && $t_user_access_level_is_reporter &&
-							!bug_is_user_reporter( $t_row['id'], $t_user_id )) {
+			if( ON == $t_limit_reporters
+					&& $t_access_limit_reporters_applies
+					&& !bug_is_user_reporter( $t_row['id'], $t_user_id ) ) {
 				continue;
 			}
 

--- a/core/access_api.php
+++ b/core/access_api.php
@@ -414,13 +414,10 @@ function access_has_bug_level( $p_access_level, $p_bug_id, $p_user_id = null ) {
 		static $s_thresholds = array();
 		if( !isset( $s_thresholds[$t_project_id] ) ) {
 			$t_report_bug_threshold = config_get( 'report_bug_threshold', null, $p_user_id, $t_project_id );
-			if( !is_array( $t_report_bug_threshold ) ) {
-				$s_thresholds[$t_project_id] = $t_report_bug_threshold + 1;
-			} else if( empty( $t_report_bug_threshold ) ) {
+			if( empty( $t_report_bug_threshold ) ) {
 				$s_thresholds[$t_project_id] = NOBODY;
 			} else {
-				sort( $t_report_bug_threshold );
-				$s_thresholds[$t_project_id] = $t_report_bug_threshold[0] + 1;
+				$s_thresholds[$t_project_id] = access_threshold_min_level( $t_report_bug_threshold ) + 1;
 			}
 		}
 		if( !access_compare_level( $t_access_level, $s_thresholds[$t_project_id] ) ) {
@@ -708,4 +705,26 @@ function access_level_get_string( $p_access_level ) {
 		$t_access_level_string = lang_get( 'no_access' );
 	}
 	return $t_access_level_string;
+}
+
+/**
+ * Return the minimum access level, as integer, that matches the threshold.
+ * $p_threshold may be a single value, or an array. If it is a single
+ * value, returns that number. If it is an array, return the value of the
+ * smallest element
+ * @param integer|array $p_threshold         Access threshold
+ * @return integer		Integer value for an access level.
+ */
+function access_threshold_min_level( $p_threshold ) {
+	if( is_array( $p_threshold ) ) {
+		if( empty( $p_threshold ) ) {
+			return NOBODY;
+		} else {
+			sort( $p_threshold );
+			return( reset( $p_threshold ) );
+		}
+	} else {
+		return $p_threshold;
+	}
+
 }

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1236,7 +1236,7 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 
 		foreach( $t_project_ids as $t_pid ) {
 			# limit reporters to visible projects
-			if( ( ON === $t_limit_reporters ) && ( !access_has_project_level( config_get( 'report_bug_threshold', null, $t_user_id, $t_pid ) + 1, $t_pid, $t_user_id ) ) ) {
+			if( ( ON === $t_limit_reporters ) && ( !access_has_project_level( access_threshold_min_level( config_get( 'report_bug_threshold', null, $t_user_id, $t_pid ) ) + 1, $t_pid, $t_user_id ) ) ) {
 				array_push( $t_limited_projects, '({bug}.project_id=' . $t_pid . ' AND ({bug}.reporter_id=' . $t_user_id . ') )' );
 			} else {
 				$t_access_required_to_view_private_bugs = config_get( 'private_bug_threshold', null, null, $t_pid );
@@ -3560,7 +3560,7 @@ function print_filter_reporter_id() {
 	# @@@ thraxisp - access_has_project_level checks greater than or equal to,
 	#   this assumed that there aren't any holes above REPORTER where the limit would apply
 	#
-	if( ( ON === config_get( 'limit_reporters' ) ) && ( !access_has_project_level( config_get( 'report_bug_threshold' ) + 1 ) ) ) {
+	if( ( ON === config_get( 'limit_reporters' ) ) && ( !access_has_project_level( access_threshold_min_level( config_get( 'report_bug_threshold' ) ) + 1 ) ) ) {
 		$t_id = auth_get_current_user_id();
 		$t_username = user_get_field( $t_id, 'username' );
 		$t_realname = user_get_field( $t_id, 'realname' );

--- a/manage_config_workflow_page.php
+++ b/manage_config_workflow_page.php
@@ -286,7 +286,7 @@ function threshold_row( $p_threshold ) {
 		echo '</select> </td>' . "\n";
 		$g_can_change_flags = true;
 	} else {
-		echo '<td' . $t_color . '>' . MantisEnum::getLabel( lang_get( 'status_enum_string' ), $t_project ) . '&#160;</td>' . "\n";
+		echo '<td class="' . $t_color . '">' . MantisEnum::getLabel( lang_get( 'status_enum_string' ), $t_project ) . '&#160;</td>' . "\n";
 		echo '<td>' . MantisEnum::getLabel( lang_get( 'access_levels_enum_string' ), config_get_access( $p_threshold ) ) . '&#160;</td>' . "\n";
 	}
 

--- a/manage_config_workflow_page.php
+++ b/manage_config_workflow_page.php
@@ -327,7 +327,8 @@ function access_row() {
 
 	$t_file_new = config_get_global( 'report_bug_threshold' );
 	$t_global_new = config_get( 'report_bug_threshold', null, ALL_USERS, ALL_PROJECTS );
-	$t_project_new = config_get( 'report_bug_threshold' );
+	$t_report_bug_threshold = config_get( 'report_bug_threshold' );
+	$t_project_new = access_threshold_min_level( $t_report_bug_threshold );
 
 	$t_file_set = config_get_global( 'set_status_threshold' );
 	$t_global_set = config_get( 'set_status_threshold', null, ALL_USERS, ALL_PROJECTS );
@@ -344,8 +345,11 @@ function access_row() {
 			# 'NEW' status
 			$t_level_project = $t_project_new;
 
-			$t_can_change = ( $g_access >= config_get_access( 'report_bug_threshold' ) );
-			$t_color = set_color_override( $t_file_new, $t_global_new, $t_project_new );
+			# If report_bug_threshold is an array (instead of an integer value), the input is not editable
+			# because it must be configured in manage_config_work_threshold_page.
+			$t_can_change = ( $g_access >= config_get_access( 'report_bug_threshold' ) )
+					&& !is_array( $t_report_bug_threshold );
+			$t_color = set_color_override( $t_file_new, $t_global_new, $t_report_bug_threshold );
 			set_overrides( 'report_bug_threshold', $t_can_change, $t_color );
 		} else {
 			# Other statuses

--- a/manage_config_workflow_set.php
+++ b/manage_config_workflow_set.php
@@ -215,17 +215,20 @@ if( config_get_access( 'set_status_threshold' ) <= $t_access ) {
 	# walk through the status labels to set the status threshold
 	$t_set_new = array();
 	foreach( $t_enum_status as $t_status_id => $t_status_label ) {
-		$f_level = gpc_get_int( 'access_change_' . $t_status_id );
-		if( config_get( 'bug_submit_status' ) == $t_status_id ) {
-			if( $f_level != $t_set_parent[$t_status_id] ) {
-				config_set( 'report_bug_threshold', (int)$f_level, ALL_USERS, $t_project, $f_access );
+		$f_level = gpc_get_int( 'access_change_' . $t_status_id, -1 );
+		# Only process those inputs that exists, since not all access_change_<status> may have been editable.
+		if( $f_level > -1 ) {
+			if( config_get( 'bug_submit_status' ) == $t_status_id ) {
+				if( $f_level != $t_set_parent[$t_status_id] ) {
+					config_set( 'report_bug_threshold', (int)$f_level, ALL_USERS, $t_project, $f_access );
+				} else {
+					config_delete( 'report_bug_threshold', ALL_USERS, $t_project );
+				}
+				unset( $t_set_parent[$t_status_id] );
+				unset( $t_set_current[$t_status_id] );
 			} else {
-				config_delete( 'report_bug_threshold', ALL_USERS, $t_project );
+				$t_set_new[$t_status_id] = $f_level;
 			}
-			unset( $t_set_parent[$t_status_id] );
-			unset( $t_set_current[$t_status_id] );
-		} else {
-			$t_set_new[$t_status_id] = $f_level;
 		}
 	}
 

--- a/manage_config_workflow_set.php
+++ b/manage_config_workflow_set.php
@@ -84,7 +84,8 @@ function config_get_access_parent( $p_project, $p_option ) {
 }
 
 
-$t_can_change_level = min( config_get_access( 'notify_flags' ), config_get_access( 'default_notify_flags' ) );
+$t_can_change_level = min( config_get_access( 'status_enum_workflow' ), config_get_access( 'report_bug_threshold' ), config_get_access( 'set_status_threshold' )
+		, config_get_access( 'bug_submit_status' ), config_get_access( 'bug_resolved_status_threshold' ), config_get_access( 'bug_reopen_status' ) );
 access_ensure_project_level( $t_can_change_level );
 
 $t_redirect_url = 'manage_config_workflow_page.php';

--- a/manage_config_workflow_set.php
+++ b/manage_config_workflow_set.php
@@ -186,7 +186,7 @@ if( config_get_access( 'status_enum_workflow' ) <= $t_access ) {
 }
 
 # process the access level changes
-if( config_get_access( 'set_status_threshold' ) <= $t_access ) {
+if( min( config_get_access( 'set_status_threshold' ), config_get_access( 'report_bug_threshold' ) ) <= $t_access ) {
 	# get changes to access level to change these values
 	$f_access = gpc_get( 'status_access' );
 	$t_access_parent = config_get_access_parent( $t_project, 'set_status_threshold' );
@@ -198,16 +198,16 @@ if( config_get_access( 'set_status_threshold' ) <= $t_access ) {
 	$t_bug_submit_status = config_get( 'bug_submit_status' );
 	foreach( $t_enum_status as $t_status => $t_status_label ) {
 		if( !isset( $t_set_parent[$t_status] ) ) {
-			if( $t_bug_submit_status == $t_status ) {
+			if( $t_bug_submit_status == $t_status && config_get_access( 'report_bug_threshold' ) <= $t_access ) {
 				$t_set_parent[$t_status] = config_get_parent( $t_project, 'report_bug_threshold' );
-			} else {
+			} elseif( config_get_access( 'set_status_threshold' ) <= $t_access ) {
 				$t_set_parent[$t_status] = config_get_parent( $t_project, 'update_bug_status_threshold' );
 			}
 		}
 		if( !isset( $t_set_current[$t_status] ) ) {
-			if( $t_bug_submit_status == $t_status ) {
+			if( $t_bug_submit_status == $t_status && config_get_access( 'report_bug_threshold' ) <= $t_access ) {
 				$t_set_current[$t_status] = config_get( 'report_bug_threshold' );
-			} else {
+			} elseif( config_get_access( 'set_status_threshold' ) <= $t_access ) {
 				$t_set_current[$t_status] = config_get( 'update_bug_status_threshold' );
 			}
 		}


### PR DESCRIPTION
"report_bug_threshold" was assumed to be an integer in some places
It can also be an array, so, in these cases some errors happens...

Fixes:
https://www.mantisbt.org/bugs/view.php?id=21579
https://www.mantisbt.org/bugs/view.php?id=21580
https://www.mantisbt.org/bugs/view.php?id=21581

More commits for fixing workflow config pages issues:
(added in this PR as they all modify the same set of pages)
https://www.mantisbt.org/bugs/view.php?id=21583
https://www.mantisbt.org/bugs/view.php?id=21582
