### PR TITLE
Opensearch improvements

### DIFF
--- a/browser_search_plugin.php
+++ b/browser_search_plugin.php
@@ -36,31 +36,28 @@ require_api( 'gpc_api.php' );
 
 $f_type = gpc_get_string( 'type', 'text' );
 
+$t_path = config_get_global( 'path' );
+$t_searchform = $t_path . 'view_all_bug_page.php';
+
+if( strtolower( $f_type ) == 'id' ) {
+	$t_shortname = 'MantisBT IssueId';
+	$t_description = 'MantisBT Issue Id Search';
+	$t_url = $t_path . 'view.php?id={searchTerms}';
+} else {
+	$t_shortname = 'MantisBT Search';
+	$t_description = 'MantisBT Text Search';
+	$t_url = $t_path . 'view_all_set.php?type=1&amp;temporary=y&amp;handler_id=[all]&amp;search={searchTerms}';
+}
+
 header( 'Content-Type: application/opensearchdescription+xml' );
 ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
                        xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-<?php
-$t_path = config_get_global( 'path' );
-
-if( strtolower( $f_type ) == 'id' ) {
-	echo '<ShortName>MantisBT IssueId</ShortName>';
-	echo '<Description>MantisBT Issue Id</Description>';
-	echo '<InputEncoding>UTF-8</InputEncoding>';
-} else {
-	echo '<ShortName>MantisBT Search</ShortName>';
-	echo '<Description>MantisBT Text Search</Description>';
-	echo '<InputEncoding>UTF-8</InputEncoding>';
-}
-?>
-<Image width="16" height="16">data:image/png,%89PNG%0D%0A%1A%0A%00%00%00%0DIHDR%00%00%00%10%00%00%00%10%08%06%00%00%00%1F%F3%FFa%00%00%00%01sRGB%00%AE%CE%1C%E9%00%00%00%06bKGD%00%FF%00%FF%00%FF%A0%BD%A7%93%00%00%00%09pHYs%00%00%0D%12%00%00%0D%3A%01%E8%DD%99%DE%00%00%00%07tIME%07%D8%0A%1B%035%18L%0A%18d%00%00%02AIDAT8%CB%8D%93%BDOZa%18%C5%7F%7C(%97%8FF%CA%0DU%7B%5BCj%D0Z%E3%AA%12%1C%D4%85A%A2%5D%5C%1C%1C%8C%93%FF%83I%FF%13%07%12'0.%9A%90%88B%24%C6%0Ej4bJ%1A%8C%A2%40%FC%00%8C%20%22%B7p%3Bq%95R%9B%9E%E9%7D%CE%9Bs%F2%BC%E7y%5EM%A9%24%2B%3E_%9CX%2C%87%2C%D7x%0D%82%A0cb%C2A%20%90%40%10t%8C%8C%BC%C7%E3%F9%88%FE%EC%AC%402Y%F8%A7%18%C0%EBu%B0%B6v%06%40%B9%5Cec%E3%02%9DN%83%CEj%FD%FAm%7C%FC%03%FD%FD%22%C9d%81J%A5%D9%A8%BB%BB%8DJ%A5%CA%F9y%B1%81%CF%E7%CBhs%B9'%FC%FE%04%91H%8A%E9%E9n%FA%FA%DE6%19%B8%5C%1D%EC%ED%DD4%F1%B9%DC%13%DAzq%7D%FD%C8%D2%D2%0FDQ%60r%D2%81V%AB%01%C0f3%90%CF%97%A9%D5%14Uh%B7%0B%EAY%FF%A7k4%9AA%92%CC%CC%CD%F5!%CB5%06%06D%0E%0En%D0h%40Q%C0%E9lcv%F63%8B%8B%DF%01%9E%3Bx%89%AB%AB%12%ED%EDF%86%86%DA1%99%F4%B8%DD%9D%B8%DD%9Dj%98%A2(%60%B3%19%5E7%B0Z%0DH%92%A5%813%9B%F5%F4%F6Z%B1%DB%8D%00j%D8%0D%06%92d%06%E0%F6%B6%CC%E6%E6%A5%CA%17%8B2%DB%DB%19%BC%5E%07%F1%F8%1D%0F%0F2%C5%A2%DC%9C%C1%C2%C2%00%3B%3B%19%C2%E1%14~%7F%02E%81%9E%1E%2B%85B%05%87%E3%0DF%A3%1E%8B%A5%85L%A6%F4%F7%10%1F%1F%7F1%3A*1%3C%DC%C1%F1q%96x%FC%8El%B6%CC%FD%7D%85%99%99%1E%02%81%04SS%9F%08%85.TM%C3%13%C2%E1%14fs%0B%E9%F4%03%A2(0%3F%FF%85%C1%C1w%1C%1E%DE%B2%B5%95%E2%E8(K%B5Zcw%F7%EA%EF%1DD%A3%19%BA%BA%2C%B8%5C%1D%AC%AC%9C%B2%BE~%8E%C9%D4B%B5%AA%10%0A%5Db%B7%1B%D9%DF%BFiX%7Bm%7D%1Cu%2C%2F%FF%C4%E7%8B36%26%A1%D5j89%C9%A9w%8A%A2%10%89%A4%D5%DAf3%A0Y%5D%3DU%82%C1d%D3(%5B%5B%B58%9DVb%B1g%83%FA2%D5%E1%F1t%A1)%16%2BJ0xA4%9A%A6%5C%AE%F2%3Fx%F9%9D%7F%03%B4%C6%E9%B0%15%8B%D3U%00%00%00%00IEND%AEB%60%82</Image>
-<?php
-if( strtolower( $f_type ) == 'id' ) {
-	echo '<Url type="text/html" method="GET" template="', $t_path, 'view.php?id={searchTerms}"></Url>';
-} else {
-	echo '<Url type="text/html" method="GET" template="', $t_path, 'view_all_set.php?type=1&amp;temporary=y&amp;handler_id=[all]&amp;search={searchTerms}"></Url>';
-}
-
-echo '<moz:SearchForm>', $t_path, 'view_all_bug_page.php</moz:SearchForm>';
-?>
+	<ShortName><?php echo $t_shortname; ?></ShortName>
+	<Description><?php echo $t_description; ?></Description>
+	<InputEncoding>UTF-8</InputEncoding>
+	<Image width="16" height="16">data:image/png,%89PNG%0D%0A%1A%0A%00%00%00%0DIHDR%00%00%00%10%00%00%00%10%08%06%00%00%00%1F%F3%FFa%00%00%00%01sRGB%00%AE%CE%1C%E9%00%00%00%06bKGD%00%FF%00%FF%00%FF%A0%BD%A7%93%00%00%00%09pHYs%00%00%0D%12%00%00%0D%3A%01%E8%DD%99%DE%00%00%00%07tIME%07%D8%0A%1B%035%18L%0A%18d%00%00%02AIDAT8%CB%8D%93%BDOZa%18%C5%7F%7C(%97%8FF%CA%0DU%7B%5BCj%D0Z%E3%AA%12%1C%D4%85A%A2%5D%5C%1C%1C%8C%93%FF%83I%FF%13%07%12'0.%9A%90%88B%24%C6%0Ej4bJ%1A%8C%A2%40%FC%00%8C%20%22%B7p%3Bq%95R%9B%9E%E9%7D%CE%9Bs%F2%BC%E7y%5EM%A9%24%2B%3E_%9CX%2C%87%2C%D7x%0D%82%A0cb%C2A%20%90%40%10t%8C%8C%BC%C7%E3%F9%88%FE%EC%AC%402Y%F8%A7%18%C0%EBu%B0%B6v%06%40%B9%5Cec%E3%02%9DN%83%CEj%FD%FAm%7C%FC%03%FD%FD%22%C9d%81J%A5%D9%A8%BB%BB%8DJ%A5%CA%F9y%B1%81%CF%E7%CBhs%B9'%FC%FE%04%91H%8A%E9%E9n%FA%FA%DE6%19%B8%5C%1D%EC%ED%DD4%F1%B9%DC%13%DAzq%7D%FD%C8%D2%D2%0FDQ%60r%D2%81V%AB%01%C0f3%90%CF%97%A9%D5%14Uh%B7%0B%EAY%FF%A7k4%9AA%92%CC%CC%CD%F5!%CB5%06%06D%0E%0En%D0h%40Q%C0%E9lcv%F63%8B%8B%DF%01%9E%3Bx%89%AB%AB%12%ED%EDF%86%86%DA1%99%F4%B8%DD%9D%B8%DD%9Dj%98%A2(%60%B3%19%5E7%B0Z%0DH%92%A5%813%9B%F5%F4%F6Z%B1%DB%8D%00j%D8%0D%06%92d%06%E0%F6%B6%CC%E6%E6%A5%CA%17%8B2%DB%DB%19%BC%5E%07%F1%F8%1D%0F%0F2%C5%A2%DC%9C%C1%C2%C2%00%3B%3B%19%C2%E1%14~%7F%02E%81%9E%1E%2B%85B%05%87%E3%0DF%A3%1E%8B%A5%85L%A6%F4%F7%10%1F%1F%7F1%3A*1%3C%DC%C1%F1q%96x%FC%8El%B6%CC%FD%7D%85%99%99%1E%02%81%04SS%9F%08%85.TM%C3%13%C2%E1%14fs%0B%E9%F4%03%A2(0%3F%FF%85%C1%C1w%1C%1E%DE%B2%B5%95%E2%E8(K%B5Zcw%F7%EA%EF%1DD%A3%19%BA%BA%2C%B8%5C%1D%AC%AC%9C%B2%BE~%8E%C9%D4B%B5%AA%10%0A%5Db%B7%1B%D9%DF%BFiX%7Bm%7D%1Cu%2C%2F%FF%C4%E7%8B36%26%A1%D5j89%C9%A9w%8A%A2%10%89%A4%D5%DAf3%A0Y%5D%3DU%82%C1d%D3(%5B%5B%B58%9DVb%B1g%83%FA2%D5%E1%F1t%A1)%16%2BJ0xA4%9A%A6%5C%AE%F2%3Fx%F9%9D%7F%03%B4%C6%E9%B0%15%8B%D3U%00%00%00%00IEND%AEB%60%82</Image>
+	<Url type="text/html" method="GET" template="<?php echo $t_url; ?>"></Url>';
+	<moz:SearchForm><?php echo $t_searchform; ?></moz:SearchForm>
 </OpenSearchDescription>

--- a/browser_search_plugin.php
+++ b/browser_search_plugin.php
@@ -37,16 +37,17 @@ require_api( 'gpc_api.php' );
 $f_type = gpc_get_string( 'type', 'text' );
 
 $t_path = config_get_global( 'path' );
+$t_title = config_get_global( 'search_title' );
 $t_icon = $t_path . config_get_global( 'favicon_image' );
 $t_searchform = $t_path . 'view_all_bug_page.php';
 
 if( strtolower( $f_type ) == 'id' ) {
-	$t_shortname = 'MantisBT IssueId';
-	$t_description = 'MantisBT Issue Id Search';
+	$t_shortname = $t_title . ' IssueId';
+	$t_description = $t_title .' Issue Id Search';
 	$t_url = $t_path . 'view.php?id={searchTerms}';
 } else {
-	$t_shortname = 'MantisBT Search';
-	$t_description = 'MantisBT Text Search';
+	$t_shortname = $t_title . ' Search';
+	$t_description = $t_title . ' Text Search';
 	$t_url = $t_path . 'view_all_set.php?type=1&amp;temporary=y&amp;handler_id=[all]&amp;search={searchTerms}';
 }
 

--- a/browser_search_plugin.php
+++ b/browser_search_plugin.php
@@ -34,20 +34,20 @@ require_once( 'core.php' );
 require_api( 'config_api.php' );
 require_api( 'gpc_api.php' );
 
-$f_type = gpc_get_string( 'type', 'text' );
+$f_type = strtolower( gpc_get_string( 'type', 'text' ) );
 
 $t_path = config_get_global( 'path' );
 $t_title = config_get_global( 'search_title' );
 $t_icon = $t_path . config_get_global( 'favicon_image' );
 $t_searchform = $t_path . 'view_all_bug_page.php';
 
-if( strtolower( $f_type ) == 'id' ) {
-	$t_shortname = $t_title . ' IssueId';
-	$t_description = $t_title .' Issue Id Search';
+# Localized ShortName and Description elements
+$t_shortname = sprintf( lang_get( "opensearch_{$f_type}_short" ), $t_title );
+$t_description = sprintf( lang_get( "opensearch_{$f_type}_description" ), $t_title );
+
+if( $f_type == 'id' ) {
 	$t_url = $t_path . 'view.php?id={searchTerms}';
 } else {
-	$t_shortname = $t_title . ' Search';
-	$t_description = $t_title . ' Text Search';
 	$t_url = $t_path . 'view_all_set.php?type=1&amp;temporary=y&amp;handler_id=[all]&amp;search={searchTerms}';
 }
 

--- a/browser_search_plugin.php
+++ b/browser_search_plugin.php
@@ -37,8 +37,8 @@ require_api( 'gpc_api.php' );
 $f_type = strtolower( gpc_get_string( 'type', 'text' ) );
 
 $t_path = config_get_global( 'path' );
-$t_title = config_get_global( 'search_title' );
-$t_icon = $t_path . config_get_global( 'favicon_image' );
+$t_title = config_get( 'search_title' );
+$t_icon = $t_path . config_get( 'favicon_image' );
 $t_searchform = $t_path . 'view_all_bug_page.php';
 
 # Localized ShortName and Description elements

--- a/browser_search_plugin.php
+++ b/browser_search_plugin.php
@@ -37,6 +37,7 @@ require_api( 'gpc_api.php' );
 $f_type = gpc_get_string( 'type', 'text' );
 
 $t_path = config_get_global( 'path' );
+$t_icon = $t_path . config_get_global( 'favicon_image' );
 $t_searchform = $t_path . 'view_all_bug_page.php';
 
 if( strtolower( $f_type ) == 'id' ) {
@@ -57,7 +58,7 @@ header( 'Content-Type: application/opensearchdescription+xml' );
 	<ShortName><?php echo $t_shortname; ?></ShortName>
 	<Description><?php echo $t_description; ?></Description>
 	<InputEncoding>UTF-8</InputEncoding>
-	<Image width="16" height="16">data:image/png,%89PNG%0D%0A%1A%0A%00%00%00%0DIHDR%00%00%00%10%00%00%00%10%08%06%00%00%00%1F%F3%FFa%00%00%00%01sRGB%00%AE%CE%1C%E9%00%00%00%06bKGD%00%FF%00%FF%00%FF%A0%BD%A7%93%00%00%00%09pHYs%00%00%0D%12%00%00%0D%3A%01%E8%DD%99%DE%00%00%00%07tIME%07%D8%0A%1B%035%18L%0A%18d%00%00%02AIDAT8%CB%8D%93%BDOZa%18%C5%7F%7C(%97%8FF%CA%0DU%7B%5BCj%D0Z%E3%AA%12%1C%D4%85A%A2%5D%5C%1C%1C%8C%93%FF%83I%FF%13%07%12'0.%9A%90%88B%24%C6%0Ej4bJ%1A%8C%A2%40%FC%00%8C%20%22%B7p%3Bq%95R%9B%9E%E9%7D%CE%9Bs%F2%BC%E7y%5EM%A9%24%2B%3E_%9CX%2C%87%2C%D7x%0D%82%A0cb%C2A%20%90%40%10t%8C%8C%BC%C7%E3%F9%88%FE%EC%AC%402Y%F8%A7%18%C0%EBu%B0%B6v%06%40%B9%5Cec%E3%02%9DN%83%CEj%FD%FAm%7C%FC%03%FD%FD%22%C9d%81J%A5%D9%A8%BB%BB%8DJ%A5%CA%F9y%B1%81%CF%E7%CBhs%B9'%FC%FE%04%91H%8A%E9%E9n%FA%FA%DE6%19%B8%5C%1D%EC%ED%DD4%F1%B9%DC%13%DAzq%7D%FD%C8%D2%D2%0FDQ%60r%D2%81V%AB%01%C0f3%90%CF%97%A9%D5%14Uh%B7%0B%EAY%FF%A7k4%9AA%92%CC%CC%CD%F5!%CB5%06%06D%0E%0En%D0h%40Q%C0%E9lcv%F63%8B%8B%DF%01%9E%3Bx%89%AB%AB%12%ED%EDF%86%86%DA1%99%F4%B8%DD%9D%B8%DD%9Dj%98%A2(%60%B3%19%5E7%B0Z%0DH%92%A5%813%9B%F5%F4%F6Z%B1%DB%8D%00j%D8%0D%06%92d%06%E0%F6%B6%CC%E6%E6%A5%CA%17%8B2%DB%DB%19%BC%5E%07%F1%F8%1D%0F%0F2%C5%A2%DC%9C%C1%C2%C2%00%3B%3B%19%C2%E1%14~%7F%02E%81%9E%1E%2B%85B%05%87%E3%0DF%A3%1E%8B%A5%85L%A6%F4%F7%10%1F%1F%7F1%3A*1%3C%DC%C1%F1q%96x%FC%8El%B6%CC%FD%7D%85%99%99%1E%02%81%04SS%9F%08%85.TM%C3%13%C2%E1%14fs%0B%E9%F4%03%A2(0%3F%FF%85%C1%C1w%1C%1E%DE%B2%B5%95%E2%E8(K%B5Zcw%F7%EA%EF%1DD%A3%19%BA%BA%2C%B8%5C%1D%AC%AC%9C%B2%BE~%8E%C9%D4B%B5%AA%10%0A%5Db%B7%1B%D9%DF%BFiX%7Bm%7D%1Cu%2C%2F%FF%C4%E7%8B36%26%A1%D5j89%C9%A9w%8A%A2%10%89%A4%D5%DAf3%A0Y%5D%3DU%82%C1d%D3(%5B%5B%B58%9DVb%B1g%83%FA2%D5%E1%F1t%A1)%16%2BJ0xA4%9A%A6%5C%AE%F2%3Fx%F9%9D%7F%03%B4%C6%E9%B0%15%8B%D3U%00%00%00%00IEND%AEB%60%82</Image>
+	<Image width="16" height="16" type="image/x-icon"><?php echo $t_icon; ?></Image>
 	<Url type="text/html" method="GET" template="<?php echo $t_url; ?>"></Url>';
 	<moz:SearchForm><?php echo $t_searchform; ?></moz:SearchForm>
 </OpenSearchDescription>

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -4529,6 +4529,7 @@ $g_public_config_names = array(
 	'roadmap_update_threshold',
 	'roadmap_view_threshold',
 	'rss_enabled',
+	'search_title',
 	'set_bug_sticky_threshold',
 	'set_configuration_threshold',
 	'set_view_status_threshold',

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -851,6 +851,18 @@ $g_fallback_language = 'english';
 $g_window_title = 'MantisBT';
 
 /**
+ * OpenSearch ShortName prefix.
+ * This is used to describe Browser Search entries, and must be 8 chars or
+ * less to be compliant with the OpenSearch specification (since we append up to
+ * 8 chars to differentiate text- and id-based searches, and the maximum length
+ * of the ShortName element is 16 chars).
+ * @link http://www.opensearch.org/Specifications/OpenSearch/1.1
+ * @see $g_window_title
+ * @global string $g_search_title
+ */
+$g_search_title = '%window_title%';
+
+/**
  * Check for admin directory, database upgrades, etc.
  * @global integer $g_admin_checks
  */

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -851,11 +851,11 @@ $g_fallback_language = 'english';
 $g_window_title = 'MantisBT';
 
 /**
- * OpenSearch ShortName prefix.
- * This is used to describe Browser Search entries, and must be 8 chars or
- * less to be compliant with the OpenSearch specification (since we append up to
- * 8 chars to differentiate text- and id-based searches, and the maximum length
- * of the ShortName element is 16 chars).
+ * OpenSearch engine title prefix.
+ * This is used to describe Browser Search entries, and must be short enough
+ * so that when inserted into the 'opensearch_XXX_short' language string, the
+ * resulting text is 16 characters or less, to be compliant with the limit for
+ * the ShortName element as defined in the OpenSearch specification.
  * @link http://www.opensearch.org/Specifications/OpenSearch/1.1
  * @see $g_window_title
  * @global string $g_search_title

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -857,7 +857,9 @@ $g_window_title = 'MantisBT';
 $g_admin_checks = ON;
 
 /**
- * Favicon image
+ * Favicon image.
+ * This icon should be of 'image/x-icon' MIME type, and its size 16x16 pixels.
+ * It is also used to decorate OpenSearch Browser search entries.
  * @global string $g_favicon_image
  */
 $g_favicon_image = 'images/favicon.ico';

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -206,14 +206,11 @@ function html_page_top1( $p_page_title = null ) {
 
 	# Advertise the availability of the browser search plug-ins.
 	$t_title = config_get_global( 'search_title' );
-	$t_searches = array(
-		'text' => $t_title . ': ' . 'Text Search',
-		'id'   => $t_title . ': ' . 'Issue Id Search',
-	);
-	foreach( $t_searches as $t_type => $t_label ) {
+	$t_searches = array( 'text', 'id' );
+	foreach( $t_searches as $t_type ) {
 		echo "\t",
 			'<link rel="search" type="application/opensearchdescription+xml" ',
-			'title="' . $t_label . '" ',
+			'title="' . sprintf( lang_get( "opensearch_{$t_type}_description" ), $t_title ) . '" ',
 			'href="' . string_sanitize_url( 'browser_search_plugin.php?type=' . $t_type, true ) .
 			'", />',
 			"\n";

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -205,8 +205,19 @@ function html_page_top1( $p_page_title = null ) {
 	}
 
 	# Advertise the availability of the browser search plug-ins.
-	echo "\t", '<link rel="search" type="application/opensearchdescription+xml" title="MantisBT: Text Search" href="' . string_sanitize_url( 'browser_search_plugin.php?type=text', true ) . '" />' . "\n";
-	echo "\t", '<link rel="search" type="application/opensearchdescription+xml" title="MantisBT: Issue Id" href="' . string_sanitize_url( 'browser_search_plugin.php?type=id', true ) . '" />' . "\n";
+	$t_title = config_get_global( 'search_title' );
+	$t_searches = array(
+		'text' => $t_title . ': ' . 'Text Search',
+		'id'   => $t_title . ': ' . 'Issue Id Search',
+	);
+	foreach( $t_searches as $t_type => $t_label ) {
+		echo "\t",
+			'<link rel="search" type="application/opensearchdescription+xml" ',
+			'title="' . $t_label . '" ',
+			'href="' . string_sanitize_url( 'browser_search_plugin.php?type=' . $t_type, true ) .
+			'", />',
+			"\n";
+	}
 
 	html_head_javascript();
 }

--- a/docbook/Admin_Guide/en-US/config/display.xml
+++ b/docbook/Admin_Guide/en-US/config/display.xml
@@ -9,9 +9,23 @@
 		<varlistentry>
 			<term>$g_window_title</term>
 			<listitem>
-				<para>This is the browser window title (&lt;TITLE&gt;
-					tag).
+				<para>This is the browser window title (&lt;TITLE&gt; tag).
 				</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
+			<term>$g_search_title</term>
+			<listitem>
+				<para>This is used as prefix for Browser Search entries,
+					and must be 8 chars or less to be compliant with the
+					<ulink url="http://www.opensearch.org/Specifications/OpenSearch/1.1">
+						OpenSearch specification
+					</ulink>
+					(since we append up to 8 chars to differentiate text- and
+					id-based searches, and the maximum length of the
+					<emphasis>ShortName </emphasis> element is 16 chars).
+				</para>
+				<para>Defaults to the value of $g_window_title.</para>
 			</listitem>
 		</varlistentry>
 		<varlistentry>

--- a/docbook/Admin_Guide/en-US/config/display.xml
+++ b/docbook/Admin_Guide/en-US/config/display.xml
@@ -16,14 +16,14 @@
 		<varlistentry>
 			<term>$g_search_title</term>
 			<listitem>
-				<para>This is used as prefix for Browser Search entries,
-					and must be 8 chars or less to be compliant with the
+				<para>This is used as prefix to describe Browser Search entries,
+					and must be short enough so that when inserted into the
+					'opensearch_XXX_short' language string, the resulting text
+					is 16 characters or less, to be compliant with the limit for
+					the ShortName element as defined in the
 					<ulink url="http://www.opensearch.org/Specifications/OpenSearch/1.1">
 						OpenSearch specification
-					</ulink>
-					(since we append up to 8 chars to differentiate text- and
-					id-based searches, and the maximum length of the
-					<emphasis>ShortName </emphasis> element is 16 chars).
+					</ulink>.
 				</para>
 				<para>Defaults to the value of $g_window_title.</para>
 			</listitem>

--- a/docbook/Admin_Guide/en-US/config/display.xml
+++ b/docbook/Admin_Guide/en-US/config/display.xml
@@ -17,7 +17,12 @@
 		<varlistentry>
 			<term>$g_favicon_image</term>
 			<listitem>
-				<para>Path to the favorites icon relative to MantisBT root folder (default 'images/favicon.ico').</para>
+				<para>Path to the favorites icon relative to MantisBT root folder
+					This icon should be of <emphasis>image/x-icon</emphasis> MIME type,
+					and its size 16x16 pixels. It is also used to decorate
+					OpenSearch Browser search entries.
+					(default 'images/favicon.ico').
+				</para>
 			</listitem>
 		</varlistentry>
 		<varlistentry>

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -180,6 +180,12 @@ $s_create_new_project_link = 'Create New Project';
 
 $s_login_link = 'Login';
 
+# Browser Search - %s is the Search Engine title (@see $g_search_title)
+$s_opensearch_id_short = '%s Id';
+$s_opensearch_id_description = '%s: search by Issue Id';
+$s_opensearch_text_short = '%s Text';
+$s_opensearch_text_description = '%s: full-text search';
+
 # comboboxes default to this to instruct user to explicitly select an entry.
 $s_select_option = '(select)';
 


### PR DESCRIPTION
This PR follows-up and improves on #73, fixes [#11964](https://www.mantisbt.org/bugs/view.php?id=11964)

- Use standard favicon instead of hardcoded PNG for Mantis search engines
- Define new config for search engine name prefix (defaults to $g_window_title)
- Localize search engine ShortNames and Descriptions
