### PR TITLE
Add missing </div>

### DIFF
--- a/api_tokens_page.php
+++ b/api_tokens_page.php
@@ -152,4 +152,5 @@ if ( count( $t_tokens ) > 0 ) {
 <?php
 }
 
+echo '</div>';
 layout_page_end();


### PR DESCRIPTION
Fixes [#21726](https://www.mantisbt.org/bugs/view.php?id=21726)

A missing ``</div>`` ruins the footer layout of api_tokens_page