### PR TITLE
Use selective bug cache for attachment count

### DIFF
--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -1085,7 +1085,7 @@ function mc_issue_update( $p_username, $p_password, $p_issue_id, stdClass $p_iss
 
 		# The issue has been cached earlier in the bug_get() call.  Flush the cache since it is
 		# now stale.  Otherwise, the email notification will be based on the cached data.
-		bugnote_clear_cache( $p_issue_id );
+		bugnote_clear_bug_cache( $p_issue_id );
 	}
 
 	if( isset( $p_issue['tags'] ) && is_array( $p_issue['tags'] ) ) {

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -2198,3 +2198,51 @@ function bug_clear_cache_all( $p_bug_id = null ) {
 	bugnote_clear_bug_cache( $p_bug_id );
 	return true;
 }
+
+/**
+ * Populate the caches related to the selected columns
+ * @param array $p_bugs	Array of BugData objects
+ * @param array $p_selected_columns	Array of columns to show
+ */
+function bug_cache_columns_data( array $p_bugs, array $p_selected_columns ) {
+	$t_bug_ids = array();
+	$t_user_ids = array();
+	$t_project_ids = array();
+	$t_category_ids = array();
+	foreach( $p_bugs as $t_bug ) {
+		$t_bug_ids[] = (int)$t_bug->id;
+		$t_user_ids[] = (int)$t_bug->handler_id;
+		$t_user_ids[] = (int)$t_bug->reporter_id;
+		$t_project_ids[] = (int)$t_bug->project_id;
+		$t_category_ids[] = (int)$t_bug->category_id;
+	}
+	$t_user_ids = array_unique( $t_user_ids );
+	$t_project_ids = array_unique( $t_project_ids );
+	$t_category_ids = array_unique( $t_category_ids );
+
+	foreach( $p_selected_columns as $t_column ) {
+
+		if( column_is_plugin_column( $t_column ) ) {
+			$plugin_objects = columns_get_plugin_columns();
+			$plugin_objects[$t_column]->cache( $p_bugs );
+			continue;
+		}
+
+		switch( $t_column ) {
+			case 'attachment_count':
+				file_bug_attachment_count_cache( $t_bug_ids );
+				break;
+			case 'handler_id':
+			case 'reporter_id':
+			case 'status':
+				user_cache_array_rows( $t_user_ids );
+				break;
+			case 'project_id':
+				project_cache_array_rows( $t_project_ids );
+				break;
+			case 'category_id':
+				category_cache_array_rows( $t_category_ids );
+				break;
+		}
+	}
+}

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1402,8 +1402,7 @@ function bug_delete( $p_bug_id ) {
 	$t_query = 'DELETE FROM {bug} WHERE id=' . db_param();
 	db_query( $t_query, array( $c_bug_id ) );
 
-	bug_clear_cache( $p_bug_id );
-	bug_text_clear_cache( $p_bug_id );
+	bug_clear_cache_all( $p_bug_id );
 }
 
 /**
@@ -2184,4 +2183,18 @@ function bug_get_status_for_assign( $p_current_handler, $p_new_handler, $p_curre
 		}
 	}
 	return $p_new_status;
+}
+
+/**
+ * Clear a bug from all the related caches or all bugs if no bug id specified.
+ * @param integer $p_bug_id A bug identifier to clear (optional).
+ * @return boolean
+ * @access public
+ */
+function bug_clear_cache_all( $p_bug_id = null ) {
+	bug_clear_cache( $p_bug_id );
+	bug_text_clear_cache( $p_bug_id );
+	file_bug_attachment_count_clear_cache( $p_bug_id );
+	bugnote_clear_bug_cache( $p_bug_id );
+	return true;
 }

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -753,10 +753,38 @@ function bugnote_clear_cache( $p_bugnote_id = null ) {
 
 	if( null === $p_bugnote_id ) {
 		$g_cache_bugnote = array();
+		$g_cache_bugnotes = array();
 	} else {
-		unset( $g_cache_bugnote[(int)$p_bugnote_id] );
+		if( isset( $g_cache_bugnote[(int)$p_bugnote_id] ) ) {
+			$t_note_obj = $g_cache_bugnote[(int)$p_bugnote_id];
+			bugnote_clear_bug_cache( $t_note_obj->bug_id );
+			unset( $g_cache_bugnote[(int)$p_bugnote_id] );
+		}
 	}
-	$g_cache_bugnotes = array();
+
+	return true;
+}
+
+/**
+ * Clear the bugnotes related to a bug, or all bugs if no bug id specified.
+ * @param integer $p_bug_id Identifier to clear (optional).
+ * @return boolean
+ * @access public
+ */
+function bugnote_clear_bug_cache( $p_bug_id = null ) {
+	global $g_cache_bugnotes, $g_cache_bugnote;
+
+	if( null === $p_bug_id ) {
+		$g_cache_bugnotes = array();
+		$g_cache_bugnote = array();
+	} else {
+		if( isset( $g_cache_bugnotes[(int)$p_bug_id] ) ) {
+			foreach( $g_cache_bugnotes[(int)$p_bug_id] as $t_note_obj ) {
+				unset( $g_cache_bugnote[(int)$t_note_obj->id] );
+			}
+			unset( $g_cache_bugnotes[(int)$p_bug_id] );
+		}
+	}
 
 	return true;
 }

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -757,8 +757,8 @@ function bugnote_clear_cache( $p_bugnote_id = null ) {
 	} else {
 		if( isset( $g_cache_bugnote[(int)$p_bugnote_id] ) ) {
 			$t_note_obj = $g_cache_bugnote[(int)$p_bugnote_id];
+			# current note id will be unset in the following call
 			bugnote_clear_bug_cache( $t_note_obj->bug_id );
-			unset( $g_cache_bugnote[(int)$p_bugnote_id] );
 		}
 	}
 

--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -205,26 +205,6 @@ function column_is_plugin_column( $p_column ) {
 }
 
 /**
- * Allow plugin columns to pre-cache data for a set of issues
- * rather than requiring repeated queries for each issue.
- * If the user columns parameter is provided, only plugin columns that are
- * contained in that column set will be cached.
- * @param array $p_bugs Array of BugData objects.
- * @param array $p_selected_columns Array of columns the user is visualizing
- * @return void
- */
-function columns_plugin_cache_issue_data( array $p_bugs, array $p_selected_columns = null ) {
-	$t_columns = columns_get_plugin_columns();
-	$t_all = ( null === $p_selected_columns );
-
-	foreach( $t_columns as $t_name => $t_column_object ) {
-		if( $t_all || in_array( $t_name, $p_selected_columns  ) ) {
-			$t_column_object->cache( $p_bugs );
-		}
-	}
-}
-
-/**
  * Get all accessible columns for the current project / current user.
  * @param integer $p_project_id A project identifier.
  * @return array array of columns

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -160,6 +160,24 @@ function file_bug_attachment_count( $p_bug_id ) {
 }
 
 /**
+ * Clear a bug from the cache or all bugs if no bug id specified.
+ * @param integer $p_bug_id A bug identifier to clear (optional).
+ * @return boolean
+ * @access public
+ */
+function file_bug_attachment_count_clear_cache( $p_bug_id = null ) {
+	global $g_cache_file_count;
+
+	if( null === $p_bug_id ) {
+		$g_cache_file_count = array();
+	} else {
+		unset( $g_cache_file_count[(int)$p_bug_id] );
+	}
+
+	return true;
+}
+
+/**
  * Check if a specific bug has attachments
  * @param integer $p_bug_id A bug identifier.
  * @return boolean

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -98,6 +98,52 @@ function file_get_display_name( $p_filename ) {
 }
 
 /**
+ * Fills the cache with the attachement count from a list of bugs
+ * If the bug doesn't have attachments, cache its value as 0.
+ * @global array $g_cache_file_count
+ * @param array $p_bug_ids Array of bug ids
+ * @return void
+ */
+function file_bug_attachment_count_cache( array $p_bug_ids ) {
+	global $g_cache_file_count;
+
+	if( empty( $p_bug_ids ) ) {
+		return;
+	}
+
+	$t_ids_to_search = array();
+	foreach( $p_bug_ids as $t_id ) {
+		$c_id = (int)$t_id;
+		$t_ids_to_search[$c_id] = $c_id;
+	}
+
+	db_param_push();
+	$t_params = array();
+	$t_in_values = array();
+	foreach( $t_ids_to_search as $t_id ) {
+		$t_params[] = (int)$t_id;
+		$t_in_values[] = db_param();
+	}
+
+	$t_query = 'SELECT B.id AS bug_id, COUNT(F.bug_id) AS attachments'
+			. ' FROM {bug} B JOIN {bug_file} F ON ( B.id = F.bug_id )'
+			. ' WHERE B.id IN (' . implode( ',', $t_in_values ) . ')'
+			. ' GROUP BY B.id';
+
+	$t_result = db_query( $t_query, $t_params );
+	while( $t_row = db_fetch_array( $t_result ) ) {
+		$c_bug_id = (int)$t_row['bug_id'];
+		$g_cache_file_count[$c_bug_id] = (int)$t_row['attachments'];
+		unset( $t_ids_to_search[$c_bug_id] );
+	}
+
+	# set bugs without result to 0
+	foreach( $t_ids_to_search as $t_id ) {
+		$g_cache_file_count[$t_id] = 0;
+	}
+}
+
+/**
  * Check the number of attachments a bug has (if any)
  * @param integer $p_bug_id A bug identifier.
  * @return integer
@@ -105,38 +151,12 @@ function file_get_display_name( $p_filename ) {
 function file_bug_attachment_count( $p_bug_id ) {
 	global $g_cache_file_count;
 
-	# First check if we have a cache hit
-	if( isset( $g_cache_file_count[$p_bug_id] ) ) {
-		return $g_cache_file_count[$p_bug_id];
+	# If it's not in cache, load the value
+	if( !isset( $g_cache_file_count[$p_bug_id] ) ) {
+		file_bug_attachment_count_cache( array( (int)$p_bug_id ) );
 	}
 
-	# If there is no cache hit, check if there is anything in
-	#   the cache. If the cache isn't empty and we didn't have
-	#   a hit, then there are not attachments for this bug.
-	if( count( $g_cache_file_count ) > 0 ) {
-		return 0;
-	}
-
-	# Otherwise build the cache and return the attachment count
-	#   for the given bug (if any).
-	$t_query = 'SELECT bug_id, COUNT(bug_id) AS attachments FROM {bug_file} GROUP BY bug_id';
-	$t_result = db_query( $t_query );
-
-	$t_file_count = 0;
-	while( $t_row = db_fetch_array( $t_result ) ) {
-		$g_cache_file_count[$t_row['bug_id']] = $t_row['attachments'];
-		if( $p_bug_id == $t_row['bug_id'] ) {
-			$t_file_count = $t_row['attachments'];
-		}
-	}
-
-	# If no attachments are present, mark the cache to avoid
-	#   repeated queries for this.
-	if( count( $g_cache_file_count ) == 0 ) {
-		$g_cache_file_count['_no_files_'] = -1;
-	}
-
-	return $t_file_count;
+	return $g_cache_file_count[$p_bug_id];
 }
 
 /**

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2233,17 +2233,13 @@ function filter_get_bug_rows_query_clauses( array $p_filter, $p_project_id = nul
 function filter_cache_result( array $p_rows, array $p_id_array_lastmod ) {
 	$t_stats = bug_get_bugnote_stats_array( $p_id_array_lastmod );
 	$t_rows = array();
-	$t_bug_ids = array();
 	foreach( $p_rows as $t_row ) {
-		$t_bug_ids[] = (int)$t_row['id'];
 		if( array_key_exists( $t_row['id'], $t_stats ) ) {
 			$t_rows[] = bug_row_to_object( bug_cache_database_result( $t_row, $t_stats[$t_row['id']] ) );
 		} else {
 			$t_rows[] = bug_row_to_object( bug_cache_database_result( $t_row ) );
 		}
 	}
-	#cache the attachment count for bug list
-	file_bug_attachment_count_cache( $t_bug_ids );
 	return $t_rows;
 }
 

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2225,6 +2225,7 @@ function filter_get_bug_rows_query_clauses( array $p_filter, $p_project_id = nul
 
 /**
  *  Cache the filter results with bugnote stats for later use
+ *  also fills bug attachment count cache
  * @param array $p_rows             Results of the filter query.
  * @param array $p_id_array_lastmod Array of bug ids.
  * @return array
@@ -2232,14 +2233,17 @@ function filter_get_bug_rows_query_clauses( array $p_filter, $p_project_id = nul
 function filter_cache_result( array $p_rows, array $p_id_array_lastmod ) {
 	$t_stats = bug_get_bugnote_stats_array( $p_id_array_lastmod );
 	$t_rows = array();
+	$t_bug_ids = array();
 	foreach( $p_rows as $t_row ) {
-		$b = $t_stats[$t_row['id']];
+		$t_bug_ids[] = (int)$t_row['id'];
 		if( array_key_exists( $t_row['id'], $t_stats ) ) {
 			$t_rows[] = bug_row_to_object( bug_cache_database_result( $t_row, $t_stats[$t_row['id']] ) );
 		} else {
 			$t_rows[] = bug_row_to_object( bug_cache_database_result( $t_row ) );
 		}
 	}
+	#cache the attachment count for bug list
+	file_bug_attachment_count_cache( $t_bug_ids );
 	return $t_rows;
 }
 

--- a/csv_export.php
+++ b/csv_export.php
@@ -105,8 +105,7 @@ echo $t_header;
 $t_end_of_results = false;
 do {
 	# Clear cache for next block
-	bug_clear_cache();
-	bug_text_clear_cache();
+	bug_clear_cache_all();
 
 	# Keep reading until reaching max block size or end of result set
 	$t_read_rows = array();

--- a/csv_export.php
+++ b/csv_export.php
@@ -119,11 +119,6 @@ do {
 			break;
 		}
 		$t_bug_id_array[] = (int)$t_row['id'];
-		$t_handler_id = (int)$t_row['handler_id'];
-		$t_unique_user_ids[$t_handler_id] = $t_handler_id;
-		$t_reporter_id = (int)$t_row['reporter_id'];
-		$t_unique_user_ids[$t_reporter_id] = $t_reporter_id;
-
 		$t_read_rows[] = $t_row;
 		$t_count++;
 	}
@@ -132,8 +127,7 @@ do {
 
 	# convert and cache data
 	$t_rows = filter_cache_result( $t_read_rows, $t_bug_id_array );
-	user_cache_array_rows( $t_unique_user_ids );
-	columns_plugin_cache_issue_data( $t_rows, $t_columns );
+	bug_cache_columns_data( $t_rows, $t_columns );
 
 	# Clear arrays that are not needed
 	unset( $t_read_rows );

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -93,8 +93,7 @@ $t_result = filter_get_bug_rows_result( $t_query_clauses );
 $t_end_of_results = false;
 do {
 	# Clear cache for next block
-	bug_clear_cache();
-	bug_text_clear_cache();
+	bug_clear_cache_all();
 
 	# Keep reading until reaching max block size or end of result set
 	$t_read_rows = array();

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -109,11 +109,6 @@ do {
 		# @TODO, the "export" bug list parameter functionality should be implemented in a more efficient way
 		if( is_blank( $f_export ) || in_array( $t_row['id'], $f_bug_arr ) ) {
 			$t_bug_id_array[] = (int)$t_row['id'];
-			$t_handler_id = (int)$t_row['handler_id'];
-			$t_unique_user_ids[$t_handler_id] = $t_handler_id;
-			$t_reporter_id = (int)$t_row['reporter_id'];
-			$t_unique_user_ids[$t_reporter_id] = $t_reporter_id;
-
 			$t_read_rows[] = $t_row;
 			$t_count++;
 		}
@@ -129,8 +124,7 @@ do {
 
 	# convert and cache data
 	$t_rows = filter_cache_result( $t_read_rows, $t_bug_id_array );
-	user_cache_array_rows( $t_unique_user_ids );
-	columns_plugin_cache_issue_data( $t_rows, $t_columns );
+	bug_cache_columns_data( $t_rows, $t_columns );
 
 	# Clear arrays that are not needed
 	unset( $t_read_rows );

--- a/print_all_bug_page.php
+++ b/print_all_bug_page.php
@@ -99,8 +99,8 @@ $t_page_count = null;
 $t_result = filter_get_bug_rows( $f_page_number, $t_per_page, $t_page_count, $t_bug_count );
 $t_row_count = count( $t_result );
 
-# pre-cache custom column data
-columns_plugin_cache_issue_data( $t_result, $t_columns );
+# pre-cache column data
+bug_cache_columns_data( $t_result, $t_columns );
 
 # for export
 $t_show_flag = gpc_get_int( 'show_flag', 0 );

--- a/print_all_bug_page_word.php
+++ b/print_all_bug_page_word.php
@@ -167,8 +167,7 @@ for( $j=0; $j < $t_row_count; $j++ ) {
 
 	if( $j % 50 == 0 ) {
 		# to save ram as report will list data once, clear cache after 50 bugs
-		bug_text_clear_cache();
-		bug_clear_cache();
+		bug_clear_cache_all();
 		bugnote_clear_cache();
 	}
 

--- a/view_all_bug_page.php
+++ b/view_all_bug_page.php
@@ -79,16 +79,7 @@ $t_unique_project_ids = array();
 $t_row_count = count( $t_rows );
 for( $i=0; $i < $t_row_count; $i++ ) {
 	array_push( $t_bugslist, $t_rows[$i]->id );
-	$t_handler_id = $t_rows[$i]->handler_id;
-	$t_unique_user_ids[$t_handler_id] = $t_handler_id;
-	$t_reporter_id = $t_rows[$i]->reporter_id;
-	$t_unique_user_ids[$t_reporter_id] = $t_reporter_id;
-	$t_project_id = $t_rows[$i]->project_id;
-	$t_unique_project_ids[$t_project_id] = $t_project_id;
 }
-user_cache_array_rows( $t_unique_user_ids );
-project_cache_array_rows( $t_unique_project_ids );
-
 gpc_set_cookie( config_get( 'bug_list_cookie' ), implode( ',', $t_bugslist ) );
 
 compress_enable();

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -66,14 +66,11 @@ $t_icon_path = config_get( 'icon_path' );
 # Improve performance by caching category data in one pass
 if( helper_get_current_project() > 0 ) {
 	category_get_all_rows( helper_get_current_project() );
-} else {
-	$t_categories = array();
-	foreach ( $t_rows as $t_row ) {
-		$t_categories[] = $t_row->category_id;
-	}
-	category_cache_array_rows( array_unique( $t_categories ) );
 }
+
 $g_columns = helper_get_columns_to_view( COLUMNS_TARGET_VIEW_PAGE );
+
+bug_cache_columns_data( $t_rows, $g_columns );
 
 $t_col_count = count( $g_columns );
 
@@ -173,9 +170,6 @@ function write_bug_rows( array $p_rows ) {
 	global $g_columns, $g_filter;
 
 	$t_in_stickies = ( $g_filter && ( 'on' == $g_filter[FILTER_PROPERTY_STICKY] ) );
-
-	# pre-cache custom column data
-	columns_plugin_cache_issue_data( $p_rows, $g_columns );
 
 	# -- Loop over bug rows --
 


### PR DESCRIPTION
Resubmit the changes from PR #654 as the main issue with long IN clauses was solved after refactoring export pages

This is a dramatic improvement in page load when there is a lot of attachments in the db.
See comment: https://github.com/mantisbt/mantisbt/pull/654#issuecomment-153838142

Additionally:
Added some changes to include this file count cache in the clearing procedures at export pages to save on memory.
Fixed some procedures for clearing caches that were wrong.