### PR TITLE
Do not use FILTER_PROPERTY_HIDE_STATUS for timeline

### DIFF
--- a/core/timeline_api.php
+++ b/core/timeline_api.php
@@ -46,6 +46,8 @@ function timeline_events( $p_start_time, $p_end_time, $p_max_events, $p_filter =
 	if( null === $p_filter ) {
 		# create an empty filter, to match all bugs
 		$t_filter = filter_ensure_valid_filter( array() );
+		# Override the default hide status, to show all bugs
+		$t_filter[FILTER_PROPERTY_HIDE_STATUS] = array();
 	}
 	$t_result = history_get_range_result_filter( $t_filter, $p_start_time, $p_end_time, 'DESC' );
 	$t_count = 0;


### PR DESCRIPTION
To match previous behaviour of Timeline, do not hide bugs based on any
status, even if the default empty filter is configured to do so.

Fixes: #21652