### PR TITLE
Markdown: Fix handling of # characters

### DIFF
--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -102,10 +102,10 @@ class MantisMarkdown extends Parsedown
 	protected function blockHeader( $line ) {
 		
 		# Text either indented 0-3 spaces
-		# The opening sequence of # characters must be followed by a space
 		# An opening sequence of 1–6 # characters
-		# The #'s can be followed by a newline also
-		if ( preg_match( '/^\s{1,3}|#{1,6}(?:[ \t]+|$)/', $line['text'] ) ) {
+		# The opening sequence of # characters must be followed by a space
+		# The #'s can be followed by a newline as well
+		if ( preg_match( '/^ {0,3}#{1,6}( |$)/', $line['text'] ) ) {
 			return parent::blockHeader($line);
 		}
 	}

--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -95,15 +95,17 @@ class MantisMarkdown extends Parsedown
 	 *
 	 * @param string $line The Markdown syntax to parse
 	 * @access protected
-	 * @return null|string HTML representation generated from markdown or null if
-                      markdown starts with # symbol immediately followed by 
-                      any character other than space.
+	 * @return null|string HTML representation generated from markdown or null 
+	 				for example text starts with # symbol and immediately followed by 
+					any character other than space.
 	 */
 	protected function blockHeader( $line ) {
 		
-		# Check if string starts with # symbol followed by space, 
-		# If pattern match, then let the parent blockHeader function handle it
-		if ( preg_match('/^#+ /', $line['text'] ) ) {
+		# Text either indented 0-3 spaces
+		# The opening sequence of # characters must be followed by a space
+		# An opening sequence of 1–6 # characters
+		# The #'s can be followed by a newline also
+		if ( preg_match( '/^\s{1,3}|#{1,6}(?:[ \t]+|$)/', $line['text'] ) ) {
 			return parent::blockHeader($line);
 		}
 	}

--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -95,9 +95,9 @@ class MantisMarkdown extends Parsedown
 	 *
 	 * @param string $line The Markdown syntax to parse
 	 * @access protected
-	 * @return null|string HTML representation generated from markdown or null 
-	 				for example text starts with # symbol and immediately followed by 
-					any character other than space.
+	 * @return string|null HTML representation generated from markdown or null
+	 *				for example text starts with # symbol and immediately followed by
+	 *				any character other than space.
 	 */
 	protected function blockHeader( $line ) {
 		

--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -105,7 +105,7 @@ class MantisMarkdown extends Parsedown
 		# An opening sequence of 1–6 # characters
 		# The opening sequence of # characters must be followed by a space
 		# The #'s can be followed by a newline as well
-		if ( preg_match( '/^ {0,3}#{1,6}( |$)/', $line['text'] ) ) {
+		if ( preg_match( '/^ {0,3}#{1,6}(?: |$)/', $line['text'] ) ) {
 			return parent::blockHeader($line);
 		}
 	}

--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -91,54 +91,20 @@ class MantisMarkdown extends Parsedown
 	}
 
 	/**
-	 * Customize the logic on Header elements
+	 * Customize the blockHeader markdown
 	 *
 	 * @param string $line The Markdown syntax to parse
 	 * @access protected
-	 * @return void if markdown starts with # symbol | string html representation generated from markdown.
+	 * @return void if markdown starts with # symbol followed by any character | string html representation generated from markdown.
 	 */
 	protected function blockHeader( $line ) {
-		$block = parent::blockHeader( $line );
-
-		# make sure config option bug_link_tag == '#' only
-		# check if string start with # symbol followed by numbers
-		# hash[numbers] should not be treated as header, then let the app handle it
-		if( '#' == config_get_global( 'bug_link_tag' ) && preg_match_all( '/^#\d+$/', $line['text'], $matches ) ) {
-			return;
+		
+		# Parsedown is not exactly follows with # symbol as stated in http://spec.commonmark.org/0.27/#atx-heading
+		# Header need a space between the # symbol and the text as required by the original ATX implementation
+		# This fix will search for a match of # symbol followed by space only
+		if ( preg_match('/^#+ /', $line['text'] ) ) {
+			return parent::blockHeader($line);
 		}
-
-		# Header rules
-		# hash[space][numbers] - treated as header
-		# hash[number][*] - treated as header since it is not a pure number
-		# hash[letter][*] - treated as header
-		# hash[space][letter][*] - treated as header
-		return $block;
-	}
-
-	/**
-	 * Customize the logic on setting the Header elements.
-	 *
-	 * @param string $line The Markdown syntax to parse
-	 * @param array $block A block-level element
-	 * @access protected
-	 * @return void if markdown starts with # symbol | string html representation generated from markdown.
-	 */
-	protected function blockSetextHeader( $line, array $block = null ) {
-		$block = parent::blockSetextHeader( $line, $block );
-
-		# make sure config option bug_link_tag == '#' only
-		# check if string start with # symbol followed by numbers
-		# hash[numbers] should not be treated as header, then let the app handle it
-		if( '#' == config_get_global( 'bug_link_tag' ) && preg_match_all( '/^#\d+$/', $line['text'], $matches ) ) {
-			return;
-		}
-
-		# Header rules
-		# hash[space][numbers] - treated as header
-		# hash[number][*] - treated as header since it is not a pure number
-		# hash[letter][*] - treated as header
-		# hash[space][letter][*] - treated as header
-		return $block;
 	}
 
 	/**

--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -95,13 +95,14 @@ class MantisMarkdown extends Parsedown
 	 *
 	 * @param string $line The Markdown syntax to parse
 	 * @access protected
-	 * @return void if markdown starts with # symbol followed by any character | string html representation generated from markdown.
+	 * @return null|string HTML representation generated from markdown or null if
+                      markdown starts with # symbol immediately followed by 
+                      any character other than space.
 	 */
 	protected function blockHeader( $line ) {
 		
-		# Parsedown is not exactly follows with # symbol as stated in http://spec.commonmark.org/0.27/#atx-heading
-		# Header need a space between the # symbol and the text as required by the original ATX implementation
-		# This fix will search for a match of # symbol followed by space only
+		# Check if string starts with # symbol followed by space, 
+		# If pattern match, then let the parent blockHeader function handle it
 		if ( preg_match('/^#+ /', $line['text'] ) ) {
 			return parent::blockHeader($line);
 		}


### PR DESCRIPTION
- parsedown is not following exactly with # symbol treated as header
- removed incorrect logic on header custom extension

Fixes #22333

![screen shot 2017-03-01 at 9 54 51 pm](https://cloud.githubusercontent.com/assets/955545/23463213/b52048de-fecb-11e6-9973-ee0d11b3d543.png)
