### PR TITLE
Add project_id param to project_*_name_unique()

### DIFF
--- a/core/project_api.php
+++ b/core/project_api.php
@@ -242,18 +242,21 @@ function project_ensure_exists( $p_project_id ) {
 /**
  * check to see if project exists by name
  * @param string $p_name The project name.
+ * @param int    $p_id   Optional project id to exclude from the check, to
+ *                       allow uniqueness check when updating.
  * @return boolean
  */
-function project_is_name_unique( $p_name ) {
+function project_is_name_unique( $p_name, $p_project_id = null ) {
 	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM {project} WHERE name=' . db_param();
-	$t_result = db_query( $t_query, array( $p_name ) );
-
-	if( 0 == db_result( $t_result ) ) {
-		return true;
-	} else {
-		return false;
+	$t_param = array( $p_name );
+	if( $p_project_id ) {
+		$t_query .= ' AND id <> ' . db_param();
+		$t_param[] = (int)$p_project_id;
 	}
+	$t_result = db_query( $t_query, $t_param );
+
+	return 0 == db_result( $t_result );
 }
 
 /**
@@ -261,10 +264,12 @@ function project_is_name_unique( $p_name ) {
  * if it doesn't exist then error
  * otherwise let execution continue undisturbed
  * @param string $p_name The project name.
+ * @param int    $p_id   Optional project id to exclude from the check, to
+ *                       allow uniqueness check when updating.
  * @return void
  */
-function project_ensure_name_unique( $p_name ) {
-	if( !project_is_name_unique( $p_name ) ) {
+function project_ensure_name_unique( $p_name, $p_project_id = null ) {
+	if( !project_is_name_unique( $p_name, $p_project_id ) ) {
 		trigger_error( ERROR_PROJECT_NAME_NOT_UNIQUE, ERROR );
 	}
 }
@@ -442,7 +447,8 @@ function project_update( $p_project_id, $p_name, $p_description, $p_status, $p_v
 	}
 
 	if( strcasecmp( $p_name, $t_old_name ) != 0 ) {
-		project_ensure_name_unique( $p_name );
+var_dump(1);
+	project_ensure_name_unique( $p_name, $p_project_id );
 	}
 
 	if( DATABASE !== config_get( 'file_upload_method', null, null, $p_project_id ) ) {

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -250,7 +250,7 @@ function project_is_name_unique( $p_name, $p_exclude_id = null ) {
 	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM {project} WHERE name=' . db_param();
 	$t_param = array( $p_name );
-	if( $p_project_id ) {
+	if( $p_exclude_id ) {
 		$t_query .= ' AND id <> ' . db_param();
 		$t_param[] = (int)$p_exclude_id;
 	}

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -241,9 +241,9 @@ function project_ensure_exists( $p_project_id ) {
 
 /**
  * check to see if project exists by name
- * @param string $p_name The project name.
- * @param int    $p_id   Optional project id to exclude from the check, to
- *                       allow uniqueness check when updating.
+ * @param string $p_name       The project name.
+ * @param int    $p_project_id Optional project id to exclude from the check,
+ *                             to allow uniqueness check when updating.
  * @return boolean
  */
 function project_is_name_unique( $p_name, $p_project_id = null ) {
@@ -263,9 +263,9 @@ function project_is_name_unique( $p_name, $p_project_id = null ) {
  * check to see if project exists by id
  * if it doesn't exist then error
  * otherwise let execution continue undisturbed
- * @param string $p_name The project name.
- * @param int    $p_id   Optional project id to exclude from the check, to
- *                       allow uniqueness check when updating.
+ * @param string $p_name       The project name.
+ * @param int    $p_project_id Optional project id to exclude from the check,
+ *                             to allow uniqueness check when updating.
  * @return void
  */
 function project_ensure_name_unique( $p_name, $p_project_id = null ) {
@@ -447,8 +447,7 @@ function project_update( $p_project_id, $p_name, $p_description, $p_status, $p_v
 	}
 
 	if( strcasecmp( $p_name, $t_old_name ) != 0 ) {
-var_dump(1);
-	project_ensure_name_unique( $p_name, $p_project_id );
+		project_ensure_name_unique( $p_name, $p_project_id );
 	}
 
 	if( DATABASE !== config_get( 'file_upload_method', null, null, $p_project_id ) ) {

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -241,18 +241,18 @@ function project_ensure_exists( $p_project_id ) {
 
 /**
  * check to see if project exists by name
- * @param string $p_name       The project name.
- * @param int    $p_project_id Optional project id to exclude from the check,
- *                             to allow uniqueness check when updating.
+ * @param string  $p_name       The project name.
+ * @param integer $p_exclude_id Optional project id to exclude from the check,
+ *                              to allow uniqueness check when updating.
  * @return boolean
  */
-function project_is_name_unique( $p_name, $p_project_id = null ) {
+function project_is_name_unique( $p_name, $p_exclude_id = null ) {
 	db_param_push();
 	$t_query = 'SELECT COUNT(*) FROM {project} WHERE name=' . db_param();
 	$t_param = array( $p_name );
 	if( $p_project_id ) {
 		$t_query .= ' AND id <> ' . db_param();
-		$t_param[] = (int)$p_project_id;
+		$t_param[] = (int)$p_exclude_id;
 	}
 	$t_result = db_query( $t_query, $t_param );
 
@@ -263,13 +263,13 @@ function project_is_name_unique( $p_name, $p_project_id = null ) {
  * check to see if project exists by id
  * if it doesn't exist then error
  * otherwise let execution continue undisturbed
- * @param string $p_name       The project name.
- * @param int    $p_project_id Optional project id to exclude from the check,
- *                             to allow uniqueness check when updating.
+ * @param string  $p_name       The project name.
+ * @param integer $p_exclude_id Optional project id to exclude from the check,
+ *                              to allow uniqueness check when updating.
  * @return void
  */
-function project_ensure_name_unique( $p_name, $p_project_id = null ) {
-	if( !project_is_name_unique( $p_name, $p_project_id ) ) {
+function project_ensure_name_unique( $p_name, $p_exclude_id = null ) {
+	if( !project_is_name_unique( $p_name, $p_exclude_id ) ) {
 		trigger_error( ERROR_PROJECT_NAME_NOT_UNIQUE, ERROR );
 	}
 }


### PR DESCRIPTION
This optional parameter is used to exclude the given id from the
uniqueness check, allowing correct behavior (avoid error 701) when
updating an existing project.

This was a problem on MySQL, because with utf8_general_ci collation,
accented characters are treated as identical, i.e. 'The' == 'thé'.

Fixes [#22479](http://www.mantisbt.org/bugs/view.php?id=22479)