### PR TITLE
Deprecate ‘mail_priority’ config option

### DIFF
--- a/admin/email_queue.php
+++ b/admin/email_queue.php
@@ -73,7 +73,6 @@ if( $f_mail_test ) {
 	$t_email_data->email = config_get_global( 'webmaster_email' );
 	$t_email_data->subject = 'Testing PHP mail() function';
 	$t_email_data->body = 'Your PHP mail settings appear to be correctly set.';
-	$t_email_data->metadata['priority'] = config_get( 'mail_priority' );
 	$t_email_data->metadata['charset'] = 'utf-8';
 	$t_result = email_send( $t_email_data );
 

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -595,14 +595,6 @@ $g_show_user_email_threshold = NOBODY;
 $g_show_user_realname_threshold = NOBODY;
 
 /**
- * If use_x_priority is set to ON, what should the value be?
- * Urgent = 1, Not Urgent = 5, Disable = 0
- * Note: some MTAs interpret X-Priority = 0 to mean 'Very Urgent'
- * @global integer $g_mail_priority
- */
-$g_mail_priority = 3;
-
-/**
  * select the method to mail by:
  * PHPMAILER_METHOD_MAIL - mail()
  * PHPMAILER_METHOD_SENDMAIL - sendmail
@@ -4466,7 +4458,6 @@ $g_public_config_names = array(
 	'logout_redirect_page',
 	'long_process_timeout',
 	'lost_password_feature',
-	'mail_priority',
 	'manage_config_cookie',
 	'manage_configuration_threshold',
 	'manage_custom_fields_threshold',

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -994,7 +994,6 @@ function email_store( $p_recipient, $p_subject, $p_message, array $p_headers = n
 	$t_email_data->body = $t_message;
 	$t_email_data->metadata = array();
 	$t_email_data->metadata['headers'] = $p_headers === null ? array() : $p_headers;
-	$t_email_data->metadata['priority'] = config_get( 'mail_priority' );
 
 	# Urgent = 1, Not Urgent = 5, Disable = 0
 	$t_email_data->metadata['charset'] = 'utf-8';
@@ -1143,7 +1142,6 @@ function email_send( EmailData $p_email_data ) {
 
 	$t_mail->IsHTML( false );              # set email format to plain text
 	$t_mail->WordWrap = 80;              # set word wrap to 80 characters
-	$t_mail->Priority = $t_email_data->metadata['priority'];  # Urgent = 1, Not Urgent = 5, Disable = 0
 	$t_mail->CharSet = $t_email_data->metadata['charset'];
 	$t_mail->Host = config_get( 'smtp_host' );
 	$t_mail->From = config_get( 'from_email' );

--- a/core/obsolete.php
+++ b/core/obsolete.php
@@ -195,3 +195,6 @@ config_obsolete( 'font_per_captcha' );
 config_obsolete( 'csv_add_bom' );
 config_obsolete( 'hr_size' );
 config_obsolete( 'hr_width' );
+
+# changes in 1.3.4
+config_obsolete( 'mail_priority' );

--- a/docbook/Admin_Guide/en-US/config/email.xml
+++ b/docbook/Admin_Guide/en-US/config/email.xml
@@ -264,15 +264,6 @@ $g_notify_flags['new'] = array(
 			</listitem>
 		</varlistentry>
 		<varlistentry>
-			<term>$g_mail_priority</term>
-			<listitem>
-				<para>If use_x_priority is set to ON, what should the value be?
-					Urgent = 1, Not Urgent = 5, Disable = 0 . Default is 3
-					Some MTAs interpret X-Priority = 0 to mean 'Very Urgent'
-				</para>
-			</listitem>
-		</varlistentry>
-		<varlistentry>
 			<term>$g_phpMailer_method</term>
 			<listitem>
 				<para>Select the method to send mail:


### PR DESCRIPTION
There are several issues with this configuration option:

1. It is not a common practice for services sending emails to set such priority.
2. As per the documentation for this config option, 0 should disable it, but it doesn't.
3. It increases the spam score for some email, specially password reset.

Fixes #21830