### PR TITLE
Re-implement issue note notifications

### DIFF
--- a/account_prefs_inc.php
+++ b/account_prefs_inc.php
@@ -82,6 +82,7 @@ function edit_account_prefs( $p_user_id = null, $p_error_if_protected = true, $p
 	}
 
 	$t_pref = user_pref_get( $p_user_id );
+	$t_email_full_issue = (int)config_get( 'email_notifications_verbose', /* default */ null, $p_user_id, ALL_PROJECTS );
 
 # Account Preferences Form BEGIN
 ?>
@@ -261,6 +262,13 @@ function edit_account_prefs( $p_user_id = null, $p_error_if_protected = true, $p
 				</span>
 				<span class="label-style"></span>
 			</div>
+			<fieldset class="field-container">
+				<legend><label for="email-full-issue"><?php echo lang_get( 'email_full_issue_details' ) ?></label></legend>
+				<span class="checkbox">
+					<input id="email-full-issue" type="checkbox" name="email_full_issue" <?php check_checked( $t_email_full_issue, ON ); ?> />
+				</span>
+				<span class="label-style"></span>
+			</fieldset>
 <?php } else { ?>
 			<input type="hidden" name="email_on_new"      value="<?php echo $t_pref->email_on_new ?>" />
 			<input type="hidden" name="email_on_assigned" value="<?php echo $t_pref->email_on_assigned ?>" />
@@ -281,6 +289,7 @@ function edit_account_prefs( $p_user_id = null, $p_error_if_protected = true, $p
 			<input type="hidden" name="email_on_status_min_severity"   value="<?php echo $t_pref->email_on_status_min_severity ?>" />
 			<input type="hidden" name="email_on_priority_min_severity" value="<?php echo $t_pref->email_on_priority_min_severity ?>" />
 			<input type="hidden" name="email_bugnote_limit" value="<?php echo $t_pref->email_bugnote_limit ?>" />
+			<input type="hidden" name="email_full_issue" value="<?php echo $t_email_full_issue ?>" />
 <?php } ?>
 			<div class="field-container">
 				<label for="timezone"><span><?php echo lang_get( 'timezone' ) ?></span></label>

--- a/account_prefs_update.php
+++ b/account_prefs_update.php
@@ -106,6 +106,13 @@ $t_prefs->email_on_priority_min_severity	= gpc_get_int( 'email_on_priority_min_s
 $t_prefs->bugnote_order = gpc_get_string( 'bugnote_order' );
 $t_prefs->email_bugnote_limit = gpc_get_int( 'email_bugnote_limit' );
 
+# Save user preference with regards to getting full issue details in notifications or not.
+$t_email_full_issue = gpc_get_bool( 'email_full_issue' ) ? 1 : 0;
+$t_email_full_config_option = 'email_notifications_verbose';
+if( config_get( $t_email_full_config_option, /* default */ null, $f_user_id, ALL_PROJECTS ) != $t_email_full_issue ) {
+	config_set( $t_email_full_config_option, $t_email_full_issue, $f_user_id, ALL_PROJECTS );
+}
+
 # make sure the delay isn't too low
 if( ( config_get( 'min_refresh_delay' ) > $t_prefs->refresh_delay )&&
 	( $t_prefs->refresh_delay != 0 )) {

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -442,7 +442,7 @@ $g_enable_email_notification	= ON;
  *
  * @global integer $g_email_notifications_verbose
  */
-$g_email_notifications_verbose = OFF;
+$g_email_notifications_verbose = ON;
 
 /**
  * The following two config options allow you to control who should get email

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -434,6 +434,15 @@ $g_return_path_email	= 'admin@example.com';
  */
 $g_enable_email_notification	= ON;
 
+/**
+ * When enabled, the email notifications will send the full issue with
+ * a hint about the change type at the top, rather than using dedicated
+ * notifications that are focused on what changed.  This change can be
+ * overridden in the database per user.
+ *
+ * @global integer $g_email_notifications_verbose
+ */
+$g_email_notifications_verbose = OFF;
 
 /**
  * The following two config options allow you to control who should get email
@@ -4420,6 +4429,7 @@ $g_public_config_names = array(
 	'due_date_view_threshold',
 	'email_ensure_unique',
 	'email_login_enabled',
+	'email_notifications_verbose',
 	'email_padding_length',
 	'email_receive_own',
 	'email_separator1',

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -615,7 +615,7 @@ function bugnote_get_all_bugnotes( $p_bug_id ) {
 /**
  * Gets the bugnote object given its id.
  *
- * @param $p_bugnote_id The bugnote id.
+ * @param int $p_bugnote_id The bugnote id.
  * @return BugnoteData The bugnote object.
  */
 function bugnote_get( $p_bugnote_id ) {

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -878,7 +878,7 @@ function email_bug_updated( $p_bug_id ) {
  * send notices when a new bugnote
  * @param int $p_bugnote_id  The bugnote id.
  * @param array $p_files The array of file information (keys: name, size)
- * @param array The id of users to exclude.
+ * @param array $p_exclude_user_ids The id of users to exclude.
  * @return void
  */
 function email_bugnote_add( $p_bugnote_id, $p_files = array(), $p_exclude_user_ids = array() ) {

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -639,6 +639,10 @@ function email_generic( $p_bug_id, $p_notify_type, $p_message_id = null, array $
  * @return void
  */
 function email_generic_to_recipients( $p_bug_id, $p_notify_type, array $p_recipients, $p_message_id = null, array $p_header_optional_params = null ) {
+	if( empty( $p_recipients ) ) {
+		return;
+	}
+
 	if( OFF == config_get( 'enable_email_notification' ) ) {
 		return;
 	}

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -58,18 +58,22 @@ $g_cache_file_count = array();
  *
  * @param int $p_bug_id    The bug id.
  * @param array $p_files   The array of files, if null, then do nothing.
+ * @return array Array of file info arrays.
  */
 function file_process_posted_files_for_bug( $p_bug_id, $p_files ) {
 	if( $p_files === null ) {
 		return;
 	}
 
+	$t_file_infos = array();
 	$t_files = helper_array_transpose( $p_files );
 	foreach( $t_files as $t_file ) {
 		if( !empty( $t_file['name'] ) ) {
-			file_add( $p_bug_id, $t_file, 'bug' );
+			$t_file_infos[] = file_add( $p_bug_id, $t_file, 'bug' );
 		}
 	}
+
+	return $t_file_infos;
 }
 
 /**
@@ -637,9 +641,11 @@ function file_is_name_unique( $p_name, $p_bug_id, $p_table = 'bug' ) {
  * @param integer $p_user_id         User id (defaults to current user).
  * @param integer $p_date_added      Date added.
  * @param boolean $p_skip_bug_update Skip bug last modification update (useful when importing bug attachments).
- * @return void
+ * @return array The file info array (keys: name, size)
  */
 function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p_desc = '', $p_user_id = null, $p_date_added = 0, $p_skip_bug_update = false ) {
+	$t_file_info = array();
+
 	file_ensure_uploaded( $p_file );
 	$t_file_name = $p_file['name'];
 	$t_tmp_file = $p_file['tmp_name'];
@@ -663,12 +669,16 @@ function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p
 		}
 	}
 
+	$t_file_info['name'] = $t_file_name;
 	antispam_check();
 
 	$t_file_size = filesize( $t_tmp_file );
 	if( 0 == $t_file_size ) {
 		trigger_error( ERROR_FILE_NO_UPLOAD_FAILURE, ERROR );
 	}
+
+	$t_file_info['size'] = $t_file_size;
+
 	$t_max_file_size = (int)min( ini_get_number( 'upload_max_filesize' ), ini_get_number( 'post_max_size' ), config_get( 'max_file_size' ) );
 	if( $t_file_size > $t_max_file_size ) {
 		trigger_error( ERROR_FILE_TOO_BIG, ERROR );
@@ -772,6 +782,8 @@ function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p
 		# log file added to bug history
 		history_log_event_special( $p_bug_id, FILE_ADDED, $t_file_name );
 	}
+
+	return $t_file_info;
 }
 
 /**

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -340,12 +340,20 @@ function history_get_event_from_row( $p_result, $p_user_id = null, $p_check_acce
 		if( $t_user_id != $v_user_id ) {
 			# bypass if user originated note
 			if( ( $v_type == BUGNOTE_ADDED ) || ( $v_type == BUGNOTE_UPDATED ) || ( $v_type == BUGNOTE_DELETED ) ) {
+				if( !bugnote_exists( $v_old_value ) ) {
+					continue;
+				}
+
 				if( !access_has_bug_level( config_get( 'private_bugnote_threshold' ), $v_bug_id, $t_user_id ) && ( bugnote_get_field( $v_old_value, 'view_state' ) == VS_PRIVATE ) ) {
 					continue;
 				}
 			}
 
 			if( $v_type == BUGNOTE_STATE_CHANGED ) {
+				if( !bugnote_exists( $v_new_value ) ) {
+					continue;
+				}
+
 				if( !access_has_bug_level( config_get( 'private_bugnote_threshold' ), $v_bug_id, $t_user_id ) && ( bugnote_get_field( $v_new_value, 'view_state' ) == VS_PRIVATE ) ) {
 					continue;
 				}

--- a/core/mention_api.php
+++ b/core/mention_api.php
@@ -127,10 +127,10 @@ function mention_get_users( $p_text ) {
  * @param array $p_mentioned_user_ids An array of user ids
  * @param string $p_message The message containing the mentions.
  * @param array $p_removed_mentions_user_ids The list of ids removed due to lack of access to issue or note.
- * @return void
+ * @return array array of user ids actually received mention notifications.
  */
 function mention_process_user_mentions( $p_bug_id, $p_mentioned_user_ids, $p_message, $p_removed_mentions_user_ids ) {
-	email_user_mention( $p_bug_id, $p_mentioned_user_ids, $p_message, $p_removed_mentions_user_ids );
+	return email_user_mention( $p_bug_id, $p_mentioned_user_ids, $p_message, $p_removed_mentions_user_ids );
 }
 
 /**

--- a/docbook/Admin_Guide/en-US/config/email.xml
+++ b/docbook/Admin_Guide/en-US/config/email.xml
@@ -49,7 +49,7 @@
 					When enabled, the email notifications will include the full issue with
 					a hint about the change type at the top, rather than using dedicated
 					notifications that are focused on what changed.  This change can be
-					overridden in the database per user.  Default is OFF.
+					overridden in the database per user.  Default is ON.
 				</para>
 			</listitem>
 		</varlistentry>

--- a/docbook/Admin_Guide/en-US/config/email.xml
+++ b/docbook/Admin_Guide/en-US/config/email.xml
@@ -43,6 +43,17 @@
 			</listitem>
 		</varlistentry>
 		<varlistentry>
+			<term>$g_email_notifications_verbose</term>
+			<listitem>
+				<para>
+					When enabled, the email notifications will include the full issue with
+					a hint about the change type at the top, rather than using dedicated
+					notifications that are focused on what changed.  This change can be
+					overridden in the database per user.  Default is OFF.
+				</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
 			<term>$g_default_notify_flags</term>
 			<listitem>
 				<para>Associates a default notification flag with each action,

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -629,7 +629,8 @@ $s_confirm_revision_drop = 'Are you sure you want to drop this issue revision?';
 $s_vote_added_msg = 'Vote has been added...';
 
 # bugnote_add.php
-$s_bugnote_added_msg = 'Note added...';
+$s_bugnote_added_email_subject = '%1s commented on %2s';
+$s_bugnote_attached_files = 'Attached Files:';
 
 # bugnote_delete.php
 $s_bugnote_deleted_msg = 'Note has been successfully deleted...';

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -409,6 +409,7 @@ $s_email_on_bugnote_added = 'E-mail on Note Added';
 $s_email_on_status_change = 'E-mail on Status Change';
 $s_email_on_priority_change = 'E-mail on Priority Change';
 $s_email_bugnote_limit = 'E-mail Notes Limit';
+$s_email_full_issue_details = 'E-mail Full Issue Details';
 $s_language = 'Language';
 $s_update_prefs_button = 'Update Prefs';
 $s_reset_prefs_button = 'Reset Prefs';

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -629,7 +629,6 @@ $s_confirm_revision_drop = 'Are you sure you want to drop this issue revision?';
 $s_vote_added_msg = 'Vote has been added...';
 
 # bugnote_add.php
-$s_bugnote_added_email_subject = '%1s commented on %2s';
 $s_bugnote_attached_files = 'Attached Files:';
 
 # bugnote_delete.php


### PR DESCRIPTION
Email notifications for notes shouldn't include full issue information
Fixes #21876

Mentioned users in a new note shouldn't receive double notifications
Fixes #21877

Include note attachments information in issue note added notification
Fixes #21875

Explicitly pass issue note id to email notifications rather than getting latest note id
Fixes #21879

Improve issue note caching
Fixes #21878

Simple note added by a reporter
![notification_simple_note](https://cloud.githubusercontent.com/assets/6446/20106757/1a83a170-a58b-11e6-9af6-b33c907b20dc.png)

Public note with time tracking and attachments
![notification_public_note_with_time_attach](https://cloud.githubusercontent.com/assets/6446/20106768/25b95b84-a58b-11e6-96a2-ec5033af2e0d.png)

Private note with time tracking and attachments
![notification_private_note_time_attach](https://cloud.githubusercontent.com/assets/6446/20106798/35fe7aec-a58b-11e6-8a15-5c30f46b9dca.png)

Public note with time tracking and attachments that are not visible to target user for the notification
![notification_time_and_attach_not_visible](https://cloud.githubusercontent.com/assets/6446/20106813/3ecc0e00-a58b-11e6-84cb-8d5b273988c0.png)
