### PR TITLE
Add missing css classes for plugins page color key

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -23,6 +23,11 @@ tr.spacer			{ background-color: #ffffff !important; color: #000000; height: 5px;
 #buglist .column-additional-information
 	{ text-align: left; }
 
+/* manage_plugin_page.php */
+span.dependency_dated		{ color: maroon; }
+span.dependency_met			{ color: green; }
+span.dependency_unmet		{ color: red; }
+span.dependency_upgrade		{ color: orange; }
 
 tr.bugnote .bugnote-note { background-color: #e8e8e8; color: #000000; width: 75%; vertical-align: top; }
 


### PR DESCRIPTION
Fixes #21117

<img width="1213" alt="screen shot 2016-08-15 at 8 21 39 am" src="https://cloud.githubusercontent.com/assets/1354889/17669150/662fb9ae-62c1-11e6-9e31-b7d0b96f49b7.png">
