### PR TITLE
Proper fix for gravatar URL '&' encoding

### DIFF
--- a/core/classes/Avatar.class.php
+++ b/core/classes/Avatar.class.php
@@ -45,7 +45,7 @@ class Avatar
      * plugins that can integrate with a variety of services like gravatar.com,
      * LDAP, Social Identities, etc.
      *
-     * If logged in user doesn't have access to view avatars or not avatar is found,
+     * If logged in user doesn't have access to view avatars or no avatar is found,
      * then a default avatar will be used.
      *
      * Note that the provided user id may no longer has a corresponding user in the
@@ -61,7 +61,7 @@ class Avatar
         $t_avatar = null;
 
         if ( $t_enabled ) {
-			$t_user_exists = user_exists( $p_user_id ); 
+			$t_user_exists = user_exists( $p_user_id );
             if ( $t_user_exists &&
                  access_has_project_level( config_get( 'show_avatar_threshold' ), null, $p_user_id ) ) {
                 $t_avatar = event_signal(

--- a/core/classes/TimelineEvent.class.php
+++ b/core/classes/TimelineEvent.class.php
@@ -80,9 +80,9 @@ class TimelineEvent {
 
 		return sprintf(
 			'<div class="entry"><div class="avatar"><a href="%s"><img class="avatar" src="%s" alt="%s" width="32" height="32" /></a></div><div class="timestamp">%s</div>',
-			$t_avatar->link,
-			$t_avatar->image,
-			$t_avatar->text,
+			htmlspecialchars( $t_avatar->link ),
+			htmlspecialchars( $t_avatar->image ),
+			htmlspecialchars( $t_avatar->text ),
 			$this->format_timestamp( $this->timestamp )
 		);
 	}

--- a/core/classes/TimelineEvent.class.php
+++ b/core/classes/TimelineEvent.class.php
@@ -75,11 +75,15 @@ class TimelineEvent {
 		$t_avatar = Avatar::get( $this->user_id, 32 );
 		if( $t_avatar === null ) {
 			return sprintf(
-				'<div class="entry"><div class="timestamp">%s</div>', $this->format_timestamp( $this->timestamp ) );
+				'<div class="entry"><div class="timestamp">%s</div>',
+				$this->format_timestamp( $this->timestamp )
+			);
 		}
 
 		return sprintf(
-			'<div class="entry"><div class="avatar"><a href="%s"><img class="avatar" src="%s" alt="%s" width="32" height="32" /></a></div><div class="timestamp">%s</div>',
+			'<div class="entry"><div class="avatar">'
+			. '<a href="%s"><img class="avatar" src="%s" alt="%s" width="32" height="32" /></a>'
+			. '</div><div class="timestamp">%s</div>',
 			htmlspecialchars( $t_avatar->link ),
 			htmlspecialchars( $t_avatar->image ),
 			htmlspecialchars( $t_avatar->text ),

--- a/plugins/Gravatar/Gravatar.php
+++ b/plugins/Gravatar/Gravatar.php
@@ -153,8 +153,7 @@ class GravatarPlugin extends MantisPlugin {
 					'd' => $t_default_avatar,
 					'r' => $t_rating,
 					's' => $p_size,
-				),
-				'', '&amp;'
+				)
 			);
 
 		$t_avatar = new Avatar();


### PR DESCRIPTION
Follow-up fix on PR #920.

I did not realize that there was inconsistent output of Gravatars: `print_avatar()` escapes the URL with htmlspecialchars(), while `TimeLineEvent::html_start()` did not.

Fixes [#21844](https://www.mantisbt.org/bugs/view.php?id=21844), [#21804](https://www.mantisbt.org/bugs/view.php?id=21804)