### PR TITLE
Fixes user management pagination with character filter

### DIFF
--- a/manage_user_page.php
+++ b/manage_user_page.php
@@ -59,7 +59,6 @@ access_ensure_global_level( config_get( 'manage_user_threshold' ) );
 
 $t_cookie_name = config_get( 'manage_users_cookie' );
 $t_lock_image = '<i class="fa fa-lock fa-lg" alt="' . lang_get( 'protected' ) . '" />';
-$c_filter = '';
 
 $f_save          = gpc_get_bool( 'save' );
 $f_filter        = utf8_strtoupper( gpc_get_string( 'filter', config_get( 'default_manage_user_prefix' ) ) );
@@ -273,7 +272,7 @@ $t_user_count = count( $t_users );
 			<input type="hidden" name="sort" value="<?php echo $c_sort ?>" />
 			<input type="hidden" name="dir" value="<?php echo $c_dir ?>" />
 			<input type="hidden" name="save" value="1" />
-			<input type="hidden" name="filter" value="<?php echo $c_filter ?>" />
+			<input type="hidden" name="filter" value="<?php echo $f_filter ?>" />
 			<label class="inline">
 			<input type="checkbox" class="ace" name="hideinactive" value="<?php echo ON ?>" <?php check_checked( (int)$c_hide_inactive, ON ); ?> />
 			<span class="lbl"> <?php echo lang_get( 'hide_inactive' ) ?></span>
@@ -306,7 +305,7 @@ $t_user_count = count( $t_users );
 		print_manage_user_sort_link( 'manage_user_page.php',
 			lang_get( $t_col ),
 			$t_col,
-			$c_dir, $c_sort, $c_hide_inactive, $c_filter, $c_show_disabled );
+			$c_dir, $c_sort, $c_hide_inactive, $f_filter, $c_show_disabled );
 		print_sort_icon( $c_dir, $c_sort, $t_col );
 		echo "</th>\n";
 	}
@@ -371,7 +370,7 @@ $t_user_count = count( $t_users );
 	<div class="btn-toolbar pull-right">
 		<?php
 		# @todo hack - pass in the hide inactive filter via cheating the actual filter value
-		print_page_links( 'manage_user_page.php', 1, $t_page_count, (int)$f_page_number, $c_filter . $t_hide_inactive_filter . $t_show_disabled_filter . "&amp;sort=$c_sort&amp;dir=$c_dir");
+		print_page_links( 'manage_user_page.php', 1, $t_page_count, (int)$f_page_number, $f_filter . $t_hide_inactive_filter . $t_show_disabled_filter . "&amp;sort=$c_sort&amp;dir=$c_dir");
 		?>
 	</div>
 </div>


### PR DESCRIPTION
The pagination with character filter on manage_user_page.php didn't work.
**Steps to reproduce the wrong behavior:**
1. Got to Manage
2. Manage User
3. Filter by a character
4. Change page in the lower right corner

**Expected behavior:**
Mantis should show the second page of users starting with the filtered character.

**Actual behavior:**
Mantis shows the second page of all users.