### PR TITLE
helper_array_transpose should always return an array

### DIFF
--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -89,13 +89,11 @@ function helper_alternate_class( $p_index = null, $p_odd_class = 'row-1', $p_eve
  * @return array|mixed transposed array or $p_array if not 2-dimensional array
  */
 function helper_array_transpose( array $p_array ) {
-	if( !is_array( $p_array ) ) {
-		return $p_array;
-	}
 	$t_out = array();
 	foreach( $p_array as $t_key => $t_sub ) {
 		if( !is_array( $t_sub ) ) {
-			return $p_array;
+			# This function can only handle bidimensional arrays
+			trigger_error( ERROR_GENERIC, ERROR );
 		}
 
 		foreach( $t_sub as $t_subkey => $t_value ) {

--- a/tests/Mantis/HelperTest.php
+++ b/tests/Mantis/HelperTest.php
@@ -37,41 +37,135 @@ require_mantis_core();
 class MantisHelperTest extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * Tests helper_array_transpose()
-	 * @dataProvider providerArrayTranspose
+	 * Custom assertion to evaluate whether the given exception was a
+	 * Mantis error of the specific type(s)
+	 *
+	 * @param Exception $e
+	 * @param array     $p_expected_errors List of expected Mantis error codes.
+	 */
+	public function assertMantisError( Exception $e, array $p_expected_errors = array( ERROR_GENERIC ) ) {
+		$this->assertEquals( E_USER_ERROR, $e->getCode(),
+			'Unexpected error occured: ' . $e->getMessage()
+		);
+
+		$t_code = $e->getMessage();
+		$this->assertContains( $t_code, $p_expected_errors,
+			"Unexpected Mantis error #$t_code occured: " . error_string( $t_code )
+		);
+	}
+
+	/**
+	 * Tests helper_array_transpose() with good values.
+	 *
 	 * @param mixed $p_in  Input array.
 	 * @param mixed $p_out Output array.
 	 * @return void
+	 *
+	 * @dataProvider providerArrayTransposeValid
 	 */
-	public function testArrayTranspose( $p_in, $p_out ) {
+	public function testArrayTransposeValid( $p_in, $p_out ) {
 		$this->assertEquals( $p_out, helper_array_transpose( $p_in ) );
 	}
 
 	/**
-	 * Returns test array
-	 * @return array
+	 * Tests helper_array_transpose() with invalid values.
+	 *
+	 * @param mixed $p_in  Input value.
+	 * @return void
+	 *
+	 * @dataProvider providerArrayTransposeInvalid
 	 */
-	public function providerArrayTranspose() {
+	public function testArrayTransposeInvalid( $p_in ) {
+		try {
+			helper_array_transpose( $p_in );
+		}
+		catch( PHPUnit_Framework_Error $e ) {
+			$this->assertMantisError( $e );
+			# This is the "normal" exit path as we expect all transpositions
+			# to fail with an error
+			return;
+		}
+
+		# Since the provider only contains invalid values, the transposition
+		# should always fail and we should never get here
+		$this->fail('The transposition was successful but should have failed.');
+	}
+
+	/**
+	 * Provides a series of "Good" test cases.
+	 *
+	 * Test case structure:
+	 *   <case> => array( <test matrix>, <expected transposition> )
+	 *
+	 * helper_array_transpose() should successfully transpose <test matrix>
+	 * into <expected transposition>.
+	 *
+	 * @return array List of test cases
+	 */
+	public function providerArrayTransposeValid() {
 		return array(
-			# simple array
-			array( array(123,456), array(123,456) ),
-
-			# mixed (1st element array, 2nd scalar)
-			array(
-				array('a'=>array('k1'=>1,'k2'=>2),'b'=>123),
-				array('a'=>array('k1'=>1,'k2'=>2),'b'=>123),
+			'Bidimensional simple array' => array(
+				array( array( 'a' ), array( 'b' ) ),
+				array( array ( 'a', 'b', ) )
 			),
 
-			# bidimentional array
-			array(
-				array('a'=>array('k1'=>1,'k2'=>2),'b'=>array('k1'=>3,'k2'=>4)),
-				array('k1'=>array('a'=>1,'b'=>3),'k2'=>array('a'=>2,'b'=>4))
+			'Bidimensional array with numeric indices' => array(
+				array( 10 => array( 100 => 'a' ), 20 => array( 100 => 'b' ) ),
+				array( 100 => array ( 10 => 'a', 20 => 'b', ) )
 			),
 
-			# bidimentional array with arrays as elements' data
-			array(
-				array('a'=>array('k1'=>array(1,2,3),'k2'=>2),'b'=>array('k1'=>array(4,5,6),'k2'=>4)),
-				array('k1'=>array('a'=>array(1,2,3),'b'=>array(4,5,6)),'k2'=>array('a'=>2,'b'=>4))
+			'Bidimensional array with numeric indices and missing keys' => array(
+				#    |  0  |  1  |  2  |            |  0  |  1  |
+				# ---+-----+-----+-----+         ---+-----+-----+
+				#  0 | 111 | 222 |  -  |          0 | 111 | 333 |
+				# ---+-----+-----+-----+   ==>   ---+-----+-----+
+				#  1 | 333 |  -  | 444 |          1 | 222 |  -  |
+				# ---+-----+-----+-----+         ---+-----+-----+
+				#                                 2 |  -  | 444 |
+				#                                ---+-----+-----+
+				array( array( 111, 222 ), array( 333, 2 => 444 ) ),
+				array( array ( 111, 333 ), array( 222 ), array( 1 => 444 ) )
+			),
+
+			'Bidimensional associative array' => array(
+				array( 'a' => array( 'k1' => 1, 'k2' => 2 ),'b' => array( 'k1' => 3,'k2' => 4) ),
+				array( 'k1' => array( 'a' => 1, 'b' => 3 ), 'k2' => array( 'a' => 2, 'b' => 4) )
+			),
+
+			'Bidimensional array with arrays as data' => array(
+				array(
+					'a' => array( 'k1' => array( 1, 2, 3 ), 'k2' => 2),
+					'b' => array( 'k1' => array( 4, 5, 6 ), 'k2' => 4)
+				),
+				array(
+					'k1' => array( 'a' => array( 1, 2, 3 ), 'b' => array( 4, 5, 6 ) ),
+					'k2' => array( 'a' => 2, 'b' => 4 )
+				)
+			),
+		);
+	}
+
+	/**
+	 * Provides a series of test cases that should fail transposition.
+	 *
+	 * Test case structure:
+	 *   <case> => array( <test matrix> )
+	 *
+	 * helper_array_transpose() is expected to fail for each case .
+	 * Note: we don't need to test non-array types as these would throw a
+	 * TypeError exception or an E_RECOVERABLE_ERROR (depending on PHP version).
+	 *
+	 * @return array List of test cases
+	 */
+	public function providerArrayTransposeInvalid() {
+		return array(
+			'Simple array' => array(
+				array( 1, 2 )
+			),
+
+			# 1st element array, 2nd scalar
+			'Mixed, "non-square" array' => array(
+				array( 'a' => array( 'k1' => 1, 'k2' => 2 ), 'b' => 123 )
 			),
 		);
 	}

--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -93,6 +93,10 @@ function require_mantis_core() {
 
 	$$t_bypass_headers = true;
 	require_once( 'core.php' );
+
+	# We need to disable MantisBT's error handler to allow PHPUnit to convert
+	# errors to exceptions, allowing us to capture and test them.
+	restore_error_handler();
 }
 
 


### PR DESCRIPTION
The function now triggers an error if the input array is not bi-dimensional.

This fixes the issues introduced by my earlier attempt, which was inadvertently pushed to the core repository (see commit eaa7286) and later reverted (in dd39f53).

Fixes [#17325](https://www.mantisbt.org/bugs/view.php?id=17325)

The related PHPUnit tests have been modified to take this change into account. 

As a prerequisite for this, the Tests configuration script was modified to disable MantisBT's error handler so that errors can be captured as exceptions by PHPUnit (see [#21696](https://www.mantisbt.org/bugs/view.php?id=21696)).
