### PR TITLE
Handle null tokens when upgrading from 1.2.x

### DIFF
--- a/core/install_helper_functions_api.php
+++ b/core/install_helper_functions_api.php
@@ -685,15 +685,19 @@ function install_check_token_serialization() {
 		$t_id = $t_row['id'];
 		$t_value = $t_row['value'];
 
-		$t_token = @unserialize( $t_value );
-		if( $t_token === false ) {
-			# If user hits a page other than install, tokens may be created using new code.
-			$t_token = json_decode( $t_value );
-			if( $t_token !== null ) {
-				continue;
-			}
+		if ( $t_value === null ) {
+			$t_token = null;
+		} else {
+			$t_token = @unserialize( $t_value );
+			if( $t_token === false ) {
+				# If user hits a page other than install, tokens may be created using new code.
+				$t_token = json_decode( $t_value );
+				if( $t_token !== null ) {
+					continue;
+				}
 
-			return 1; # Fatal: invalid data found in tokens table
+				return 1; # Fatal: invalid data found in tokens table
+			}
 		}
 
 		$t_json_token = json_encode( $t_token );


### PR DESCRIPTION
I haven't tested the fix, appreciate if someone who has a repro to test.  I can simulate it if no one has a real repro from a failing db.

Fixes #21573