### PR TITLE
Update .htaccess files to support Apache 2.4 new authz syntax

### DIFF
--- a/config/.htaccess
+++ b/config/.htaccess
@@ -1,3 +1,12 @@
 ## no access to this folder
-order allow,deny
-deny from all
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Order Allow,Deny
+	Deny from all
+</IfModule>

--- a/core/.htaccess
+++ b/core/.htaccess
@@ -1,3 +1,12 @@
 ## no access to this folder
-order allow,deny
-deny from all
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Order Allow,Deny
+	Deny from all
+</IfModule>

--- a/doc/.htaccess
+++ b/doc/.htaccess
@@ -1,3 +1,12 @@
 ## no access to this folder
-order allow,deny
-deny from all
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Order Allow,Deny
+	Deny from all
+</IfModule>

--- a/lang/.htaccess
+++ b/lang/.htaccess
@@ -1,3 +1,12 @@
 ## no access to this folder
-order allow,deny
-deny from all
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Order Allow,Deny
+	Deny from all
+</IfModule>

--- a/library/.htaccess
+++ b/library/.htaccess
@@ -1,3 +1,12 @@
 ## no access to this folder
-order allow,deny
-deny from all
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Order Allow,Deny
+	Deny from all
+</IfModule>

--- a/library/README.md
+++ b/library/README.md
@@ -15,7 +15,7 @@ ezc/Graph       | Zeta Graph      | 1.5.2     | unpatched [1]
 phpmailer       | PHPMailer       | 5.2.21    | unpatched [1]
 rssbuilder      | RSSBuilder      | 2.2.1     | patched [2]
 utf8            | phputf8         | 0.5       | unpatched
-securimage      | PHP Captcha     | 3.6.5     | unpatched [1]
+securimage      | PHP Captcha     | 3.6.5     | patched [1]
 
 **Notes**
 

--- a/library/README.md
+++ b/library/README.md
@@ -15,7 +15,7 @@ ezc/Graph       | Zeta Graph      | 1.5.2     | unpatched [1]
 phpmailer       | PHPMailer       | 5.2.21    | unpatched [1]
 rssbuilder      | RSSBuilder      | 2.2.1     | patched [2]
 utf8            | phputf8         | 0.5       | unpatched
-securimage      | PHP Captcha     | 3.6.4     | unpatched [1]
+securimage      | PHP Captcha     | 3.6.5     | unpatched [1]
 
 **Notes**
 

--- a/plugins/.htaccess
+++ b/plugins/.htaccess
@@ -1,3 +1,12 @@
 ## no access to this folder
-order allow,deny
-deny from all
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Order Allow,Deny
+	Deny from all
+</IfModule>

--- a/scripts/.htaccess
+++ b/scripts/.htaccess
@@ -1,3 +1,12 @@
 ## no access to this folder
-order allow,deny
-deny from all
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+	Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+	Order Allow,Deny
+	Deny from all
+</IfModule>


### PR DESCRIPTION
Fixes [#21588](http://www.mantisbt.org/bugs/view.php?id=21588)

This also updates the [securimage captcha submodule](https://github.com/mantisbt/securimage) to the latest version (3.6.5, fixes [#22194](http://www.mantisbt.org/bugs/view.php?id=22194)), and patches the library to fix their bundled .htaccess files as well as the one we added at the root (see mantisbt/securimage@b9f0d5053432aa477a058635e4b9a6a5ddf38cf2).

The patch to securimage's .htaccess files has been submitted upstream: dapphp/securimage#64, hopefully they'll include the fix in a future version.

Note that this is targeted at 1.3.x, because the problem is present there as well (Apache 2.4 is the recommended version), and it makes sense to reduce maintenance overhead by keeping the submodule in sync across all maintained branches (the change will of course be merged into 2.0.x and master when approved).