### PR TITLE
More bug cache

### DIFF
--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -710,6 +710,7 @@ echo '<tr class="hidden"></tr>';
 # Custom Fields
 $t_custom_fields_found = false;
 $t_related_custom_field_ids = custom_field_get_linked_ids( $t_bug->project_id );
+custom_field_cache_values( array( $t_bug->id ) , $t_related_custom_field_ids );
 
 foreach( $t_related_custom_field_ids as $t_id ) {
 	if( !custom_field_has_read_access( $t_id, $f_bug_id ) ) {

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -2197,6 +2197,7 @@ function bug_clear_cache_all( $p_bug_id = null ) {
 	file_bug_attachment_count_clear_cache( $p_bug_id );
 	bugnote_clear_bug_cache( $p_bug_id );
 	tag_clear_cache_bug_tags( $p_bug_id );
+	custom_field_clear_cache_values( $p_bug_id );
 	return true;
 }
 

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -2196,6 +2196,7 @@ function bug_clear_cache_all( $p_bug_id = null ) {
 	bug_text_clear_cache( $p_bug_id );
 	file_bug_attachment_count_clear_cache( $p_bug_id );
 	bugnote_clear_bug_cache( $p_bug_id );
+	tag_clear_cache_bug_tags( $p_bug_id );
 	return true;
 }
 
@@ -2253,6 +2254,9 @@ function bug_cache_columns_data( array $p_bugs, array $p_selected_columns ) {
 				break;
 			case 'category_id':
 				category_cache_array_rows( $t_category_ids );
+				break;
+			case 'tags':
+				tag_cache_bug_tag_rows( $t_bug_ids );
 				break;
 		}
 	}

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -2228,6 +2228,7 @@ function bug_cache_columns_data( array $p_bugs, array $p_selected_columns ) {
 	$t_category_ids = array_unique( $t_category_ids );
 
 	$t_custom_field_ids = array();
+	$t_users_cached = false;
 	foreach( $p_selected_columns as $t_column ) {
 
 		if( column_is_plugin_column( $t_column ) ) {
@@ -2253,7 +2254,10 @@ function bug_cache_columns_data( array $p_bugs, array $p_selected_columns ) {
 			case 'handler_id':
 			case 'reporter_id':
 			case 'status':
-				user_cache_array_rows( $t_user_ids );
+				if( !$t_users_cached ) {
+					user_cache_array_rows( $t_user_ids );
+					$t_users_cached = true;
+				}
 				break;
 			case 'project_id':
 				project_cache_array_rows( $t_project_ids );

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -2198,6 +2198,11 @@ function bug_clear_cache_all( $p_bug_id = null ) {
 	bugnote_clear_bug_cache( $p_bug_id );
 	tag_clear_cache_bug_tags( $p_bug_id );
 	custom_field_clear_cache_values( $p_bug_id );
+
+	$t_plugin_objects = columns_get_plugin_columns();
+	foreach( $t_plugin_objects as $t_plugin_column ) {
+		$t_plugin_column->clear_cache();
+	}
 	return true;
 }
 

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -2220,12 +2220,23 @@ function bug_cache_columns_data( array $p_bugs, array $p_selected_columns ) {
 	$t_project_ids = array_unique( $t_project_ids );
 	$t_category_ids = array_unique( $t_category_ids );
 
+	$t_custom_field_ids = array();
 	foreach( $p_selected_columns as $t_column ) {
 
 		if( column_is_plugin_column( $t_column ) ) {
 			$plugin_objects = columns_get_plugin_columns();
 			$plugin_objects[$t_column]->cache( $p_bugs );
 			continue;
+		}
+
+		if( strncmp( $t_column, 'custom_', 7 ) === 0 ) {
+			# @TODO cproensa, this will we replaced with column_is_custom_field()
+			$t_cf_name = utf8_substr( $t_column, 7 );
+			$t_cf_id = custom_field_get_id_from_name( $t_cf_name );
+			if( $t_cf_id ) {
+				$t_custom_field_ids[] = $t_cf_id;
+				continue;
+			}
 		}
 
 		switch( $t_column ) {
@@ -2244,5 +2255,9 @@ function bug_cache_columns_data( array $p_bugs, array $p_selected_columns ) {
 				category_cache_array_rows( $t_category_ids );
 				break;
 		}
+	}
+
+	if( !empty( $t_custom_field_ids ) ) {
+		custom_field_cache_values( $t_bug_ids, $t_custom_field_ids );
 	}
 }

--- a/core/classes/MantisColumn.class.php
+++ b/core/classes/MantisColumn.class.php
@@ -65,6 +65,14 @@ abstract class MantisColumn {
 	public function cache( array $p_bugs ) {}
 
 	/**
+	 * Function to clear the cache of values that was built with the cache() method.
+	 * This can be requested as part of an export of bugs, and clearing the used
+	 * memory helps to keep a long export process within memory limits.
+	 * @return void
+	 */
+	public function clear_cache() {}
+
+	/**
 	 * Function to display column data for a given bug row.
 	 * @param BugData $p_bug            A BugData object.
 	 * @param integer $p_columns_target Column display target.

--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -92,6 +92,10 @@ $g_cache_cf_list = null;
 $g_cache_cf_linked = array();
 $g_cache_name_to_id_map = array();
 
+# Values are indexed by [ bug_id, field_id ]
+# a non existant value will have a cached value of null
+$g_cache_cf_bug_values = array();
+
 /**
  * Cache a custom field row if necessary and return the cached copy
  * If the second parameter is true (default), trigger an error
@@ -103,21 +107,16 @@ $g_cache_name_to_id_map = array();
  * @access public
  */
 function custom_field_cache_row( $p_field_id, $p_trigger_errors = true ) {
-	global $g_cache_custom_field, $g_cache_name_to_id_map;
+	global $g_cache_custom_field;
 
-	$p_field_id = (int)$p_field_id;
-
-	if( isset( $g_cache_custom_field[$p_field_id] ) ) {
-		return $g_cache_custom_field[$p_field_id];
+	$c_field_id = (int)$p_field_id;
+	if( !isset( $g_cache_custom_field[$c_field_id] ) ) {
+		custom_field_cache_array_rows( array( $c_field_id ) );
 	}
 
-	db_param_push();
-	$t_query = 'SELECT * FROM {custom_field} WHERE id=' . db_param();
-	$t_result = db_query( $t_query, array( $p_field_id ) );
-
-	$t_row = db_fetch_array( $t_result );
-
-	if( !$t_row ) {
+	# the cached index exist, even when not found
+	$t_cf_row = $g_cache_custom_field[$c_field_id];
+	if( !$t_cf_row ) {
 		if( $p_trigger_errors ) {
 			error_parameters( 'Custom ' . $p_field_id );
 			trigger_error( ERROR_CUSTOM_FIELD_NOT_FOUND, ERROR );
@@ -125,11 +124,7 @@ function custom_field_cache_row( $p_field_id, $p_trigger_errors = true ) {
 			return false;
 		}
 	}
-
-	$g_cache_custom_field[$p_field_id] = $t_row;
-	$g_cache_name_to_id_map[$t_row['name']] = $p_field_id;
-
-	return $t_row;
+	return $t_cf_row;
 }
 
 /**
@@ -139,12 +134,13 @@ function custom_field_cache_row( $p_field_id, $p_trigger_errors = true ) {
  * @access public
  */
 function custom_field_cache_array_rows( array $p_cf_id_array ) {
-	global $g_cache_custom_field;
+	global $g_cache_custom_field, $g_cache_name_to_id_map;
 	$c_cf_id_array = array();
 
 	foreach( $p_cf_id_array as $t_cf_id ) {
-		if( !isset( $g_cache_custom_field[(int)$t_cf_id] ) ) {
-			$c_cf_id_array[] = (int)$t_cf_id;
+		$c_id = (int)$t_cf_id;
+		if( !isset( $g_cache_custom_field[$c_id] ) ) {
+			$c_cf_id_array[$c_id] = $c_id;
 		}
 	}
 
@@ -152,13 +148,107 @@ function custom_field_cache_array_rows( array $p_cf_id_array ) {
 		return;
 	}
 
-	$t_query = 'SELECT * FROM {custom_field} WHERE id IN (' . implode( ',', $c_cf_id_array ) . ')';
-	$t_result = db_query( $t_query );
+	db_param_push();
+	$t_params = array();
+	$t_in_caluse_dbparams = array();
+	foreach( $c_cf_id_array as $t_id) {
+		$t_in_caluse_dbparams[] = db_param();
+		$t_params[] = $t_id;
+	}
+	$t_query = 'SELECT * FROM {custom_field} WHERE id IN (' . implode( ',', $t_in_caluse_dbparams ) . ')';
+	$t_result = db_query( $t_query, $t_params );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
-		$g_cache_custom_field[(int)$t_row['id']] = $t_row;
+		$c_id = (int)$t_row['id'];
+		$g_cache_custom_field[$c_id] = $t_row;
+		$g_cache_name_to_id_map[$t_row['name']] = $c_id;
+		unset( $c_cf_id_array[$c_id] );
+	}
+	# set the remaining ids as not found
+	foreach( $c_cf_id_array as $t_id) {
+		$g_cache_custom_field[$t_id] = false;
 	}
 	return;
+}
+
+/**
+ * Load in cache values of custom fields, for given bugs and field ids.
+ * When a value for a given bug and field does not exist, fill the cached value as null
+ * @global array $g_cache_cf_bug_values
+ * @param array $p_bug_id_array
+ * @param array $p_field_id_array
+ * @return void
+ */
+function custom_field_cache_values( array $p_bug_id_array, array $p_field_id_array ) {
+	global $g_cache_cf_bug_values;
+
+	if( empty( $p_field_id_array ) ) {
+		return;
+	}
+
+	# clean fields ids
+	$t_fields_to_search = array();
+	$f_cf_defs = array();
+	foreach( $p_field_id_array as $t_field_id ) {
+		$c_field_id = (int)$t_field_id;
+		$t_fields_to_search[$c_field_id] = $c_field_id;
+		$f_cf_defs[$c_field_id] = custom_field_get_definition( $c_field_id );
+	}
+
+	# get bugs to fetch
+	$t_bugs_to_search = array();
+	foreach( $p_bug_id_array as $t_bug_id ) {
+		$c_bug_id = (int)$t_bug_id;
+		if( !isset( $g_cache_cf_bug_values[$c_bug_id] ) ) {
+			$t_bugs_to_search[] = $c_bug_id;
+		} else {
+			$t_diff = array_diff( $t_fields_to_search, array_keys( $g_cache_cf_bug_values[$c_bug_id] ) );
+			if( !empty( $t_diff ) ) {
+				$t_bugs_to_search[] = $c_bug_id;
+			}
+		}
+	}
+	if( empty( $t_bugs_to_search ) ) {
+		return;
+	}
+
+	db_param_push();
+	$t_params= array();
+	$t_query = 'SELECT B.id AS bug_id, CF.id AS field_id, CFS.value, CFS.text FROM mantis_bug_table B'
+			. ' LEFT OUTER JOIN mantis_custom_field_table CF ON 1 = 1'
+			. ' LEFT OUTER JOIN mantis_custom_field_string_table CFS ON ( B.id = CFS.bug_id AND CF.id = CFS.field_id )';
+	$t_bug_in_params = array();
+	foreach( $t_bugs_to_search as $t_bug_id ) {
+		$t_bug_in_params[] = db_param();
+		$t_params[] = $t_bug_id;
+	}
+	$t_query .= ' WHERE B.id IN (' . implode( ',', $t_bug_in_params ) . ')';
+	$t_field_in_params = array();
+	foreach( $t_fields_to_search as $t_field_id ) {
+		$t_field_in_params[] = db_param();
+		$t_params[] = $t_field_id;
+	}
+	$t_query .= ' AND CF.id IN (' . implode( ',', $t_field_in_params ) . ')';
+
+	$t_result = db_query( $t_query, $t_params );
+
+	# By having the left outer joins, non existant values are fetched as nulls,
+	# and can be stored in cache to mark them as not-found
+	while( $t_row = db_fetch_array( $t_result ) ) {
+		$c_bug_id = (int)$t_row['bug_id'];
+		# create a bug index if necessary
+		if( !isset( $g_cache_cf_bug_values[$c_bug_id] ) ) {
+			$g_cache_cf_bug_values[$c_bug_id] = array();
+		}
+		$c_field_id = (int)$t_row['field_id'];
+		$t_value_column = ( $f_cf_defs[$c_field_id]['type'] == CUSTOM_FIELD_TYPE_TEXTAREA ? 'text' : 'value' );
+		$t_value = $t_row[$t_value_column];
+		if( null !== $t_value ) {
+			$t_value = custom_field_database_to_value( $t_value, $f_cf_defs[$c_field_id]['type'] );
+		}
+		# non-existant will be stored as null
+		$g_cache_cf_bug_values[$c_bug_id][$c_field_id] = $t_value;
+	}
 }
 
 /**
@@ -824,29 +914,21 @@ function custom_field_get_display_name( $p_name ) {
  * @access public
  */
 function custom_field_get_value( $p_field_id, $p_bug_id ) {
+	global $g_cache_cf_bug_values;
+
 	$t_row = custom_field_cache_row( $p_field_id );
-
 	$t_access_level_r = $t_row['access_level_r'];
-	$t_default_value = $t_row['default_value'];
 
+	# first check permissions
 	if( !custom_field_has_read_access( $p_field_id, $p_bug_id, auth_get_current_user_id() ) ) {
 		return false;
 	}
 
-	$t_value_field = ( $t_row['type'] == CUSTOM_FIELD_TYPE_TEXTAREA ? 'text' : 'value' );
-
-	db_param_push();
-	$t_query = 'SELECT ' . $t_value_field . '
-				  FROM {custom_field_string}
-				  WHERE bug_id=' . db_param() . ' AND
-				  		field_id=' . db_param();
-	$t_result = db_query( $t_query, array( $p_bug_id, $p_field_id ) );
-
-	if( db_num_rows( $t_result ) > 0 ) {
-		return custom_field_database_to_value( db_result( $t_result ), $t_row['type'] );
-	} else {
-		return null;
+	if( !isset( $g_cache_cf_bug_values[(int)$p_bug_id][(int)$p_field_id] ) ) {
+		custom_field_cache_values( array( $p_bug_id ), array( $p_field_id ) );
 	}
+
+	return $g_cache_cf_bug_values[(int)$p_bug_id][(int)$p_field_id];
 }
 
 /**

--- a/csv_export.php
+++ b/csv_export.php
@@ -65,9 +65,6 @@ if( 0 == $p_bug_count ) {
 	print_header_redirect( 'view_all_set.php?type=0' );
 }
 
-# Execute query
-$t_result = filter_get_bug_rows_result( $t_query_clauses );
-
 # Get columns to be exported
 $t_columns = csv_get_columns();
 
@@ -103,9 +100,14 @@ if( strcmp( $t_first_three_chars, 'ID' . $t_sep ) == 0 ) {
 echo $t_header;
 
 $t_end_of_results = false;
+$t_offset = 0;
 do {
 	# Clear cache for next block
 	bug_clear_cache_all();
+
+	# select a new block
+	$t_result = filter_get_bug_rows_result( $t_query_clauses, EXPORT_BLOCK_SIZE, $t_offset, /* pop params */ false );
+	$t_offset += EXPORT_BLOCK_SIZE;
 
 	# Keep reading until reaching max block size or end of result set
 	$t_read_rows = array();
@@ -115,6 +117,7 @@ do {
 	while( $t_count < EXPORT_BLOCK_SIZE ) {
 		$t_row = db_fetch_array( $t_result );
 		if( false === $t_row ) {
+			# a premature end indicates end of query results. Set flag as finished
 			$t_end_of_results = true;
 			break;
 		}

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -87,13 +87,15 @@ if( 0 == $p_bug_count ) {
 	print_header_redirect( 'view_all_set.php?type=0&print=1' );
 }
 
-# Execute query
-$t_result = filter_get_bug_rows_result( $t_query_clauses );
-
 $t_end_of_results = false;
+$t_offset = 0;
 do {
 	# Clear cache for next block
 	bug_clear_cache_all();
+
+	# select a new block
+	$t_result = filter_get_bug_rows_result( $t_query_clauses, EXPORT_BLOCK_SIZE, $t_offset, /* pop params */ false );
+	$t_offset += EXPORT_BLOCK_SIZE;
 
 	# Keep reading until reaching max block size or end of result set
 	$t_read_rows = array();
@@ -103,6 +105,7 @@ do {
 	while( $t_count < EXPORT_BLOCK_SIZE ) {
 		$t_row = db_fetch_array( $t_result );
 		if( false === $t_row ) {
+			# a premature end indicates end of query results. Set flag as finished
 			$t_end_of_results = true;
 			break;
 		}

--- a/my_view_inc.php
+++ b/my_view_inc.php
@@ -277,6 +277,8 @@ if( helper_get_current_project() == 0 ) {
 	category_cache_array_rows( array_unique( $t_categories ) );
 }
 
+bug_cache_columns_data( $t_rows , array( 'attachment_count' ) );
+
 $t_filter = array_merge( $c_filter[$t_box_title], $t_filter );
 
 $t_box_title_label = lang_get( 'my_view_title_' . $t_box_title );

--- a/tag_delete.php
+++ b/tag_delete.php
@@ -47,6 +47,7 @@ form_security_validate( 'tag_delete' );
 access_ensure_global_level( config_get( 'tag_edit_threshold' ) );
 
 $f_tag_id = gpc_get_int( 'tag_id' );
+tag_ensure_exists( $f_tag_id );
 $t_tag_row = tag_get( $f_tag_id );
 
 helper_ensure_confirmed( lang_get( 'tag_delete_message' ), lang_get( 'tag_delete_button' ) );

--- a/tag_update.php
+++ b/tag_update.php
@@ -49,6 +49,7 @@ form_security_validate( 'tag_update' );
 compress_enable();
 
 $f_tag_id = gpc_get_int( 'tag_id' );
+tag_ensure_exists( $f_tag_id );
 $t_tag_row = tag_get( $f_tag_id );
 
 if( !( access_has_global_level( config_get( 'tag_edit_threshold' ) )

--- a/tag_update_page.php
+++ b/tag_update_page.php
@@ -59,6 +59,7 @@ require_api( 'user_api.php' );
 compress_enable();
 
 $f_tag_id = gpc_get_int( 'tag_id' );
+tag_ensure_exists( $f_tag_id );
 $t_tag_row = tag_get( $f_tag_id );
 
 $t_name = string_display_line( $t_tag_row['name'] );

--- a/tag_view_page.php
+++ b/tag_view_page.php
@@ -56,6 +56,7 @@ access_ensure_global_level( config_get( 'tag_view_threshold' ) );
 compress_enable();
 
 $f_tag_id = gpc_get_int( 'tag_id' );
+tag_ensure_exists( $f_tag_id );
 $t_tag_row = tag_get( $f_tag_id );
 
 $t_name = string_display_line( $t_tag_row['name'] );


### PR DESCRIPTION
- Following the changes for attachment count cache, it's needed to be called from my-view page.

- Add a cache for custom fields values, since currently they are issuin one query for each value:
This is view-all page with 50 issues and 4 custom fields columns
Before:
DB	Unique queries executed: 274
DB	Total queries executed: 283
DB	Total query execution time: 0.1127 seconds
Page execution time: 0.6414 seconds
After:
DB	Unique queries executed: 75
DB	Total queries executed: 84
DB	Total query execution time: 0.0335 seconds
Page execution time: 0.4558 seconds

Fixes: #21900

- Add cache for bug tags

Fixes: #21900

