### PR TITLE
Enlarge status color boxes & remove black frame

### DIFF
--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -476,7 +476,7 @@ if( $t_show_status || $t_show_resolution ) {
 		$t_status_label = html_get_status_css_class( $t_bug->status );
 
 		echo '<td class="bug-status">';
-		echo '<i class="fa fa-square-o fa-xlg ' . $t_status_label . '"></i> ';
+		echo '<i class="fa fa-square fa-status-box ' . $t_status_label . '"></i> ';
 		echo $t_status, '</td>';
 	} else {
 		$t_spacer += 2;

--- a/core/bug_group_action_api.php
+++ b/core/bug_group_action_api.php
@@ -98,7 +98,7 @@ function bug_group_action_print_bug_list( array $p_bug_ids_array ) {
 	foreach( $p_bug_ids_array as $t_bug_id ) {
 		# choose color based on status
 		$t_status_label = html_get_status_css_class( bug_get_field( $t_bug_id, 'status' ), auth_get_current_user_id(), bug_get_field( $t_bug_id, 'project_id' ) );
-		$t_lead = '<i class="fa fa-square-o fa-xlg ' . $t_status_label . '"></i> ';
+		$t_lead = '<i class="fa fa-square fa-status-box ' . $t_status_label . '"></i> ';
 		$t_lead .= ' ' . string_get_bug_view_link( $t_bug_id );
 		echo sprintf( "<tr> <td>%s</td> <td>%s</td> </tr>\n", $t_lead, string_attribute( bug_get_field( $t_bug_id, 'summary' ) ) );
 	}

--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -1372,7 +1372,7 @@ function print_column_status( BugData $p_bug, $p_columns_target = COLUMNS_TARGET
 	$status_label = html_get_status_css_class( $p_bug->status, auth_get_current_user_id(), $p_bug->project_id );
 	echo '<td class="column-status">';
 	echo '<div class="align-left">';
-	echo '<i class="fa fa-square-o fa-xlg ' . $status_label . '"></i> ';
+	echo '<i class="fa fa-square fa-status-box ' . $status_label . '"></i> ';
 	printf( '<span title="%s">%s</span>',
 		get_enum_element( 'resolution', $p_bug->resolution, auth_get_current_user_id(), $p_bug->project_id ),
 		get_enum_element( 'status', $p_bug->status, auth_get_current_user_id(), $p_bug->project_id )

--- a/core/custom_function_api.php
+++ b/core/custom_function_api.php
@@ -105,7 +105,7 @@ function custom_function_default_changelog_print_issue( $p_issue_id, $p_issue_le
 	$t_status_title = string_attribute( get_enum_element( 'status', bug_get_field( $t_bug->id, 'status' ), $t_bug->project_id ) );;
 
 	echo utf8_str_pad( '', $p_issue_level * 36, '&#160;' );
-	echo '<i class="fa fa-square-o fa-xlg ' . $status_label . '" title="' . $t_status_title . '"></i> ';
+	echo '<i class="fa fa-square fa-status-box ' . $status_label . '" title="' . $t_status_title . '"></i> ';
 	echo string_get_bug_view_link( $p_issue_id );
 	echo ': <span class="label label-light">', $t_category, '</span> ' , string_display_line_links( $t_bug->summary );
 	if( $t_bug->handler_id != 0 ) {
@@ -161,7 +161,7 @@ function custom_function_default_roadmap_print_issue( $p_issue_id, $p_issue_leve
 	$t_status_title = string_attribute( get_enum_element( 'status', bug_get_field( $t_bug->id, 'status' ), $t_bug->project_id ) );;
 
 	echo utf8_str_pad( '', $p_issue_level * 36, '&#160;' );
-	echo '<i class="fa fa-square-o fa-xlg ' . $status_label . '" title="' . $t_status_title . '"></i> ';
+	echo '<i class="fa fa-square fa-status-box ' . $status_label . '" title="' . $t_status_title . '"></i> ';
 	echo string_get_bug_view_link( $p_issue_id );
 	echo ': <span class="label label-light">', $t_category, '</span> ', $t_strike_start, string_display_line_links( $t_bug->summary ), $t_strike_end;
 	if( $t_bug->handler_id != 0 ) {

--- a/core/custom_function_api.php
+++ b/core/custom_function_api.php
@@ -167,7 +167,7 @@ function custom_function_default_roadmap_print_issue( $p_issue_id, $p_issue_leve
 	if( $t_bug->handler_id != 0 ) {
 		echo ' (', prepare_user_name( $t_bug->handler_id ), ')';
 	}
-	echo '<br />';
+	echo '<div class="space-2"></div>';
 }
 
 /**

--- a/core/relationship_api.php
+++ b/core/relationship_api.php
@@ -642,7 +642,7 @@ function relationship_get_details( $p_bug_id, BugRelationshipData $p_relationshi
 		# choose color based on status
 		$status_label = html_get_status_css_class( $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
 		$t_relationship_info_html .= '<td><a href="' . string_get_bug_view_url( $t_related_bug_id ) . '">' . string_display_line( bug_format_id( $t_related_bug_id ) ) . '</a></td>';
-		$t_relationship_info_html .= '<td><i class="fa fa-square-o fa-xlg ' . $status_label . '"></i> ';
+		$t_relationship_info_html .= '<td><i class="fa fa-square fa-status-box ' . $status_label . '"></i> ';
 		$t_relationship_info_html .= '<span class="issue-status" title="' . string_attribute( $t_resolution_string ) . '">' . string_display_line( $t_status_string ) . '</span></td>';
 	} else {
 		$t_relationship_info_html .= $t_td . string_display_line( bug_format_id( $t_related_bug_id ) ) . '</td>';

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -193,6 +193,12 @@ pre {
     vertical-align: -15%;
 }
 
+.fa-status-box {
+    font-size: 1.8em;
+    line-height: 0.73em;
+    vertical-align: -25%;
+}
+
 .skin-3 .navbar .navbar-toggle {
     background-color:  #777 !important;
 }

--- a/css/status_config.php
+++ b/css/status_config.php
@@ -82,7 +82,7 @@ foreach( $t_statuses as $t_id => $t_label ) {
 	# Status color class
 	if( array_key_exists( $t_label, $t_colors ) ) {
 		echo '.' . $t_css_class
-			. " { background-color: {$t_colors[$t_label]}; }\n";
+			. " { color: {$t_colors[$t_label]}; background-color: {$t_colors[$t_label]}; }\n";
 	}
 
 	# Status percentage width class

--- a/my_view_inc.php
+++ b/my_view_inc.php
@@ -348,7 +348,7 @@ for( $i = 0;$i < $t_count; $i++ ) {
 			# choose color based on status
 			$status_label = html_get_status_css_class( $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
 			$t_status = string_attribute( get_enum_element( 'status', bug_get_field( $t_bug->id, 'status' ), $t_bug->project_id ) );
-			echo '<i class="fa fa-square-o fa-xlg ' . $status_label . '" title="' . $t_status . '"></i> ';
+			echo '<i class="fa fa-square fa-status-box ' . $status_label . '" title="' . $t_status . '"></i> ';
 
 			if( !bug_is_readonly( $t_bug->id ) && access_has_bug_level( $t_update_bug_threshold, $t_bug->id ) ) {
 				echo '<a class="edit" href="' . string_get_bug_update_url( $t_bug->id ) . '"><i class="fa fa-pencil bigger-130 padding-2 grey" alt="' . lang_get( 'update_bug_button' ) . '" title="' . lang_get( 'update_bug_button' ) . '"></i></a>';


### PR DESCRIPTION
This change make the status color more prominent than before & less eye soar as the black frame is gone ... see before and after images.

Before:
![screenshot from 2017-01-29 18-08-38](https://cloud.githubusercontent.com/assets/1354889/22410532/5e4df136-e64e-11e6-891b-bf90d8aea9a1.png)

After:
![screenshot from 2017-01-29 18-13-16](https://cloud.githubusercontent.com/assets/1354889/22410561/adb635b2-e64e-11e6-9498-20503e6443cc.png)


Fixes #21724