### PR TITLE
Fix querying zero projects

### DIFF
--- a/core/category_api.php
+++ b/core/category_api.php
@@ -265,7 +265,6 @@ function category_remove_all( $p_project_id, $p_new_category_id = 0 ) {
 	$t_category_ids = join( ',', $t_category_ids );
 
 	# update bug history entries
-	db_param_push();
 	$t_query = 'SELECT id, category_id FROM {bug} WHERE category_id IN ( ' . $t_category_ids . ' )';
 	$t_result = db_query( $t_query );
 

--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -731,7 +731,6 @@ function custom_field_get_ids() {
 	global $g_cache_cf_list, $g_cache_custom_field;
 
 	if( $g_cache_cf_list === null ) {
-		db_param_push();
 		$t_query = 'SELECT * FROM {custom_field} ORDER BY name ASC';
 		$t_result = db_query( $t_query );
 		$t_ids = array();

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -1314,3 +1314,13 @@ function db_mysql_fix_utf8( $p_string ) {
 		$p_string
 	);
 }
+
+/**
+ * Creates an empty record set, compatible with db_query() result
+ * This object can be used when a query can't be performed, or is not needed,
+ * and still want to return an empty result as a transparent return value.
+ * @return \ADORecordSet_empty
+ */
+function db_empty_result() {
+	return new ADORecordSet_empty();
+}

--- a/core/email_queue_api.php
+++ b/core/email_queue_api.php
@@ -192,7 +192,6 @@ function email_queue_delete( $p_email_id ) {
  * @return array
  */
 function email_queue_get_ids() {
-	db_param_push();
 	$t_query = 'SELECT email_id FROM {email} ORDER BY email_id ASC';
 	$t_result = db_query( $t_query );
 

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1049,6 +1049,10 @@ function filter_unique_query_clauses( array $p_query_clauses ) {
  * @return integer
  */
 function filter_get_bug_count( array $p_query_clauses ) {
+	# If query caluses is an empty array, the query can't be created
+	if( empty( $p_query_clauses ) ) {
+		return 0;
+	}
 	$p_query_clauses = filter_unique_query_clauses( $p_query_clauses );
 	$t_select_string = 'SELECT Count( DISTINCT {bug}.id ) as idcnt ';
 	$t_from_string = ' FROM ' . implode( ', ', $p_query_clauses['from'] );
@@ -1163,6 +1167,13 @@ function filter_get_bug_rows_filter( $p_project_id = null, $p_user_id = null ) {
  * @return IteratorAggregate|boolean adodb result set or false if the query failed.
  */
 function filter_get_bug_rows_result( array $p_query_clauses, $p_count = null, $p_offset = null ) {
+	# if the query can't be formed, there are no results
+	if( empty( $p_query_clauses ) ) {
+		# reset the db_param stack that was initialized by "filter_get_bug_rows_query_clauses()"
+		db_param_pop();
+		return db_empty_result();
+	}
+
 	if( null === $p_count ) {
 		$t_count = -1;
 	} else {

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1045,12 +1045,22 @@ function filter_unique_query_clauses( array $p_query_clauses ) {
 
 /**
  * Build a query with the query clauses array, query for bug count and return the result
+ *
+ * Note: The parameter $p_pop_param can be used as 'false' to keep db_params in the stack,
+ * if the same query clauses object is reused for several queries. In that case a db_param_pop()
+ * should be used manually when required.
+ * This is the case when "filter_get_bug_count" is used followed by "filter_get_bug_rows_result"
  * @param array $p_query_clauses Array of query clauses.
+ * @param type $p_pop_param      Whether to pop DB params from the stack
  * @return integer
  */
-function filter_get_bug_count( array $p_query_clauses ) {
+function filter_get_bug_count( array $p_query_clauses, $p_pop_param = true ) {
 	# If query caluses is an empty array, the query can't be created
 	if( empty( $p_query_clauses ) ) {
+		if( $p_pop_param ) {
+			# reset the db_param stack, this woould have been done by db_query if executed
+			db_param_pop();
+		}
 		return 0;
 	}
 	$p_query_clauses = filter_unique_query_clauses( $p_query_clauses );
@@ -1063,7 +1073,11 @@ function filter_get_bug_count( array $p_query_clauses ) {
 		$t_where_string .= implode( $p_query_clauses['operator'], $p_query_clauses['where'] );
 		$t_where_string .= ' ) ';
 	}
-	$t_result = db_query( $t_select_string . ' ' . $t_from_string . ' ' . $t_join_string . ' ' . $t_where_string, $p_query_clauses['where_values'] );
+	$t_result = db_query(
+			$t_select_string . ' ' . $t_from_string . ' ' . $t_join_string . ' ' . $t_where_string,
+			$p_query_clauses['where_values'],
+			/* limit */ -1, /* offset */ -1,
+			$p_pop_param );
 	return db_result( $t_result );
 }
 
@@ -1098,8 +1112,11 @@ function filter_get_bug_rows( &$p_page_number, &$p_per_page, &$p_page_count, &$p
 	$t_query_clauses = filter_get_bug_rows_query_clauses( $t_filter, $p_project_id, $p_user_id, $p_show_sticky );
 
 	# Get the total number of bugs that meet the criteria.
-	$p_bug_count = filter_get_bug_count( $t_query_clauses );
+	# Keep the db_params in stack for next query
+	$p_bug_count = filter_get_bug_count( $t_query_clauses, /* pop_params */ false );
 	if( 0 == $p_bug_count ) {
+		# reset the db_param stack that was initialized by "filter_get_bug_rows_query_clauses()"
+		db_param_pop();
 		return array();
 	}
 
@@ -1159,18 +1176,26 @@ function filter_get_bug_rows_filter( $p_project_id = null, $p_user_id = null ) {
 
 /**
  * Creates a sql query with the supplied filter query clauses, and returns the unprocessed result set opbject
+ *
+ * Note: The parameter $p_pop_param can be used as 'false' to keep db_params in the stack,
+ * if the same query clauses object is reused for several queries. In that case a db_param_pop()
+ * should be used manually when required.
+ * This is the case when "filter_get_bug_count" is used followed by "filter_get_bug_rows_result"
  * @param array   $p_query_clauses Array of query clauses
  * @param integer $p_count         The number of rows to return
  *                                 -1 or null indicates default query (no limits)
  * @param integer $p_offset        Offset query results for paging (number of rows)
  *                                 -1 or null indicates default query (no offset)
+ * @param type $p_pop_param        Whether to pop DB params from the stack
  * @return IteratorAggregate|boolean adodb result set or false if the query failed.
  */
-function filter_get_bug_rows_result( array $p_query_clauses, $p_count = null, $p_offset = null ) {
+function filter_get_bug_rows_result( array $p_query_clauses, $p_count = null, $p_offset = null, $p_pop_param = true ) {
 	# if the query can't be formed, there are no results
 	if( empty( $p_query_clauses ) ) {
-		# reset the db_param stack that was initialized by "filter_get_bug_rows_query_clauses()"
-		db_param_pop();
+		if( $p_pop_param ) {
+			# reset the db_param stack, this woould have been done by db_query if executed
+			db_param_pop();
+		}
 		return db_empty_result();
 	}
 
@@ -1200,7 +1225,8 @@ function filter_get_bug_rows_result( array $p_query_clauses, $p_count = null, $p
 		$t_select_string . $t_from_string . $t_join_string . $t_where_string . $t_order_string,
 		$t_query_clauses['where_values'],
 		$t_count,
-		$t_offset
+		$t_offset,
+		$p_pop_param
 	);
 	return $t_result;
 }

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -196,6 +196,13 @@ function history_get_range_result_filter( $p_filter, $p_start_time = null, $p_en
 	# Note: filter_get_bug_rows_query_clauses() calls db_param_push();
 	$t_query_clauses = filter_get_bug_rows_query_clauses( $p_filter, null, null, null );
 
+	# if the query can't be formed, there are no results
+	if( empty( $t_query_clauses ) ) {
+		# reset the db_param stack that was initialized by "filter_get_bug_rows_query_clauses()"
+		db_param_pop();
+		return db_empty_result();
+	}
+
 	$t_select_string = 'SELECT DISTINCT {bug}.id ';
 	$t_from_string = ' FROM ' . implode( ', ', $t_query_clauses['from'] );
 	$t_join_string = count( $t_query_clauses['join'] ) > 0 ? implode( ' ', $t_query_clauses['join'] ) : ' ';

--- a/csv_export.php
+++ b/csv_export.php
@@ -59,7 +59,7 @@ $t_filter = filter_get_bug_rows_filter();
 $t_query_clauses = filter_get_bug_rows_query_clauses( $t_filter );
 
 # Get the total number of bugs that meet the criteria.
-$p_bug_count = filter_get_bug_count( $t_query_clauses );
+$p_bug_count = filter_get_bug_count( $t_query_clauses, /* pop_params */ false );
 
 if( 0 == $p_bug_count ) {
 	print_header_redirect( 'view_all_set.php?type=0' );

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -81,7 +81,7 @@ $t_filter = filter_get_bug_rows_filter();
 $t_query_clauses = filter_get_bug_rows_query_clauses( $t_filter );
 
 # Get the total number of bugs that meet the criteria.
-$p_bug_count = filter_get_bug_count( $t_query_clauses );
+$p_bug_count = filter_get_bug_count( $t_query_clauses, /* pop_params */ false );
 
 if( 0 == $p_bug_count ) {
 	print_header_redirect( 'view_all_set.php?type=0&print=1' );


### PR DESCRIPTION
Fix the new api functions, to support the case when a user has not any
accesible project. In this case the filter query can't be
built, so fix returning empty values.

The affected functions were introduced in relation to Issue #20424
and Isssue #21072


