### PR TITLE
Fix regression for function tag_bug_get_row()

### DIFF
--- a/core/tag_api.php
+++ b/core/tag_api.php
@@ -709,11 +709,11 @@ function tag_bug_get_row( $p_tag_id, $p_bug_id ) {
 		tag_cache_bug_tag_rows( array( $c_bug_id ) );
 	}
 
-	$t_row = $g_cache_bug_tags[$c_bug_id];
-	if( !$t_row ) {
+	$t_bug_tags = $g_cache_bug_tags[$c_bug_id];
+	if( !$t_bug_tags || !isset( $t_bug_tags[$p_tag_id] ) ) {
 		trigger_error( TAG_NOT_ATTACHED, ERROR );
 	}
-	return $t_row;
+	return $t_bug_tags[$p_tag_id];
 }
 
 /**


### PR DESCRIPTION
Fix regression caused by changes in function tag_bug_get_row() where parameter
$p_tag_id is no longer used.
The modified function was returning an array of all tag rows for the bug_id,
instead of a single tag row, if it exists.

Fixes: #22074