### PR TITLE
Markdown: Enable line breaks by default

### DIFF
--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -62,6 +62,10 @@ class MantisMarkdown extends Parsedown
 	 * MantisMarkdown constructor.
 	 */
 	public function __construct() {
+		
+		# enable line break by default
+		$this->breaksEnabled = true;
+
 		# set the table class
 		$this->table_class = 'table table-nonfluid';
 


### PR DESCRIPTION
- this will enable newlines to insert line break <br>

Fixes #22172