### PR TITLE
fix: Repeat 302 after the project appears to be disabled

### DIFF
--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -138,7 +138,7 @@ if( $f_master_bug_id > 0 ) {
 	}
 
 	if( ( ALL_PROJECTS == $t_project_id || project_exists( $t_project_id ) )
-	 && $t_project_id != $t_current_project
+	 && $t_project_id != $t_current_project && project_get_field( $t_project_id, 'enabled' )
 	) {
 		helper_set_current_project( $t_project_id );
 		# Reloading the page is required so that the project browser


### PR DESCRIPTION
fix: Repeat 302 after the project appears to be disabled