### PR TITLE
Enhance wording in manage_config_email_page.php and manage_config_wor…

### DIFF
--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -764,6 +764,7 @@ $s_issue_reporter = 'User who reported the issue';
 $s_issue_handler = 'User who is handling the issue';
 $s_users_added_bugnote = 'Users who added Issue Notes';
 $s_category_assigned_to = 'Category Owner';
+$s_email_notify_users = 'Any user with access level';
 $s_change_configuration = 'Update Configuration';
 $s_message = 'Message';
 $s_default_notify = 'Setting default notification flags to';
@@ -800,6 +801,7 @@ $s_access_change_access_label = 'Who can change access levels:';
 $s_default_not_in_flow = 'The default status of %1$s is not selected in the next statuses for %2$s. It will be ignored.';
 
 # manage_config_work_threshold_page
+$s_allowed_access_levels = 'Allowed for any user with access level';
 $s_assign_issue = 'Assign an issue';
 $s_allow_reporter_close = 'Allow Reporter to close Issue';
 $s_allow_reporter_reopen = 'Allow Reporter to re-open Issue';

--- a/manage_config_email_page.php
+++ b/manage_config_email_page.php
@@ -230,7 +230,7 @@ function get_section_begin_for_email( $p_section_name ) {
 	echo '<th class="bold" style="text-align:center" rowspan="2">&#160;' . lang_get( 'users_monitoring_bug' ) . '&#160;</th>' . "\n";
 	echo '<th class="bold" style="text-align:center" rowspan="2">&#160;' . lang_get( 'users_added_bugnote' ) . '&#160;</th>' . "\n";
 	echo '<th class="bold" style="text-align:center" rowspan="2">&#160;' . lang_get( 'category_assigned_to' ) . '&#160;</th>' . "\n";
-	echo '<th class="bold" style="text-align:center" colspan="' . count( $t_access_levels ) . '">&#160;' . lang_get( 'access_levels' ) . '&#160;</th>' . "\n";
+	echo '<th class="bold" style="text-align:center" colspan="' . count( $t_access_levels ) . '">&#160;' . lang_get( 'email_notify_users' ) . '&#160;</th>' . "\n";
 	echo '  </tr><tr>' . "\n";
 
 	foreach( $t_access_levels as $t_access_level ) {

--- a/manage_config_work_threshold_page.php
+++ b/manage_config_work_threshold_page.php
@@ -103,7 +103,7 @@ function get_section_begin_mcwt( $p_section_name ) {
 	echo '<thead>';
 	echo '<tr>';
 	echo '<th class="bold" width="40%" rowspan="2">' . lang_get( 'perm_rpt_capability' ) . '</th>';
-	echo '<th class="bold" style="text-align:center"  width="40%" colspan="' . count( $g_access_levels ) . '">' . lang_get( 'access_levels' ) . '</th>';
+	echo '<th class="bold" style="text-align:center"  width="40%" colspan="' . count( $g_access_levels ) . '">' . lang_get( 'allowed_access_levels' ) . '</th>';
 	echo '<th class="bold" style="text-align:center" rowspan="2">&#160;' . lang_get( 'alter_level' ) . '&#160;</th>';
 	echo '</tr><tr>';
 	foreach( $g_access_levels as $t_access_level => $t_access_label ) {


### PR DESCRIPTION
Enhance wording in manage_config_email_page.php and manage_config_work_threshold_page.php pages

As discussed in #6249, the manage_config_email_page.php is confusing.
One part of the confusion is caused by wording.

It should be `Any user with access level` Instead of `Access Levels`.

The affected string `$s_access_levels` is used also at other places.
Changing the string would work on manage_config_work_threshold_page.php, but not on manage_config_workflow_page.php.

A new message string has to be introduced to solve it.

Fixes #22541