### PR TITLE
Update existing versions when copying from project

### DIFF
--- a/core/version_api.php
+++ b/core/version_api.php
@@ -82,6 +82,18 @@ class VersionData {
 	protected $date_order = 1;
 
 	/**
+	 * VersionData constructor.
+	 * Initialize the object with default values, or with data from a
+	 * project_version table row.
+	 * @param array|null $p_row
+	 */
+	public function __construct( array $p_row = null ) {
+		if( $p_row !== null ) {
+			$this->set_from_db_row( $p_row );
+		}
+	}
+
+	/**
 	 * Overloaded function
 	 * @param string         $p_name  A valid property name.
 	 * @param integer|string $p_value The property value to set.
@@ -655,10 +667,7 @@ function version_full_name( $p_version_id, $p_show_project = null, $p_current_pr
 function version_get( $p_version_id ) {
 	$t_row = version_cache_row( $p_version_id );
 
-	$t_version_data = new VersionData;
-	$t_version_data->set_from_db_row( $t_row );
-
-	return $t_version_data;
+	return new VersionData( $t_row );
 }
 
 /**

--- a/core/version_api.php
+++ b/core/version_api.php
@@ -114,6 +114,28 @@ class VersionData {
 	public function __get( $p_name ) {
 		return $this->{$p_name};
 	}
+
+	/**
+	 * Initialize the object with data from a database row.
+	 * @param array $p_row
+	 */
+	public function set_from_db_row( array $p_row ) {
+		static $s_vars;
+
+		if( $s_vars == null ) {
+			$t_reflection = new ReflectionClass( $this );
+			$s_vars = $t_reflection->getDefaultProperties();
+		}
+
+		# Check each variable in the class
+		foreach( $s_vars as $t_var => $t_val ) {
+			# If we got a field from the DB with the same name
+			if( array_key_exists( $t_var, $p_row ) ) {
+				# Store that value in the object
+				$this->$t_var = $p_row[$t_var];
+			}
+		}
+	}
 }
 
 $g_cache_versions = array();
@@ -631,26 +653,10 @@ function version_full_name( $p_version_id, $p_show_project = null, $p_current_pr
  * @return VersionData
  */
 function version_get( $p_version_id ) {
-	static $s_vars;
-
 	$t_row = version_cache_row( $p_version_id );
 
-	if( $s_vars == null ) {
-		$t_reflection = new ReflectionClass( 'VersionData' );
-		$s_vars = $t_reflection->getDefaultProperties();
-	}
-
 	$t_version_data = new VersionData;
-	$t_row_keys = array_keys( $t_row );
-
-	# Check each variable in the class
-	foreach( $s_vars as $t_var => $t_val ) {
-		# If we got a field from the DB with the same name
-		if( in_array( $t_var, $t_row_keys, true ) ) {
-			# Store that value in the object
-			$t_version_data->$t_var = $t_row[$t_var];
-		}
-	}
+	$t_version_data->set_from_db_row( $t_row );
 
 	return $t_version_data;
 }

--- a/core/version_api.php
+++ b/core/version_api.php
@@ -671,20 +671,6 @@ function version_get( $p_version_id ) {
 }
 
 /**
- * Return a copy of the version structure with all the variables prepared for database insertion
- * @param VersionData $p_version_info A version data structure.
- * @return VersionData
- */
-function version_prepare_db( VersionData $p_version_info ) {
-	$p_version_info->id = (int)$p_version_info->id;
-	$p_version_info->project_id = (int)$p_version_info->project_id;
-	$p_version_info->released = (bool)$p_version_info->released;
-	$p_version_info->obsolete = (bool)$p_version_info->obsolete;
-
-	return $p_version_info;
-}
-
-/**
  * Checks whether the product version should be shown
  * (i.e. report, update, view, print).
  * @param integer $p_project_id The project id.

--- a/core/version_api.php
+++ b/core/version_api.php
@@ -72,14 +72,14 @@ class VersionData {
 	protected $released = VERSION_FUTURE;
 
 	/**
-	 * Date Order
-	 */
-	protected $date_order = 1;
-
-	/**
 	 * Obsolete
 	 */
 	protected $obsolete = 0;
+
+	/**
+	 * Date Order
+	 */
+	protected $date_order = 1;
 
 	/**
 	 * Overloaded function


### PR DESCRIPTION
Fixes [#10242](https://www.mantisbt.org/bugs/view.php?id=10242)

Note that since the copy function currently ignores obsolete versions, those marked as such in the source project after an earlier copy operation will *not* be updated in the target project. Since it is most likely by design that obsolete versions are not copied, I was not quite sure whether they should be updated or not. Your feedback would be appreciated.

PR also includes some Version API cleanup.
