### PR TITLE
Use multiple tokens for action links in same page

### DIFF
--- a/bug_revision_view_page.php
+++ b/bug_revision_view_page.php
@@ -100,11 +100,10 @@ if( $f_bug_id ) {
  */
 function show_revision( array $p_revision ) {
 	static $s_can_drop = null;
-	static $s_drop_token = null;
 	static $s_user_access = null;
+
 	if( is_null( $s_can_drop ) ) {
 		$s_can_drop = access_has_bug_level( config_get( 'bug_revision_drop_threshold' ), $p_revision['bug_id'] );
-		$s_drop_token = form_security_param( 'bug_revision_drop' );
 	}
 
 	switch( $p_revision['type'] ) {
@@ -144,7 +143,8 @@ function show_revision( array $p_revision ) {
 			<td class="center" width="5%">
 <?php
 	if( $s_can_drop ) {
-		print_bracket_link( 'bug_revision_drop.php?id=' . $p_revision['id'] . $s_drop_token, lang_get( 'revision_drop' ) );
+		$t_drop_token = form_security_param( 'bug_revision_drop' );
+		print_bracket_link( 'bug_revision_drop.php?id=' . $p_revision['id'] . $t_drop_token, lang_get( 'revision_drop' ) );
 	}
 ?>
 		</tr>

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1830,11 +1830,10 @@ function get_dropdown( array $p_control_array, $p_control_name, $p_match = '', $
  */
 function print_bug_attachments_list( $p_bug_id ) {
 	$t_attachments = file_get_visible_attachments( $p_bug_id );
-	$t_security_token = form_security_token( 'bug_file_delete' );
 	echo "\n<ul>";
 	foreach ( $t_attachments as $t_attachment ) {
 		echo "\n<li>";
-		print_bug_attachment( $t_attachment, $t_security_token );
+		print_bug_attachment( $t_attachment );
 		echo "\n</li>";
 	}
 	echo "\n</ul>";
@@ -1861,6 +1860,10 @@ function print_bug_attachment( array $p_attachment, $p_security_token = null ) {
 		global $g_collapse_cache_token;
 		$g_collapse_cache_token[$t_collapse_id] = false;
 		collapse_open( $t_collapse_id );
+	}
+	# The same token is used for both links in the collapse section
+	if( null === $p_security_token ) {
+		$p_security_token = form_security_token( 'bug_file_delete' );
 	}
 	print_bug_attachment_header( $p_attachment, $p_security_token );
 	if( $t_show_attachment_preview ) {


### PR DESCRIPTION
Previously, due to performance issues with session store, only one security token was used for several action links in the same page
The side effect is that only one of those actions can be performed from
the specific originating page.
This is especially a drawback when the actions are links that can be open
in new browsers tabs.

Reverting to separate tokens allows to perform all the actions without
having to reload the originating page.

Note, the original performance issue was solved at the session layer
with 8092c3d.