### PR TITLE
Timeline get history based on filter

### DIFF
--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1185,6 +1185,9 @@ function filter_get_bug_rows_result( array $p_query_clauses, $p_count = null, $p
 
 /**
  * Creates an array of formatted query clauses, based on the supplied filter and parameters
+ * Note: this function executes db_param_push():
+ *  - If the returned query is not executed, a manual db_param_pop() should be executed to clean the parameter stack
+ *  - If the final query adds db_param() outside of this function, they must be added after this function is called.
  * @param array   $p_filter       Filter array object
  * @param integer $p_project_id   Project id to use in filtering.
  * @param integer $p_user_id      User id to use as current user when filtering.

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -287,18 +287,12 @@ function history_get_range_result( $p_bug_id = null, $p_start_time = null, $p_en
 function history_get_event_from_row( $p_result, $p_user_id = null, $p_check_access_to_issue = true ) {
 	static $s_bug_visible = array();
 	$t_user_id = ( null === $p_user_id ) ? auth_get_current_user_id() : $p_user_id;
-	$t_project_id = helper_get_current_project();
 
 	while ( $t_row = db_fetch_array( $p_result ) ) {
 		extract( $t_row, EXTR_PREFIX_ALL, 'v' );
 
 		# Ignore entries related to non-existing bugs (see #20727)
 		if( !bug_exists( $v_bug_id ) ) {
-			continue;
-		}
-
-		# Make sure the entry belongs to current project.
-		if ( $t_project_id != ALL_PROJECTS && $t_project_id != bug_get_field( $v_bug_id, 'project_id' ) ) {
 			continue;
 		}
 

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -193,6 +193,7 @@ function history_get_range_result_filter( $p_filter, $p_start_time = null, $p_en
 		$t_history_order = $p_history_order;
 	}
 
+	# Note: filter_get_bug_rows_query_clauses() calls db_param_push();
 	$t_query_clauses = filter_get_bug_rows_query_clauses( $p_filter, null, null, null );
 
 	$t_select_string = 'SELECT DISTINCT {bug}.id ';

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -179,6 +179,58 @@ function history_count_user_recent_events( $p_duration_in_seconds, $p_user_id = 
 }
 
 /**
+ * Creates and executes a query for the history rows related to bugs matched by the provided filter
+ * @param  array $p_filter           Filter array
+ * @param  integer $p_start_time     The start time to filter by, or null for all.
+ * @param  integer $p_end_time       The end time to filter by, or null for all.
+ * @param  string  $p_history_order  The sort order.
+ * @return database result to pass into history_get_event_from_row().
+ */
+function history_get_range_result_filter( $p_filter, $p_start_time = null, $p_end_time = null, $p_history_order = null ) {
+	if ( $p_history_order === null ) {
+		$t_history_order = config_get( 'history_order' );
+	} else {
+		$t_history_order = $p_history_order;
+	}
+
+	$t_query_clauses = filter_get_bug_rows_query_clauses( $p_filter, null, null, null );
+
+	$t_select_string = 'SELECT DISTINCT {bug}.id ';
+	$t_from_string = ' FROM ' . implode( ', ', $t_query_clauses['from'] );
+	$t_join_string = count( $t_query_clauses['join'] ) > 0 ? implode( ' ', $t_query_clauses['join'] ) : ' ';
+	$t_where_string = ' WHERE '. implode( ' AND ', $t_query_clauses['project_where'] );
+	if( count( $t_query_clauses['where'] ) > 0 ) {
+		$t_where_string .= ' AND ( ';
+		$t_where_string .= implode( $t_query_clauses['operator'], $t_query_clauses['where'] );
+		$t_where_string .= ' ) ';
+	}
+
+	$t_query = 'SELECT * FROM {bug_history} JOIN'
+			. ' ( ' . $t_select_string . $t_from_string . $t_join_string . $t_where_string . ' ) B'
+			. ' ON {bug_history}.bug_id=B.id';
+
+	$t_params = $t_query_clauses['where_values'];
+	$t_where = array();
+	if ( $p_start_time !== null ) {
+		$t_where[] = 'date_modified >= ' . db_param();
+		$t_params[] = $p_start_time;
+	}
+
+	if ( $p_end_time !== null ) {
+		$t_where[] = 'date_modified < ' . db_param();
+		$t_params[] = $p_end_time;
+	}
+
+	if ( count( $t_where ) > 0 ) {
+		$t_query .= ' WHERE ' . implode( ' AND ', $t_where );
+	}
+
+	$t_query .= ' ORDER BY {bug_history}.date_modified ' . $t_history_order . ', {bug_history}.id ' . $t_history_order;
+	$t_result = db_query( $t_query, $t_params );
+	return $t_result;
+}
+
+/**
  * Creates and executes a query for the history rows matching the specified criteria.
  * @param  integer $p_bug_id         The bug id or null for matching any bug.
  * @param  integer $p_start_time     The start time to filter by, or null for all.

--- a/core/timeline_api.php
+++ b/core/timeline_api.php
@@ -37,12 +37,18 @@ require_api( 'history_api.php' );
  * @param integer $p_start_time Timestamp representing start time of the period.
  * @param integer $p_end_time   Timestamp representing end time of the period.
  * @param integer $p_max_events The maximum number of events to return or 0 for unlimited.
+ * @param type $p_filter		Filter array to use for filtering bugs
  * @return array
  */
-function timeline_events( $p_start_time, $p_end_time, $p_max_events ) {
+function timeline_events( $p_start_time, $p_end_time, $p_max_events, $p_filter = null ) {
 	$t_timeline_events = array();
 
-	$t_result = history_get_range_result( /* $p_bug_id */ null, $p_start_time, $p_end_time, 'DESC' );
+	if( null === $p_filter ) {
+		# create an empty filter, to match all bugs
+		$t_filter = array();
+		$t_filter = filter_ensure_valid_filter( $t_filter );
+	}
+	$t_result = history_get_range_result_filter( $t_filter, $p_start_time, $p_end_time, 'DESC' );
 	$t_count = 0;
 
 	while ( $t_history_event = history_get_event_from_row( $t_result, /* $p_user_id */ auth_get_current_user_id(), /* $p_check_access_to_issue */ true ) ) {


### PR DESCRIPTION
commit 3c1860188c9f74bf98612d516b2f19f270bfcaf1

    Create a new history api function to retrieve history rows related to
    bugs included in a filter.

commit 671cc51dd2440febfa0974f5598548b44f86f7db

    Make timeline show history for a set of bugs based on a filter.
    By default, create a filter to show current project and subprojects, to
    match the visibility of my view page.
    
    Fixes: #21072

commit 04a6139712acba0f0c0c148770daa8e1f278b220

    Revert the changes made by #19945 adbd0882
    The api function history_get_event_from_row should not impose a
    limitation for current project queries.
    
    The original timeline issue, which #19945 was addressing, has now been
    resolved in antoher way: #21072 
    
    Fixes: #21146



this branch is for 1.3.x. Tell me if its better to target master, or i can submit a separate PR for master
