### PR TITLE
Allow helper_mantis_url() to be called twice

### DIFF
--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -605,7 +605,14 @@ function helper_mantis_url( $p_url ) {
 	if( is_blank( $p_url ) ) {
 		return $p_url;
 	}
-	return config_get_global( 'short_path' ) . $p_url;
+
+	# Return URL as-is if it already starts with short path
+	$t_short_path = config_get_global( 'short_path' );
+	if( strpos( $p_url, $t_short_path ) === 0 ) {
+		return $p_url;
+	}
+
+	return $t_short_path . $p_url;
 }
 
 /**


### PR DESCRIPTION
Starting with Mantis 2.0, the Layout API's layout_sidebar_menu()
function takes care of calling helper_mantis_url() for relative URLs in
menu items.

Since that function blindly prepends $g_short_path to the given URL,
this causes issues for plugins relying on a plugin_page() call with
default parameters, e.g. to display menu items via EVENT_MENU_MAIN
event, because the short path is prefixed twice resulting in generation
of an invalid URL.

As pointed out by user @TiKu in ~54922 using plugin_page()'s $p_redirect
parameter = true as it was done for the Source Integration plugin [1] is
really a workaround.

This commit fixes the issue by only prepending the short path if it is
not yet part of the given URL string.

Fixes [#22107](http://www.mantisbt.org/bugs/view.php?id=22107)

[1] https://github.com/mantisbt-plugins/source-integration/commit/1491ba13b288d1b8ac18d3025e3db29e62265cb5