### PR TITLE
Fix print page error when cookie not set

### DIFF
--- a/docbook/Admin_Guide/en-US/Customizing.xml
+++ b/docbook/Admin_Guide/en-US/Customizing.xml
@@ -785,7 +785,7 @@ $g_notify_flags['owner'] = array(
                         about. Also send new issue notifications to managers so they can
                         screen them.
 <programlisting>
-$g_mail_receive_own = OFF;
+$g_email_receive_own = OFF;
 $g_default_notify_flags = array(
 	'reporter'      => ON,
 	'handler'       => ON,

--- a/docbook/Admin_Guide/en-US/Page_Descriptions.xml
+++ b/docbook/Admin_Guide/en-US/Page_Descriptions.xml
@@ -457,7 +457,7 @@
                 unless these values are 0. If the values are 0, the check is
                 skipped. All fields are also compared against the regular
                 expression. If the value matches the expression, then the value is
-                stored. For example, the expression "/^-?([0-9])*$/" can be used to
+                stored. For example, the expression "^-?([0-9])*$" can be used to
                 constrain an integer.The table below describes the field types and
                 the value constraints.
             </para>

--- a/docbook/Admin_Guide/en-US/config/email.xml
+++ b/docbook/Admin_Guide/en-US/config/email.xml
@@ -254,14 +254,14 @@ $g_notify_flags['new'] = array(
 			</listitem>
 		</varlistentry>
 		<varlistentry>
-			<term>$g_limit_email_domain</term>
+			<term>$g_limit_email_domains</term>
 			<listitem>
-				<para>Only allow and send email to addresses in the given domain.
+				<para>Only allow and send email to addresses in the given domain(s).
 					This is useful as a security feature and it is also useful in cases
 					like Sourceforge where its servers are only limited to send emails
 					to SourceForge email addresses in order to avoid
-					spam. $g_limit_email_domain =
-					'users.sourceforge.net';
+					spam. $g_limit_email_domains =
+					array( 'users.sourceforge.net', 'sourceforge.net' );
 				</para>
 			</listitem>
 		</varlistentry>

--- a/print_all_bug_page.php
+++ b/print_all_bug_page.php
@@ -62,9 +62,6 @@ auth_ensure_user_authenticated();
 $f_search		= gpc_get_string( FILTER_PROPERTY_SEARCH, false ); # @todo need a better default
 $f_offset		= gpc_get_int( 'offset', 0 );
 
-$t_cookie_value_id = gpc_get_cookie( config_get( 'view_all_cookie' ), '' );
-$t_cookie_value = filter_db_get_filter( $t_cookie_value_id );
-
 $f_highlight_changed 	= 0;
 $f_sort 				= null;
 $f_dir		 			= null;
@@ -73,22 +70,24 @@ $t_project_id 			= 0;
 $t_columns = helper_get_columns_to_view( COLUMNS_TARGET_PRINT_PAGE );
 $t_num_of_columns = count( $t_columns );
 
-# check to see if the cookie exists
-if( !is_blank( $t_cookie_value ) ) {
-
+# Initialize the filter from the cookie, use default if not set
+$t_cookie_value_id = gpc_get_cookie( config_get( 'view_all_cookie' ), '' );
+$t_cookie_value = filter_db_get_filter( $t_cookie_value_id );
+if( is_blank( $t_cookie_value ) ) {
+	$t_filter_cookie_arr = filter_get_default();
+} else {
 	# check to see if new cookie is needed
 	if( !filter_is_cookie_valid() ) {
 		print_header_redirect( 'view_all_set.php?type=0&print=1' );
 	}
-
 	$t_setting_arr = explode( '#', $t_cookie_value, 2 );
 	$t_filter_cookie_arr = json_decode( $t_setting_arr[1], true );
-
-	$f_highlight_changed 	= $t_filter_cookie_arr[FILTER_PROPERTY_HIGHLIGHT_CHANGED];
-	$f_sort 				= $t_filter_cookie_arr[FILTER_PROPERTY_SORT_FIELD_NAME];
-	$f_dir		 			= $t_filter_cookie_arr[FILTER_PROPERTY_SORT_DIRECTION];
-	$t_project_id 			= helper_get_current_project();
 }
+
+$f_highlight_changed = $t_filter_cookie_arr[FILTER_PROPERTY_HIGHLIGHT_CHANGED];
+$f_sort              = $t_filter_cookie_arr[FILTER_PROPERTY_SORT_FIELD_NAME];
+$f_dir               = $t_filter_cookie_arr[FILTER_PROPERTY_SORT_DIRECTION];
+$t_project_id        = helper_get_current_project();
 
 # This replaces the actual search that used to be here
 $f_page_number = gpc_get_int( 'page_number', 1 );


### PR DESCRIPTION
When the VIEW_ALL_COOKIE is not set or blank, an attempt to display
print_all_bug_page.php will trigger a system error: 'Argument 1 passed
to filter_get_visible_sort_properties_array() must be an array, null
given'.

This is due to the filter ($t_filter_cookie_arr) not being initialized
in this case, leading to an error as it's defaulted to NULL while the
filter_get_visible_sort_properties_array() function expects an array.

Use a default filter when the cookie is not set or empty.

Fixes [#22442](http://mantisbt.org/bugs/view.php?id=22442)