### PR TITLE
Sanitize window title

### DIFF
--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -415,7 +415,7 @@ function layout_navbar() {
 	echo '<div class="navbar-header">';
 	echo '<a href="' . $t_logo_url . '" class="navbar-brand">';
 	echo '<span class="smaller-75"> ';
-	echo config_get('window_title');
+	echo string_display_line( config_get('window_title') );
 	echo ' </span>';
 	echo '</a>';
 


### PR DESCRIPTION
The window title is not sanitized.  That is not an issue when CSP is enable (default),
but if disabled, it can execute javascript that is set by a user who has access
to set configuration via Manage - Manage Configuration - Configuration Report page.

Fixes #22266