### PR TITLE
Dont break complex threshold in workflow config page

### DIFF
--- a/manage_config_workflow_page.php
+++ b/manage_config_workflow_page.php
@@ -328,7 +328,6 @@ function access_row() {
 	$t_file_new = config_get_global( 'report_bug_threshold' );
 	$t_global_new = config_get( 'report_bug_threshold', null, ALL_USERS, ALL_PROJECTS );
 	$t_report_bug_threshold = config_get( 'report_bug_threshold' );
-	$t_project_new = access_threshold_min_level( $t_report_bug_threshold );
 
 	$t_file_set = config_get_global( 'set_status_threshold' );
 	$t_global_set = config_get( 'set_status_threshold', null, ALL_USERS, ALL_PROJECTS );
@@ -343,12 +342,9 @@ function access_row() {
 
 		if( $t_status == $t_submit_status ) {
 			# 'NEW' status
-			$t_level_project = $t_project_new;
+			$t_threshold = $t_report_bug_threshold;
 
-			# If report_bug_threshold is an array (instead of an integer value), the input is not editable
-			# because it must be configured in manage_config_work_threshold_page.
-			$t_can_change = ( $g_access >= config_get_access( 'report_bug_threshold' ) )
-					&& !is_array( $t_report_bug_threshold );
+			$t_can_change = $g_access >= config_get_access( 'report_bug_threshold' );
 			$t_color = set_color_override( $t_file_new, $t_global_new, $t_report_bug_threshold );
 			set_overrides( 'report_bug_threshold', $t_can_change, $t_color );
 		} else {
@@ -362,21 +358,25 @@ function access_row() {
 			}
 
 			$t_level_global  = isset( $t_global_set[$t_status] ) ? $t_global_set[$t_status] : $t_level_file;
-			$t_level_project = isset( $t_project_set[$t_status] ) ? $t_project_set[$t_status] : $t_level_global;
+			$t_threshold = isset( $t_project_set[$t_status] ) ? $t_project_set[$t_status] : $t_level_global;
 
 			$t_can_change = ( $g_access >= config_get_access( 'set_status_threshold' ) );
-			$t_color = set_color_override( $t_level_file, $t_level_global, $t_level_project );
+
+			$t_color = set_color_override( $t_level_file, $t_level_global, $t_threshold );
 			set_overrides( 'set_status_threshold', $t_can_change, $t_color );
 		}
 
-		if( $t_can_change ) {
+		# If threshold is an array (instead of an integer value), the input is not editable
+		$t_can_edit = !is_array( $t_threshold );
+		$t_min_level = access_threshold_min_level( $t_threshold );
+		if( $t_can_change && $t_can_edit ) {
 			echo '<td class="center ' . $t_color . '"><select name="access_change_' . $t_status . '">' . "\n";
-			print_enum_string_option_list( 'access_levels', $t_level_project );
+			print_enum_string_option_list( 'access_levels', $t_min_level );
 			echo '</select> </td>' . "\n";
 			$g_can_change_flags = true;
 		} else {
 			echo '<td class="center ' . $t_color . '">'
-				. MantisEnum::getLabel( lang_get( 'access_levels_enum_string' ), $t_level_project )
+				. MantisEnum::getLabel( lang_get( 'access_levels_enum_string' ), $t_min_level )
 				. '</td>' . "\n";
 		}
 

--- a/manage_config_workflow_set.php
+++ b/manage_config_workflow_set.php
@@ -216,18 +216,25 @@ if( min( config_get_access( 'set_status_threshold' ), config_get_access( 'report
 	$t_set_new = array();
 	foreach( $t_enum_status as $t_status_id => $t_status_label ) {
 		$f_level = gpc_get_int( 'access_change_' . $t_status_id, -1 );
-		# Only process those inputs that exists, since not all access_change_<status> may have been editable.
-		if( $f_level > -1 ) {
-			if( config_get( 'bug_submit_status' ) == $t_status_id ) {
+		if( config_get( 'bug_submit_status' ) == $t_status_id ) {
+			# Check if input exists
+			if( $f_level > -1 ) {
 				if( $f_level != $t_set_parent[$t_status_id] ) {
 					config_set( 'report_bug_threshold', (int)$f_level, ALL_USERS, $t_project, $f_access );
 				} else {
 					config_delete( 'report_bug_threshold', ALL_USERS, $t_project );
 				}
-				unset( $t_set_parent[$t_status_id] );
-				unset( $t_set_current[$t_status_id] );
-			} else {
+			}
+			unset( $t_set_parent[$t_status_id] );
+			unset( $t_set_current[$t_status_id] );
+		} else {
+			# Only process those inputs that exist, since not all access_change_<status> may have been editable.
+			if( $f_level > -1 ) {
 				$t_set_new[$t_status_id] = $f_level;
+			} else {
+				if( isset( $t_set_current[$t_status_id] ) ) {
+					$t_set_new[$t_status_id] = $t_set_current[$t_status_id];
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The configuration option "set_status_threshold" may contain complex
thresholds defined as arrays instead of integer values.
In this case, on manage_config_workflow_page, show those fields as not
editable.

Fixes: #21655, #21656