### PR TITLE
Don't force lowercase for custom field column names

### DIFF
--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -279,9 +279,7 @@ function column_get_custom_field_name( $p_column ) {
  * @access public
  */
 function columns_string_to_array( $p_string ) {
-	$t_string = utf8_strtolower( $p_string );
-
-	$t_columns = explode( ',', $t_string );
+	$t_columns = explode( ',', $p_string );
 	$t_count = count( $t_columns );
 
 	for( $i = 0; $i < $t_count; $i++ ) {


### PR DESCRIPTION
Custom field names are referenced by name in columns definitions.
There were some conversions in place to compare column names by
converting to lowercase.
However, the field name is stored in custom fields table without any
conversion. This causes:
- The configured columns array can be inconsistent with the available
  columns names.
- When the database uses case sensitive matching, the columns are not
  shown properly and are presented as not existant.

So given that custom field names are already stored with unrestricted
names, which include spaces and non-alphanumeric characters, forcing
them to lowercase while treating them is not a significant requirement
at the moment.

Fixes: #17367, #20248