### PR TITLE
Improve db_fetch_array performance

### DIFF
--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -624,3 +624,11 @@ define( 'EXPORT_BLOCK_SIZE', 500 );
 # the closest integer (4 bytes) type available. As some DBs dont support unsigned
 # types, 2^31 is a safe limit to be used for all.
 define( 'DB_MAX_INT', 2147483647 );
+
+# Databse functional type identifiers.
+define( 'DB_TYPE_UNDEFINED', 0 );
+define( 'DB_TYPE_MYSQL', 1 );
+define( 'DB_TYPE_PGSQL', 2 );
+define( 'DB_TYPE_MSSQL', 3 );
+define( 'DB_TYPE_ORACLE', 4 );
+define( 'DB_TYPE_DB2', 5 );

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -59,6 +59,9 @@ global $ADODB_FETCH_MODE;
 $ADODB_FETCH_MODE = ADODB_FETCH_ASSOC;
 define( 'ADODB_ASSOC_CASE', ADODB_ASSOC_CASE_LOWER );
 
+# Stores the functional database type based on db driver
+$g_db_functional_type;
+
 /**
  * Mantis Database Parameters Count class
  * Stores the current parameter count, provides method to generate parameters
@@ -127,8 +130,9 @@ $g_db_param = new MantisDbParam();
  * @return boolean indicating if the connection was successful
  */
 function db_connect( $p_dsn, $p_hostname = null, $p_username = null, $p_password = null, $p_database_name = null, $p_db_schema = null, $p_pconnect = false ) {
-	global $g_db_connected, $g_db;
+	global $g_db_connected, $g_db, $g_db_functional_type;
 	$t_db_type = config_get_global( 'db_type' );
+	$g_db_functional_type = db_get_type( $t_db_type );
 
 	if( !db_check_database_support( $t_db_type ) ) {
 		error_parameters( 0, 'PHP Support for database is not enabled' );
@@ -222,19 +226,39 @@ function db_check_database_support( $p_db_type ) {
 }
 
 /**
+ * Maps a db driver type to the functional databse type
+ * @param string	$p_driver_type Database driver name
+ * @return int		Database type
+ */
+function db_get_type( $p_driver_type ) {
+	switch( $p_driver_type ) {
+		case 'mysql':
+		case 'mysqli':
+			return DB_TYPE_MYSQL;
+		case 'postgres':
+		case 'postgres7':
+		case 'pgsql':
+			return DB_TYPE_PGSQL;
+		case 'mssql':
+		case 'mssqlnative':
+		case 'odbc_mssql':
+			return DB_TYPE_MSSQL;
+		case 'db2':
+			return DB_TYPE_DB2;
+		case 'oci8':
+			return DB_TYPE_ORACLE;
+		default:
+			return DB_TYPE_UNDEFINED;
+	}
+}
+
+/**
  * Checks if the database driver is MySQL
  * @return boolean true if mysql
  */
 function db_is_mysql() {
-	$t_db_type = config_get_global( 'db_type' );
-
-	switch( $t_db_type ) {
-		case 'mysql':
-		case 'mysqli':
-			return true;
-	}
-
-	return false;
+	global $g_db_functional_type;
+	return( DB_TYPE_MYSQL == $g_db_functional_type );
 }
 
 /**
@@ -242,16 +266,8 @@ function db_is_mysql() {
  * @return boolean true if postgres
  */
 function db_is_pgsql() {
-	$t_db_type = config_get_global( 'db_type' );
-
-	switch( $t_db_type ) {
-		case 'postgres':
-		case 'postgres7':
-		case 'pgsql':
-			return true;
-	}
-
-	return false;
+	global $g_db_functional_type;
+	return( DB_TYPE_PGSQL == $g_db_functional_type );
 }
 
 /**
@@ -259,16 +275,8 @@ function db_is_pgsql() {
  * @return boolean true if mssql
  */
 function db_is_mssql() {
-	$t_db_type = config_get_global( 'db_type' );
-
-	switch( $t_db_type ) {
-		case 'mssql':
-		case 'mssqlnative':
-		case 'odbc_mssql':
-			return true;
-	}
-
-	return false;
+	global $g_db_functional_type;
+	return( DB_TYPE_MSSQL == $g_db_functional_type );
 }
 
 /**
@@ -276,14 +284,8 @@ function db_is_mssql() {
  * @return boolean true if db2
  */
 function db_is_db2() {
-	$t_db_type = config_get_global( 'db_type' );
-
-	switch( $t_db_type ) {
-		case 'db2':
-			return true;
-	}
-
-	return false;
+	global $g_db_functional_type;
+	return( DB_TYPE_DB2 == $g_db_functional_type );
 }
 
 /**
@@ -291,9 +293,8 @@ function db_is_db2() {
  * @return boolean true if oracle
  */
 function db_is_oracle() {
-	$t_db_type = config_get_global( 'db_type' );
-
-	return ( $t_db_type == 'oci8' );
+	global $g_db_functional_type;
+	return( DB_TYPE_ORACLE == $g_db_functional_type );
 }
 
 /**

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -60,7 +60,7 @@ $ADODB_FETCH_MODE = ADODB_FETCH_ASSOC;
 define( 'ADODB_ASSOC_CASE', ADODB_ASSOC_CASE_LOWER );
 
 # Stores the functional database type based on db driver
-$g_db_functional_type;
+$g_db_functional_type = db_get_type( config_get_global( 'db_type' ) );
 
 /**
  * Mantis Database Parameters Count class

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -528,11 +528,21 @@ function db_fetch_array( IteratorAggregate &$p_result ) {
 		return false;
 	}
 
+	# cache these checks to avoid repeated api calls
+	static $t_db_is_pgsql = null;
+	static $t_db_is_oracle = null;
+	if( null === $t_db_is_pgsql ) {
+		$t_db_is_pgsql = db_is_pgsql();
+	}
+	if( null === $t_db_is_oracle ) {
+		$t_db_is_oracle = db_is_oracle();
+	}
+
 	# Retrieve the fields from the recordset
 	$t_row = $p_result->fields;
 
 	# Additional handling for specific RDBMS
-	if( db_is_pgsql() ) {
+	if( $t_db_is_pgsql ) {
 		# pgsql's boolean fields are stored as 't' or 'f' and must be converted
 		static $s_current_result = null, $s_convert_needed;
 
@@ -562,7 +572,7 @@ function db_fetch_array( IteratorAggregate &$p_result ) {
 			}
 		}
 
-	} elseif( db_is_oracle() ) {
+	} elseif( $t_db_is_oracle ) {
 		# oci8 returns null values for empty strings, convert them back
 		foreach( $t_row as &$t_value ) {
 			if( !isset( $t_value ) ) {


### PR DESCRIPTION
Improve db_fetch_array performance by caching the result from:
db_is_pgsql()
db_is_oracle()

Based on profiling, the repeated calls were using up to 20% of total time
for the db_fetch_array execution.

Fixes: #21871