### PR TITLE
Show report bug menu entry if allowed for any project

### DIFF
--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -151,6 +151,12 @@ if( $f_master_bug_id > 0 ) {
 		print_header_redirect( 'login_select_proj_page.php?ref=bug_report_page.php' );
 	}
 
+	# Check for bug report threshold
+	if( !access_has_project_level( config_get( 'report_bug_threshold' ) ) ) {
+		# If can't report on current project, show project selector if there is any other allowed project
+		access_ensure_any_project_level( 'report_bug_threshold' );
+		print_header_redirect( 'login_select_proj_page.php?ref=bug_report_page.php' );
+	}
 	access_ensure_project_level( config_get( 'report_bug_threshold' ) );
 
 	$f_build				= gpc_get_string( 'build', '' );

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -881,7 +881,7 @@ function print_menu() {
 		$t_menu_options[] = '<a href="' . helper_mantis_url( 'view_all_bug_page.php">' ) . lang_get( 'view_bugs_link' ) . '</a>';
 
 		# Report Bugs
-		if( access_has_project_level( config_get( 'report_bug_threshold' ) ) ) {
+		if( access_has_any_project_level( 'report_bug_threshold' ) ) {
 			$t_menu_options[] = string_get_bug_report_link();
 		}
 


### PR DESCRIPTION
Create api function to check a threshold in several projects

```
Add an api function to check the current user's access against the given
threshold, in each of the provided projects, and return true if the
user's access is equal to or higher in any of the projects, false otherwise.

The provided threshold can be the config literal to be evaluated in each
project's context.
```

Show report bug menu entry if allowed for any project

```
Previously, the "report bug" menu entry was not displayed when:
1. current project is ALL PROJECTS and user has not global report bug access
2. current project is a specific one, and user has not report access in
  that project

(1) is confusing for users, when they have access to report in any of
the specific projects they are assigned to, but still cant find the menu
entry.
Note that for globally allowed users, when trying to report in ALL
PROJECTS, a page appears that promts the user to select a valid project

(2) can be also confusing like (1), when the user is positioned in a
project where is effectively a "viewer", want to report a bug and cant
find the menu entry. This forces the user to select a valid project
before being allowed to use the report menu.

The fix implemented here checks if the user has permissions to report in
any of his assigned projects, then show the menu entry.
If the user cant report in current project once the menu entry is
selected, show the project selection page to choose a valid project.

This fixes (1) which is a common complaint from new users
and (2), which also provides a more intuitive way to use the report
option, as first choose the action, later choose the project.

Fixes: #14268
```
