### PR TITLE
Add missing sidebar trigger button for midsize screen 

### DIFF
--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -409,7 +409,6 @@ function layout_navbar() {
 
 	echo '</div>';
 
-	echo '<div class="hidden-xs">';
 	echo '<div class="navbar-buttons navbar-header pull-right navbar-collapse collapse">';
 	echo '<ul class="nav ace-nav">';
 	if (auth_is_user_authenticated()) {
@@ -421,19 +420,6 @@ function layout_navbar() {
 		layout_navbar_user_menu();
 	}
 	echo '</ul>';
-	echo '</div>';
-	echo '</div>';
-
-	# mobile view
-	echo '<div class="hidden-sm hidden-md hidden-lg">';
-	echo '<div class="navbar-menu pull-left navbar-collapse collapse" role="navigation" style="height: auto;">';
-	echo '<ul class="nav navbar-nav">';
-	if (auth_is_user_authenticated()) {
-		layout_navbar_user_menu(false);
-		layout_navbar_projects_menu();
-	}
-	echo '</ul>';
-	echo '</div>';
 	echo '</div>';
 
 	echo '</div>';

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -382,10 +382,16 @@ function layout_navbar() {
 	$t_logo_url = config_get('logo_url');
 
 	echo '<div id="navbar" class="navbar navbar-default navbar-collapse navbar-fixed-top noprint">';
-
 	echo '<div id="navbar-container" class="navbar-container">';
 
-	echo '<div class="navbar-header pull-left">';
+	echo '<button id="menu-toggler" type="button" class="navbar-toggle menu-toggler pull-left hidden-lg" data-target="#sidebar">';
+	echo '<span class="sr-only">Toggle sidebar</span>';
+	echo '<span class="icon-bar"></span>';
+	echo '<span class="icon-bar"></span>';
+	echo '<span class="icon-bar"></span>';
+	echo '</button>';
+
+	echo '<div class="navbar-header">';
 	echo '<a href="' . $t_logo_url . '" class="navbar-brand">';
 	echo '<span class="smaller-75"> ';
 	echo config_get('window_title');
@@ -393,23 +399,16 @@ function layout_navbar() {
 	echo '</a>';
 
 	$t_toggle_class = (OFF == config_get('show_avatar') ? 'navbar-toggle' : 'navbar-toggle-img');
-	echo '<button type="button" class="navbar-toggle ' . $t_toggle_class . ' collapsed pull-right hidden-sm hidden-md" data-toggle="collapse" data-target=".navbar-buttons,.navbar-menu">';
+	echo '<button type="button" class="navbar-toggle ' . $t_toggle_class . ' collapsed pull-right hidden-sm hidden-md hidden-lg" data-toggle="collapse" data-target=".navbar-buttons,.navbar-menu">';
 	echo '<span class="sr-only">Toggle user menu</span>';
 	if (auth_is_user_authenticated()) {
 		layout_navbar_user_avatar();
 	}
 	echo '</button>';
 
-	echo '<button type="button" class="small navbar-toggle menu-toggler pull-right grey" id="menu-toggler" data-target="#sidebar">';
-	echo '<span class="sr-only">Toggle sidebar</span>';
-	echo '<span class="icon-bar"></span>';
-	echo '<span class="icon-bar"></span>';
-	echo '<span class="icon-bar"></span>';
-	echo '</button>';
-
 	echo '</div>';
 
-	echo '<div class="navbar-buttons navbar-header pull-right navbar-collapse collapse">';
+	echo '<div class="navbar-buttons navbar-header navbar-collapse collapse">';
 	echo '<ul class="nav ace-nav">';
 	if (auth_is_user_authenticated()) {
 		# shortcuts button bar

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -393,7 +393,7 @@ function layout_navbar() {
 	echo '</a>';
 
 	$t_toggle_class = (OFF == config_get('show_avatar') ? 'navbar-toggle' : 'navbar-toggle-img');
-	echo '<button type="button" class="navbar-toggle ' . $t_toggle_class . ' collapsed pull-right" data-toggle="collapse" data-target=".navbar-buttons,.navbar-menu">';
+	echo '<button type="button" class="navbar-toggle ' . $t_toggle_class . ' collapsed pull-right hidden-sm hidden-md" data-toggle="collapse" data-target=".navbar-buttons,.navbar-menu">';
 	echo '<span class="sr-only">Toggle user menu</span>';
 	if (auth_is_user_authenticated()) {
 		layout_navbar_user_avatar();

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -277,6 +277,10 @@ textarea.input-xs, select.input-xs[multiple] {
     overflow-x: hidden;
 }
 
+.navbar-toggle {
+    display:  block;
+}
+
 /* Small devices (tablets, 768px and up) */
 @media (min-width: 768px) {
     .page-content {
@@ -287,8 +291,14 @@ textarea.input-xs, select.input-xs[multiple] {
         width: 120px !important;
     }
 
-    .navbar-toggle {
-        display: block;
+    .navbar.navbar-collapse .navbar-header {
+        float: left !important;
+    }
+
+    .navbar.navbar-collapse .navbar-buttons {
+        float: right !important;
+        border-style: none !important;
+        width: auto;
     }
 }
 
@@ -341,6 +351,16 @@ textarea.input-xs, select.input-xs[multiple] {
     .rtl .sidebar.menu-min ~ .footer .footer-inner {
         right: 43px !important;
     }
+
+    .navbar.navbar-collapse .navbar-header {
+        float: left !important;
+    }
+
+    .navbar.navbar-collapse .navbar-buttons {
+        float: right !important;
+        border-style: none !important;
+        width: auto;
+    }
 }
 
 /* Large devices (large desktops, 1200px and up) */
@@ -392,5 +412,6 @@ textarea.input-xs, select.input-xs[multiple] {
     .rtl .sidebar.menu-min ~ .footer .footer-inner {
         right: 43px !important;
     }
+
 }
 

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -48,16 +48,6 @@
     font-size: x-small;
 }
 
-.navbar-default .navbar-nav .open .dropdown-menu > .active > a {
-    background: #e7e7e7 none repeat scroll 0 0;
-    color: #444 !important;
-}
-
-.navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus,
-.navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover {
-    color: #fff !important;
-}
-
 .uppercase {
     text-transform: uppercase;
 }

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -286,6 +286,10 @@ textarea.input-xs, select.input-xs[multiple] {
     .input-sm {
         width: 120px !important;
     }
+
+    .navbar-toggle {
+        display: block;
+    }
 }
 
 /* Medium devices (desktops, 992px and up) */


### PR DESCRIPTION
+ Also fix consistency issues between mobile screen menu vs. larger screens

Fixes #21715

Before:
![image](https://cloud.githubusercontent.com/assets/1354889/19620900/55e569e0-983b-11e6-94f3-76bccd4d06f7.png)

![image](https://cloud.githubusercontent.com/assets/1354889/19620895/48c7776c-983b-11e6-8750-1e7fada2fcf5.png)

Note: Missing trigger button for sidebar menu
<img width="786" alt="screen shot 2016-10-22 at 10 13 08 am" src="https://cloud.githubusercontent.com/assets/1354889/19621142/3ea98f40-9840-11e6-8f1e-8490e09d3e8a.png">


After:

Note: the two buttons up right are trigger buttons. They show/hide sidebar and navbar menus
![image](https://cloud.githubusercontent.com/assets/1354889/19620902/63d8d186-983b-11e6-97b4-ef953b27adcc.png)

![image](https://cloud.githubusercontent.com/assets/1354889/19620905/68922092-983b-11e6-9a04-010e784a58b0.png)

Note: Only one trigger button is needed on larger screen - the sidebar toggler
<img width="799" alt="screen shot 2016-10-22 at 10 10 05 am" src="https://cloud.githubusercontent.com/assets/1354889/19621129/08338916-9840-11e6-96e9-fe93e753a805.png">


