### PR TITLE
Fix markdown eating apostrophe or single quote

### DIFF
--- a/plugins/MantisCoreFormatting/MantisCoreFormatting.php
+++ b/plugins/MantisCoreFormatting/MantisCoreFormatting.php
@@ -116,14 +116,6 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 
 		$t_string = $p_string;
 
-		# restore and allows img tag to display
-		$t_string = preg_replace_callback( "/&quot;|'/",
-			function ( ) {
-				return "";
-			},
-			str_replace('/">', '">', preg_replace( '#&lt;img.+?src=(.*).*?&gt;#i', '<img src="$1">', $t_string ))
-		);
-
 		# We need to enabled quote conversion
 		# "> quote or >quote" is part of an html tag
 		# Make sure to replaced the restored tags with ">"


### PR DESCRIPTION
Removed condition that fix the img tag causing apostrophe or single quote not working, as we don't need to reference the image from the internet at the moment. Instead, we will just add it or override the custom method in plugins/MantisCoreFormatting/core/MantisMarkdown later.

Fixes #22179