### PR TITLE
Group attachments into a single entry

### DIFF
--- a/bugnote_view_inc.php
+++ b/bugnote_view_inc.php
@@ -308,14 +308,6 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 
 			if( isset( $t_activity['attachments'] ) && count( $t_activity['attachments'] ) > 0 ) {
 				echo '<br /><br />';
-
-				if ( !$t_security_token_attachments_delete ) {
-					$t_security_token_attachments_delete = form_security_token( 'bug_file_delete' );
-				}
-
-				foreach( $t_activity['attachments'] as $t_attachment ) {
-					print_bug_attachment( $t_attachment, $t_security_token_attachments_delete );
-				}
 			}
 		} else {
 			if ( !$t_security_token_attachments_delete ) {
@@ -323,6 +315,16 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 			}
 
 			print_bug_attachment( $t_activity['attachment'], $t_security_token_attachments_delete );
+		}
+
+		if( isset( $t_activity['attachments'] ) && count( $t_activity['attachments'] ) > 0 ) {
+			if ( !$t_security_token_attachments_delete ) {
+				$t_security_token_attachments_delete = form_security_token( 'bug_file_delete' );
+			}
+
+			foreach( $t_activity['attachments'] as $t_attachment ) {
+				print_bug_attachment( $t_attachment, $t_security_token_attachments_delete );
+			}
 		}
 	?>
 	</td>

--- a/core/bug_activity_api.php
+++ b/core/bug_activity_api.php
@@ -228,11 +228,10 @@ function bug_activity_combine( $p_entries ) {
 	foreach( $p_entries as $t_activity ) {
 		if( $t_last_entry != null ) {
 			if( $t_last_entry['user_id'] == $t_activity['user_id'] &&
-				$t_last_entry['type'] == ENTRY_TYPE_NOTE &&
 				$t_activity['type'] == ENTRY_TYPE_ATTACHMENT &&
 				abs( $t_activity['timestamp'] - $t_last_entry['timestamp'] ) <=
 					$t_threshold_in_seconds ) {
-			$t_last_entry['attachments'][] = $t_activity['attachment'];
+				$t_last_entry['attachments'][] = $t_activity['attachment'];
 			} else {
 				$t_combined_entries[] = $t_last_entry;
 				$t_last_entry = $t_activity;


### PR DESCRIPTION
If user attaches multiple files as part of submitting the issue,
or via the note dropzone without a note, they were not grouped.
Now they are grouped into a single entry similar to attachments
submitted with a note.

Issue #21727

Here is a screenshot of grouped attachments:

![grouped-attachment](https://cloud.githubusercontent.com/assets/6446/19674842/9f96a850-9a3f-11e6-890a-a066b6ab261c.png)
