### PR TITLE
Implement bugnotes_count, attachment_count in CSV, Excel export (2)

### DIFF
--- a/core/csv_api.php
+++ b/core/csv_api.php
@@ -480,3 +480,35 @@ function csv_format_due_date( BugData $p_bug ) {
 function csv_format_sponsorship_total( BugData $p_bug ) {
 	return csv_escape_string( $p_bug->sponsorship_total );
 }
+
+/**
+ * return the attachment count for an issue
+ * @param BugData $p_bug A BugData object.
+ * @return string
+ * @access public
+ */
+function csv_format_attachment_count( BugData $p_bug ) {
+	# Check for attachments
+	$t_attachment_count = 0;
+	if( file_can_view_bug_attachments( $p_bug->id, null ) ) {
+		$t_attachment_count = file_bug_attachment_count( $p_bug->id );
+	}
+	return csv_escape_string( $t_attachment_count );
+}
+
+/**
+ * return the bug note count for an issue
+ * @param BugData $p_bug A BugData object.
+ * @return string
+ * @access public
+ */
+function csv_format_bugnotes_count( BugData $p_bug ) {
+	# grab the bugnote count
+	$t_bugnote_stats = bug_get_bugnote_stats( $p_bug->id );
+	if( $t_bugnote_stats ) {
+		$t_bugnote_count = $t_bugnote_stats['count'];
+	} else {
+		$t_bugnote_count = 0;
+	}
+	return csv_escape_string( $t_bugnote_count );
+}

--- a/core/excel_api.php
+++ b/core/excel_api.php
@@ -252,15 +252,6 @@ function excel_format_reporter_id( BugData $p_bug ) {
 }
 
 /**
- * Gets the formatted number of bug notes.
- * @param BugData $p_bug A bug object.
- * @return string The number of bug notes.
- */
-function excel_format_bugnotes_count( BugData $p_bug ) {
-	return excel_prepare_number( $p_bug->bugnotes_count );
-}
-
-/**
  * Gets the formatted handler id.
  * @param BugData $p_bug A bug object.
  * @return string The handler user name or empty string.
@@ -574,6 +565,38 @@ function excel_format_due_date( BugData $p_bug ) {
  */
 function excel_format_sponsorship_total( BugData $p_bug ) {
 	return excel_prepare_string( $p_bug->sponsorship_total );
+}
+
+/**
+ * Gets the attachment count for an issue
+ * @param BugData $p_bug A bug object.
+ * @return string
+ * @access public
+ */
+function excel_format_attachment_count( BugData $p_bug ) {
+	# Check for attachments
+	$t_attachment_count = 0;
+	if( file_can_view_bug_attachments( $p_bug->id, null ) ) {
+		$t_attachment_count = file_bug_attachment_count( $p_bug->id );
+	}
+	return excel_prepare_number( $t_attachment_count );
+}
+
+/**
+ * Gets the bug note count for an issue
+ * @param BugData $p_bug A bug object.
+ * @return string
+ * @access public
+ */
+function excel_format_bugnotes_count( BugData $p_bug ) {
+	# grab the bugnote count
+	$t_bugnote_stats = bug_get_bugnote_stats( $p_bug->id );
+	if( null !== $t_bugnote_stats ) {
+		$t_bugnote_count = $t_bugnote_stats['count'];
+	} else {
+		$t_bugnote_count = 0;
+	}
+	return excel_prepare_number( $t_bugnote_count );
 }
 
 /**

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -506,13 +506,7 @@ function helper_get_columns_to_view( $p_columns_target = COLUMNS_TARGET_VIEW_PAG
 	if( $p_columns_target == COLUMNS_TARGET_CSV_PAGE || $p_columns_target == COLUMNS_TARGET_EXCEL_PAGE ) {
 		$t_keys_to_remove[] = 'selection';
 		$t_keys_to_remove[] = 'edit';
-		$t_keys_to_remove[] = 'bugnotes_count';
-		$t_keys_to_remove[] = 'attachment_count';
 		$t_keys_to_remove[] = 'overdue';
-	}
-
-	if( $p_columns_target == COLUMNS_TARGET_CSV_PAGE || $p_columns_target == COLUMNS_TARGET_EXCEL_PAGE ) {
-		$t_keys_to_remove[] = 'attachment_count';
 	}
 
 	$t_current_project_id = helper_get_current_project();


### PR DESCRIPTION
Resubmit of PR #696 
rebased to current master-1.3.x

Original PR found a problem where the queries used to cache bugnotes may run out of limits for long IN clauses.
This should not happen after #832 was implemented, since bugs are treated in batches of controlled size