### PR TITLE
Fixes #21805 'uncaught error ... requires jQuery' on signup and login page

### DIFF
--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -350,7 +350,7 @@ function layout_login_page_begin() {
 	echo "\t", '<link rel="search" type="application/opensearchdescription+xml" title="MantisBT: Text Search" href="' . string_sanitize_url( 'browser_search_plugin.php?type=text', true) . '" />' . "\n";
 	echo "\t", '<link rel="search" type="application/opensearchdescription+xml" title="MantisBT: Issue Id" href="' . string_sanitize_url( 'browser_search_plugin.php?type=id', true) . '" />' . "\n";
 	
-	html_head_end();
+	html_head_javascript();
 	
 	event_signal( 'EVENT_LAYOUT_RESOURCES' );
 	html_head_end();

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -349,7 +349,9 @@ function layout_login_page_begin() {
 	# Advertise the availability of the browser search plug-ins.
 	echo "\t", '<link rel="search" type="application/opensearchdescription+xml" title="MantisBT: Text Search" href="' . string_sanitize_url( 'browser_search_plugin.php?type=text', true) . '" />' . "\n";
 	echo "\t", '<link rel="search" type="application/opensearchdescription+xml" title="MantisBT: Issue Id" href="' . string_sanitize_url( 'browser_search_plugin.php?type=id', true) . '" />' . "\n";
-
+	
+	html_head_end();
+	
 	event_signal( 'EVENT_LAYOUT_RESOURCES' );
 	html_head_end();
 


### PR DESCRIPTION
Fixes #21805
This will fix 'uncaught error ... requires jQuery' on login and signup page.
Added html_head_javascript() to layout_login_page_begin()