### PR TITLE
Do not set HSTS header

### DIFF
--- a/core/http_api.php
+++ b/core/http_api.php
@@ -236,10 +236,6 @@ function http_security_headers() {
 		}
 
 		http_csp_emit_header();
-
-		if( http_is_protocol_https() ) {
-			header( 'Strict-Transport-Security: max-age=7776000' );
-		}
 	}
 }
 


### PR DESCRIPTION
Enabling HTTP Strict-Transport-Security should be a decision made by the
system administrator, and implemented at server level, probably
site-wide and not just for MantisBT's PHP files.

Furthermore, Mantis setting this header causes issues if it is already
set for the server (invalid header), and may have unwanted side effects
as described in #21262.

This reverts the change implemented to resolve issue #12881.

Fixes [#21262](https://www.mantisbt.org/bugs/view.php?id=21262)