### PR TITLE
Add tags to permalink url parse

### DIFF
--- a/search.php
+++ b/search.php
@@ -93,6 +93,8 @@ $t_my_filter[FILTER_PROPERTY_OS_BUILD] = gpc_get_string_array( FILTER_PROPERTY_O
 $t_my_filter[FILTER_PROPERTY_VIEW_STATE] = gpc_get_string_array( FILTER_PROPERTY_VIEW_STATE, $t_meta_filter_any_array );
 $t_my_filter[FILTER_PROPERTY_VERSION] = gpc_get_string_array( FILTER_PROPERTY_VERSION, $t_meta_filter_any_array );
 $t_my_filter[FILTER_PROPERTY_MATCH_TYPE] = gpc_get_int( FILTER_PROPERTY_MATCH_TYPE, FILTER_MATCH_ALL );
+$t_my_filter[FILTER_PROPERTY_TAG_STRING] = gpc_get_string( FILTER_PROPERTY_TAG_STRING, '' );
+$t_my_filter[FILTER_PROPERTY_TAG_SELECT] = gpc_get_int( FILTER_PROPERTY_TAG_SELECT, 0 );
 
 # Filtering by Date
 # Creation Date


### PR DESCRIPTION
Permalink url parse did not read parameter for tags.
Previously it worked as a side effect of reading gpc vars at
filter_ensure_valid, which is not done any more.

Fixes: #22302