### PR TITLE
Modify schema to get install/upgrade work with db-mssql.

### DIFF
--- a/admin/schema.php
+++ b/admin/schema.php
@@ -846,7 +846,7 @@ $g_upgrade[199] = null;
 #
 $g_upgrade[200] = array('CreateTableSQL', array( db_get_table( 'api_token' ), "
 	id						I		UNSIGNED NOTNULL PRIMARY AUTOINCREMENT,
-	user_id					I		DEFAULT '0',
+	user_id					I		NOTNULL DEFAULT '0',
 	name					C(128)	NOTNULL,
 	hash					C(128)	NOTNULL,
 	date_created			I		UNSIGNED NOTNULL DEFAULT '0',


### PR DESCRIPTION
Although the problem appears in step 209, the real cause is the combination of
steps 200 and 201. The Index ('user_id','name') created in step 201 (with a nullable
'user_id' as of step 200) forbids the alteration of 'user_id' to NOTNULL in step 209,
at least with mssql. So fix this in step 200 and set 'user_id' NOTNULL right from start.

While this is a 'post release' change, it is justifiable as it happens in the same
install/upgrade sequence and the final db (schema) is identical.

Fixes #22063