### PR TITLE
Remove undeclared variables from excel, csv export

### DIFF
--- a/csv_export.php
+++ b/csv_export.php
@@ -56,7 +56,7 @@ $t_sep = csv_get_separator();
 $t_filter = filter_get_bug_rows_filter();
 
 # Get the query clauses
-$t_query_clauses = filter_get_bug_rows_query_clauses( $t_filter, $p_project_id, $p_user_id, $p_show_sticky );
+$t_query_clauses = filter_get_bug_rows_query_clauses( $t_filter );
 
 # Get the total number of bugs that meet the criteria.
 $p_bug_count = filter_get_bug_count( $t_query_clauses );

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -81,7 +81,7 @@ $t_columns = excel_get_columns();
 $t_filter = filter_get_bug_rows_filter();
 
 # Get the query clauses
-$t_query_clauses = filter_get_bug_rows_query_clauses( $t_filter, $p_project_id, $p_user_id, $p_show_sticky );
+$t_query_clauses = filter_get_bug_rows_query_clauses( $t_filter );
 
 # Get the total number of bugs that meet the criteria.
 $p_bug_count = filter_get_bug_count( $t_query_clauses );

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -52,9 +52,6 @@ require_api( 'helper_api.php' );
 require_api( 'print_api.php' );
 require_api( 'utility_api.php' );
 
-define( 'PRINT_ALL_BUG_OPTIONS_INC_ALLOW', true );
-include( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'print_all_bug_options_inc.php' );
-
 auth_ensure_user_authenticated();
 
 $f_export = gpc_get_string( 'export', '' );


### PR DESCRIPTION
Remove undeclared variables from excel, csv export
    
    The undeclared variables were introduced by error after rebasing PR from
    Issue #20424

Remove unused include in excel_xml_export
    
    The page print_all_bug_options_inc.php is no longer used, as stated in
    Issue #19370


