### PR TITLE
Prevent inline error in RSS output

### DIFF
--- a/issues_rss.php
+++ b/issues_rss.php
@@ -44,6 +44,9 @@
  * @uses utility_api.php
  */
 
+# Prevent output of HTML in the content if errors occur
+define( 'DISABLE_INLINE_ERROR_REPORTING', true );
+
 require_once( 'core.php' );
 require_api( 'access_api.php' );
 require_api( 'bug_api.php' );


### PR DESCRIPTION
Disable inline error reporting to not mess with RSS output.

Fixes: #22031