### PR TITLE
Don't show reset option for disabled or protected users

### DIFF
--- a/core/email_api.php
+++ b/core/email_api.php
@@ -538,11 +538,18 @@ function email_signup( $p_user_id, $p_confirm_hash, $p_admin_name = '' ) {
  * @return void
  */
 function email_send_confirm_hash_url( $p_user_id, $p_confirm_hash ) {
-	if( OFF == config_get( 'send_reset_password' ) ||
-		OFF == config_get( 'enable_email_notification' ) ) {
+	if( OFF == config_get( 'send_reset_password' ) ) {
+		log_event( LOG_EMAIL_VERBOSE, 'Password reset email notifications disabled.' );
 		return;
 	}
-
+	if( OFF == config_get( 'enable_email_notification' ) ) {
+		log_event( LOG_EMAIL_VERBOSE, 'email notifications disabled.' );
+		return;
+	}
+	if( !user_is_enabled( $p_user_id ) ) {
+		log_event( LOG_EMAIL_RECIPIENT, 'Password reset for user @U%d not sent, user is disabled', $p_user_id );
+		return;
+	}
 	lang_push( user_pref_get_language( $p_user_id ) );
 
 	# retrieve the username and email
@@ -558,6 +565,8 @@ function email_send_confirm_hash_url( $p_user_id, $p_confirm_hash ) {
 	if( !is_blank( $t_email ) ) {
 		email_store( $t_email, $t_subject, $t_message, null, true );
 		log_event( LOG_EMAIL, 'Password reset for user @U%d sent to %s', $p_user_id, $t_email );
+	} else {
+		log_event( LOG_EMAIL_RECIPIENT, 'Password reset for user @U%d not sent, email is empty', $p_user_id );
 	}
 
 	lang_pop();

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -547,7 +547,7 @@ function email_send_confirm_hash_url( $p_user_id, $p_confirm_hash ) {
 		return;
 	}
 	if( !user_is_enabled( $p_user_id ) ) {
-		log_event( LOG_EMAIL_RECIPIENT, 'Password reset for user @U%d not sent, user is disabled', $p_user_id );
+		log_event( LOG_EMAIL, 'Password reset for user @U%d not sent, user is disabled', $p_user_id );
 		return;
 	}
 	lang_push( user_pref_get_language( $p_user_id ) );
@@ -566,7 +566,7 @@ function email_send_confirm_hash_url( $p_user_id, $p_confirm_hash ) {
 		email_store( $t_email, $t_subject, $t_message, null, true );
 		log_event( LOG_EMAIL, 'Password reset for user @U%d sent to %s', $p_user_id, $t_email );
 	} else {
-		log_event( LOG_EMAIL_RECIPIENT, 'Password reset for user @U%d not sent, email is empty', $p_user_id );
+		log_event( LOG_EMAIL, 'Password reset for user @U%d not sent, email is empty', $p_user_id );
 	}
 
 	lang_pop();

--- a/manage_user_edit_page.php
+++ b/manage_user_edit_page.php
@@ -185,7 +185,9 @@ print_manage_menu();
 # User action buttons: RESET/UNLOCK and DELETE
 
 $t_reset = $t_user['id'] != auth_get_current_user_id()
-	&& helper_call_custom_function( 'auth_can_change_password', array() );
+	&& helper_call_custom_function( 'auth_can_change_password', array() )
+	&& user_is_enabled( $t_user['id'] )
+	&& !user_is_protected( $t_user['id'] );
 $t_unlock = OFF != config_get( 'max_failed_login_count' ) && $t_user['failed_login_count'] > 0;
 $t_delete = !( ( user_is_administrator( $t_user_id ) && ( user_count_level( config_get_global( 'admin_site_threshold' ) ) <= 1 ) ) );
 $t_impersonate = auth_can_impersonate( $t_user['id'] );


### PR DESCRIPTION
Don't show reset option for disabled or protected users
    
    Don't show the password reset option for disabled or protected users:
    - Disabled users can't have email sent.
    - Protected users must not have its password changed (and will show an
      error anyway)
    
    Fixes: #21793

Don't send reset email for disabled users
    
    Don't send email for password reset if the user is disabled.
    Adds log messages to several failure conditions.
