### PR TITLE
Fix missing tooltips on issue Ids

### DIFF
--- a/core/string_api.php
+++ b/core/string_api.php
@@ -649,7 +649,11 @@ function string_get_bug_view_link( $p_bug_id, $p_detail_info = true, $p_fqdn = f
 		}
 		$t_link .= string_get_bug_view_url( $p_bug_id ) . '"';
 		if( $p_detail_info ) {
+			$t_summary = string_attribute( bug_get_field( $p_bug_id, 'summary' ) );
 			$t_project_id = bug_get_field( $p_bug_id, 'project_id' );
+			$t_status = string_attribute( get_enum_element( 'status', bug_get_field( $p_bug_id, 'status' ), $t_project_id ) );
+			$t_link .= ' title="[' . $t_status . '] ' . $t_summary . '"';
+
 			$t_resolved = bug_get_field( $p_bug_id, 'status' ) >= config_get( 'bug_resolved_status_threshold', null, null, $t_project_id );
 			if( $t_resolved ) {
 				$t_link .= ' class="resolved"';

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -386,7 +386,7 @@ function summary_print_by_activity() {
 	bug_cache_array_rows( $t_summarybugs );
 
 	foreach( $t_summarydata as $t_row ) {
-		$t_bugid = string_get_bug_view_link( $t_row['id'] );
+		$t_bugid = string_get_bug_view_link( $t_row['id'], false );
 		$t_summary = string_display_line( $t_row['summary'] );
 		$t_notescount = $t_row['count'];
 
@@ -431,7 +431,7 @@ function summary_print_by_age() {
 			break;
 		}
 
-		$t_bugid = string_get_bug_view_link( $t_row['id'] );
+		$t_bugid = string_get_bug_view_link( $t_row['id'], false );
 		$t_summary = string_display_line( $t_row['summary'] );
 		$t_days_open = intval( ( time() - $t_row['date_submitted'] ) / SECONDS_PER_DAY );
 

--- a/my_view_inc.php
+++ b/my_view_inc.php
@@ -360,7 +360,7 @@ for( $i = 0;$i < $t_count; $i++ ) {
 	# -- Bug ID and details link + Pencil shortcut --?>
 	<td class="nowrap width-13 my-buglist-id">
 		<?php
-			print_bug_link( $t_bug->id );
+			print_bug_link( $t_bug->id, false );
 
 			echo '<br />';
 


### PR DESCRIPTION
This is a partial revert of 4d8ce6ff687ab5bec9af3d635aefe7fe9f24d6f7
(see issue #21112).

Hiding the tooltip in My View page is now done using print_bug_link()'s
$p_detail_info parameter.

Fixes [#21721](https://www.mantisbt.org/bugs/view.php?id=21721)