### PR TITLE
Obsolete configuration option icon_path

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -213,13 +213,6 @@ if( isset ( $_SERVER['SCRIPT_NAME'] ) ) {
 $g_path	= $t_protocol . '://' . $t_host . $t_path;
 
 /**
- * path to your images directory (for icons)
- * requires trailing /
- * @global string $g_icon_path
- */
-$g_icon_path = '%path%images/';
-
-/**
  * Short web path without the domain name
  * requires trailing /
  * @global string $g_short_path
@@ -4295,7 +4288,7 @@ $g_global_settings = array(
 	'session_save_path', 'session_validation', 'show_detailed_errors', 'show_queries_count',
 	'stop_on_errors', 'version_suffix', 'debug_email',
 	'fileinfo_magic_db_file', 'css_include_file', 'css_rtl_include_file', 'meta_include_file',
-	'file_type_icons', 'path', 'icon_path', 'short_path', 'absolute_path', 'core_path',
+	'file_type_icons', 'path', 'short_path', 'absolute_path', 'core_path',
 	'class_path','library_path', 'language_path', 'absolute_path_default_upload_folder',
 	'ldap_simulation_file_path', 'plugin_path', 'bottom_include_page', 'top_include_page',
 	'default_home_page', 'logout_redirect_page', 'manual_url', 'logo_url', 'wiki_engine_url',

--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -656,7 +656,6 @@ function print_column_title_target_version( $p_sort, $p_dir, $p_columns_target =
  * @access public
  */
 function print_column_title_view_state( $p_sort, $p_dir, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
-	global $t_icon_path;
 	echo '<th class="column-view-state">';
 	$t_view_state_text = lang_get( 'view_status' );
 	$t_view_state_icon = ' <i class="fa fa-lock" title="' . $t_view_state_text . '"></i>';
@@ -775,7 +774,6 @@ function print_column_title_date_submitted( $p_sort, $p_dir, $p_columns_target =
  * @access public
  */
 function print_column_title_attachment_count( $p_sort, $p_dir, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
-	global $t_icon_path;
 	$t_attachment_count_text = lang_get( 'attachment_count' );
 	$t_attachment_count_icon = "<i class=\"fa fa-paperclip blue\" title=\"$t_attachment_count_text\" ></i>";
 	echo "\t" . '<th class="column-attachments">' . $t_attachment_count_icon . '</th>' . "\n";
@@ -990,7 +988,6 @@ function print_column_title_due_date( $p_sort, $p_dir, $p_columns_target = COLUM
  * @access public
  */
 function print_column_title_overdue( $p_sort, $p_dir, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
-	global $t_icon_path;
 	echo '<th class="column-overdue">';
 	$t_overdue_text = lang_get( 'overdue' );
 	$t_overdue_icon = ' <i class="fa fa-times-circle-o" title="' . $t_overdue_text . '"></i>';
@@ -1085,7 +1082,6 @@ function print_column_plugin( $p_column_object, BugData $p_bug, $p_columns_targe
  * @access public
  */
 function print_column_edit( BugData $p_bug, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
-	global $t_icon_path;
 
 	echo '<td class="column-edit">';
 
@@ -1197,7 +1193,6 @@ function print_column_bugnotes_count( BugData $p_bug, $p_columns_target = COLUMN
  * @access public
  */
 function print_column_attachment_count( BugData $p_bug, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
-	global $t_icon_path;
 
 	# Check for attachments
 	$t_attachment_count = 0;
@@ -1524,7 +1519,6 @@ function print_column_target_version( BugData $p_bug, $p_columns_target = COLUMN
  * @access public
  */
 function print_column_view_state( BugData $p_bug, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
-	global $t_icon_path;
 
 	echo '<td class="column-view-state">';
 
@@ -1590,7 +1584,6 @@ function print_column_due_date( BugData $p_bug, $p_columns_target = COLUMNS_TARG
  * @access public
  */
 function print_column_overdue( BugData $p_bug, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
-	global $t_icon_path;
 
 	echo '<td class="column-overdue">';
 

--- a/core/icon_api.php
+++ b/core/icon_api.php
@@ -41,7 +41,6 @@ require_api( 'utility_api.php' );
  * @access public
  */
 function icon_get_status_icon( $p_icon ) {
-	$t_icon_path = config_get( 'icon_path' );
 	$t_status_icon_arr = config_get( 'status_icon_arr' );
 	$t_priotext = get_enum_element( 'priority', $p_icon );
 	if( isset( $t_status_icon_arr[$p_icon] ) && !is_blank( $t_status_icon_arr[$p_icon] ) ) {

--- a/core/obsolete.php
+++ b/core/obsolete.php
@@ -199,3 +199,6 @@ config_obsolete( 'csv_add_bom' );
 config_obsolete( 'hr_size' );
 config_obsolete( 'hr_width' );
 config_obsolete( 'db_schema' );
+
+# changes in 2.0.0dev
+config_obsolete( 'icon_path' );

--- a/core/relationship_api.php
+++ b/core/relationship_api.php
@@ -601,7 +601,6 @@ function relationship_can_resolve_bug( $p_bug_id ) {
  */
 function relationship_get_details( $p_bug_id, BugRelationshipData $p_relationship, $p_html = false, $p_html_preview = false, $p_show_project = false ) {
 	$t_summary_wrap_at = utf8_strlen( config_get( 'email_separator2' ) ) - 28;
-	$t_icon_path = config_get( 'icon_path' );
 
 	if( $p_bug_id == $p_relationship->src_bug_id ) {
 		# root bug is in the source side, related bug in the destination side

--- a/docbook/Admin_Guide/en-US/config/path.xml
+++ b/docbook/Admin_Guide/en-US/config/path.xml
@@ -24,16 +24,6 @@
 			</listitem>
 		</varlistentry>
 		<varlistentry>
-			<term>$g_icon_path</term>
-			<listitem>
-				<para>This is the URL to the icons (images) directory as seen from
-					the web browser. All MantisBT images/icons are loaded from this URL.
-					The default value for this URL is based on $g_path (i.e. '%path%images/').  Note that a trailing
-					'/' is required.
-				</para>
-			</listitem>
-		</varlistentry>
-		<varlistentry>
 			<term>$g_short_path</term>
 			<listitem>
 				<para>Short web path without the domain name.  This requires the trailing '/'.

--- a/javascript_config.php
+++ b/javascript_config.php
@@ -60,5 +60,4 @@ header( 'X-Content-Type-Options: nosniff' );
 
 echo "var config = new Array();\n";
 print_config_value( 'calendar_js_date_format' );
-print_config_value( 'icon_path' );
 print_config_value( 'short_path' );

--- a/my_view_inc.php
+++ b/my_view_inc.php
@@ -66,7 +66,6 @@ if( $t_filter === false ) {
 $t_sort = $t_filter['sort'];
 $t_dir = $t_filter['dir'];
 
-$t_icon_path = config_get( 'icon_path' );
 $t_update_bug_threshold = config_get( 'update_bug_threshold' );
 $t_bug_resolved_status_threshold = config_get( 'bug_resolved_status_threshold' );
 $t_hide_status_default = config_get( 'hide_status_default' );

--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -106,7 +106,6 @@ class MantisGraphPlugin extends MantisPlugin  {
 	 * @return array
 	 */
 	function summary_submenu() {
-		$t_icon_path = config_get( 'icon_path' );
 		return array(
             '<a class="btn btn-sm btn-primary btn-white" href="' . helper_mantis_url( 'summary_page.php' ) . '"> <i class="fa fa-table"></i> ' . plugin_lang_get( 'synthesis_link' ) . '</a>',
 			'<a class="btn btn-sm btn-primary btn-white" href="' . plugin_page( 'developer_graph.php' ) . '"> <i class="fa fa-bar-chart"></i> ' . lang_get( 'by_developer' ) . '</a>',

--- a/print_all_bug_page.php
+++ b/print_all_bug_page.php
@@ -140,7 +140,6 @@ for( $i=0; $i < $t_row_count; $i++ ) {
 }
 $f_export = implode( ',', $f_bug_arr );
 
-$t_icon_path = config_get( 'icon_path' );
 ?>
 
 <tr>

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -61,7 +61,6 @@ list( $t_dir, ) = explode( ',', $g_filter['dir'] );
 
 $g_checkboxes_exist = false;
 
-$t_icon_path = config_get( 'icon_path' );
 
 # Improve performance by caching category data in one pass
 if( helper_get_current_project() > 0 ) {


### PR DESCRIPTION
After using FontAwesome for icons there is some dead code in Mantis.
After removing the dead code, there is no longer any access to setting
icon_path.

Fixes #21689