### PR TITLE
Markdown: Add Markdown own styling

### DIFF
--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -242,7 +242,7 @@ echo $t_form_title;
 echo '</h4>';
 echo '</div>';
 
-echo '<div class="widget-body">';
+echo '<div class="widget-body markdown-body">';
 
 echo '<div class="widget-toolbox padding-8 clearfix noprint">';
 echo '<div class="btn-group pull-left">';

--- a/bugnote_view_inc.php
+++ b/bugnote_view_inc.php
@@ -266,7 +266,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 		</div>
 		</div>
 	</td>
-	<td class="<?php echo $t_activity['style'] ?>">
+	<td class="<?php echo $t_activity['style'] ?> markdown-body">
 	<?php
 		if( $t_activity['type'] == ENTRY_TYPE_NOTE ) {
 			switch ( $t_activity['note']->note_type ) {

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -519,7 +519,7 @@ function print_news_entry( $p_headline, $p_body, $p_poster_id, $p_view_state, $p
 			</div>
 		</div>
 
-		<div class="widget-body">
+		<div class="widget-body markdown-body">
 			<div class="widget-toolbox padding-8 clearfix">
 				<i class="fa fa-user"></i> <?php echo prepare_user_name( $p_poster_id ); ?>
 				&#160;&#160;&#160;&#160;

--- a/css/default.css
+++ b/css/default.css
@@ -107,4 +107,5 @@ td.print-overdue    { font-weight: bold; }
 
 .markdown-body pre {
 	border: 0;
+	margin-top: 9.5px;
 }

--- a/css/default.css
+++ b/css/default.css
@@ -92,3 +92,10 @@ td.print-overdue    { font-weight: bold; }
 .table-nonfluid {
    width: auto !important;
 }
+
+/* Markdown */
+.markdown-body blockquote {
+	padding: 0.13em 1em;
+	color: #777;
+	border-left: 0.25em solid #C0C0C0; font-size: 13px;
+}

--- a/css/default.css
+++ b/css/default.css
@@ -100,7 +100,11 @@ td.print-overdue    { font-weight: bold; }
 	border-left: 0.25em solid #C0C0C0; font-size: 13px;
 }
 
-.markdown-body p code {
+.markdown-body code {
 	color: #777;
 	background-color: #f5f5f5;
+}
+
+.markdown-body pre {
+	border: 0;
 }

--- a/css/default.css
+++ b/css/default.css
@@ -99,3 +99,8 @@ td.print-overdue    { font-weight: bold; }
 	color: #777;
 	border-left: 0.25em solid #C0C0C0; font-size: 13px;
 }
+
+.markdown-body p code {
+	color: #777;
+	background-color: #f5f5f5;
+}

--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -187,48 +187,6 @@ class MantisMarkdown extends Parsedown
 	}
 
 	/**
-	 * Add an inline style on a blockquote markdown elements
-	 *
-	 * @param string $line The Markdown syntax to parse
-	 * @param array $block A block-level element
-	 * @param string $fn the function name to call (blockQuote or blockQuoteContinue)
-	 * @access private
-	 * @return string html representation generated from markdown.
-	 */
-	private function __quote( $line, $block, $fn ) {
-
-		if( $block = call_user_func( 'parent::' . $fn, $line, $block ) ) {
-			# TODO: To open another issue to track css style sheet issue vs. inline style.
-			$block['element']['attributes']['style'] = 'padding:0.13em 1em;color:#777;border-left:0.25em solid #C0C0C0;font-size:13px;';
-		}
-
-		return $block;
-	}
-
-	/**
-	 * Customize the blockQuote method by adding a style attribute
-	 *
-	 * @param string $line The Markdown syntax to parse
-	 * @access protected
-	 * @return string html representation generated from markdown.
-	 */
-	protected function blockQuote( $line ){
-		return $this->__quote( $line, array(), __FUNCTION__ );
-	}
-
-	/**
-	 * Customize the blockQuoteContinue method by adding a style attribute
-	 *
-	 * @param string $line The Markdown syntax to parse
-	 * @param array $block A block-level element
-	 * @access protected
-	 * @return string html representation generated from markdown.
-	 */
-	protected function blockQuoteContinue( $line, array $block ){
-		return $this->__quote( $line, $block, __FUNCTION__ );
-	}
-
-	/**
 	 * Customize the inlineCode method
 	 *
 	 * @param array $block A block-level element


### PR DESCRIPTION
- customize markdown styling
- this commit use classes as preferable over the current use of hardcoded inline styles
- this commit added custom style for blockquote markdown

Fixes #22190