### PR TITLE
Plugin requirements

### DIFF
--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -21,7 +21,7 @@
 /**
  * Mantis Version
  */
-define( 'MANTIS_VERSION', '2.0.0' );
+define( 'MANTIS_VERSION', '2.1.0-dev' );
 define( 'FILTER_VERSION', 'v9' );
 
 # --- constants -------------------

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -458,6 +458,11 @@ function plugin_version_check( $p_version, $p_required, $p_maximum = false ) {
 		$t_operator = '<';
 	} else {
 		$t_operator = '>=';
+
+		# Special handling for dev versions: we consider them as meeting the
+		# requirement for their baseline, i.e. 2.0.0-dev matches 2.0.0.
+		preg_match( '/^(.*?)([._+-]?dev.*)?$/', $p_version, $t_matches );
+		$p_version = $t_matches[1];
 	}
 	$t_result = version_compare( $p_version, $p_required, $t_operator );
 	return $t_result ? 1 : -1;

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -494,38 +494,20 @@ function plugin_dependency( $p_base_name, $p_required, $p_initialized = false ) 
 
 		$t_required_array = explode( ',', $p_required );
 
-		# If the plugin's minimum dependency for MantisCore is unspecified or
-		# lower than the current release (i.e. the plugin does not specifically
-		# list the current core version as supported) and the plugin does not
-		# define a maximum dependency, we add one with the current version's
-		# minor release (i.e. for 1.3.1 we would add '<1.3').
-		# The purpose of this is to avoid compatibility issues by disabling
-		# plugins which have not been updated for a new Mantis release; authors
-		# have to revise their code (if necessary), and release a new version
-		# of the plugin with updated dependencies.
-		# To indicate compatibility (e.g. with release 1.3), one can either:
-		# 1. update the minimum required version (i.e. plugin only works with
-		#    1.3; 1.2-compatible code is maintained separately):
-		#    $this->requires = array( 'MantisCore' => '1.3' );
-		# 2. add the new release as a 2nd minimum version (i.e. the plugin is
-		#    compatible with both versions):
-		#    $this->requires = array( 'MantisCore' => '1.2, 1.3' );
-		# 3. add a maximum version higher than the new release:
-		#    $this->requires = array( 'MantisCore' => '1.2, <2.0' );
-		#    Note that this may cause the plugin to face compatibility issues
-		#    if and when a version 1.4 is released.
+		# Set maximum dependency for MantisCore if none is specified.
+		# This effectively disables plugins which have not been specifically
+		# designed for a new major Mantis release to force authors to review
+		# their code, adapt it if necessary, and release a new version of the
+		# plugin with updated dependencies.
 		if( $p_base_name == 'MantisCore' && strpos( $p_required, '<' ) === false ) {
-			$t_version_core = substr(
-				$t_plugin_version,
-				0,
-				strpos( $t_plugin_version, '.', strpos( $t_plugin_version, '.' ) + 1 )
-			);
+			$t_version_core = utf8_substr( $t_plugin_version, 0, strpos( $t_plugin_version, '.' ) );
 			$t_is_current_core_supported = false;
 			foreach( $t_required_array as $t_version_required ) {
 				$t_is_current_core_supported = $t_is_current_core_supported
 					|| version_compare( trim( $t_version_required ), $t_version_core, '>=' );
 			}
 			if( !$t_is_current_core_supported ) {
+				# Add current major version as maximum
 				$t_required_array[] = '<' . $t_version_core;
 			}
 		}

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -458,11 +458,6 @@ function plugin_version_check( $p_version, $p_required, $p_maximum = false ) {
 		$t_operator = '<';
 	} else {
 		$t_operator = '>=';
-
-		# Special handling for dev versions: we consider them as meeting the
-		# requirement for their baseline, i.e. 2.0.0-dev matches 2.0.0.
-		preg_match( '/^(.*?)([._+-]?dev.*)?$/', $p_version, $t_matches );
-		$p_version = $t_matches[1];
 	}
 	$t_result = version_compare( $p_version, $p_required, $t_operator );
 	return $t_result ? 1 : -1;

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -553,6 +553,8 @@ function plugin_dependency( $p_base_name, $p_required, $p_initialized = false ) 
 			return 0;
 		}
 
+		$t_plugin_version = $g_plugin_cache[$p_base_name]->version;
+
 		$t_required_array = explode( ',', $p_required );
 
 		# If the plugin's minimum dependency for MantisCore is unspecified or
@@ -577,9 +579,9 @@ function plugin_dependency( $p_base_name, $p_required, $p_initialized = false ) 
 		#    if and when a version 1.4 is released.
 		if( $p_base_name == 'MantisCore' && strpos( $p_required, '<' ) === false ) {
 			$t_version_core = substr(
-				MANTIS_VERSION,
+				$t_plugin_version,
 				0,
-				strpos( MANTIS_VERSION, '.', strpos( MANTIS_VERSION, '.' ) + 1 )
+				strpos( $t_plugin_version, '.', strpos( $t_plugin_version, '.' ) + 1 )
 			);
 			$t_is_current_core_supported = false;
 			foreach( $t_required_array as $t_version_required ) {
@@ -591,7 +593,7 @@ function plugin_dependency( $p_base_name, $p_required, $p_initialized = false ) 
 			}
 		}
 
-		$t_version_installed = plugin_version_array( $g_plugin_cache[$p_base_name]->version );
+		$t_version_installed = plugin_version_array( $t_plugin_version );
 
 		foreach( $t_required_array as $t_required ) {
 			$t_required = trim( $t_required );

--- a/docbook/Developers_Guide/en-US/Plugins_Building.xml
+++ b/docbook/Developers_Guide/en-US/Plugins_Building.xml
@@ -22,8 +22,8 @@
 			although every part of it will be built up in steps throughout this section.
 		</para>
 
-		<section id="dev.plugins.building.basics">
-			<title>The Basics</title>
+		<section id="dev.plugins.building.structure">
+			<title>Plugin Structure</title>
 
 			<para>
 				This section will introduce the general concepts of plugin structure,
@@ -32,55 +32,66 @@
 				get the development process rolling.
 			</para>
 
-			<section id="dev.plugins.building.basics.structure">
-				<title>Plugin Structure</title>
 
-				<para>
-					The backbone of every plugin is what MantisBT calls the "basename", a
-					succinct, and most importantly, unique name that identifies the plugin.
-					It may not contain any spacing or special characters beyond the ASCII
-					upper- and lowercase alphabet, numerals, and underscore.  This is used
-					to identify the plugin everywhere except for what the end-user sees.
-					For our "Example" plugin, the basename we will use should be obvious
-					enough: "Example".
-				</para>
+			<para>
+				The backbone of every plugin is what MantisBT calls the
+				<emphasis>basename</emphasis>, a succinct, and most
+				importantly, unique name that identifies the plugin. It may
+				not contain any spacing or special characters beyond the
+				ASCII upper- and lowercase alphabet, numerals, and
+				underscore.  This is used to identify the plugin everywhere
+				except for what the end-user sees. For our "Example" plugin,
+				the basename we will use should be obvious enough:
+				<literal>Example</literal>.
+			</para>
 
-				<para>
-					Every plugin must be contained in a single directory named to match the
-					plugin's basename, as well as contain at least a single PHP file, also
-					named to match the basename, as such:
-				</para>
+			<para>
+				Every plugin must be contained in a single directory, named
+				to match the plugin's basename, as well as contain at least
+				a single PHP file, also named to match the basename, as such:
+			</para>
 
-				<programlisting>
+			<programlisting>
 Example/
 	Example.php
-				</programlisting>
+			</programlisting>
 
+			<warning>
 				<para>
-					This top-level PHP file must then contain a concrete class deriving from
-					the <classname>MantisPlugin</classname> class, which must be named in the
-					form of <classname>%Basename%Plugin</classname>, which for our purpose
-					becomes <classname>ExamplePlugin</classname>.
+					Depending on case sensitivity of the underlying file system,
+					these names must <emphasis>exactly match</emphasis> the plugin's
+					base name, i.e. <literal>example</literal> will not work.
 				</para>
+			</warning>
 
-				<para>
-					Because of how <classname>MantisPlugin</classname> declares the
-					<function>register()</function>	method as <literal>abstract</literal>, our
-					plugin must implement that method before PHP will find it semantically
-					valid.  This method is meant for one simple purpose, and should never be
-					used for any other task: setting the plugin's information properties,
-					including the plugin's name, description, version, and more.
-				</para>
 
-				<para>
-					Once your plugin defines its class, implements the <function>register()</function>
-					method, and sets at least the name and version properties, it is then
-					considered a "complete" plugin, and can be loaded and installed within
-					MantisBT's plugin manager.  At this stage, our Example plugin, with all the
-					possible plugin properties set at registration, looks like this:
-				</para>
+			<para>
+				This top-level PHP file must then contain a concrete class deriving from
+				the <classname>MantisPlugin</classname> class, which must be named in the
+				form of <classname>%Basename%Plugin</classname>, which for our purpose
+				becomes <classname>ExamplePlugin</classname>.
+			</para>
 
-				<programlisting><filename>Example/Example.php</filename>
+			<para>
+				Because of how <classname>MantisPlugin</classname> declares the
+				<function>register()</function>	method as <literal>abstract</literal>, our
+				plugin must implement that method before PHP will find it semantically
+				valid.  This method is meant for one simple purpose, and should never be
+				used for any other task: setting the plugin's information properties
+				including the plugin's name, description, version, and more.
+				Please refer to <xref linkend="dev.plugins.building.properties" />
+				below for  details about available properties.
+			</para>
+
+			<para>
+				Once your plugin defines its class, implements the <function>register()</function>
+				method, and sets at least the name and version properties, it is then
+				considered a "complete" plugin, and can be loaded and installed within
+				MantisBT's plugin manager.  At this stage, our Example plugin, with all the
+				possible plugin properties set at registration, looks like this:
+			</para>
+
+			<programlisting><filename>Example/Example.php</filename>
 
 &lt;?php
 class ExamplePlugin extends MantisPlugin {
@@ -90,23 +101,216 @@ class ExamplePlugin extends MantisPlugin {
         $this->page = '';           # Default plugin page
 
         $this->version = '1.0';     # Plugin version string
-        $this->requires = array(    # Plugin dependencies, array of basename => version pairs
-            'MantisCore' => '1.2.0, &lt;= 1.2.0',  #   Should always depend on an appropriate version of MantisBT
-            );
+        $this->requires = array(    # Plugin dependencies
+            'MantisCore' => '1.3, &lt; 3.0',  # Should always depend on an appropriate
+                                           # version of MantisBT
+        );
 
         $this->author = '';         # Author/team name
         $this->contact = '';        # Author/team e-mail address
         $this->url = '';            # Support webpage
     }
 }
-				</programlisting>
+			</programlisting>
 
-				<para>
-					This alone will allow the Example plugin to be installed with MantisBT, and
-					is the foundation of any plugin.  More of the plugin development process
-					will be continued in the next sections.
-				</para>
-			</section>
+			<para>
+				This alone will allow the Example plugin to be installed with MantisBT, and
+				is the foundation of any plugin.  More of the plugin development process
+				will be continued in the next sections.
+			</para>
+		</section>
+
+		<section id="dev.plugins.building.properties">
+			<title>Properties</title>
+			<para>
+				This section describes the properties that can be defined when
+				registering the plugin.
+			</para>
+
+			<variablelist>
+
+				<varlistentry>
+					<term>name</term>
+					<listitem>
+						<para>Your plugin's full name.
+							<emphasis>Required value.</emphasis>
+						</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>description</term>
+					<listitem>
+						<para>A full description of your plugin.</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>page</term>
+					<listitem>
+						<para>The name of a plugin page for further information
+							and administration of the plugin.
+							This is used to create a link to the specified page
+							on Mantis' manage plugin page.
+						</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>version</term>
+					<listitem>
+						<para>Your plugin's version string.
+							<emphasis>Required value.</emphasis>
+						</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>requires</term>
+					<listitem>
+						<para>An array of key/value pairs of basename/version
+							plugin dependencies.
+							<note>
+								<para>The special, reserved basename
+									<literal>MantisCore</literal> can be used to
+									specify the minimum requirement for MantisBT
+									core.
+								</para>
+							</note>
+							The version string can be defined as:
+						</para>
+						<itemizedlist>
+							<listitem>
+								<para><emphasis>Minimum requirement</emphasis>:
+									the plugin specified by the given basename
+									must be installed, and its version must be
+									equal or higher than the indicated one.
+								</para>
+							</listitem>
+							<listitem>
+								<para><emphasis>Maximum requirement</emphasis>:
+									prefixing a version number with
+									'<literal>&lt;</literal>' will allow the
+									plugin to specify the highest version
+									(non-inclusive) up to which the required
+									dependency is supported.
+									<note>
+										<para>If the plugin's minimum dependency
+											for MantisCore is unspecified or lower
+											than the current release (i.e. it does
+											not specifically list the current core
+											version as supported) and the plugin
+											does not define a maximum dependency,
+											a default one will be set to the next
+											major release of MantisBT.
+											(i.e. for 2.x.y we would add
+											<literal>'&lt;2</literal>').
+										</para>
+										<para>This effectively disables plugins
+											which have not been specifically designed
+											for a new major Mantis release, thus
+											forcing authors to review their code,
+											adapt it if necessary, and release a
+											new version of the plugin with updated
+											dependencies.
+										</para>
+									</note>
+								</para>
+							</listitem>
+							<listitem>
+								<para><emphasis>Both minimum and maximum</emphasis>:
+									the two version numbers must be separated by
+									a comma.
+								</para>
+							</listitem>
+						</itemizedlist>
+						<para>
+							Here are a few examples to illustrate the above
+							explanations, assuming that the current Mantis
+							release (<emphasis>MantisCore</emphasis> version)
+							is 2.1:
+							<itemizedlist>
+								<listitem>
+									<para>Old release without a maximum version
+										specified
+										<programlisting>
+$this->requires = array( 'MantisCore' => '1.3.1' );
+										</programlisting>
+										The plugin is compatible with MantisBT
+										>= 1.3.1 and &lt; 2(.0) - note the maximum
+										version that was added by the system.
+									</para>
+								</listitem>
+								<listitem>
+									<para>Current release without a maximum
+										version specified
+										<programlisting>
+$this->requires = array( 'MantisCore' => '2.0' );
+										</programlisting>
+										The plugin is compatible with MantisBT
+										>= 2.0 and &lt; 3.0 (the latter is implicit);
+										code supporting older releases (e.g. 1.3)
+										must be maintained separately (i.e. in a
+										different branch).
+									</para>
+								</listitem>
+								<listitem>
+									<para>Only specify a maximum version
+										<programlisting>
+$this->requires = array( 'MantisCore' => '&lt; 3.1' );
+										</programlisting>
+										The plugin is compatible up to MantisBT
+										3.1 (not included).
+									</para>
+								</listitem>
+								<listitem>
+									<para>Old release with a maximum version
+										<programlisting>
+$this->requires = array( 'MantisCore' => '1.3, &lt; 4.0' );
+										</programlisting>
+										The plugin is compatible with MantisBT
+										>= 1.3 and &lt; 4.0.
+									</para>
+								</listitem>
+							</itemizedlist>
+						</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>uses</term>
+					<listitem>
+						<para>An array of key/value pairs of
+							basename/version optional (soft) plugin dependencies.
+							See <literal>requires</literal> above
+							for details on how to specify versions.
+						</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>author</term>
+					<listitem>
+						<para>Your name, or an array of names.</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>contact</term>
+					<listitem>
+						<para>An email address where you can be contacted.
+						</para>
+					</listitem>
+				</varlistentry>
+
+				<varlistentry>
+					<term>url</term>
+					<listitem>
+						<para>A web address for your plugin.</para>
+					</listitem>
+				</varlistentry>
+
+			</variablelist>
 		</section>
 
 		<section id="dev.plugins.building.pages">

--- a/docbook/Developers_Guide/en-US/Plugins_Building.xml
+++ b/docbook/Developers_Guide/en-US/Plugins_Building.xml
@@ -51,6 +51,18 @@
 				a single PHP file, also named to match the basename, as such:
 			</para>
 
+			<para>
+				Note that for plugins that require a database schema to operate,
+				the basename is also used to build the table names, using the
+				MantisBT table prefixes and suffix (please refer to the
+				Admin Guide's <emphasis>Configuration</emphasis> section for
+				further information).
+				If our Example plugin were to create a table named 'foo',
+				assuming default values for prefixes and suffix in MantisBT
+				configuration, the physical table name would be
+				<literal>mantis_plugin_Example_foo_table</literal>.
+			</para>
+
 			<programlisting>
 Example/
 	Example.php
@@ -80,7 +92,7 @@ Example/
 				used for any other task: setting the plugin's information properties
 				including the plugin's name, description, version, and more.
 				Please refer to <xref linkend="dev.plugins.building.properties" />
-				below for  details about available properties.
+				below for details about available properties.
 			</para>
 
 			<para>
@@ -102,8 +114,8 @@ class ExamplePlugin extends MantisPlugin {
 
         $this->version = '1.0';     # Plugin version string
         $this->requires = array(    # Plugin dependencies
-            'MantisCore' => '1.3, &lt; 3.0',  # Should always depend on an appropriate
-                                           # version of MantisBT
+            'MantisCore' => '2.0',  # Should always depend on an appropriate
+                                    # version of MantisBT
         );
 
         $this->author = '';         # Author/team name
@@ -161,6 +173,13 @@ class ExamplePlugin extends MantisPlugin {
 					<listitem>
 						<para>Your plugin's version string.
 							<emphasis>Required value.</emphasis>
+							We recommend following the
+							<ulink url="http://semver.org/">Semantic Versioning</ulink>
+							specification, but you are free to use any
+							versioning scheme that can be handled by PHP's
+							<ulink url="http://php.net/manual/en/function.version-compare.php">
+								version_compare()
+							</ulink> function.
 						</para>
 					</listitem>
 				</varlistentry>
@@ -237,8 +256,9 @@ class ExamplePlugin extends MantisPlugin {
 $this->requires = array( 'MantisCore' => '1.3.1' );
 										</programlisting>
 										The plugin is compatible with MantisBT
-										>= 1.3.1 and &lt; 2(.0) - note the maximum
-										version that was added by the system.
+										>= 1.3.1 and &lt; 2.0.0 - note that the
+										maximum version (<literal>&lt;2</literal>)
+										was added by the system.
 									</para>
 								</listitem>
 								<listitem>
@@ -260,7 +280,7 @@ $this->requires = array( 'MantisCore' => '2.0' );
 $this->requires = array( 'MantisCore' => '&lt; 3.1' );
 										</programlisting>
 										The plugin is compatible up to MantisBT
-										3.1 (not included).
+										3.1 (not inclusive).
 									</para>
 								</listitem>
 								<listitem>

--- a/docbook/Developers_Guide/en-US/Plugins_Building_Source.xml
+++ b/docbook/Developers_Guide/en-US/Plugins_Building_Source.xml
@@ -38,8 +38,8 @@ class ExamplePlugin extends MantisPlugin {
 
         $this->version = '1.0';     # Plugin version string
         $this->requires = array(    # Plugin dependencies
-            'MantisCore' => '1.3, &lt; 3.0',  # Should always depend on an appropriate
-                                           # version of MantisBT
+            'MantisCore' => '2.0',  # Should always depend on an appropriate
+                                    # version of MantisBT
         );
 
         $this->author = '';         # Author/team name

--- a/docbook/Developers_Guide/en-US/Plugins_Building_Source.xml
+++ b/docbook/Developers_Guide/en-US/Plugins_Building_Source.xml
@@ -37,9 +37,10 @@ class ExamplePlugin extends MantisPlugin {
         $this->page = '';           # Default plugin page
 
         $this->version = '1.0';     # Plugin version string
-        $this->requires = array(    # Plugin dependencies, array of basename => version pairs
-            'MantisCore' => '1.2.0, &lt;= 1.2.0',  #   Should always depend on an appropriate version of MantisBT
-            );
+        $this->requires = array(    # Plugin dependencies
+            'MantisCore' => '1.3, &lt; 3.0',  # Should always depend on an appropriate
+                                           # version of MantisBT
+        );
 
         $this->author = '';         # Author/team name
         $this->contact = '';        # Author/team e-mail address

--- a/manage_plugin_page.php
+++ b/manage_plugin_page.php
@@ -135,7 +135,7 @@ foreach ( $t_plugins_installed as $t_basename => $t_plugin ) {
 		$t_name = '<a href="' . string_attribute( plugin_page( $t_page, false, $t_basename ) ) . '">' . $t_name . '</a>';
 	}
 
-	if( !is_blank( $t_author ) ) {
+	if( !empty( $t_author ) ) {
 		if( is_array( $t_author ) ) {
 			$t_author = implode( $t_author, ', ' );
 		}
@@ -267,7 +267,7 @@ if( 0 < count( $t_plugins_available ) ) {
 
 		$t_name = string_display_line( $t_plugin->name.' '.$t_plugin->version );
 
-		if( !is_blank( $t_author ) ) {
+		if( !empty( $t_author ) ) {
 			if( is_array( $t_author ) ) {
 				$t_author = implode( $t_author, ', ' );
 			}

--- a/plugins/Gravatar/Gravatar.php
+++ b/plugins/Gravatar/Gravatar.php
@@ -68,7 +68,7 @@ class GravatarPlugin extends MantisPlugin {
 
 		$this->version = MANTIS_VERSION;
 		$this->requires = array(
-			'MantisCore' => MANTIS_VERSION,
+			'MantisCore' => '2.0.0',
 		);
 
 		$this->author = 'Victor Boctor';

--- a/plugins/MantisCoreFormatting/MantisCoreFormatting.php
+++ b/plugins/MantisCoreFormatting/MantisCoreFormatting.php
@@ -36,7 +36,7 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 
 		$this->version = MANTIS_VERSION;
 		$this->requires = array(
-			'MantisCore' => MANTIS_VERSION,
+			'MantisCore' => '2.0.0',
 		);
 
 		$this->author = 'MantisBT Team';

--- a/plugins/MantisCoreFormatting/MantisCoreFormatting.php
+++ b/plugins/MantisCoreFormatting/MantisCoreFormatting.php
@@ -36,7 +36,7 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 
 		$this->version = MANTIS_VERSION;
 		$this->requires = array(
-			'MantisCore' => '2.0.0',
+			'MantisCore' => '2.1.0-dev',
 		);
 
 		$this->author = 'MantisBT Team';

--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -34,7 +34,7 @@ class MantisGraphPlugin extends MantisPlugin  {
 
 		$this->version = MANTIS_VERSION;
 		$this->requires = array(
-			'MantisCore' => MANTIS_VERSION,
+			'MantisCore' => '2.0.0',
 		);
 
 		$this->author = 'MantisBT Team';

--- a/plugins/XmlImportExport/XmlImportExport.php
+++ b/plugins/XmlImportExport/XmlImportExport.php
@@ -38,7 +38,7 @@ class XmlImportExportPlugin extends MantisPlugin {
 
 		$this->version = MANTIS_VERSION;
 		$this->requires = array(
-			'MantisCore' => MANTIS_VERSION,
+			'MantisCore' => '2.0.0',
 		);
 
 		$this->author = 'MantisBT Team';

--- a/tests/Mantis/AllTests.php
+++ b/tests/Mantis/AllTests.php
@@ -30,6 +30,7 @@ require_once dirname( dirname( __FILE__ ) ) . '/TestConfig.php';
 
 require_once 'EnumTest.php';
 require_once 'HelperTest.php';
+require_once 'PluginTest.php';
 require_once 'MentionParsingTest.php';
 require_once 'StringTest.php';
 require_once 'ConfigParserTest.php';
@@ -49,6 +50,7 @@ class MantisAllTests extends PHPUnit_Framework_TestSuite {
 
 		$t_suite->addTestSuite( 'MantisEnumTest' );
 		$t_suite->addTestSuite( 'MantisHelperTest' );
+		$t_suite->addTestSuite( 'MantisPluginTest' );
 		$t_suite->addTestSuite( 'MantisStringTest' );
 		$t_suite->addTestSuite( 'MentionParsingTest' );
 		$t_suite->addTestSuite( 'MantisConfigParserTest' );

--- a/tests/Mantis/PluginTest.php
+++ b/tests/Mantis/PluginTest.php
@@ -131,10 +131,9 @@ class MantisPluginTest extends PHPUnit_Framework_TestCase {
 			array( '2.1.0', self::REQ_210_B1, true ),
 			array( '2.1.0', self::REQ_211, false ),
 			array( '2.1.0-dev', self::REQ_21, true ),
-			array( '2.1.0-dev', self::REQ_210, true ),
+			array( '2.1.0-dev', self::REQ_210, false ),
 			array( '2.1.0-dev', self::REQ_210_DEV, true ),
-			array( '2.1.0-dev', self::REQ_210_A1, true ),
-			array( '2.1.0-dev', self::REQ_210_B1, true ),
+			array( '2.1.0-dev', self::REQ_210_A1, false ),
 			array( '2.1.0-alpha.1', self::REQ_21, true ),
 			array( '2.1.0-alpha.1', self::REQ_210_DEV, true ),
 

--- a/tests/Mantis/PluginTest.php
+++ b/tests/Mantis/PluginTest.php
@@ -1,0 +1,151 @@
+<?php
+# MantisBT - a php based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mantis Unit Tests
+ * @package Tests
+ * MantisBT Core Unit Tests
+ * @subpackage Plugin
+ * @copyright Copyright 2017  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ */
+
+# Includes
+require_once dirname( dirname( __FILE__ ) ) . '/TestConfig.php';
+
+# MantisBT Core API
+require_mantis_core();
+
+/**
+ * Helper API tests
+ * @package Tests
+ * @subpackage String
+ */
+class MantisPluginTest extends PHPUnit_Framework_TestCase {
+
+	const MANTISCORE = 'MantisCore';
+
+	/**
+	 * References of version requirements to test against MantisCore versions.
+	 */
+	const REQ_13 = '1.3';
+	const REQ_130 = '1.3.0';
+	const REQ_131 = '1.3.1';
+	const REQ_13_20 = '1.3, <2.0';
+	const REQ_13_21 = '1.3, <2.1';
+	const REQ_13_30 = '1.3, <3.0';
+	const REQ_20 = '2.0';
+	const REQ_21 = '2.1';
+	const REQ_210 = '2.1.0';
+	const REQ_210_DEV = '2.1.0-dev';
+	const REQ_210_A1 = '2.1.0-beta.1';
+	const REQ_210_B1 = '2.1.0-beta.1';
+	const REQ_211 = '2.1.1';
+
+	/**
+	 * Tests setup.
+	 */
+	public function setUp() {
+		plugin_register(self::MANTISCORE);
+	}
+
+
+	/**
+	 * Tests plugin_dependency() for MantisCore.
+	 *
+	 * @param string $p_core_version MantisCore version to test against
+	 * @param string $p_requirement  Version requirement string
+	 * @param bool   $p_expected     True if dependency OK (function returned 1)
+	 *
+	 * @dataProvider providerDependency
+	 */
+	public function testPluginDependency( $p_core_version, $p_requirement, $p_expected ) {
+		global $g_plugin_cache;
+
+		# Set MantisCore version for the test
+		$g_plugin_cache[self::MANTISCORE]->version = $p_core_version;
+
+		$t_result = plugin_dependency(
+			self::MANTISCORE,
+			$p_requirement
+		);
+
+		$this->assertEquals(
+			$p_expected,
+			$t_result == 1,
+			"MantisCore '$p_core_version' should "
+			. ( $p_expected ? 'meet' : 'have failed' )
+			. " requirement '$p_requirement'"
+		);
+	}
+
+	/**
+	 * Provides a series of dependency test cases.
+	 *
+	 * Test case structure:
+	 *   array( <core version>, <requirement>, <result> )
+	 *
+	 * plugin_dependency() is called to check the given <core version> against
+	 * <requirement>. <result> indicates whether we expect the test to
+	 * pass (i.e. function returns 1) or fail (returns value is 0 or -1).
+	 *
+	 * @return array List of test cases
+	 */
+	public function providerDependency() {
+		return array(
+			array( '1.3.0', self::REQ_13, true ),
+			array( '1.3.0', self::REQ_130, true ),
+			array( '1.3.0', self::REQ_131, false ),
+			array( '1.3.0', self::REQ_13_20, true ),
+			array( '1.3.0', self::REQ_13_30, true ),
+			array( '1.3.0', self::REQ_20, false ),
+
+			array( '2.0.0', self::REQ_13, false ),
+			array( '2.0.0', self::REQ_13_20, false ),
+			array( '2.0.0', self::REQ_13_21, true ),
+			array( '2.0.0', self::REQ_13_30, true ),
+			array( '2.0.0', self::REQ_20, true ),
+			array( '2.0.0', self::REQ_210_DEV, false ),
+			array( '2.0.0-beta.1', self::REQ_20, true ),
+
+			array( '2.1.0', self::REQ_13, false ),
+			array( '2.1.0', self::REQ_13_20, false ),
+			array( '2.1.0', self::REQ_13_21, false ),
+			array( '2.1.0', self::REQ_13_30, true ),
+			array( '2.1.0', self::REQ_20, true ),
+			array( '2.1.0', self::REQ_21, true ),
+			array( '2.1.0', self::REQ_210_DEV, true ),
+			array( '2.1.0', self::REQ_210_B1, true ),
+			array( '2.1.0', self::REQ_211, false ),
+			array( '2.1.0-dev', self::REQ_21, true ),
+			array( '2.1.0-dev', self::REQ_210, true ),
+			array( '2.1.0-dev', self::REQ_210_DEV, true ),
+			array( '2.1.0-dev', self::REQ_210_A1, true ),
+			array( '2.1.0-dev', self::REQ_210_B1, true ),
+			array( '2.1.0-alpha.1', self::REQ_21, true ),
+			array( '2.1.0-alpha.1', self::REQ_210_DEV, true ),
+
+			array( '2.1.1', self::REQ_20, true ),
+			array( '2.1.1', self::REQ_21, true ),
+			array( '2.1.1', self::REQ_211, true ),
+
+			array( '3.0.0', self::REQ_13_20, false ),
+			array( '3.0.0', self::REQ_13_30, false ),
+			array( '3.0.0', self::REQ_20, false ),
+		);
+	}
+
+}

--- a/tests/Mantis/PluginTest.php
+++ b/tests/Mantis/PluginTest.php
@@ -51,7 +51,7 @@ class MantisPluginTest extends PHPUnit_Framework_TestCase {
 	const REQ_21 = '2.1';
 	const REQ_210 = '2.1.0';
 	const REQ_210_DEV = '2.1.0-dev';
-	const REQ_210_A1 = '2.1.0-beta.1';
+	const REQ_210_A1 = '2.1.0-alpha.1';
 	const REQ_210_B1 = '2.1.0-beta.1';
 	const REQ_211 = '2.1.1';
 


### PR DESCRIPTION
This PR addresses the issue of plugins getting disabled when bumping the MANTIS_VERSION to 2.1.x
[#22171](http://www.mantisbt.org/bugs/view.php?id=22171).

It also contains the following changes and improvements
- PHPUnit tests for plugin_dependency()  function -- I may have missed test cases, so your **suggestions for additional test cases are welcome**
- Refactor plugin_version_check() to use PHP's version_compare() function instead of custom code
- Proper handling of "dev" versions (with [version_compare()](http://php.net/manual/en/function.version-compare.php), 2.1.0-dev is < than 2.1.0)
- Reset MANTIS_VERSION to 2.1.
- Revert MantisCore version requirements in bundled plugins
- Fix PHP notice, align code with documentation [#22205](http://www.mantisbt.org/bugs/view.php?id=22205)
- Improved plugin documentation in Developers guide [#22206](http://www.mantisbt.org/bugs/view.php?id=22206)
