### PR TITLE
Timeline view threshold option added. Closes #592

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2766,6 +2766,12 @@ $g_update_readonly_bug_threshold = MANAGER;
 $g_view_changelog_threshold = VIEWER;
 
 /**
+* threshold for viewing timeline
+* @global integer $g_timeline_view_threshold
+*/
+$g_timeline_view_threshold = VIEWER;
+
+/**
  * threshold for viewing roadmap
  * @global integer $g_roadmap_view_threshold
  */

--- a/docbook/Admin_Guide/en-US/config/defaults.xml
+++ b/docbook/Admin_Guide/en-US/config/defaults.xml
@@ -39,6 +39,15 @@
 				</para>
 			</listitem>
 		</varlistentry>
+        <varlistentry>
+            <term>$g_timeline_view_threshold</term>
+            <listitem>
+                <para>Threshold for viewing timeline information. Use NOBODY to turn it off.
+                    If the timeline is turned off, the other widgets are displayed in a two column view.
+                    The default is VIEWER.
+                </para>
+            </listitem>
+		</varlistentry>
 		<varlistentry>
 			<term>$g_default_reminder_view_status</term>
 			<listitem>

--- a/my_view_page.php
+++ b/my_view_page.php
@@ -89,13 +89,16 @@ reset( $t_boxes );
 #print_r ($t_boxes);
 
 $t_project_id = helper_get_current_project();
+$t_timeline_view_threshold_access = access_has_project_level( config_get( 'timeline_view_threshold' ) );
+$t_timeline_view_class = ( $t_timeline_view_threshold_access ) ? "col-md-7" : "col-md-6";
 ?>
-<div class="col-md-7 col-xs-12">
+<div class="col-xs-12 <?php echo $t_timeline_view_class ?>">
 
 <?php
 $t_number_of_boxes = count ( $t_boxes );
 $t_boxes_position = config_get( 'my_view_boxes_fixed_position' );
 $t_counter = 0;
+$t_two_columns_applied = false;
 
 define( 'MY_VIEW_INC_ALLOW', true );
 
@@ -125,16 +128,31 @@ while (list ($t_box_title, $t_box_display) = each ($t_boxes)) {
 
 			# display the box
 	else {
-		include( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'my_view_inc.php' );
-		echo '<div class="space-10"></div>';
+		if( !$t_timeline_view_threshold_access ) {
+			if ($t_counter >= $t_number_of_boxes / 2 && !$t_two_columns_applied) {
+				echo '</div>';
+				echo '<div class="col-xs-12 col-md-6">';
+				$t_two_columns_applied = true;
+			} elseif ($t_counter >= $t_number_of_boxes && $t_two_columns_applied) {
+				echo '</div>';
+			} else {
+				include( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'my_view_inc.php' );
+				echo '<div class="space-10"></div>';
+			}
+			$t_counter++;
+		} else {
+			include( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'my_view_inc.php' );
+			echo '<div class="space-10"></div>';
+		}
 	}
 }
 ?>
 </div>
 
+<?php if( $t_timeline_view_threshold_access ) { ?>
 <div class="col-md-5 col-xs-12">
-	<?php  include( $g_core_path . 'timeline_inc.php' ); ?>
+	<?php include( $g_core_path . 'timeline_inc.php' ); ?>
 	<div class="space-10"></div>
 </div>
-<?php
+<?php }
 layout_page_end();


### PR DESCRIPTION
In the PR #592, @schriftgestalt added the functionality to set the visibility of the timeline. Due to [#529 (comment)](https://github.com/mantisbt/mantisbt/pull/592#issuecomment-93680455) the PR was never merged. So I added the fall back to a 1.2.x behaviour of the view, mentioned by @dregad and rebased it to 2.0.

**$g_timeline_view_threshold = VIEWER;**
![screen shot 2016-12-12 at 18 29 14](https://cloud.githubusercontent.com/assets/5406078/21109600/152fde12-c09a-11e6-88a2-e1e4ed635824.png)

**$g_timeline_view_threshold = NOBODY;**
![screen shot 2016-12-12 at 18 29 42](https://cloud.githubusercontent.com/assets/5406078/21109615/2203853a-c09a-11e6-804a-6f1a7a229817.png)
