### PR TITLE
Remove leading newline from email body

### DIFF
--- a/core/email_api.php
+++ b/core/email_api.php
@@ -1174,7 +1174,7 @@ function email_send( EmailData $p_email_data ) {
 	}
 
 	$t_mail->Subject = $t_subject;
-	$t_mail->Body = make_lf_crlf( "\n" . $t_message );
+	$t_mail->Body = make_lf_crlf( $t_message );
 
 	if( isset( $t_email_data->metadata['headers'] ) && is_array( $t_email_data->metadata['headers'] ) ) {
 		foreach( $t_email_data->metadata['headers'] as $t_key => $t_value ) {


### PR DESCRIPTION
This extra blank line prevents email clients such as Outlook from
displaying a preview of MantisBT's notification messages in a list view.

The newline does not serve any known purpose (PHPMailer already adds one
to separate the message header from its body), and testing does not show
any regression when notifications are sent sent without it.

This commit removes the extra '\n'.

Fixes [#21896](https://www.mantisbt.org/bugs/view.php?id=21896)