### PR TITLE
Fix regression setting version fields on View Issues

### DIFF
--- a/view_all_bug_page.php
+++ b/view_all_bug_page.php
@@ -79,6 +79,8 @@ $t_unique_project_ids = array();
 $t_row_count = count( $t_rows );
 for( $i=0; $i < $t_row_count; $i++ ) {
 	array_push( $t_bugslist, $t_rows[$i]->id );
+	$t_project_id = $t_rows[$i]->project_id;
+	$t_unique_project_ids[$t_project_id] = $t_project_id;
 }
 gpc_set_cookie( config_get( 'bug_list_cookie' ), implode( ',', $t_bugslist ) );
 


### PR DESCRIPTION
There are no entries in bulk operation menu of View Issues page to set:
Product Versions, Target Version or Fixed in Version
Regression in 1.3.4
Caused by d47f367fea8dfda1e5bce918419a1bda1dd0e10b

Fixes: #21963