### PR TITLE
Add UTF-8 header to Office Word output

### DIFF
--- a/print_all_bug_page_word.php
+++ b/print_all_bug_page_word.php
@@ -112,7 +112,8 @@ if( $f_type_page == 'html' ) {
 } else {
 	echo '<html xmlns:o="urn:schemas-microsoft-com:office:office"
 		xmlns:w="urn:schemas-microsoft-com:office:word"
-		xmlns="http://www.w3.org/TR/REC-html40">';
+		xmlns="http://www.w3.org/TR/REC-html40">
+		<head><meta charset="utf-8"></head>';
 	html_body_begin();
 }
 


### PR DESCRIPTION
Fixes #21798

Tested using MS Office 2013 on Windows 7 and also Libre Office and TextEdit on MacOS