### PR TITLE
Prevent TLS if smtp_connection_mode is empty (no encryption)

### DIFF
--- a/core/email_api.php
+++ b/core/email_api.php
@@ -1120,7 +1120,10 @@ function email_send( EmailData $p_email_data ) {
 				$t_mail->Password = config_get( 'smtp_password' );
 			}
 
-			if( !is_blank( config_get( 'smtp_connection_mode' ) ) ) {
+			if( is_blank( config_get( 'smtp_connection_mode' ) ) ) {
+				$t_mail->SMTPAutoTLS = false;
+			}
+			else {
 				$t_mail->SMTPSecure = config_get( 'smtp_connection_mode' );
 			}
 


### PR DESCRIPTION
Since version 5.2.10 PHPMailer automatically tries to enable TLS.
This is not what we want if the Mantis administrator decided not to use
encryption (smtp_connection_mode is empty)

Fixes #21293

Replaces PR https://github.com/mantisbt/mantisbt/pull/821