### PR TITLE
Fix report stay button

### DIFF
--- a/bug_report.php
+++ b/bug_report.php
@@ -327,30 +327,24 @@ $t_buttons = array(
 	array( string_get_bug_view_url( $t_bug_id ), sprintf( lang_get( 'view_submitted_bug_link' ), $t_bug_id ) ),
 	array( 'view_all_bug_page.php', lang_get( 'view_bugs_link' ) ),
 );
-html_operation_confirmation( $t_buttons, '', CONFIRMATION_TYPE_SUCCESS );
 
 if( $f_report_stay ) {
-?>
-	<p>
-	<form method="post" action="<?php echo string_get_bug_report_url() ?>">
-	<?php # CSRF protection not required here - form does not result in modifications ?>
-		<input type="hidden" name="category_id" value="<?php echo string_attribute( $t_bug_data->category_id ) ?>" />
-		<input type="hidden" name="severity" value="<?php echo string_attribute( $t_bug_data->severity ) ?>" />
-		<input type="hidden" name="reproducibility" value="<?php echo string_attribute( $t_bug_data->reproducibility ) ?>" />
-		<input type="hidden" name="profile_id" value="<?php echo string_attribute( $t_bug_data->profile_id ) ?>" />
-		<input type="hidden" name="platform" value="<?php echo string_attribute( $t_bug_data->platform ) ?>" />
-		<input type="hidden" name="os" value="<?php echo string_attribute( $t_bug_data->os ) ?>" />
-		<input type="hidden" name="os_build" value="<?php echo string_attribute( $t_bug_data->os_build ) ?>" />
-		<input type="hidden" name="product_version" value="<?php echo string_attribute( $t_bug_data->version ) ?>" />
-		<input type="hidden" name="target_version" value="<?php echo string_attribute( $t_bug_data->target_version ) ?>" />
-		<input type="hidden" name="build" value="<?php echo string_attribute( $t_bug_data->build ) ?>" />
-		<input type="hidden" name="report_stay" value="1" />
-		<input type="hidden" name="view_state" value="<?php echo string_attribute( $t_bug_data->view_state ) ?>" />
-		<input type="hidden" name="due_date" value="<?php echo string_attribute( $t_bug_data->due_date ) ?>" />
-		<input type="submit" class="btn btn-primary btn-white btn-round" value="<?php echo lang_get( 'report_more_bugs' ) ?>" />
-	</form>
-	</p>
-<?php
+	$t_fields = array(
+		'category_id', 'severity', 'reproducibility', 'profile_id', 'platform',
+		'os', 'os_build', 'target_version', 'build', 'view_state', 'due_date'
+	);
+	foreach( $t_fields as $t_field ) {
+		$t_data[$t_field] = $t_bug_data->$t_field;
+	}
+	$t_data['product_version'] = $t_bug_data->version;
+	$t_data['report_stay'] = 1;
+
+	$t_buttons[] = array(
+		string_get_bug_report_url() . '?' . http_build_query($t_data),
+		lang_get( 'report_more_bugs' )
+	);
 }
+
+html_operation_confirmation( $t_buttons, '', CONFIRMATION_TYPE_SUCCESS );
 
 layout_page_end();

--- a/bug_report.php
+++ b/bug_report.php
@@ -302,7 +302,21 @@ form_security_purge( 'bug_report' );
 
 layout_page_header_begin();
 
-if( !$f_report_stay ) {
+if( $f_report_stay ) {
+	$t_fields = array(
+		'category_id', 'severity', 'reproducibility', 'profile_id', 'platform',
+		'os', 'os_build', 'target_version', 'build', 'view_state', 'due_date'
+	);
+	foreach( $t_fields as $t_field ) {
+		$t_data[$t_field] = $t_bug_data->$t_field;
+	}
+	$t_data['product_version'] = $t_bug_data->version;
+	$t_data['report_stay'] = 1;
+
+	$t_report_more_bugs_url = string_get_bug_report_url() . '?' . http_build_query($t_data);
+
+	html_meta_redirect( $t_report_more_bugs_url );
+} else {
 	html_meta_redirect( 'view_all_bug_page.php' );
 }
 
@@ -327,22 +341,8 @@ $t_buttons = array(
 	array( string_get_bug_view_url( $t_bug_id ), sprintf( lang_get( 'view_submitted_bug_link' ), $t_bug_id ) ),
 	array( 'view_all_bug_page.php', lang_get( 'view_bugs_link' ) ),
 );
-
 if( $f_report_stay ) {
-	$t_fields = array(
-		'category_id', 'severity', 'reproducibility', 'profile_id', 'platform',
-		'os', 'os_build', 'target_version', 'build', 'view_state', 'due_date'
-	);
-	foreach( $t_fields as $t_field ) {
-		$t_data[$t_field] = $t_bug_data->$t_field;
-	}
-	$t_data['product_version'] = $t_bug_data->version;
-	$t_data['report_stay'] = 1;
-
-	$t_buttons[] = array(
-		string_get_bug_report_url() . '?' . http_build_query($t_data),
-		lang_get( 'report_more_bugs' )
-	);
+	$t_buttons[] = array( $t_report_more_bugs_url, lang_get( 'report_more_bugs' ) );
 }
 
 html_operation_confirmation( $t_buttons, '', CONFIRMATION_TYPE_SUCCESS );


### PR DESCRIPTION
To leverage the new API functions handling the display of operation confirmation messages, the _Report More Issues_ button is now handled as a single URL query with get parameters, instead of an HTML form.

Fixes [#21704](https://www.mantisbt.org/bugs/view.php?id=21704)

This replaces @jllano's PR #894