### PR TITLE
cleanup db_now()

### DIFF
--- a/core/database_api.php
+++ b/core/database_api.php
@@ -838,9 +838,8 @@ function db_prepare_bool( $p_bool ) {
 }
 
 /**
- * return current timestamp for DB
- * @todo add param bool $p_gmt whether to use GMT or current timezone (default false)
- * @return string Formatted Date for DB insertion e.g. 1970-01-01 00:00:00 ready for database insertion
+ * return current time as Unix timestamp
+ * @return integer Unix timestamp of the current date and time
  */
 function db_now() {
 	return time();


### PR DESCRIPTION
db_now() returns a Unix timestamp, not a DATETIME-formatted string as
currently described in the DocBlock. The proposed changes fix the
function description and introduce a new function, db_now_datetime(),
that returns a DATETIME-formatted string.

In addition, the proposed changes introduce an optional parameter,
$p_gmt. When the parameter is set to TRUE, the current time is
interpreted as GMT time.

Signed-off-by: Val Kulkov <val.kulkov@gmail.com>