### PR TITLE
Clearer distinction between private and public notes

### DIFF
--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -355,9 +355,9 @@ if( $f_new_status >= $t_resolved
 		$t_default_bugnote_view_status = config_get( 'default_bugnote_view_status' );
 		if( access_has_bug_level( config_get( 'set_view_status_threshold' ), $f_bug_id ) ) {
 ?>
-			<input type="checkbox" class="ace" name="private"
+			<input type="checkbox" id="bugnote_add_view_status" class="ace" name="private"
 				<?php check_checked( $t_default_bugnote_view_status, VS_PRIVATE ); ?> />
-			<label class="lbl"> <?php echo lang_get( 'private' ) ?> </label>
+			<label class="lbl" for="bugnote_add_view_status"> <?php echo lang_get( 'private' ) ?> </label>
 <?php
 		} else {
 			echo get_enum_element( 'project_view_state', $t_default_bugnote_view_status );

--- a/bugnote_add_inc.php
+++ b/bugnote_add_inc.php
@@ -85,14 +85,6 @@ require_api( 'lang_api.php' );
 		<div class="table-responsive">
 		<table class="table table-bordered table-condensed">
 		<tbody>
-			<tr>
-				<th class="category" width="15%">
-					<?php echo lang_get( 'bugnote' ) ?>
-				</th>
-				<td width="85%">
-					<textarea name="bugnote_text" class="form-control" rows="7"></textarea>
-				</td>
-			</tr>
 
 <?php
 	if( access_has_bug_level( config_get( 'set_view_status_threshold' ), $f_bug_id ) ) {
@@ -117,9 +109,19 @@ require_api( 'lang_api.php' );
 ?>
 				</td>
 			</tr>
-<?php
-	}
+<?php }?>
 
+			<tr>
+				<th class="category" width="15%">
+					<?php echo lang_get( 'bugnote' ) ?>
+				</th>
+				<td width="85%">
+					<textarea name="bugnote_text" class="form-control" rows="7"></textarea>
+				</td>
+			</tr>
+
+
+<?php
 	if( config_get( 'time_tracking_enabled' ) ) {
 		if( access_has_bug_level( config_get( 'time_tracking_edit_threshold' ), $f_bug_id ) ) {
 ?>

--- a/bugnote_view_inc.php
+++ b/bugnote_view_inc.php
@@ -169,7 +169,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 	        $t_bugnote_css    .= ' bugnote-reminder';
 		}
 ?>
-<tr class="bugnote <?php echo $t_bugnote_css ?>" id="c<?php echo $t_bugnote->id ?>">
+<tr class="bugnote" id="c<?php echo $t_bugnote->id ?>">
 		<td class="category">
 		<div class="pull-left padding-2"><?php print_avatar( $t_bugnote->reporter_id ); ?>
 		</div>
@@ -290,7 +290,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 		</div>
 		</div>
 	</td>
-	<td class="bugnote-note">
+	<td class="bugnote-note <?php echo $t_bugnote_css ?>">
 		<?php
 			switch ( $t_bugnote->note_type ) {
 				case REMINDER:

--- a/css/default.css
+++ b/css/default.css
@@ -31,12 +31,10 @@ span.dependency_upgrade		{ color: orange; }
 
 tr.bugnote .bugnote-note { background-color: #e8e8e8; color: #000000; width: 75%; vertical-align: top; }
 
-tr.bugnote > td.bugnote-note.bugnote-private { background-color: #fcf8e3;}
-
 .bugnote-private { background-color: #fcf8e3 !important;}
 
 .nowrap
-{ 
+{
 	white-space: nowrap;
 }
 

--- a/css/default.css
+++ b/css/default.css
@@ -31,6 +31,8 @@ span.dependency_upgrade		{ color: orange; }
 
 tr.bugnote .bugnote-note { background-color: #e8e8e8; color: #000000; width: 75%; vertical-align: top; }
 
+tr.bugnote > td.bugnote-note.bugnote-private { background-color: #fcf8e3;}
+
 .nowrap
 {
 	white-space: nowrap;

--- a/css/default.css
+++ b/css/default.css
@@ -33,8 +33,10 @@ tr.bugnote .bugnote-note { background-color: #e8e8e8; color: #000000; width: 75%
 
 tr.bugnote > td.bugnote-note.bugnote-private { background-color: #fcf8e3;}
 
+.bugnote-private { background-color: #fcf8e3 !important;}
+
 .nowrap
-{
+{ 
 	white-space: nowrap;
 }
 

--- a/js/common.js
+++ b/js/common.js
@@ -335,6 +335,15 @@ $(document).ready( function() {
 	$('a.click-url').bind("click", function() {
 		$(this).attr("href", $(this).attr("url"));
 	});
+
+	$('input[name=private].ace').bind("click", function() {
+		if ($(this).is(":checked")){
+			$('textarea[name=bugnote_text]').css("background-color", "#fcf8e3");
+		} else {
+			$('textarea[name=bugnote_text]').css("background-color", "#fff");
+		}
+	});
+
 });
 
 function setBugLabel() {

--- a/js/common.js
+++ b/js/common.js
@@ -338,9 +338,9 @@ $(document).ready( function() {
 
 	$('input[name=private].ace').bind("click", function() {
 		if ($(this).is(":checked")){
-			$('textarea[name=bugnote_text]').css("background-color", "#fcf8e3");
+			$('textarea[name=bugnote_text]').addClass("bugnote-private");
 		} else {
-			$('textarea[name=bugnote_text]').css("background-color", "#fff");
+			$('textarea[name=bugnote_text]').removeClass("bugnote-private");
 		}
 	});
 


### PR DESCRIPTION
Use a different color for private notes when being edited and viewed.

Fixes #21697

Before:
![before1](https://cloud.githubusercontent.com/assets/955545/18658091/a41c8106-7f32-11e6-8965-b7198bab26be.png)
![before2](https://cloud.githubusercontent.com/assets/955545/18658092/a41c69e6-7f32-11e6-9229-d3a9cd40e450.png)

After:
![after2](https://cloud.githubusercontent.com/assets/955545/18658149/c376f860-7f32-11e6-8dbe-2babdbd5237d.png)
![after1](https://cloud.githubusercontent.com/assets/955545/18658150/c3d9ae24-7f32-11e6-875b-9164fa4a580e.png)
