### PR TITLE
Change view issue menu to allow plugin links

### DIFF
--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -268,7 +268,7 @@ foreach ( $t_links as $t_plugin => $t_hooks ) {
 				if( is_numeric( $t_label ) ) {
 					echo '<li>' .  $t_href . '</li>';
 				} else {
-					print_small_button( $t_href, $t_label );
+					echo '<li><a href="' . $t_href . '">' . $t_label . '</a></li>';
 				}
 			}
 		} elseif( !empty( $t_hook ) ) {

--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -245,18 +245,20 @@ echo '</div>';
 echo '<div class="widget-body">';
 
 echo '<div class="widget-toolbox padding-8 clearfix noprint">';
-echo '<div class="btn-group pull-left">';
+
+echo '<div class="pull-left">';
+echo '<ul class="nav nav-tabs">';
 
 # Jump to Bugnotes
-print_small_button( '#bugnotes', lang_get( 'jump_to_bugnotes' ) );
+echo '<li><a href="#bugnotes">' . lang_get( 'jump_to_bugnotes' ) . '</a></li>';
 
 # Send Bug Reminder
 if( $t_show_reminder_link ) {
-	print_small_button( $t_bug_reminder_link, lang_get( 'bug_reminder' ) );
+	echo '<li><a href="' . $t_bug_reminder_link . '">' . lang_get( 'bug_reminder' ) . '</a></li>';
 }
 
 if( !is_blank( $t_wiki_link ) ) {
-	print_small_button( $t_wiki_link, lang_get( 'wiki' ) );
+	echo '<li><a href="' . $t_wiki_link . '">' . lang_get( 'wiki' ) . '</a></li>';
 }
 
 foreach ( $t_links as $t_plugin => $t_hooks ) {
@@ -264,13 +266,13 @@ foreach ( $t_links as $t_plugin => $t_hooks ) {
 		if( is_array( $t_hook ) ) {
 			foreach( $t_hook as $t_label => $t_href ) {
 				if( is_numeric( $t_label ) ) {
-					print_bracket_link_prepared( $t_href );
+					echo '<li>' .  $t_href . '</li>';
 				} else {
 					print_small_button( $t_href, $t_label );
 				}
 			}
 		} elseif( !empty( $t_hook ) ) {
-			print_bracket_link_prepared( $t_hook );
+			echo '<li>' .  $t_hook . '</li>';
 		}
 	}
 }
@@ -278,9 +280,9 @@ foreach ( $t_links as $t_plugin => $t_hooks ) {
 # Links
 if( !is_blank( $t_history_link ) ) {
 	# History
-	print_small_button( $t_history_link, lang_get( 'bug_history' ) );
+	echo '<li><a href="' . $t_history_link . '">' . lang_get( 'bug_history' ) . '</a></li>';
 }
-
+echo '<ul>';
 echo '</div>';
 
 # prev/next links


### PR DESCRIPTION
Changed the style of the upper menu in bug view page, to allow the
correct formatting of links provided by plugins with EVENT_MENU_ISSUE.

This event may return a prepared html link, which was being shown as a
bracketed plain link (old style)
The new style introduced by new ui, used link buttons, but the function
provided to print abutton from the event return (print_small_button),
must provide a separated urn and label, which is not possible with an
already prepared html link.

The changed style now uses list items that formats the link html "as
is" in an uniform way with the ui.

Fixes: #21559