### PR TITLE
Markdown: Fix markdown converting '&' signs to '&amp;' inside the code block and 'a' inline element

### DIFF
--- a/plugins/MantisCoreFormatting/MantisCoreFormatting.php
+++ b/plugins/MantisCoreFormatting/MantisCoreFormatting.php
@@ -107,31 +107,6 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 	}
 
 	/**
-	 * Process Markdown
-	 * @param string  $p_string    Raw text to process.
-	 *
-	 * @return string Formatted text
-	 */
-	private function processMarkdown( $p_string ){
-
-		$t_string = $p_string;
-
-		# We need to enabled quote conversion
-		# "> quote or >quote" is part of an html tag
-		# Make sure to replaced the restored tags with ">"
-		$t_string = str_replace( "&gt;", ">", $t_string );
-
-		$t_string = MantisMarkdown::convert_text( $t_string );
-
-		# markdown is unable to process '<' signs within the code block tag (backticks)
-		# markdown convert '<' signs into '&amp;lt;' after the text proccessing process
-		# therefore we need restore the entity back into its original name '&lt;'
-		$t_string = str_replace( '&amp;lt;', '&lt;', $t_string );
-
-		return $t_string;
-	}
-
-	/**
 	 * Plain text processing.
 	 *
 	 * @param string  $p_event     Event name.
@@ -216,7 +191,7 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 
 		# Process Markdown
 		if( ON == $s_markdown && $p_multiline ) {
-			$t_string = $this->processMarkdown ( $t_string );
+			$t_string = MantisMarkdown::convert_text( $t_string );
 		}
 
 		return $t_string;

--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -77,6 +77,12 @@ class MantisMarkdown extends Parsedown
 	 */
 	public static function convert_text( $p_text ) {
 		self::init();
+
+		# Enabled quote conversion
+		# Text processing converts special character to entity name 
+		# Make sure to restore "&gt;" entity name to its characted result ">"
+		$p_text = str_replace( "&gt;", ">", $p_text );
+
 		return self::$mantis_markdown->text( $p_text );
 	}
 
@@ -222,6 +228,72 @@ class MantisMarkdown extends Parsedown
 	 */
 	protected function blockQuoteContinue( $line, array $block ){
 		return $this->__quote( $line, $block, __FUNCTION__ );
+	}
+
+	/**
+	 * Customize the inlineCode method
+	 *
+	 * @param array $block A block-level element
+	 * @access protected
+	 * @return string html representation generated from markdown.
+	 */
+	protected function inlineCode( $block ) {
+
+		$block = parent::inlineCode( $block );
+		
+		if( isset( $block['element']['text'] )) {
+			# replaced any &amp; entity name with '&' under the code block: 
+			#
+			# Text processing will convert & sign within the code block or backtick, 
+			# into entity name, and that becomes &amp; <code>&amp;amp;</code>
+			$block['element']['text'] = str_replace( '&amp;', '&', $block['element']['text'] );
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Customize the blockFencedCodeComplete method
+	 *
+	 * @param array $block A block-level element
+	 * @access protected
+	 * @return string html representation generated from markdown.
+	 */
+	protected function blockFencedCodeComplete( $block = null){
+
+		$block = parent::blockFencedCodeComplete( $block );
+		
+		if( isset( $block['element']['text']['text'] )) {
+			# replaced any &amp; entity name with '&' under the preformatted text code block: 
+			#
+			# Text processing will convert & sign within the code block or backtick, 
+			# into entity name, and that becomes &amp; <pre><code>&amp;amp;</code></pre>
+			$block['element']['text']['text'] = str_replace( '&amp;', '&', $block['element']['text']['text'] );
+		}
+
+		return $block;
+	}
+	
+	/**
+	 * Customize the inlineLink method
+	 *
+	 * @param array $block A block-level element
+	 * @access protected
+	 * @return string html representation generated from markdown.
+	 */
+	protected function inlineLink( $block ){
+
+		$block = parent::inlineLink( $block );
+
+		if( isset( $block['element']['attributes']['href'] )) {
+			# replaced any &amp; entity name with '&' under the inline link: 
+			#
+			# Text processing will convert & sign within the inline link <a>, 
+			# into entity name, and that becomes &amp; <a href="&amp;amp;">
+			$block['element']['attributes']['href'] = str_replace( '&amp;', '&', $block['element']['attributes']['href'] );
+		}
+
+		return $block;
 	}
 
 	/**


### PR DESCRIPTION

- Moved logic removing the html entity `&amp;` from MantisCoreFormattingPlugin into MantisMarkdown Extention

Fixes #22242, #22246