### PR TITLE
set default timezone during install

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -338,7 +338,9 @@ print_test( 'Checking if safe mode is enabled for install script',
 
 # got database information, check and install
 if( 2 == $t_install_state ) {
-	?>
+    # By now user has picked a timezone, ensure it is set
+    date_default_timezone_set( $f_timezone );
+?>
 
 <!-- Checking DB support-->
 <?php


### PR DESCRIPTION
installing with a recent PHP (tested with 5.6.25) leads to a
system warning about missing the default timezone setting
that blocks the installation. Since we select the
timezone in the first install step, we can use that before
continuing with the second

![screenshot from 2016-09-17 09-40-23](https://cloud.githubusercontent.com/assets/6527/18910737/a5a5d8d6-8579-11e6-91cb-c5ee5f4e0559.png)
