### PR TITLE
Modify empty and default cases for workflow configuration

### DIFF
--- a/core/workflow_api.php
+++ b/core/workflow_api.php
@@ -52,9 +52,15 @@ function workflow_transition_edge_exists( $p_from_status_id, $p_to_status_id ) {
  */
 function workflow_parse( array $p_enum_workflow ) {
 	$t_status_arr = MantisEnum::getAssocArrayIndexedByValues( config_get( 'status_enum_string' ) );
-	if( count( $p_enum_workflow ) == 0 ) {
-		# workflow is not set, default it to all transitions
-		foreach ( $t_status_arr as $t_status => $t_label ) {
+
+	# If workflow is not set, defaults to array(), which means all transitions are valid
+	if( !is_array( $p_enum_workflow ) ) {
+		$p_enum_workflow = array();
+	}
+
+	# If any status row is not presents, it defaults to all transitions
+	foreach ( $t_status_arr as $t_status => $t_label ) {
+		if( !isset( $p_enum_workflow[$t_status] ) ) {
 			$t_temp_workflow = array();
 			foreach ( $t_status_arr as $t_next => $t_next_label ) {
 				if( $t_status != $t_next ) {
@@ -86,6 +92,7 @@ function workflow_parse( array $p_enum_workflow ) {
 	# add user defined arcs
 	$t_default = array();
 	foreach ( $t_status_arr as $t_status => $t_status_label ) {
+		$t_exit[$t_status] = array();
 		if( isset( $p_enum_workflow[$t_status] ) ) {
 			$t_next_arr = MantisEnum::getAssocArrayIndexedByValues( $p_enum_workflow[$t_status] );
 			foreach ( $t_next_arr as $t_next => $t_next_label ) {
@@ -95,8 +102,6 @@ function workflow_parse( array $p_enum_workflow ) {
 				$t_exit[$t_status][$t_next] = '';
 				$t_entry[$t_next][$t_status] = '';
 			}
-		} else {
-			$t_exit[$t_status] = array();
 		}
 		if( !isset( $t_entry[$t_status] ) ) {
 			$t_entry[$t_status] = array();

--- a/manage_config_workflow_set.php
+++ b/manage_config_workflow_set.php
@@ -154,9 +154,8 @@ if( config_get_access( 'status_enum_workflow' ) <= $t_access ) {
 				$t_first = false;
 			}
 		}
-		if( '' <> $t_workflow_row ) {
-			$t_workflow[$t_state] = $t_workflow_row;
-		}
+		# $t_workflow_row is allowed to be empty ''
+		$t_workflow[$t_state] = $t_workflow_row;
 	}
 
 	# Get the parent's workflow, if not set default to all transitions


### PR DESCRIPTION
Fix several inconsistencies with the treatment of status_enum_workflow
configuration.

(1) Fix showing a non existant status row in workflow config array.
This is interpreted as if that status allows all transitions, but in the
config page, the checks were shown unmarked, which can be confusing.
Now the checks appear marked in this situation.

(2) As consequence of (1), now the message "You cannot move an issue out
of this status" is not showed in that situation.

(3) When a status row is saved with all transitions unchecked, now an
empty enum string is saved, meaning effectively that no transitions is
allowed from that status.
This specific configuration was previously unavailable from the workflow
config page.

Fixes: #20682