### PR TITLE
Provide API for plugins to update CSP header

### DIFF
--- a/core.php
+++ b/core.php
@@ -274,6 +274,7 @@ if( file_exists( $g_config_path . 'custom_functions_inc.php' ) ) {
 
 # Set HTTP response headers
 require_api( 'http_api.php' );
+event_signal( 'EVENT_CORE_HEADERS' );
 http_all_headers();
 
 # Push default language to speed calls to lang_get

--- a/core/events_inc.php
+++ b/core/events_inc.php
@@ -33,6 +33,7 @@ event_declare_many( array(
 
 	# Events specific to the core system
 	'EVENT_CORE_READY' => EVENT_TYPE_EXECUTE,
+	'EVENT_CORE_HEADERS' => EVENT_TYPE_EXECUTE,
 
 	# MantisBT Layout Events
 	'EVENT_LAYOUT_RESOURCES' => EVENT_TYPE_OUTPUT,

--- a/core/http_api.php
+++ b/core/http_api.php
@@ -154,6 +154,11 @@ function http_content_headers() {
 function http_csp_add( $p_type, $p_value ) {
 	global $g_csp;
 
+	if ( $g_csp === null ) {
+		# Development error, headers already emitted.
+		trigger_error( ERROR_GENERIC, ERROR );
+	}
+
 	if ( isset( $g_csp[$p_type] ) ) {
 		if ( !in_array( $p_value, $g_csp[$p_type] ) ) {
 			$g_csp[$p_type][] = $p_value;
@@ -170,6 +175,11 @@ function http_csp_add( $p_type, $p_value ) {
 function http_csp_value() {
 	global $g_csp;
 
+	if ( $g_csp === null ) {
+		# Development error, headers already emitted.
+		trigger_error( ERROR_GENERIC, ERROR );
+	}
+
 	$t_csp_value = '';
 
 	foreach ( $g_csp as $t_key => $t_values ) {
@@ -179,6 +189,17 @@ function http_csp_value() {
 	$t_csp_value = trim( $t_csp_value, '; ' );
 
 	return $t_csp_value;
+}
+
+/**
+ * Send header for Content-Security-Policy.
+ * @return void
+ */
+function http_csp_emit_header() {
+	header( 'Content-Security-Policy: ' . http_csp_value() );
+
+	global $g_csp;
+	$g_csp = null;
 }
 
 /**
@@ -209,8 +230,7 @@ function http_security_headers() {
 			http_csp_add( 'style-src', "'unsafe-inline'" );
 		}
 
-		# Set CSP header
-		header( 'Content-Security-Policy: ' . http_csp_value() );
+		http_csp_emit_header();
 
 		if( http_is_protocol_https() ) {
 			header( 'Strict-Transport-Security: max-age=7776000' );

--- a/core/http_api.php
+++ b/core/http_api.php
@@ -30,6 +30,12 @@
 require_api( 'config_api.php' );
 
 /**
+ * The Content-Security-Policy settings array.  Use http_csp_add() to update it.
+ * @var array
+ */
+$g_csp = array();
+
+/**
  * Checks to see if script was queried through the HTTPS protocol
  * @return boolean True if protocol is HTTPS
  */
@@ -139,6 +145,43 @@ function http_content_headers() {
 }
 
 /**
+ * Add a Content-Security-Policy directive.
+ *
+ * @param  string $p_type  The directive type, e.g. style-src, script-src.
+ * @param  string $p_value The directive value, e.g. 'self', https://ajax.googleapis.com
+ * @return void
+ */
+function http_csp_add( $p_type, $p_value ) {
+	global $g_csp;
+
+	if ( isset( $g_csp[$p_type] ) ) {
+		if ( !in_array( $p_value, $g_csp[$p_type] ) ) {
+			$g_csp[$p_type][] = $p_value;
+		}
+	} else {
+		$g_csp[$p_type] = array( $p_value );
+	}
+}
+
+/**
+ * Constructs the value of the CSP header.
+ * @return string CSP header value.
+ */
+function http_csp_value() {
+	global $g_csp;
+
+	$t_csp_value = '';
+
+	foreach ( $g_csp as $t_key => $t_values ) {
+		$t_csp_value .= $t_key . ' ' . implode( ' ', $t_values ) . '; ';
+	}
+
+	$t_csp_value = trim( $t_csp_value, '; ' );
+
+	return $t_csp_value;
+}
+
+/**
  * Set security headers (frame busting, clickjacking/XSS/CSRF protection).
  * @return void
  */
@@ -147,32 +190,27 @@ function http_security_headers() {
 		header( 'X-Frame-Options: DENY' );
 
 		# Define Content Security Policy
-		$t_csp = array(
-			"default-src 'self'",
-			"frame-ancestors 'none'",
-		);
-
-		$t_style_src = "style-src 'self'";
-		$t_script_src = "script-src 'self'";
+		http_csp_add( 'default-src', "'self'" );
+		http_csp_add( 'frame-ancestors', "'none'" );
+		http_csp_add( 'style-src', "'self'" );
+		http_csp_add( 'script-src', "'self'" );
+		http_csp_add( 'img-src', "'self'" );
 
 		# White list the CDN urls (if enabled)
 		if ( config_get_global( 'cdn_enabled' ) == ON ) {
 			$t_cdn_url = 'https://ajax.googleapis.com';
-			$t_style_src .= " $t_cdn_url";
-			$t_script_src .= " $t_cdn_url";
+			http_csp_add( 'style-src', $t_cdn_url );
+			http_csp_add( 'script-src', $t_cdn_url );
 		}
 
 		# Relaxing policy for roadmap page to allow inline styles
 		# This is a workaround to fix the broken progress bars (see #19501)
 		if( 'roadmap_page.php' == basename( $_SERVER['SCRIPT_NAME'] ) ) {
-			$t_style_src .= " 'unsafe-inline'";
+			http_csp_add( 'style-src', "'unsafe-inline'" );
 		}
 
-		$t_csp[] = $t_style_src;
-		$t_csp[] = $t_script_src;
-
 		# Set CSP header
-		header( 'Content-Security-Policy: ' . implode('; ', $t_csp) );
+		header( 'Content-Security-Policy: ' . http_csp_value() );
 
 		if( http_is_protocol_https() ) {
 			header( 'Strict-Transport-Security: max-age=7776000' );

--- a/docbook/Developers_Guide/en-US/Events_Reference.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference.xml
@@ -83,6 +83,19 @@
 			</blockquote>
 		</blockquote>
 
+		<blockquote id="dev.eventref.system.coreheaders">
+			<title>EVENT_CORE_HEADERS (Execute)</title>
+
+			<blockquote>
+				<para>
+					This event is triggered by the MantisBT bootstrap process just before emitting the
+					headers.  This enables plugins to emit their own headers or use API that enables
+					tweaking values of headers emitted by core.  An example, of headers that can be
+					tweaked is Content-Security-Policy header which can be tweaked using http_csp_*() APIs.
+				</para>
+			</blockquote>
+		</blockquote>
+
 		<blockquote id="dev.eventref.system.coreready">
 			<title>EVENT_CORE_READY (Execute)</title>
 

--- a/plugins/Gravatar/Gravatar.php
+++ b/plugins/Gravatar/Gravatar.php
@@ -104,24 +104,14 @@ class GravatarPlugin extends MantisPlugin {
 	 * Register event hooks for plugin.
 	 */
 	function hooks() {
-		return array(
-			'EVENT_USER_AVATAR' => 'user_get_avatar',
-			'EVENT_LAYOUT_RESOURCES' => 'csp_headers',
-		);
-	}
-
-	/**
-	 * Add Content-Security-Policy for retrieving Avatar images.
-	 *
-	 * @return void
-	 */
-	function csp_headers() {
-		# Policy for images: Allow gravatar URL
 		if( config_get( 'show_avatar' ) !== OFF ) {
 			# Set CSP header
-			header( "Content-Security-Policy: img-src 'self' " .
-				self::getAvatarUrl() );
+			http_csp_add( 'img-src', self::getAvatarUrl() );
 		}
+
+		return array(
+			'EVENT_USER_AVATAR' => 'user_get_avatar',
+		);
 	}
 
 	/**

--- a/plugins/Gravatar/Gravatar.php
+++ b/plugins/Gravatar/Gravatar.php
@@ -104,14 +104,19 @@ class GravatarPlugin extends MantisPlugin {
 	 * Register event hooks for plugin.
 	 */
 	function hooks() {
-		if( config_get( 'show_avatar' ) !== OFF ) {
-			# Set CSP header
-			http_csp_add( 'img-src', self::getAvatarUrl() );
-		}
-
 		return array(
 			'EVENT_USER_AVATAR' => 'user_get_avatar',
+			'EVENT_CORE_HEADERS' => 'csp_headers',
 		);
+	}
+
+	/**
+	 * Register gravatar url as an img-src for CSP header
+	 */
+	function csp_headers() {
+		if( config_get( 'show_avatar' ) !== OFF ) {
+			http_csp_add( 'img-src', self::getAvatarUrl() );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Provide an API to manage the Content-Security-Header and change the Gravatar plugin to use it.

This fixes a bug where Gravatar plugin was generating its own header and hence overwriting the default headers.

Fixes #21263