### PR TITLE
Add spacer in manage overview page

### DIFF
--- a/manage_overview_page.php
+++ b/manage_overview_page.php
@@ -95,6 +95,9 @@ print_manage_menu( 'manage_overview_page.php' );
 			<th class="category"><?php echo lang_get( 'plugin_path' ) ?></th>
 			<td><?php echo config_get( 'plugin_path' ) ?></td>
 		</tr>
+		<tr class="spacer">
+			<td colspan="2"></td>
+		</tr>
 	<?php
 	}
 


### PR DESCRIPTION
Add a spacer row between system info rows and plugin info rows.
This spacer was present in v1.3 layout.

Before:
![seleccion_070](https://cloud.githubusercontent.com/assets/14123811/19612992/1690b26e-97ea-11e6-80f2-507fbd3223e1.png)

After:
![seleccion_068](https://cloud.githubusercontent.com/assets/14123811/19612997/1e59b69e-97ea-11e6-87b7-fe66ef9745ab.png)

As v1.3:
![seleccion_069](https://cloud.githubusercontent.com/assets/14123811/19613008/288689e4-97ea-11e6-9ee2-eb1d93dd94f6.png)
