### PR TITLE
Fix my view link for filter resolved

### DIFF
--- a/my_view_inc.php
+++ b/my_view_inc.php
@@ -146,7 +146,7 @@ $c_filter['resolved'] = array(
 		'0' => META_FILTER_ANY,
 	),
 );
-$t_url_link_parameters['resolved'] = FILTER_PROPERTY_STATUS . '=' . $t_bug_resolved_status_threshold . '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_bug_resolved_status_threshold;
+$t_url_link_parameters['resolved'] = FILTER_PROPERTY_STATUS . '=' . $t_bug_resolved_status_threshold . '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_hide_status_default;
 
 
 $c_filter['unassigned'] = filter_create_assigned_to_unresolved( helper_get_current_project(), 0 );


### PR DESCRIPTION
The link generated for "resolved" filter in my_view_inc.php was setting
an incorrect value for parameter hide_status.
Fix to use the default value for hide_status, in the same way other
filters in this page do.

Fixes: #21812