### PR TITLE
Fix false positive for FilterTest::testGetProjectClosedIssues

### DIFF
--- a/tests/soap/FilterTest.php
+++ b/tests/soap/FilterTest.php
@@ -345,10 +345,9 @@ class FilterTest extends SoapBase {
 	 */
 	public function testGetProjectClosedIssues() {
 		$t_initial_issues = $this->getProjectIssues();
-
 		$t_issue_to_add = $this->getIssueToAdd( 'FilterTest.testGetProjectClosedIssues' );
-		$t_issue_to_add['status'] = 'closed';
-		$t_issue_to_add['resolution'] = 'fixed';
+		$t_issue_to_add['status'] = array( 'id' => CLOSED );
+		$t_issue_to_add['resolution'] = array( 'id' => FIXED );
 
 		$t_issue_id = $this->client->mc_issue_add( $this->userName, $this->password, $t_issue_to_add );
 


### PR DESCRIPTION
The test did not work as expected (returning false successful results),
due to incorrect initialization of 'status' and 'resolution' fields for
the created test issue, resulting in status defaulting to 'new' instead
of being set to 'closed' as expected.

Note: this will cause unit tests to fail when $g_hide_status_default is
set to hide closed issues (as it is by default), see issue #21996.

Fixes [#22001](https://www.mantisbt.org/bugs/view.php?id=22001)