### PR TITLE
Disable ‘X-Priority’ header for priority 0

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -581,12 +581,10 @@ $g_show_user_email_threshold = NOBODY;
 $g_show_user_realname_threshold = NOBODY;
 
 /**
- * If use_x_priority is set to ON, what should the value be?
  * Urgent = 1, Not Urgent = 5, Disable = 0
- * Note: some MTAs interpret X-Priority = 0 to mean 'Very Urgent'
  * @global integer $g_mail_priority
  */
-$g_mail_priority = 3;
+$g_mail_priority = 0;
 
 /**
  * select the method to mail by:

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -994,7 +994,11 @@ function email_store( $p_recipient, $p_subject, $p_message, array $p_headers = n
 	$t_email_data->body = $t_message;
 	$t_email_data->metadata = array();
 	$t_email_data->metadata['headers'] = $p_headers === null ? array() : $p_headers;
-	$t_email_data->metadata['priority'] = config_get( 'mail_priority' );
+
+	$t_mail_priority = config_get( 'mail_priority' );
+	if( $t_mail_priority != 0 ) {
+		$t_email_data->metadata['priority'] = $t_mail_priority;
+	}
 
 	# Urgent = 1, Not Urgent = 5, Disable = 0
 	$t_email_data->metadata['charset'] = 'utf-8';
@@ -1143,7 +1147,6 @@ function email_send( EmailData $p_email_data ) {
 
 	$t_mail->IsHTML( false );              # set email format to plain text
 	$t_mail->WordWrap = 80;              # set word wrap to 80 characters
-	$t_mail->Priority = $t_email_data->metadata['priority'];  # Urgent = 1, Not Urgent = 5, Disable = 0
 	$t_mail->CharSet = $t_email_data->metadata['charset'];
 	$t_mail->Host = config_get( 'smtp_host' );
 	$t_mail->From = config_get( 'from_email' );
@@ -1155,6 +1158,10 @@ function email_send( EmailData $p_email_data ) {
 	# Setup new line and encoding to avoid extra new lines with some smtp gateways like sendgrid.net
 	$t_mail->LE         = "\r\n";
 	$t_mail->Encoding   = 'quoted-printable';
+
+	if( isset( $t_email_data->metadata['priority'] ) ) {
+		$t_mail->Priority = $t_email_data->metadata['priority'];  # Urgent = 1, Not Urgent = 5, Disable = 0
+	}
 
 	if( !empty( $t_debug_email ) ) {
 		$t_message = 'To: ' . $t_recipient . "\n\n" . $t_message;

--- a/docbook/Admin_Guide/en-US/config/email.xml
+++ b/docbook/Admin_Guide/en-US/config/email.xml
@@ -266,9 +266,8 @@ $g_notify_flags['new'] = array(
 		<varlistentry>
 			<term>$g_mail_priority</term>
 			<listitem>
-				<para>If use_x_priority is set to ON, what should the value be?
-					Urgent = 1, Not Urgent = 5, Disable = 0 . Default is 3
-					Some MTAs interpret X-Priority = 0 to mean 'Very Urgent'
+				<para>
+					Urgent = 1, Not Urgent = 5, Disable = 0 . Default is 0.
 				</para>
 			</listitem>
 		</varlistentry>


### PR DESCRIPTION
Honor the documentation and don’t emit the X-Priority header when value is 0.

Default the configuration option to 0, since having this header set increases
spam ranking as per mailtrap.io analysis specially for password reset emails.

Fixes #21829

I would like to deprecate this configuration option completely as per the issue details in MantisBT.  However, in the meantime, this change fixes it to behave as per its documentation and changes default to disabled.