### PR TITLE
Re-authentication flow should re-use login page

### DIFF
--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -753,7 +753,7 @@ function auth_set_tokens( $p_user_id ) {
 }
 
 /**
- * Check for authentication tokens, and display re-authentication page if needed.
+ * Check for authentication tokens, and redirect to login page for re-authentication.
  * Currently, if using BASIC or HTTP authentication methods, or if logged in anonymously,
  * this function will always "authenticate" the user (do nothing).
  *
@@ -781,101 +781,20 @@ function auth_reauthenticate() {
 			return true;
 		}
 
-		return auth_reauthenticate_page( $t_user_id, $t_username );
+		$t_request_uri = string_url( $_SERVER['REQUEST_URI'] );
+
+		$t_query_params = http_build_query(
+			array(
+				'reauthenticate' => 1,
+				'username' => $t_username,
+				'return' => $t_request_uri,
+			),
+			'', '&'
+		);
+
+		# redirect to login page
+		print_header_redirect( 'login_page.php?' . $t_query_params );
 	}
-}
-
-/**
- * Generate the intermediate authentication page.
- * @param integer $p_user_id  User ID.
- * @param string  $p_username Username.
- * @return boolean
- * @access public
- */
-function auth_reauthenticate_page( $p_user_id, $p_username ) {
-	$t_error = false;
-
-	if( true == gpc_get_bool( '_authenticate' ) ) {
-		$f_password = gpc_get_string( 'password', '' );
-
-		if( auth_attempt_login( $p_username, $f_password ) ) {
-			auth_set_tokens( $p_user_id );
-			return true;
-		} else {
-			$t_error = true;
-		}
-	}
-	
-	layout_page_header();
-
-	layout_page_begin();
-
-	?>
-<div class="col-md-12 col-xs-12">
-	<div class="space-10"></div>
-<?php
-	if( $t_error != false ) {
-		echo '<div class="alert alert-danger">';
-		echo '<p>' . lang_get( 'reauthenticate_message' ) . ' ' . lang_get( 'login_error' ) . '</p>';
-		echo '</div>';
-	}
-?>
-
-<div class="form-container">
-<form id="reauth-form" method="post" action="">
-<div class="widget-box widget-color-blue2">
-<div class="widget-header widget-header-small">
-	<h4 class="widget-title lighter">
-		<i class="ace-icon fa fa-lock"></i>
-		<?php echo lang_get( 'reauthenticate_title' ) ?>
-	</h4>
-</div>
-
-<div class="widget-body">
-	<div class="widget-main no-padding">
-		<fieldset>
-		<?php
-			# CSRF protection not required here - user needs to enter password
-			# (confirmation step) before the form is accepted.
-			print_hidden_inputs( $_POST );
-			print_hidden_inputs( $_GET );
-		?>
-
-			<input type="hidden" name="_authenticate" value="1" />
-			<div class="table-responsive">
-			<table class="table table-bordered table-condensed table-striped">
-				<tr>
-					<th class="category">
-						<?php echo lang_get( 'username' );?>
-					</th>
-					<td>
-						<input id="username" type="text" disabled="disabled" class="input-sm" size="32" maxlength="<?php echo DB_FIELD_SIZE_USERNAME;?>" value="<?php echo string_attribute( $p_username );?>" />
-					</td>
-				</tr>
-				<tr>
-					<th class="category">
-						<?php echo lang_get( 'password' );?>
-					</th>
-					<td>
-						<input id="password" type="password" name="password" class="input-sm" size="32" maxlength="<?php echo auth_get_password_max_size(); ?>" class="autofocus" />
-					</td>
-				</tr>
-			</table>
-			</div>
-		</fieldset>
-	</div>
-	<div class="widget-toolbox padding-8 clearfix">
-		<input type="submit" class="btn btn-primary btn-white btn-round" value="<?php echo lang_get( 'login_button' );?>" />
-	</div>
-</div>
-</div>
-</form>
-</div>
-</div>
-
-<?php
-	layout_page_end();
-	exit;
 }
 
 /**

--- a/login.php
+++ b/login.php
@@ -49,6 +49,7 @@ $f_perm_login	= $t_allow_perm_login && gpc_get_bool( 'perm_login' );
 $t_return		= string_url( string_sanitize_url( gpc_get_string( 'return', config_get( 'default_home_page' ) ) ) );
 $f_from			= gpc_get_string( 'from', '' );
 $f_secure_session = gpc_get_bool( 'secure_session', false );
+$f_reauthenticate = gpc_get_bool( 'reauthenticate', false );
 $f_install = gpc_get_bool( 'install' );
 
 # If upgrade required, always redirect to install page.
@@ -69,14 +70,28 @@ if( auth_attempt_login( $f_username, $f_password, $f_perm_login ) ) {
 	}
 
 	$t_redirect_url = 'login_cookie_test.php?return=' . $t_return;
-
 } else {
-	$t_redirect_url = 'login_page.php?return=' . $t_return .
-		'&error=1&username=' . urlencode( $f_username ) .
-		'&secure_session=' . ( $f_secure_session ? 1 : 0 );
-	if( $t_allow_perm_login ) {
-		$t_redirect_url .= '&perm_login=' . ( $f_perm_login ? 1 : 0 );
+	$t_query_args = array(
+		'error' => 1,
+		'username' => $f_username,
+		'return' => $t_return,
+	);
+
+	if( $f_reauthenticate ) {
+		$t_query_args['reauthenticate'] = 1;
 	}
+
+	if( $f_secure_session ) {
+		$t_query_args['secure_session'] = 1;
+	}
+
+	if( $t_allow_perm_login && $f_perm_login ) {
+		$t_query_args['perm_login'] = 1;
+	}
+
+	$t_query_text = http_build_query( $t_query_args, '', '&' );
+
+	$t_redirect_url = 'login_page.php?' . $t_query_text;
 
 	if( HTTP_AUTH == config_get( 'login_method' ) ) {
 		auth_http_prompt();

--- a/login_page.php
+++ b/login_page.php
@@ -335,20 +335,24 @@ if( $t_show_warnings && count( $t_warnings ) > 0 ) {
 ?>
 </div>
 
-<div class="toolbar center">
-
 <?php
-if( $t_show_anonymous_login ) {
-	echo '<a class="back-to-login-link pull-right" href="login_anon.php?return=' . string_url( $f_return ) . '">' . lang_get( 'login_anonymously' ) . '</a>';
-}
+if( $t_show_anonymous_login || $t_show_signup ) {
+	echo '<div class="toolbar center">';
 
-if( $t_show_signup ) {
-	echo '<a class="back-to-login-link pull-left" href="signup_page.php">', lang_get( 'signup_link' ), '</a>';
+	if( $t_show_anonymous_login ) {
+		echo '<a class="back-to-login-link pull-right" href="login_anon.php?return=' . string_url( $f_return ) . '">' . lang_get( 'login_anonymously' ) . '</a>';
+	}
+
+	if( $t_show_signup ) {
+		echo '<a class="back-to-login-link pull-left" href="signup_page.php">', lang_get( 'signup_link' ), '</a>';
+	}
+
+	echo '<div class="clearfix"></div>';
+	echo '</div>';
 }
 ?>
-<div class="clearfix"></div>
-</div>
-</div>
+
+		</div>
 </div>
 </div>
 </div>

--- a/login_page.php
+++ b/login_page.php
@@ -57,6 +57,7 @@ $f_error                 = gpc_get_bool( 'error' );
 $f_cookie_error          = gpc_get_bool( 'cookie_error' );
 $f_return                = string_sanitize_url( gpc_get_string( 'return', '' ) );
 $f_username              = gpc_get_string( 'username', '' );
+$f_reauthenticate        = gpc_get_bool( 'reauthenticate', false );
 $f_perm_login            = gpc_get_bool( 'perm_login', false );
 $f_secure_session        = gpc_get_bool( 'secure_session', false );
 $f_secure_session_cookie = gpc_get_cookie( config_get_global( 'cookie_prefix' ) . '_secure_session', null );
@@ -75,7 +76,7 @@ if( config_get_global( 'email_login_enabled' ) ) {
 $t_session_validation = ( ON == config_get_global( 'session_validation' ) );
 
 # If user is already authenticated and not anonymous
-if( auth_is_user_authenticated() && !current_user_is_anonymous() ) {
+if( auth_is_user_authenticated() && !current_user_is_anonymous() && !$f_reauthenticate) {
 	# If return URL is specified redirect to it; otherwise use default page
 	if( !is_blank( $f_return ) ) {
 		print_header_redirect( $f_return, false, false, true );

--- a/login_page.php
+++ b/login_page.php
@@ -300,6 +300,10 @@ if( config_get_global( 'admin_checks' ) == ON && file_exists( dirname( __FILE__ 
 				</div>
 			<?php } ?>
 
+			<?php if( $f_reauthenticate ) {
+				echo '<input id="reauthenticate" type="hidden" name="reauthenticate" value="1" />';
+			} ?>
+
 			<div class="space-10"></div>
 
 			<input type="submit" class="width-40 pull-right btn btn-success btn-inverse bigger-110" value="<?php echo lang_get( 'login_button' ) ?>" />


### PR DESCRIPTION
This changes removes a redundant re-authentication page in favor of the standard login page.
This removes redundant code and makes it easier for plugins or custom authentication
schemes to plugin into one place for providing extra functionality.

Fixes #21854

Remove black bar when sign up and sign-in anonymously are disabled.

Fixes #21861

## Login form
![login_form](https://cloud.githubusercontent.com/assets/6446/20126033/cfaff6d8-a5e6-11e6-9647-90603f4b4a1d.png)

## Login form - wrong password
![login_failure](https://cloud.githubusercontent.com/assets/6446/20126039/dcebba1c-a5e6-11e6-9a3c-4804590e7770.png)

## Reauthenticate form
![reauthenticate](https://cloud.githubusercontent.com/assets/6446/20126043/e6ff6756-a5e6-11e6-8249-27cc70de20ed.png)

## Reauthenticate form - wrong password
![reauthenticate_error](https://cloud.githubusercontent.com/assets/6446/20126047/f09c8532-a5e6-11e6-83ab-7e845308dc00.png)
