### PR TITLE
Standardize "operation successful" messages

### DIFF
--- a/bug_report.php
+++ b/bug_report.php
@@ -323,10 +323,11 @@ if( !is_blank( $f_tag_string ) || $f_tag_select != 0 ) {
 	}
 }
 
-html_operation_confirmation( array(
+$t_buttons = array(
 	array( string_get_bug_view_url( $t_bug_id ), sprintf( lang_get( 'view_submitted_bug_link' ), $t_bug_id ) ),
 	array( 'view_all_bug_page.php', lang_get( 'view_bugs_link' ) ),
-) );
+);
+html_operation_confirmation( $t_buttons, CONFIRMATION_TYPE_SUCCESS );
 
 if( $f_report_stay ) {
 ?>

--- a/bug_report.php
+++ b/bug_report.php
@@ -323,7 +323,7 @@ if( !is_blank( $f_tag_string ) || $f_tag_select != 0 ) {
 	}
 }
 
-html_operation_successful_buttons( array(
+html_operation_confirmation( array(
 	array( string_get_bug_view_url( $t_bug_id ), sprintf( lang_get( 'view_submitted_bug_link' ), $t_bug_id ) ),
 	array( 'view_all_bug_page.php', lang_get( 'view_bugs_link' ) ),
 ) );

--- a/bug_report.php
+++ b/bug_report.php
@@ -322,16 +322,11 @@ if( !is_blank( $f_tag_string ) || $f_tag_select != 0 ) {
 		}
 	}
 }
-?>
 
-<div class="col-md-12 col-xs-12">
-	<div class="space-10"></div>
-	<div class="alert alert-success">
-
-<?php
-echo '<p>' . lang_get( 'operation_successful' ) . '</p><br />';
-print_button( string_get_bug_view_url( $t_bug_id ), sprintf( lang_get( 'view_submitted_bug_link' ), $t_bug_id ) );
-print_button( 'view_all_bug_page.php', lang_get( 'view_bugs_link' ) );
+html_operation_successful_buttons( array(
+	array( string_get_bug_view_url( $t_bug_id ), sprintf( lang_get( 'view_submitted_bug_link' ), $t_bug_id ) ),
+	array( 'view_all_bug_page.php', lang_get( 'view_bugs_link' ) ),
+) );
 
 if( $f_report_stay ) {
 ?>

--- a/core/access_api.php
+++ b/core/access_api.php
@@ -100,17 +100,11 @@ function access_denied() {
 		} else {
 			layout_page_header();
 			layout_admin_page_begin();
-			echo '<div class="col-md-12 col-xs-12">';
 			echo '<div class="space-10"></div>';
-			echo '<div class="alert alert-danger">';
-			echo '<div class="center bigger-130">' . error_string( ERROR_ACCESS_DENIED ) . '</div>';
-			echo '<p class="center">';
-			print_button(
+			html_operation_failure(
 				helper_mantis_url( config_get( 'default_home_page' ) ),
-				lang_get( 'proceed' )
+				error_string( ERROR_ACCESS_DENIED )
 			);
-			echo '</p>';
-			echo '</div></div>';
 			layout_admin_page_end();
 		}
 	}

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -226,6 +226,11 @@ define( 'BUG_UPDATE_TYPE_CLOSE', 'close' );
 define( 'BUG_UPDATE_TYPE_REOPEN', 'reopen' );
 define( 'BUG_UPDATE_TYPE_CHANGE_STATUS', 'change_status' );
 
+# confirmation message types
+define( 'CONFIRMATION_TYPE_SUCCESS', 0 );
+define( 'CONFIRMATION_TYPE_WARNING', 1 );
+define( 'CONFIRMATION_TYPE_FAILURE', 2 );
+
 # error messages
 define( 'ERROR_GENERIC', 0 );
 define( 'ERROR_SQL', 1 );

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -373,7 +373,8 @@ function html_top_banner() {
  * @param array  $p_buttons      Array of (URL, label) pairs used to generate
  *                               the buttons; if label is null or unspecified,
  *                               the default 'proceed' text will be displayed.
- * @param string $p_message      Message to display to the user.
+ * @param string $p_message      Message to display to the user. If none is
+ *                               provided, a default message will be printed
  * @param string $p_type         One of the constants CONFIRMATION_TYPE_SUCCESS,
  *                               CONFIRMATION_TYPE_WARNING, CONFIRMATION_TYPE_FAILURE
  * @return void
@@ -382,16 +383,16 @@ function html_operation_successful_buttons( array $p_buttons, $p_message = '', $
 	switch( $p_type ) {
 		case CONFIRMATION_TYPE_FAILURE:
 			$t_alert_css = 'alert-danger';
-			$t_message = lang_get( 'operation_failed' );
+			$t_message = 'operation_failed';
 			break;
 		case CONFIRMATION_TYPE_WARNING:
-			$t_message = lang_get( 'operation_warnings' );
+			$t_message = 'operation_warnings';
 			$t_alert_css = 'alert-warning';
 			break;
 		case CONFIRMATION_TYPE_SUCCESS:
 		default:
 			$t_alert_css = 'alert-success';
-			$t_message = lang_get( 'operation_successful' );
+			$t_message = 'operation_successful';
 			break;
 	}
 
@@ -401,8 +402,10 @@ function html_operation_successful_buttons( array $p_buttons, $p_message = '', $
 	echo '<div class="alert ' . $t_alert_css . ' center">';
 
 	# Print message
-	if( !is_blank( $p_message ) ) {
-		echo $p_message . '<br />';
+	if( is_blank( $p_message ) ) {
+		$t_message = lang_get( $t_message );
+	} else {
+		$t_message = $p_message;
 	}
 	echo '<p class="bold bigger-110">' . $t_message  . '</p><br />';
 

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -374,20 +374,21 @@ function html_top_banner() {
  *                               the buttons; if label is null or unspecified,
  *                               the default 'proceed' text will be displayed.
  * @param string $p_message      Message to display to the user.
- * @param string $p_type         One of 'success', 'warning', 'failure'
+ * @param string $p_type         One of the constants CONFIRMATION_TYPE_SUCCESS,
+ *                               CONFIRMATION_TYPE_WARNING, CONFIRMATION_TYPE_FAILURE
  * @return void
  */
-function html_operation_successful_buttons( array $p_buttons, $p_message = '', $p_type = 'success' ) {
+function html_operation_successful_buttons( array $p_buttons, $p_message = '', $p_type = CONFIRMATION_TYPE_SUCCESS ) {
 	switch( $p_type ) {
-		case 'failure':
+		case CONFIRMATION_TYPE_FAILURE:
 			$t_alert_css = 'alert-danger';
 			$t_message = lang_get( 'operation_failed' );
 			break;
-		case 'warning':
+		case CONFIRMATION_TYPE_WARNING:
 			$t_message = lang_get( 'operation_warnings' );
 			$t_alert_css = 'alert-warning';
 			break;
-		case 'success':
+		case CONFIRMATION_TYPE_SUCCESS:
 		default:
 			$t_alert_css = 'alert-success';
 			$t_message = lang_get( 'operation_successful' );
@@ -438,7 +439,7 @@ function html_operation_warning( $p_redirect_url, $p_message = '' ) {
 	html_operation_successful_buttons(
 		array( array( $p_redirect_url ) ),
 		$p_message,
-		'warning'
+		CONFIRMATION_TYPE_WARNING
 	);
 }
 
@@ -452,7 +453,7 @@ function html_operation_failure( $p_redirect_url, $p_message = '' ) {
 	html_operation_successful_buttons(
 		array( array( $p_redirect_url ) ),
 		$p_message,
-		'failure'
+		CONFIRMATION_TYPE_FAILURE
 	);
 }
 

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -369,24 +369,46 @@ function html_top_banner() {
 }
 
 /**
- * A function that outputs that an operation was successful and provides a redirect link.
- * @param string $p_redirect_url The url to redirect to.
+ * Outputs an operation successful message with multiple redirection buttons.
+ * @param array  $p_buttons      Array of (URL, label) pairs used to generate
+ *                               the buttons; if label is null or unspecified,
+ *                               the default 'proceed' text will be displayed.
  * @param string $p_message      Message to display to the user.
  * @return void
  */
-function html_operation_successful( $p_redirect_url, $p_message = '' ) {
+function html_operation_successful_buttons( array $p_buttons, $p_message = '' ) {
 	echo '<div class="container-fluid">';
 	echo '<div class="col-md-12 col-xs-12">';
 	echo '<div class="space-0"></div>';
 	echo '<div class="alert alert-success center">';
 
+	# Print message
 	if( !is_blank( $p_message ) ) {
 		echo $p_message . '<br />';
 	}
-
 	echo '<p class="bold bigger-110">' . lang_get( 'operation_successful' ).'</p><br />';
-	print_button( string_sanitize_url( $p_redirect_url ), lang_get( 'proceed' ) );
+
+	# Print buttons
+	foreach( $p_buttons as $t_button ) {
+		$t_url = string_sanitize_url( $t_button[0] );
+		$t_label = isset( $t_button[1] ) ? $t_button[1] : lang_get( 'proceed' );
+
+		print_button( $t_url, $t_label );
+		# @TODO spacing should be done with CSS margin
+		echo '&nbsp;&nbsp;';
+	}
+
 	echo '</div></div></div>', PHP_EOL;
+}
+
+/**
+ * Outputs an operation successful message with a single redirect link.
+ * @param string $p_redirect_url The url to redirect to.
+ * @param string $p_message      Message to display to the user.
+ * @return void
+ */
+function html_operation_successful( $p_redirect_url, $p_message = '' ) {
+	html_operation_successful_buttons( array( array( $p_redirect_url ) ), $p_message );
 }
 
 /**

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -389,14 +389,14 @@ function html_operation_successful_buttons( array $p_buttons, $p_message = '' ) 
 	echo '<p class="bold bigger-110">' . lang_get( 'operation_successful' ).'</p><br />';
 
 	# Print buttons
+	echo '<div class="btn-group">';
 	foreach( $p_buttons as $t_button ) {
 		$t_url = string_sanitize_url( $t_button[0] );
 		$t_label = isset( $t_button[1] ) ? $t_button[1] : lang_get( 'proceed' );
 
 		print_button( $t_url, $t_label );
-		# @TODO spacing should be done with CSS margin
-		echo '&nbsp;&nbsp;';
 	}
+	echo '</div>';
 
 	echo '</div></div></div>', PHP_EOL;
 }

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -369,25 +369,25 @@ function html_top_banner() {
 }
 
 /**
- * Outputs an operation successful message with multiple redirection buttons.
- * @param array  $p_buttons      Array of (URL, label) pairs used to generate
+ * Outputs a message to confirm an operation's result.
+ * @param array   $p_buttons     Array of (URL, label) pairs used to generate
  *                               the buttons; if label is null or unspecified,
  *                               the default 'proceed' text will be displayed.
- * @param string $p_message      Message to display to the user. If none is
+ * @param string  $p_message     Message to display to the user. If none is
  *                               provided, a default message will be printed
- * @param string $p_type         One of the constants CONFIRMATION_TYPE_SUCCESS,
+ * @param integer $p_type        One of the constants CONFIRMATION_TYPE_SUCCESS,
  *                               CONFIRMATION_TYPE_WARNING, CONFIRMATION_TYPE_FAILURE
  * @return void
  */
-function html_operation_successful_buttons( array $p_buttons, $p_message = '', $p_type = CONFIRMATION_TYPE_SUCCESS ) {
+function html_operation_confirmation( array $p_buttons, $p_message = '', $p_type = CONFIRMATION_TYPE_SUCCESS ) {
 	switch( $p_type ) {
 		case CONFIRMATION_TYPE_FAILURE:
 			$t_alert_css = 'alert-danger';
 			$t_message = 'operation_failed';
 			break;
 		case CONFIRMATION_TYPE_WARNING:
-			$t_message = 'operation_warnings';
 			$t_alert_css = 'alert-warning';
+			$t_message = 'operation_warnings';
 			break;
 		case CONFIRMATION_TYPE_SUCCESS:
 		default:
@@ -429,7 +429,7 @@ function html_operation_successful_buttons( array $p_buttons, $p_message = '', $
  * @return void
  */
 function html_operation_successful( $p_redirect_url, $p_message = '' ) {
-	html_operation_successful_buttons( array( array( $p_redirect_url ) ), $p_message );
+	html_operation_confirmation( array( array( $p_redirect_url ) ), $p_message );
 }
 
 /**
@@ -439,7 +439,7 @@ function html_operation_successful( $p_redirect_url, $p_message = '' ) {
  * @return void
  */
 function html_operation_warning( $p_redirect_url, $p_message = '' ) {
-	html_operation_successful_buttons(
+	html_operation_confirmation(
 		array( array( $p_redirect_url ) ),
 		$p_message,
 		CONFIRMATION_TYPE_WARNING
@@ -453,7 +453,7 @@ function html_operation_warning( $p_redirect_url, $p_message = '' ) {
  * @return void
  */
 function html_operation_failure( $p_redirect_url, $p_message = '' ) {
-	html_operation_successful_buttons(
+	html_operation_confirmation(
 		array( array( $p_redirect_url ) ),
 		$p_message,
 		CONFIRMATION_TYPE_FAILURE

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -374,19 +374,36 @@ function html_top_banner() {
  *                               the buttons; if label is null or unspecified,
  *                               the default 'proceed' text will be displayed.
  * @param string $p_message      Message to display to the user.
+ * @param string $p_type         One of 'success', 'warning', 'failure'
  * @return void
  */
-function html_operation_successful_buttons( array $p_buttons, $p_message = '' ) {
+function html_operation_successful_buttons( array $p_buttons, $p_message = '', $p_type = 'success' ) {
+	switch( $p_type ) {
+		case 'failure':
+			$t_alert_css = 'alert-danger';
+			$t_message = lang_get( 'operation_failed' );
+			break;
+		case 'warning':
+			$t_message = lang_get( 'operation_warnings' );
+			$t_alert_css = 'alert-warning';
+			break;
+		case 'success':
+		default:
+			$t_alert_css = 'alert-success';
+			$t_message = lang_get( 'operation_successful' );
+			break;
+	}
+
 	echo '<div class="container-fluid">';
 	echo '<div class="col-md-12 col-xs-12">';
 	echo '<div class="space-0"></div>';
-	echo '<div class="alert alert-success center">';
+	echo '<div class="alert ' . $t_alert_css . ' center">';
 
 	# Print message
 	if( !is_blank( $p_message ) ) {
 		echo $p_message . '<br />';
 	}
-	echo '<p class="bold bigger-110">' . lang_get( 'operation_successful' ).'</p><br />';
+	echo '<p class="bold bigger-110">' . $t_message  . '</p><br />';
 
 	# Print buttons
 	echo '<div class="btn-group">';
@@ -409,6 +426,34 @@ function html_operation_successful_buttons( array $p_buttons, $p_message = '' ) 
  */
 function html_operation_successful( $p_redirect_url, $p_message = '' ) {
 	html_operation_successful_buttons( array( array( $p_redirect_url ) ), $p_message );
+}
+
+/**
+ * Outputs a warning message with a single redirect link.
+ * @param string $p_redirect_url The url to redirect to.
+ * @param string $p_message      Message to display to the user.
+ * @return void
+ */
+function html_operation_warning( $p_redirect_url, $p_message = '' ) {
+	html_operation_successful_buttons(
+		array( array( $p_redirect_url ) ),
+		$p_message,
+		'warning'
+	);
+}
+
+/**
+ * Outputs an error message with a single redirect link.
+ * @param string $p_redirect_url The url to redirect to.
+ * @param string $p_message      Message to display to the user.
+ * @return void
+ */
+function html_operation_failure( $p_redirect_url, $p_message = '' ) {
+	html_operation_successful_buttons(
+		array( array( $p_redirect_url ) ),
+		$p_message,
+		'failure'
+	);
 }
 
 /**

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -103,6 +103,8 @@ $s_actiongroup_error_issue_is_readonly = 'Issue is readonly.';
 $s_all_projects = 'All Projects';
 $s_move_bugs = 'Move Issues';
 $s_operation_successful = 'Operation successful.';
+$s_operation_warnings = 'Operation completed with warnings.';
+$s_operation_failed = 'Operation did not complete successfully.';
 $s_date_order = 'Date Order';
 $s_print_all_bug_page_link = 'Print Reports';
 $s_csv_export = 'CSV Export';
@@ -1255,7 +1257,7 @@ $s_select_all = 'Select All';
 # stored query strings
 $s_use_query = 'Use Filter';
 $s_delete_query = 'Delete Filter';
-$s_query_deleted = 'Filter Deleted';
+$s_query_deleted = 'Filter "%s" Deleted';
 $s_save_query = 'Save Current Filter';
 $s_reset_query = 'Reset Filter';
 $s_query_name = 'Filter Name';

--- a/lost_pwd.php
+++ b/lost_pwd.php
@@ -105,29 +105,10 @@ form_security_purge( 'lost_pwd' );
 $t_redirect_url = 'login_page.php';
 
 layout_page_header();
-
 layout_page_begin();
-?>
-
-<div class="col-md-12 col-xs-12">
-<div class="space-10"></div>
-<table class="width50" cellspacing="1">
-<tr>
-	<td class="center">
-		<strong><?php echo lang_get( 'lost_password_done_title' ) ?></strong>
-	</td>
-</tr>
-<tr>
-	<td>
-		<br />
-		<?php echo lang_get( 'reset_request_in_progress_msg' ) ?>
-		<br /><br />
-	</td>
-</tr>
-</table>
-<br />
-<?php print_button( 'login_page.php', lang_get( 'proceed' ) ); ?>
-</div>
-
-<?php
+html_operation_successful(
+	'login_page.php',
+	'<p class="bold bigger-110">' . lang_get( 'lost_password_done_title' ) . '</p>'
+	. lang_get( 'reset_request_in_progress_msg' )
+);
 layout_page_end();

--- a/manage_user_create.php
+++ b/manage_user_create.php
@@ -131,16 +131,12 @@ if( $t_cookie === false ) {
 layout_page_header( null, $t_redirect_url );
 
 layout_page_begin( 'manage_overview_page.php' );
-?>
 
-<div class="space-20"></div>
-<div class="alert alert-success">
-<?php
-$t_access_level = get_enum_element( 'access_levels', $f_access_level );
-echo lang_get( 'created_user_part1' ) . ' <span class="bold">' . $f_username . '</span> ' . lang_get( 'created_user_part2' ) . ' <span class="bold">' . $t_access_level . '</span><br />';
-
-echo '<div class="space-10"></div>';
-print_button( $t_redirect_url, lang_get( 'proceed' ) );
+$t_message = lang_get( 'created_user_part1' )
+	. ' <span class="bold">' . $f_username . '</span> '
+	. lang_get( 'created_user_part2' )
+	. ' <span class="bold">' . $t_access_level . '</span><br />';
+html_operation_successful( $t_redirect_url, $t_message );
 ?>
 </div>
 

--- a/manage_user_create.php
+++ b/manage_user_create.php
@@ -131,7 +131,7 @@ if( $t_cookie === false ) {
 layout_page_header( null, $t_redirect_url );
 
 layout_page_begin( 'manage_overview_page.php' );
-
+$t_access_level = get_enum_element( 'access_levels', $f_access_level );
 $t_message = lang_get( 'created_user_part1' )
 	. ' <span class="bold">' . $f_username . '</span> '
 	. lang_get( 'created_user_part2' )

--- a/manage_user_reset.php
+++ b/manage_user_reset.php
@@ -79,31 +79,24 @@ layout_page_header( null, $t_result ? $t_redirect_url : null );
 
 layout_page_begin( 'manage_overview_page.php' );
 
-echo '<div class="col-md-12 col-xs-12">';
-echo '<div class="space-10"></div>';
-echo '<div class="alert alert-success">';
-
-echo '<p class="bigger-110">';
 if( $t_reset ) {
 	if( false == $t_result ) {
 		# PROTECTED
-		echo lang_get( 'account_reset_protected_msg' );
+		# @TODO this should be a failure message !
+		html_operation_successful( $t_redirect_url, lang_get( 'account_reset_protected_msg' ) );
 	} else {
 		# SUCCESSFUL RESET
 		if( ( ON == config_get( 'send_reset_password' ) ) && ( ON == config_get( 'enable_email_notification' ) ) ) {
 			# send the new random password via email
-			echo lang_get( 'account_reset_msg' );
+			html_operation_successful( $t_redirect_url, lang_get( 'account_reset_msg' ) );
 		} else {
 			# email notification disabled, then set the password to blank
-			echo lang_get( 'account_reset_msg2' );
+			html_operation_successful( $t_redirect_url, lang_get( 'account_reset_msg2' ) );
 		}
 	}
 } else {
 	# UNLOCK
-	echo lang_get( 'account_unlock_msg' );
+	html_operation_successful( $t_redirect_url, lang_get( 'account_unlock_msg' ) );
 }
-echo '</p>';
-echo '<div class="space-10"></div>';
-print_button( $t_redirect_url, lang_get( 'proceed' ) );
-echo '</div></div>';
+
 layout_page_end();

--- a/manage_user_reset.php
+++ b/manage_user_reset.php
@@ -82,8 +82,7 @@ layout_page_begin( 'manage_overview_page.php' );
 if( $t_reset ) {
 	if( false == $t_result ) {
 		# PROTECTED
-		# @TODO this should be a failure message !
-		html_operation_successful( $t_redirect_url, lang_get( 'account_reset_protected_msg' ) );
+		html_operation_failure( $t_redirect_url, lang_get( 'account_reset_protected_msg' ) );
 	} else {
 		# SUCCESSFUL RESET
 		if( ( ON == config_get( 'send_reset_password' ) ) && ( ON == config_get( 'enable_email_notification' ) ) ) {

--- a/manage_user_update.php
+++ b/manage_user_update.php
@@ -228,8 +228,7 @@ layout_page_begin( 'manage_overview_page.php' );
 
 if( $f_protected && $t_old_protected ) {
 	# PROTECTED
-	# @TODO this should actually be a warning message
-	html_operation_successful( $t_redirect_url, lang_get( 'manage_user_protected_msg' ) );
+	html_operation_warning( $t_redirect_url, lang_get( 'manage_user_protected_msg' ) );
 } else if( $t_result ) {
 	# SUCCESS
 	html_operation_successful( $t_redirect_url );

--- a/manage_user_update.php
+++ b/manage_user_update.php
@@ -226,12 +226,12 @@ layout_page_header( null, $t_result ? $t_redirect_url : null );
 
 layout_page_begin( 'manage_overview_page.php' );
 
-if( $f_protected && $t_old_protected ) {				# PROTECTED
-	echo '<div class="failure-msg">';
-	echo lang_get( 'manage_user_protected_msg' ) . '<br />';
-	print_button( $t_redirect_url, lang_get( 'proceed' ) );
-	echo '</div>';
-} else if( $t_result ) {					# SUCCESS
+if( $f_protected && $t_old_protected ) {
+	# PROTECTED
+	# @TODO this should actually be a warning message
+	html_operation_successful( $t_redirect_url, lang_get( 'manage_user_protected_msg' ) );
+} else if( $t_result ) {
+	# SUCCESS
 	html_operation_successful( $t_redirect_url );
 }
 

--- a/news_update.php
+++ b/news_update.php
@@ -69,10 +69,11 @@ layout_page_begin( 'main_page.php' );
 
 echo '<div class="space-20"></div>';
 
-html_operation_confirmation( array(
+$t_buttons = array(
 	array( 'news_menu_page.php' ),
 	array( 'news_edit_page.php?news_id=' . $f_news_id . '&action=edit', lang_get( 'edit_link' ) ),
-) );
+);
+html_operation_confirmation( $t_buttons, CONFIRMATION_TYPE_SUCCESS );
 
 echo '<br />';
 

--- a/news_update.php
+++ b/news_update.php
@@ -69,7 +69,7 @@ layout_page_begin( 'main_page.php' );
 
 echo '<div class="space-20"></div>';
 
-html_operation_successful_buttons( array(
+html_operation_confirmation( array(
 	array( 'news_menu_page.php' ),
 	array( 'news_edit_page.php?news_id=' . $f_news_id . '&action=edit', lang_get( 'edit_link' ) ),
 ) );

--- a/news_update.php
+++ b/news_update.php
@@ -69,17 +69,10 @@ layout_page_begin( 'main_page.php' );
 
 echo '<div class="space-20"></div>';
 
-echo '<div class="container-fluid">';
-echo '<div class="col-md-12 col-xs-12">';
-echo '<div class="alert alert-success">';
-echo lang_get( 'operation_successful' );
-echo '<br /><br />';
-print_button( 'news_edit_page.php?news_id=' . $f_news_id . '&action=edit', lang_get( 'edit_link' ) );
-echo '&nbsp;&nbsp;&nbsp;&nbsp;';
-print_button( 'news_menu_page.php', lang_get( 'proceed' ) );
-echo '</div>';
-echo '</div>';
-echo '</div>';
+html_operation_successful_buttons( array(
+	array( 'news_menu_page.php' ),
+	array( 'news_edit_page.php?news_id=' . $f_news_id . '&action=edit', lang_get( 'edit_link' ) ),
+) );
 
 echo '<br />';
 

--- a/query_delete.php
+++ b/query_delete.php
@@ -56,23 +56,15 @@ $t_redirect_url = 'query_view_page.php';
 if( !filter_db_can_delete_filter( $f_query_id ) ) {
 	print_header_redirect( $t_redirect_url );
 } else {
+	$t_message = sprintf(
+		lang_get( 'query_deleted' ),
+		filter_db_get_name( $f_query_id )
+	);
+
 	layout_page_header();
 	layout_page_begin();
 	filter_db_delete_filter( $f_query_id );
 	form_security_purge( 'query_delete' );
-	?>
-	<div class="col-md-12 col-xs-12">
-		<div class="space-10"></div>
-		<div class="alert alert-success">
-			<div class="center">
-				<p class="bold bigger-110"><?php print filter_db_get_name( $f_query_id ) . ' ' . lang_get( 'query_deleted' ); ?></p>
-				<form method="post" action="<?php print $t_redirect_url; ?>">
-					<?php # CSRF protection not required here - form does not result in modifications ?>
-					<input type="submit" class="btn btn-primary btn-white btn-round" value="<?php print lang_get( 'go_back' ); ?>"/>
-				</form>
-			</div>
-		</div>
-	</div>
-	<?php
+	html_operation_successful( $t_redirect_url, $t_message );
 	layout_page_end();
 }


### PR DESCRIPTION
Adding new API functions to handle display of confirmation messages, and replace custom HTML in various files to display the same by calls to these functions.

Fixes [#21683](https://www.mantisbt.org/bugs/view.php?id=21683)
