### PR TITLE
Cache latest data in function user_cache_database_result

### DIFF
--- a/core/user_api.php
+++ b/core/user_api.php
@@ -130,16 +130,12 @@ function user_cache_array_rows( array $p_user_id_array ) {
 }
 
 /**
- * Cache an object as a bug.
+ * Cache a user row
  * @param array $p_user_database_result A user row to cache.
- * @return array|null
+ * @return void
  */
 function user_cache_database_result( array $p_user_database_result ) {
 	global $g_cache_user;
-
-	if( isset( $g_cache_user[$p_user_database_result['id']] ) ) {
-		return $g_cache_user[$p_user_database_result['id']];
-	}
 
 	$g_cache_user[$p_user_database_result['id']] = $p_user_database_result;
 }


### PR DESCRIPTION
The functions did not return a value in all cases.
There is no place in code where the return value of the function is used.

The cache was not updated with latest data if's been set before.

Fixes #20551