### PR TITLE
Markdown: Ensure font for quoted string in markdown is not too large

### DIFF
--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -190,8 +190,8 @@ class MantisMarkdown extends Parsedown
 	private function __quote( $line, $block, $fn ) {
 
 		if( $block = call_user_func( 'parent::' . $fn, $line, $block ) ) {
-			# set mantis style
-			$block['element']['attributes']['style'] = 'border-color:#847d7d;font-size:13px;';
+			# TODO: To open another issue to track css style sheet issue vs. inline style.
+			$block['element']['attributes']['style'] = 'padding:0.13em 1em;color:#777;border-left:0.25em solid #C0C0C0;font-size:13px;';
 		}
 
 		return $block;

--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -64,9 +64,6 @@ class MantisMarkdown extends Parsedown
 	public function __construct() {
 		# set the table class
 		$this->table_class = 'table table-nonfluid';
-
-		# set the border color of blockquote
-		$this->inline_style = 'border-color:#847d7d';
 	}
 
 	/**
@@ -193,7 +190,8 @@ class MantisMarkdown extends Parsedown
 	private function __quote( $line, $block, $fn ) {
 
 		if( $block = call_user_func( 'parent::' . $fn, $line, $block ) ) {
-			$block['element']['attributes']['style'] = $this->inline_style;
+			# set mantis style
+			$block['element']['attributes']['style'] = 'border-color:#847d7d;font-size:13px;';
 		}
 
 		return $block;


### PR DESCRIPTION
- remove setting of style from global to element specific

Fixes #22164