### PR TITLE
Due Date fixes for bug creation and update

### DIFF
--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -767,7 +767,7 @@ function mc_issue_add( $p_username, $p_password, stdClass $p_issue ) {
 		$t_bug_data->sticky = $p_issue['sticky'];
 	}
 
-	if( isset( $p_issue['due_date'] ) && access_has_global_level( config_get( 'due_date_update_threshold' ) ) ) {
+	if( isset( $p_issue['due_date'] ) && access_has_project_level( config_get( 'due_date_update_threshold' ), $t_project_id ) ) {
 		$t_bug_data->due_date = SoapObjectsFactory::parseDateTimeString( $p_issue['due_date'] );
 	} else {
 		# The create API will handle setting the default value for due date.
@@ -1011,10 +1011,14 @@ function mc_issue_update( $p_username, $p_password, $p_issue_id, stdClass $p_iss
 		$t_bug_data->sticky = $p_issue['sticky'];
 	}
 
-	if( isset( $p_issue['due_date'] ) && access_has_global_level( config_get( 'due_date_update_threshold' ) ) ) {
-		$t_bug_data->due_date = SoapObjectsFactory::parseDateTimeString( $p_issue['due_date'] );
-	} else {
-		$t_bug_data->due_date = date_get_null();
+	if( isset( $p_issue['due_date'] ) ) {
+		if( access_has_bug_level( config_get( 'due_date_update_threshold' ), $t_bug_data->id ) ) {
+			if( is_null( $p_issue['due_date'] ) || is_blank( $p_issue['due_date'] ) ) {
+				$t_bug_data->due_date = date_get_null();
+			} else {
+				$t_bug_data->due_date = SoapObjectsFactory::parseDateTimeString( $p_issue['due_date'] );
+			}
+		}
 	}
 
 	if( access_has_project_level( config_get( 'roadmap_update_threshold' ), $t_bug_data->project_id, $t_user_id ) ) {

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -767,11 +767,12 @@ function mc_issue_add( $p_username, $p_password, stdClass $p_issue ) {
 		$t_bug_data->sticky = $p_issue['sticky'];
 	}
 
-	if( isset( $p_issue['due_date'] ) && access_has_project_level( config_get( 'due_date_update_threshold' ), $t_project_id ) ) {
+	if( isset( $p_issue['due_date'] ) &&
+		access_has_project_level( config_get( 'due_date_update_threshold' ), $t_project_id ) ) {
 		$t_bug_data->due_date = SoapObjectsFactory::parseDateTimeString( $p_issue['due_date'] );
 	} else {
 		# The create API will handle setting the default value for due date.
-		$t_bug_data->due_date = '';
+		$t_bug_data->due_date = null;
 	}
 
 	if( access_has_project_level( config_get( 'roadmap_update_threshold' ), $t_bug_data->project_id, $t_user_id ) ) {

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -770,7 +770,8 @@ function mc_issue_add( $p_username, $p_password, stdClass $p_issue ) {
 	if( isset( $p_issue['due_date'] ) && access_has_global_level( config_get( 'due_date_update_threshold' ) ) ) {
 		$t_bug_data->due_date = SoapObjectsFactory::parseDateTimeString( $p_issue['due_date'] );
 	} else {
-		$t_bug_data->due_date = date_get_null();
+		# The create API will handle setting the default value for due date.
+		$t_bug_data->due_date = '';
 	}
 
 	if( access_has_project_level( config_get( 'roadmap_update_threshold' ), $t_bug_data->project_id, $t_user_id ) ) {

--- a/bug_report.php
+++ b/bug_report.php
@@ -127,10 +127,7 @@ $t_bug_data->summary                = gpc_get_string( 'summary' );
 $t_bug_data->description            = gpc_get_string( 'description' );
 $t_bug_data->steps_to_reproduce     = gpc_get_string( 'steps_to_reproduce', config_get( 'default_bug_steps_to_reproduce' ) );
 $t_bug_data->additional_information = gpc_get_string( 'additional_info', config_get( 'default_bug_additional_info' ) );
-$t_bug_data->due_date               = gpc_get_string( 'due_date', date_strtotime( config_get( 'due_date_default' ) ) );
-if( is_blank( $t_bug_data->due_date ) ) {
-	$t_bug_data->due_date = date_get_null();
-}
+$t_bug_data->due_date               = gpc_get_string( 'due_date', '' );
 
 $f_rel_type                         = gpc_get_int( 'rel_type', BUG_REL_NONE );
 $f_files                            = gpc_get_file( 'ufile', null );

--- a/bug_report.php
+++ b/bug_report.php
@@ -127,7 +127,6 @@ $t_bug_data->summary                = gpc_get_string( 'summary' );
 $t_bug_data->description            = gpc_get_string( 'description' );
 $t_bug_data->steps_to_reproduce     = gpc_get_string( 'steps_to_reproduce', config_get( 'default_bug_steps_to_reproduce' ) );
 $t_bug_data->additional_information = gpc_get_string( 'additional_info', config_get( 'default_bug_additional_info' ) );
-$t_bug_data->due_date               = gpc_get_string( 'due_date', '' );
 
 $f_rel_type                         = gpc_get_int( 'rel_type', BUG_REL_NONE );
 $f_files                            = gpc_get_file( 'ufile', null );
@@ -136,6 +135,10 @@ $f_copy_notes_from_parent           = gpc_get_bool( 'copy_notes_from_parent', fa
 $f_copy_attachments_from_parent     = gpc_get_bool( 'copy_attachments_from_parent', false );
 $f_tag_select                       = gpc_get_int( 'tag_select', 0 );
 $f_tag_string                       = gpc_get_string( 'tag_string', '' );
+
+if( access_has_project_level( config_get( 'due_date_update_threshold' ), $t_bug_data->project_id ) ) {
+	$t_bug_data->due_date = gpc_get_string( 'due_date', null );
+}
 
 if( access_has_project_level( config_get( 'roadmap_update_threshold' ), $t_bug_data->project_id ) ) {
 	$t_bug_data->target_version = gpc_get_string( 'target_version', '' );

--- a/bug_update.php
+++ b/bug_update.php
@@ -79,14 +79,13 @@ $t_updated_bug->additional_information = gpc_get_string( 'additional_information
 $t_updated_bug->build = gpc_get_string( 'build', $t_existing_bug->build );
 $t_updated_bug->category_id = gpc_get_int( 'category_id', $t_existing_bug->category_id );
 $t_updated_bug->description = gpc_get_string( 'description', $t_existing_bug->description );
-$t_due_date = gpc_get_string( 'due_date', null );
-if( $t_due_date !== null ) {
-	if( is_blank( $t_due_date ) ) {
-		$t_updated_bug->due_date = 1;
-	} else {
-		$t_updated_bug->due_date = strtotime( $t_due_date );
-	}
+
+if( access_has_bug_level( config_get( 'due_date_update_threshold' ), $f_bug_id ) ) {
+	$t_updated_bug->due_date = gpc_get_string( 'due_date', $t_existing_bug->due_date );
+} else {
+	$t_updated_bug->due_date = $t_existing_bug->due_date;
 }
+
 $t_updated_bug->duplicate_id = gpc_get_int( 'duplicate_id', 0 );
 $t_updated_bug->eta = gpc_get_int( 'eta', $t_existing_bug->eta );
 $t_updated_bug->fixed_in_version = gpc_get_string( 'fixed_in_version', $t_existing_bug->fixed_in_version );

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -478,7 +478,7 @@ class BugData {
 
 		antispam_check();
 
-		if( is_null( $this->due_date ) || is_blank( $this->due_date ) ) {
+		if( is_blank( $this->due_date ) ) {
 			$t_due_date_default = config_get( 'due_date_default' );
 
 			if( is_blank( $t_due_date_default ) ) {
@@ -631,7 +631,7 @@ class BugData {
 
 		$c_bug_id = $this->id;
 
-		if( is_null( $this->due_date ) || is_blank( $this->due_date ) ) {
+		if( is_blank( $this->due_date ) ) {
 			$this->due_date = date_get_null();
 		} else if( is_numeric( $this->due_date ) ) {
 			$this->due_date = (int)$this->due_date;

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -478,14 +478,20 @@ class BugData {
 
 		antispam_check();
 
-		# check due_date format
-		if( is_blank( $this->due_date ) ) {
-			$this->due_date = date_get_null();
+		if( is_null( $this->due_date ) || is_blank( $this->due_date ) ) {
+			$t_due_date_default = config_get( 'due_date_default' );
+
+			if( is_blank( $t_due_date_default ) ) {
+				$this->due_date = date_get_null();
+			} else {
+				$this->due_date = date_strtotime( $t_due_date_default );
+			}
 		}
-		# check date submitted and last modified
+
 		if( is_blank( $this->date_submitted ) ) {
 			$this->date_submitted = db_now();
 		}
+
 		if( is_blank( $this->last_updated ) ) {
 			$this->last_updated = db_now();
 		}

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -631,8 +631,12 @@ class BugData {
 
 		$c_bug_id = $this->id;
 
-		if( is_blank( $this->due_date ) ) {
+		if( is_null( $this->due_date ) || is_blank( $this->due_date ) ) {
 			$this->due_date = date_get_null();
+		} else if( is_numeric( $this->due_date ) ) {
+			$this->due_date = (int)$this->due_date;
+		} else {
+			$this->due_date = strtotime( $this->due_date );
 		}
 
 		$t_old_data = bug_get( $this->id, true );


### PR DESCRIPTION
This PR fixes the following issues:

- [22411](https://www.mantisbt.org/bugs/view.php?id=22411) - Due date default is not honored by SOAP API
- [22415](https://www.mantisbt.org/bugs/view.php?id=22415) - Due date access level check in SOAP API should use project/bug access rather than global-access
- [22416](https://www.mantisbt.org/bugs/view.php?id=22416) - Due date is wiped if user has update access but not due date update access
