### PR TITLE
Added filling tags and custom fields from POST/GET args when submitting bug

### DIFF
--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -124,6 +124,7 @@ if( $f_master_bug_id > 0 ) {
 	$f_additional_info		= $t_bug->additional_information;
 	$f_view_state			= (int)$t_bug->view_state;
 	$f_due_date				= $t_bug->due_date;
+	$f_tag_string			= '';
 
 	$t_project_id			= $t_bug->project_id;
 } else {
@@ -179,6 +180,7 @@ if( $f_master_bug_id > 0 ) {
 	$f_additional_info		= gpc_get_string( 'additional_info', config_get( 'default_bug_additional_info' ) );
 	$f_view_state			= gpc_get_int( 'view_state', (int)config_get( 'default_bug_view_status' ) );
 	$f_due_date				= gpc_get_string( 'due_date', date_strtotime( config_get( 'due_date_default' ) ) );
+	$f_tag_string			= gpc_get_string( 'tag_string', '' );
 
 	if( $f_due_date == '' ) {
 		$f_due_date = date_get_null();
@@ -581,7 +583,7 @@ if( $t_show_attachments ) {
 			<label for="attach_tag"><?php echo lang_get( 'tag_attach_long' ) ?></label>
 		</th>
 		<td>
-			<?php print_tag_input( '' ); ?>
+			<?php print_tag_input( 0, $f_tag_string ); ?>
 		</td>
 	</tr>
 <?php
@@ -592,6 +594,11 @@ if( $t_show_attachments ) {
 
 	foreach( $t_related_custom_field_ids as $t_id ) {
 		$t_def = custom_field_get_definition( $t_id );
+		if( intval( gpc_get_string( 'custom_field_' . string_attribute( $t_def['id'] ) . '_presence', '0') ) === 1 ){
+			$t_value = gpc_get_string( 'custom_field_' . string_attribute( $t_def['id'] ) );
+		} else {
+			$t_value = '';
+		}
 		if( ( $t_def['display_report'] || $t_def['require_report']) && custom_field_has_write_access_to_project( $t_id, $t_project_id ) ) {
 			$t_custom_fields_found = true;
 
@@ -613,7 +620,7 @@ if( $t_show_attachments ) {
 			<?php } else { echo string_display( lang_get_defaulted( $t_def['name'] ) ); } ?>
 		</th>
 		<td>
-			<?php print_custom_field_input( $t_def, ( $f_master_bug_id === 0 ) ? null : $f_master_bug_id ) ?>
+			<?php print_custom_field_input( $t_def, ( $f_master_bug_id === 0 ) ? null : $f_master_bug_id, $t_value ) ?>
 		</td>
 	</tr>
 <?php

--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -1380,20 +1380,24 @@ function custom_field_set_sequence( $p_field_id, $p_project_id, $p_sequence ) {
  * @return void
  * @access public
  */
-function print_custom_field_input( array $p_field_def, $p_bug_id = null ) {
-	if( null === $p_bug_id ) {
-		$t_custom_field_value = custom_field_default_to_value( $p_field_def['default_value'], $p_field_def['type'] );
-	} else {
-		$t_custom_field_value = custom_field_get_value( $p_field_def['id'], $p_bug_id );
-		# If the custom field value is undefined and the field cannot hold a null value, use the default value instead
-		if( $t_custom_field_value === null &&
-			( $p_field_def['type'] == CUSTOM_FIELD_TYPE_ENUM ||
-				$p_field_def['type'] == CUSTOM_FIELD_TYPE_LIST ||
-				$p_field_def['type'] == CUSTOM_FIELD_TYPE_MULTILIST ||
-				$p_field_def['type'] == CUSTOM_FIELD_TYPE_RADIO ) ) {
+function print_custom_field_input( array $p_field_def, $p_bug_id = null, $p_value = null ) {
+	if( null === $p_value) {
+		if( null === $p_bug_id ) {
 			$t_custom_field_value = custom_field_default_to_value( $p_field_def['default_value'], $p_field_def['type'] );
+		} else {
+			$t_custom_field_value = custom_field_get_value( $p_field_def['id'], $p_bug_id );
+			# If the custom field value is undefined and the field cannot hold a null value, use the default value instead
+			if( $t_custom_field_value === null &&
+				( $p_field_def['type'] == CUSTOM_FIELD_TYPE_ENUM ||
+					$p_field_def['type'] == CUSTOM_FIELD_TYPE_LIST ||
+					$p_field_def['type'] == CUSTOM_FIELD_TYPE_MULTILIST ||
+					$p_field_def['type'] == CUSTOM_FIELD_TYPE_RADIO ) ) {
+				$t_custom_field_value = custom_field_default_to_value( $p_field_def['default_value'], $p_field_def['type'] );
+			}
 		}
-	}
+	} else {
+		$t_custom_field_value = $p_value;
+	}	
 
 	global $g_custom_field_type_definition;
 	if( isset( $g_custom_field_type_definition[$p_field_def['type']]['#function_print_input'] ) ) {


### PR DESCRIPTION
Bug report/submit page supports reading pre-fill values for fields from GET/POST arguments. This allows one to open bug submission form with prefilled values. However, "tags" column and custom fields do not use defaults from GET/POST arguments. This minor patch solves this.