### PR TITLE
plugin_get() fails to use the default argument

### DIFF
--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -117,7 +117,7 @@ function plugin_get( $p_basename = null ) {
 		trigger_error( ERROR_PLUGIN_NOT_REGISTERED, ERROR );
 	}
 
-	return $g_plugin_cache[$p_basename];
+	return $g_plugin_cache[$t_current];
 }
 
 /**


### PR DESCRIPTION
Fixes a bug that prevents defaulting to current plugin if plugin_get() is called without arguments.

The bug is fairly obvious, given that $t_current is assigned either the function argument or the default value and then the value of $t_current is not used at all in the function's return value.

Fixes [#21707](https://www.mantisbt.org/bugs/view.php?id=21707)