### PR TITLE
Markdown: Fix broken layout in news page (main_page.php)

### DIFF
--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -428,3 +428,6 @@ i.datetimepicker {
 
 }
 
+#news-items .widget-header p {
+    all: unset;
+}


### PR DESCRIPTION
Ensure to unset style wherein markdown is enclosing `<p>` tag around news headline

Fixes #22204