### PR TITLE
Report Stay checkbox shows broken layout on action page

### DIFF
--- a/bug_report.php
+++ b/bug_report.php
@@ -329,15 +329,18 @@ if( !is_blank( $f_tag_string ) || $f_tag_select != 0 ) {
 	<div class="alert alert-success">
 
 <?php
-echo '<p>' . lang_get( 'operation_successful' ) . '</p><br />';
-print_button( string_get_bug_view_url( $t_bug_id ), sprintf( lang_get( 'view_submitted_bug_link' ), $t_bug_id ) );
-print_button( 'view_all_bug_page.php', lang_get( 'view_bugs_link' ) );
-
 if( $f_report_stay ) {
 ?>
 	<p>
 	<form method="post" action="<?php echo string_get_bug_report_url() ?>">
-	<?php # CSRF protection not required here - form does not result in modifications ?>
+	<?php # CSRF protection not required here - form does not result in modifications 
+
+		echo '<p>' . lang_get( 'operation_successful' ) . '</p><br />';
+		print_button( string_get_bug_view_url( $t_bug_id ), sprintf( lang_get( 'view_submitted_bug_link' ), $t_bug_id ) );
+		echo "&nbsp;";
+		print_button( 'view_all_bug_page.php', lang_get( 'view_bugs_link' ) );
+
+	?>
 		<input type="hidden" name="category_id" value="<?php echo string_attribute( $t_bug_data->category_id ) ?>" />
 		<input type="hidden" name="severity" value="<?php echo string_attribute( $t_bug_data->severity ) ?>" />
 		<input type="hidden" name="reproducibility" value="<?php echo string_attribute( $t_bug_data->reproducibility ) ?>" />
@@ -354,9 +357,16 @@ if( $f_report_stay ) {
 		<input type="submit" class="btn btn-primary btn-white btn-round" value="<?php echo lang_get( 'report_more_bugs' ) ?>" />
 	</form>
 	</p>
-<?php
+<?php 
+} else {
+
+	echo '<p>' . lang_get( 'operation_successful' ) . '</p><br />';
+	print_button( string_get_bug_view_url( $t_bug_id ), sprintf( lang_get( 'view_submitted_bug_link' ), $t_bug_id ) );
+	echo "&nbsp;";
+	print_button( 'view_all_bug_page.php', lang_get( 'view_bugs_link' ) );
 }
 ?>
+
 </div>
 </div>
 


### PR DESCRIPTION
Fix Broken layout when "Report Stay" checkbox is checked

Fixes #21704

Previous looks:
![stay_before](https://cloud.githubusercontent.com/assets/955545/18664113/eb1556ac-7f53-11e6-8f11-4b8481eedcc9.png)

After:
![stay_report](https://cloud.githubusercontent.com/assets/955545/18664133/fa985cb4-7f53-11e6-80e5-efb5b7c9ec3f.png)
