### PR TITLE
Hide 'View Issues' buttons in small screens

### DIFF
--- a/my_view_inc.php
+++ b/my_view_inc.php
@@ -313,7 +313,7 @@ echo '<span class="badge"> ' . " $v_start - $v_end / $t_bug_count " . ' </span>'
 				<i class="1 ace-icon fa <?php echo $t_block_icon ?> bigger-125"></i>
 			</a>
 		</div>
-		<div class="widget-toolbar no-border">
+		<div class="widget-toolbar no-border hidden-xs">
 			<div class="widget-menu">
 				<?php print_small_button( $t_box_url, lang_get( 'view_bugs_link' ) ); ?>
 			</div>


### PR DESCRIPTION
Fixes #21794

Before:
<img width="341" alt="screen shot 2016-10-11 at 8 57 00 pm" src="https://cloud.githubusercontent.com/assets/1354889/19297287/3eec2562-8ff8-11e6-9e68-cc4f85a20c88.png">

After:
<img width="332" alt="screen shot 2016-10-11 at 9 11 50 pm" src="https://cloud.githubusercontent.com/assets/1354889/19297289/479f99d2-8ff8-11e6-9b50-3e56472b8f2f.png">

