### PR TITLE
Fix lowercase custom field column names

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -2221,9 +2221,8 @@ function bug_cache_columns_data( array $p_bugs, array $p_selected_columns ) {
 			continue;
 		}
 
-		if( strncmp( $t_column, 'custom_', 7 ) === 0 ) {
-			# @TODO cproensa, this will we replaced with column_is_custom_field()
-			$t_cf_name = utf8_substr( $t_column, 7 );
+		if( column_is_custom_field( $t_column ) ) {
+			$t_cf_name = column_get_custom_field_name( $t_column );
 			$t_cf_id = custom_field_get_id_from_name( $t_cf_name );
 			if( $t_cf_id ) {
 				$t_custom_field_ids[] = $t_cf_id;

--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -200,8 +200,7 @@ function columns_get_custom_fields() {
 	$t_all_cfids = custom_field_get_ids();
 	$t_col_names = array();
 	foreach( $t_all_cfids as $t_id ) {
-		$t_def = custom_field_get_definition( $t_id );
-		$t_col_names[] = 'custom_' . $t_def['name'];
+		$t_col_names[] = column_get_custom_field_column_name( $t_id );
 	}
 	return $t_col_names;
 }
@@ -348,6 +347,21 @@ function column_get_custom_field_name( $p_column ) {
 	}
 
 	return null;
+}
+
+/**
+ * Returns the name of a column corresponding to a custom field, providing the id as parameter.
+ *
+ * @param integer $p_cf_id	Custom field id
+ * @return string	The column name
+ */
+function column_get_custom_field_column_name( $p_cf_id ) {
+	$t_def = custom_field_get_definition( $p_cf_id );
+	if( $t_def ) {
+		return 'custom_' . $t_def['name'];
+	} else {
+		return null;
+	}
 }
 
 /**

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -503,6 +503,17 @@ function helper_project_specific_where( $p_project_id, $p_user_id = null ) {
 function helper_get_columns_to_view( $p_columns_target = COLUMNS_TARGET_VIEW_PAGE, $p_viewable_only = true, $p_user_id = null ) {
 	$t_columns = helper_call_custom_function( 'get_columns_to_view', array( $p_columns_target, $p_user_id ) );
 
+	# Fix column names for custom field columns that may be stored as lowercase in configuration. See issue #17367
+	# If the system was working fine with lowercase names, then database is case-insensitive, eg: mysql
+	# Fix by forcing a search with current name to get the id, then get the actual name by looking up this id
+	foreach( $t_columns as &$t_column_name ) {
+		$t_cf_name = column_get_custom_field_name( $t_column_name );
+		if( $t_cf_name ) {
+			$t_cf_id = custom_field_get_id_from_name( $t_cf_name );
+			$t_column_name = column_get_custom_field_column_name( $t_cf_id );
+		}
+	}
+
 	if( !$p_viewable_only ) {
 		return $t_columns;
 	}


### PR DESCRIPTION
Fix column names for custom field columns that may be stored as
lowercase in configuration. See issue #17367
If the system was working fine with lowercase names, then database is
case-insensitive, eg: mysql.
Fix by forcing a search with current name to get the id, then get the
actual name by looking up this id.

Fixes: #22555