### PR TITLE
Decouple widget colours css class names

### DIFF
--- a/account_page.php
+++ b/account_page.php
@@ -131,7 +131,7 @@ print_account_menu( 'account_page.php' );
 <div id="account-update-div" class="form-container">
 	<form id="account-update-form" method="post" action="account_update.php">
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-user"></i>

--- a/account_prefs_inc.php
+++ b/account_prefs_inc.php
@@ -99,7 +99,7 @@ function edit_account_prefs( $p_user_id = null, $p_error_if_protected = true, $p
 <div id="account-prefs-update-div" class="form-container">
 	<form id="account-prefs-update-form" method="post" action="account_prefs_update.php" class="form-inline">
 
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-sliders"></i>

--- a/account_prof_edit_page.php
+++ b/account_prof_edit_page.php
@@ -83,7 +83,7 @@ if( profile_is_global( $f_profile_id ) ) {
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 <form method="post" action="account_prof_update.php">
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-user"></i>

--- a/account_prof_menu_page.php
+++ b/account_prof_menu_page.php
@@ -93,7 +93,7 @@ if( $g_global_profiles ) {
 	<form id="account-profile-form" method="post" action="account_prof_update.php">
 		<fieldset>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-file-o"></i>
@@ -165,7 +165,7 @@ if( $g_global_profiles ) {
 
 <div id="account-profile-update-div" class="form-container">
 	<form id="account-profile-update-form" method="post" action="account_prof_update.php">
-		<div class="widget-box widget-color-blue2">
+		<div class="widget-box widget-color-main">
 			<div class="widget-header widget-header-small">
 				<h4 class="widget-title lighter">
 					<i class="ace-icon fa fa-file-o"></i>

--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -312,7 +312,7 @@ $t_result = db_query( $t_query, $t_param );
 	<?php # CSRF protection not required here - form does not result in modifications ?>
 		<input type="hidden" name="save" value="1" />
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 <h4 class="widget-title lighter">
 	<i class="ace-icon fa fa-filter"></i>
@@ -389,7 +389,7 @@ $t_result = db_query( $t_query, $t_param );
 <div class="space-10"></div>
 
 <!-- CONFIGURATIONS LIST -->
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 <h4 class="widget-title lighter">
 <i class="ace-icon fa fa-database"></i>
@@ -524,7 +524,7 @@ if( $t_read_write_access ) {
 <form id="config_set_form" method="post" action="adm_config_set.php">
 
 		<!-- Title -->
-		<div class="widget-box widget-color-blue2">
+		<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-sliders"></i>

--- a/adm_permissions_report.php
+++ b/adm_permissions_report.php
@@ -63,7 +63,7 @@ function get_section_begin_apr( $p_section_name ) {
 	$t_output = '<div class="col-md-12 col-xs-12">';
 	$t_output .= '<div class="space-10"></div>';
 
-	$t_output .= '<div class="widget-box widget-color-blue2">';
+	$t_output .= '<div class="widget-box widget-color-main">';
 	$t_output .= '   <div class="widget-header widget-header-small">';
 	$t_output .= '        <h4 class="widget-title lighter uppercase">';
 	$t_output .= '            <i class="ace-icon fa fa-lock"></i>';

--- a/admin/check/index.php
+++ b/admin/check/index.php
@@ -97,7 +97,7 @@ layout_admin_page_begin();
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		Checking your MantisBT installation...

--- a/admin/db_stats.php
+++ b/admin/db_stats.php
@@ -62,7 +62,7 @@ function helper_table_row_count( $p_table ) {
 ?>
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 <h4 class="widget-title lighter">
 	<i class="ace-icon fa fa-database"></i>

--- a/admin/email_queue.php
+++ b/admin/email_queue.php
@@ -102,7 +102,7 @@ $t_ids = email_queue_get_ids();
 
 if( count( $t_ids ) > 0 ) {
 ?>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 	<i class="ace-icon fa fa-envelope"></i>
@@ -153,7 +153,7 @@ if( count( $t_ids ) > 0 ) {
 	echo '<p class="lead">Email Queue Empty</p>';
 }
 ?>
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 	<div class="widget-body">
 	<div class="widget-main">
 		<form method="post" action="<?php echo $_SERVER['SCRIPT_NAME']?>">

--- a/admin/index.php
+++ b/admin/index.php
@@ -52,7 +52,7 @@ function print_info_row( $p_description, $p_value ) {
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-download"></i>

--- a/admin/install.php
+++ b/admin/install.php
@@ -149,7 +149,7 @@ if( 0 == $t_install_state || 2 == $t_install_state ) {
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		Checking Installation
@@ -522,7 +522,7 @@ if( 1 == $t_install_state ) {
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<?php echo
@@ -734,7 +734,7 @@ if( 3 == $t_install_state ) {
 	?>
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		Installing Database
@@ -1047,7 +1047,7 @@ if( 5 == $t_install_state ) {
 
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		Write Configuration File(s)
@@ -1182,7 +1182,7 @@ if( 6 == $t_install_state ) {
 ?>
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		Checking Installation
@@ -1288,7 +1288,7 @@ if( 7 == $t_install_state ) {
 	?>
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		Installation Complete
@@ -1326,7 +1326,7 @@ if( $g_failed && $t_install_state != 1 ) {
 	?>
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		Installation Failed

--- a/admin/move_attachments.php
+++ b/admin/move_attachments.php
@@ -306,7 +306,7 @@ if( null == $f_project_to_move ) {
 		foreach( $t_moved as $t_row ) {
 			$t_row = $t_row[0];
 
-			echo '<div class="widget-box widget-color-blue2">';
+			echo '<div class="widget-box widget-color-main">';
 			echo '<div class="widget-header widget-header-small">';
 			echo '<h4 class="widget-title lighter">';
 			echo '<i class="ace-icon fa fa-paperclip"></i>';

--- a/admin/move_attachments_page.php
+++ b/admin/move_attachments_page.php
@@ -104,7 +104,7 @@ if( isset( $t_projects[ALL_PROJECTS] ) ) {
 </p>
 </div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-paperclip"></i>

--- a/admin/system_utils.php
+++ b/admin/system_utils.php
@@ -40,7 +40,7 @@ print_admin_menu_bar( 'system_utils.php' );
 ?>
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-wrench"></i>

--- a/admin/test_langs.php
+++ b/admin/test_langs.php
@@ -58,7 +58,7 @@ print_admin_menu_bar( 'test_langs.php' );
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-text-width"></i>

--- a/api_tokens_page.php
+++ b/api_tokens_page.php
@@ -51,7 +51,7 @@ print_account_menu( 'api_tokens_page.php' );
 <div id="api-token-create-div" class="form-container">
 	<form id="account-create-api-token-form" method="post" action="api_token_create.php">
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-plus"></i>
@@ -97,7 +97,7 @@ if ( count( $t_tokens ) > 0 ) {
 	<div class="space-10"></div>
 
 	<div id="api-token-list-div" class="form-container">
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-ticket"></i>

--- a/billing_inc.php
+++ b/billing_inc.php
@@ -78,7 +78,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 ?>
 
 <div class="col-md-12 col-xs-12">
-<div id="time_tracking_stats" class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
+<div id="time_tracking_stats" class="widget-box widget-color-main <?php echo $t_block_css ?>">
 <div class="widget-header widget-header-small">
     <h4 class="widget-title lighter">
         <i class="ace-icon fa fa-clock-o"></i>

--- a/bug_actiongroup_ext_page.php
+++ b/bug_actiongroup_ext_page.php
@@ -59,7 +59,7 @@ bug_group_action_print_top();
 <form method="post" action="bug_actiongroup_ext.php">
 	<?php echo form_security_field( $t_form_name ); ?>
 	<input type="hidden" name="action" value="<?php echo string_attribute( $t_external_action ) ?>" />
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<?php bug_group_action_print_title( $t_external_action ); ?>

--- a/bug_actiongroup_page.php
+++ b/bug_actiongroup_page.php
@@ -240,7 +240,7 @@ if( $t_multiple_projects ) {
 		echo "<input type=\"hidden\" name=\"custom_field_id\" value=\"$t_custom_field_id\" />";
 	}
 ?>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<?php echo $t_question_title ?>

--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -134,7 +134,7 @@ layout_page_begin();
 	<fieldset>
 
 	<?php echo form_security_field( 'bug_update' ) ?>
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<?php echo lang_get( $t_status_label . '_bug_title' ) ?>

--- a/bug_monitor_list_view_inc.php
+++ b/bug_monitor_list_view_inc.php
@@ -60,7 +60,7 @@ if( access_has_bug_level( config_get( 'show_monitor_list_threshold' ), $f_bug_id
 	$t_block_css = $t_collapse_block ? 'collapsed' : '';
 	$t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 ?>
-<div id="monitoring" class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
+<div id="monitoring" class="widget-box widget-color-main <?php echo $t_block_css ?>">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-users"></i>

--- a/bug_reminder_page.php
+++ b/bug_reminder_page.php
@@ -75,7 +75,7 @@ layout_page_begin();
 <form method="post" action="bug_reminder.php">
 <?php echo form_security_field( 'bug_reminder' ) ?>
 <input type="hidden" name="bug_id" value="<?php echo $f_bug_id ?>" />
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-envelope"></i>

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -243,7 +243,7 @@ if( $t_show_attachments ) {
 <?php echo form_security_field( 'bug_report' ) ?>
 <input type="hidden" name="m_id" value="<?php echo $f_master_bug_id ?>" />
 <input type="hidden" name="project_id" value="<?php echo $t_project_id ?>" />
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-edit"></i>

--- a/bug_revision_view_page.php
+++ b/bug_revision_view_page.php
@@ -161,7 +161,7 @@ layout_page_begin();
 ?>
 
 <div class="col-md-12 col-xs-12">
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 <h4 class="widget-title lighter">
 	<i class="ace-icon fa fa-history"></i>

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -167,7 +167,7 @@ layout_page_begin();
 		<input type="hidden" name="bug_id" value="<?php echo $t_bug_id ?>" />
         <input type="hidden" name="last_updated" value="<?php echo $t_bug->last_updated ?>" />
 
-		<div class="widget-box widget-color-blue2">
+		<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-comments"></i>

--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -234,7 +234,7 @@ $t_links = event_signal( 'EVENT_MENU_ISSUE', $f_bug_id );
 #
 
 echo '<div class="col-md-12 col-xs-12">';
-echo '<div class="widget-box widget-color-blue2">';
+echo '<div class="widget-box widget-color-main">';
 echo '<div class="widget-header widget-header-small">';
 echo '<h4 class="widget-title lighter">';
 echo '<i class="ace-icon fa fa-bars"></i>';

--- a/bugnote_add_inc.php
+++ b/bugnote_add_inc.php
@@ -71,7 +71,7 @@ require_api( 'lang_api.php' );
 	<?php print_dropzone_form_data() ?>>
 	<?php echo form_security_field( 'bugnote_add' ) ?>
 	<input type="hidden" name="bug_id" value="<?php echo $f_bug_id ?>" />
-	<div id="bugnote_add" class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
+	<div id="bugnote_add" class="widget-box widget-color-main <?php echo $t_block_css ?>">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-comment"></i>

--- a/bugnote_edit_page.php
+++ b/bugnote_edit_page.php
@@ -117,7 +117,7 @@ $t_bugnote_class = bugnote_get_field( $f_bugnote_id, 'view_state' ) == VS_PUBLIC
 <form method="post" action="bugnote_update.php">
 <?php echo form_security_field( 'bugnote_update' ) ?>
 <input type="hidden" name="bugnote_id" value="<?php echo $f_bugnote_id ?>" />
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-comment"></i>

--- a/bugnote_stats_inc.php
+++ b/bugnote_stats_inc.php
@@ -70,7 +70,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 <div class="col-md-12 col-xs-12 noprint">
 <a id="bugnotestats"></a>
 <div class="space-10"></div>
-<div id="bugnotestats" class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
+<div id="bugnotestats" class="widget-box widget-color-main <?php echo $t_block_css ?>">
 
     <div class="widget-header widget-header-small">
         <h4 class="widget-title lighter">

--- a/bugnote_view_inc.php
+++ b/bugnote_view_inc.php
@@ -106,7 +106,7 @@ $t_block_css = $t_collapse_block ? 'collapsed' : '';
 $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 
 ?>
-<div id="bugnotes" class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
+<div id="bugnotes" class="widget-box widget-color-main <?php echo $t_block_css ?>">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 	<i class="ace-icon fa fa-comments"></i>

--- a/changelog_page.php
+++ b/changelog_page.php
@@ -98,7 +98,7 @@ function print_version_header( $p_version_id ) {
 	$t_block_css = $t_collapse_block ? 'collapsed' : '';
 	$t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 
-	echo '<div id="' . $t_block_id . '" class="widget-box widget-color-blue2 ' . $t_block_css . '">';
+	echo '<div id="' . $t_block_id . '" class="widget-box widget-color-main ' . $t_block_css . '">';
 	echo '<div class="widget-header widget-header-small">';
 	echo '<h4 class="widget-title lighter">';
 	echo '<i class="ace-icon fa fa-retweet"></i>';

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2355,7 +2355,7 @@ function filter_draw_selection_area2( $p_page_number, $p_for_screen = true, $p_e
 		$t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 		?>
 
-		<div id="filter" class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
+		<div id="filter" class="widget-box widget-color-main <?php echo $t_block_css ?>">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-filter"></i>

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -502,7 +502,7 @@ function print_news_entry( $p_headline, $p_body, $p_poster_id, $p_view_state, $p
 	$t_body = string_display_links( $p_body );
 	$t_date_posted = date( config_get( 'normal_date_format' ), $p_date_posted );
 
-	$t_news_css = VS_PRIVATE == $p_view_state ? 'widget-color-red' : 'widget-color-blue2';
+	$t_news_css = VS_PRIVATE == $p_view_state ? 'widget-color-red' : 'widget-color-main';
 	?>
 
 	<div class="space-10"></div>

--- a/core/relationship_api.php
+++ b/core/relationship_api.php
@@ -879,7 +879,7 @@ function relationship_view_box( $p_bug_id ) {
 	$t_block_css = $t_collapse_block ? 'collapsed' : '';
 	$t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 	?>
-	<div id="relationships" class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
+	<div id="relationships" class="widget-box widget-color-main <?php echo $t_block_css ?>">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-sitemap"></i>

--- a/core/timeline_inc.php
+++ b/core/timeline_inc.php
@@ -32,7 +32,7 @@ $t_block_css = $t_collapse_block ? 'collapsed' : '';
 $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 ?>
 
-<div id="timeline" class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
+<div id="timeline" class="widget-box widget-color-main <?php echo $t_block_css ?>">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-clock-o"></i>

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -479,6 +479,15 @@ input.typeahead.scrollable ~ .tt-menu {
   margin-bottom: 10px;
 }
 
+/* widget color definitions */
+.widget-color-main {
+    border-color: #5090C1;
+}
+.widget-color-main > .widget-header {
+	/* color: #FFFFFF !important; */
+    border-color: #5090C1;
+    background: #5090C1;
+}
 
 /* Small devices (tablets, 768px and up) */
 @media (min-width: 768px) {

--- a/history_inc.php
+++ b/history_inc.php
@@ -62,7 +62,7 @@ if( !access_has_bug_level( $t_access_level_needed, $f_bug_id ) ) {
 	$t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 	$t_history = history_get_events_array( $f_bug_id );
 ?>
-<div id="history" class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
+<div id="history" class="widget-box widget-color-main <?php echo $t_block_css ?>">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-history"></i>

--- a/login_select_proj_page.php
+++ b/login_select_proj_page.php
@@ -68,7 +68,7 @@ layout_page_begin();
 <div id="select-project-div" class="form-container">
 	<form id="select-project-form" method="post" action="set_project.php">
 		<?php # CSRF protection not required here - form does not result in modifications ?>
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-puzzle-piece"></i>

--- a/manage_columns_inc.php
+++ b/manage_columns_inc.php
@@ -85,7 +85,7 @@ if( $t_account_page ) {
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-columns "></i>

--- a/manage_config_email_page.php
+++ b/manage_config_email_page.php
@@ -211,7 +211,7 @@ function show_notify_threshold( $p_access, $p_action ) {
 function get_section_begin_for_email( $p_section_name ) {
 	$t_access_levels = MantisEnum::getValues( config_get( 'access_levels_enum_string' ) );
 	echo '<div class="space-10"></div>';
-	echo '<div class="widget-box widget-color-blue2">';
+	echo '<div class="widget-box widget-color-main">';
 	echo '   <div class="widget-header widget-header-small">';
 	echo '        <h4 class="widget-title lighter uppercase">';
 	echo '            <i class="ace-icon fa fa-envelope"></i>';

--- a/manage_config_work_threshold_page.php
+++ b/manage_config_work_threshold_page.php
@@ -89,7 +89,7 @@ function get_section_begin_mcwt( $p_section_name ) {
 	global $g_access_levels;
 
 	echo '<div class="space-10"></div>';
-	echo '<div class="widget-box widget-color-blue2">';
+	echo '<div class="widget-box widget-color-main">';
 	echo '   <div class="widget-header widget-header-small">';
 	echo '        <h4 class="widget-title lighter uppercase">';
 	echo '            <i class="ace-icon fa fa-sliders"></i>';

--- a/manage_config_workflow_page.php
+++ b/manage_config_workflow_page.php
@@ -164,7 +164,7 @@ function show_flag( $p_from_status_id, $p_to_status_id ) {
 function section_begin( $p_section_name ) {
 	$t_enum_statuses = MantisEnum::getValues( config_get( 'status_enum_string' ) );
 	echo '<div class="space-10"></div>';
-	echo '<div class="widget-box widget-color-blue2">';
+	echo '<div class="widget-box widget-color-main">';
 	echo '   <div class="widget-header widget-header-small">';
 	echo '        <h4 class="widget-title lighter uppercase">';
 	echo '            <i class="ace-icon fa fa-random"></i>';
@@ -254,7 +254,7 @@ function section_end() {
  */
 function threshold_begin( $p_section_name ) {
 	echo '<div class="space-10"></div>';
-	echo '<div class="widget-box widget-color-blue2">';
+	echo '<div class="widget-box widget-color-main">';
 	echo '   <div class="widget-header widget-header-small">';
 	echo '        <h4 class="widget-title lighter uppercase">';
 	echo '            <i class="ace-icon fa fa-sliders"></i>';
@@ -331,7 +331,7 @@ function threshold_end() {
  */
 function access_begin( $p_section_name ) {
 	echo '<div class="space-10"></div>';
-	echo '<div class="widget-box widget-color-blue2">';
+	echo '<div class="widget-box widget-color-main">';
 	echo '   <div class="widget-header widget-header-small">';
 	echo '        <h4 class="widget-title lighter uppercase">';
 	echo '            <i class="ace-icon fa fa-lock"></i>';
@@ -520,7 +520,7 @@ threshold_row( 'bug_reopen_status' );
 threshold_end();
 
 if( '' <> $t_validation_result ) {
-	echo '<div class="widget-box widget-color-blue2">';
+	echo '<div class="widget-box widget-color-main">';
 	echo '<div class="widget-header widget-header-small">';
 	echo '	<h4 class="widget-title lighter">';
 	echo '		<i class="ace-icon fa fa-hand-o-right"></i>';

--- a/manage_custom_field_edit_page.php
+++ b/manage_custom_field_edit_page.php
@@ -73,7 +73,7 @@ $t_definition = custom_field_get_definition( $f_field_id );
 
 <div id="manage-custom-field-update-div" class="form-container">
 <form id="manage-custom-field-update-form" method="post" action="manage_custom_field_update.php">
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-flask"></i>
@@ -313,7 +313,7 @@ $t_definition = custom_field_get_definition( $f_field_id );
 <div class="col-md-12 col-xs-12">
 	<div class="space-10"></div>
 
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-link"></i>

--- a/manage_custom_field_page.php
+++ b/manage_custom_field_page.php
@@ -59,7 +59,7 @@ print_manage_menu( 'manage_custom_field_page.php' );
 <div class="col-md-12 col-xs-12">
 	<div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-flask"></i>

--- a/manage_filter_edit_page.php
+++ b/manage_filter_edit_page.php
@@ -97,7 +97,7 @@ $t_filter_project_id = filter_get_field( $f_filter_id, 'project_id' );
 	<input type="hidden" name="view_type" value="<?php echo $t_filter['_view_type'] ?>" >
 	<?php echo form_security_field( 'manage_filter_edit_update' ) ?>
 
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-filter"></i>

--- a/manage_filter_page.php
+++ b/manage_filter_page.php
@@ -148,7 +148,7 @@ function table_print_filters( array $p_filter_array ) {
 <div class="col-md-12 col-xs-12">
 	<div class="space-10"></div>
 
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-filter"></i>

--- a/manage_overview_page.php
+++ b/manage_overview_page.php
@@ -56,7 +56,7 @@ print_manage_menu( 'manage_overview_page.php' );
 
 <div class="col-md-12 col-xs-12">
 	<div class="space-10"></div>
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-info"></i>

--- a/manage_plugin_page.php
+++ b/manage_plugin_page.php
@@ -85,7 +85,7 @@ if( 0 < count( $t_plugins_installed ) ) {
 		<fieldset>
 		<?php echo form_security_field( 'manage_plugin_update' ) ?>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-cubes"></i>
@@ -227,7 +227,7 @@ if( 0 < count( $t_plugins_available ) ) {
 ?>
 
 <div class="space-10"></div>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-cube"></i>

--- a/manage_proj_cat_edit_page.php
+++ b/manage_proj_cat_edit_page.php
@@ -72,7 +72,7 @@ print_manage_menu( 'manage_proj_cat_edit_page.php' );
 	<div class="space-10"></div>
 	<div id="manage-proj-category-update-div" class="form-container">
 	<form id="manage-proj-category-update-form" method="post" action="manage_proj_cat_update.php">
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-sitemap"></i>

--- a/manage_proj_create_page.php
+++ b/manage_proj_create_page.php
@@ -72,7 +72,7 @@ $f_parent_id = gpc_get( 'parent_id', null );
 
 	<div id="manage-project-create-div" class="form-container">
 	<form method="post" id="manage-project-create-form" action="manage_proj_create.php">
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-puzzle-piece"></i>

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -96,7 +96,7 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 	<div class="space-10"></div>
 	<div id="manage-proj-update-div" class="form-container">
 	<form id="manage-proj-update-form" method="post" action="manage_proj_update.php">
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 <h4 class="widget-title lighter">
 	<i class="ace-icon fa fa-puzzle-piece "></i>
@@ -228,7 +228,7 @@ if ( config_get( 'subprojects_enabled') == ON ) {
 <div class="col-md-12 col-xs-12">
 	<div class="space-10"></div>
 	<div id="manage-project-update-subprojects-div" class="form-container">
-		<div class="widget-box widget-color-blue2">
+		<div class="widget-box widget-color-main">
 			<div class="widget-header widget-header-small">
 				<h4 class="widget-title lighter">
 					<i class="ace-icon fa fa-share-alt"></i>
@@ -279,7 +279,7 @@ if ( config_get( 'subprojects_enabled') == ON ) {
 	<div class="col-md-12 col-xs-12">
 	<div class="space-10"></div>
 	<form id="manage-project-update-subprojects-form" action="manage_proj_update_children.php" method="post">
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-share-alt"></i>
@@ -376,7 +376,7 @@ if ( config_get( 'subprojects_enabled') == ON ) {
 <div class="col-md-12 col-xs-12">
 	<div class="space-10"></div>
 	<div id="categories" class="form-container">
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-sitemap"></i>
@@ -465,7 +465,7 @@ if ( config_get( 'subprojects_enabled') == ON ) {
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 <div id="project-versions-div" class="form-container">
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-share-alt"></i>
@@ -571,7 +571,7 @@ if( access_has_project_level( config_get( 'custom_field_link_threshold' ), $f_pr
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 <div id="customfields" class="form-container">
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-flask"></i>
@@ -689,7 +689,7 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 <div id="manage-project-users-div" class="form-container">
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-users"></i>
@@ -830,7 +830,7 @@ if( count( $t_users ) > 0 ) { ?>
 	<div class="space-10"></div>
 	<div class="form-container">
 	<form id="manage-project-add-user-form" method="post" action="manage_proj_user_add.php">
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-user"></i>

--- a/manage_proj_page.php
+++ b/manage_proj_page.php
@@ -83,7 +83,7 @@ print_manage_menu( 'manage_proj_page.php' );
 
 <div class="col-md-12 col-xs-12">
     <div class="space-10"></div>
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-puzzle-piece"></i>
@@ -187,7 +187,7 @@ print_manage_menu( 'manage_proj_page.php' );
 
 	<div id="categories" class="form-container">
 
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-sitemap"></i>

--- a/manage_proj_ver_edit_page.php
+++ b/manage_proj_ver_edit_page.php
@@ -70,7 +70,7 @@ print_manage_menu( 'manage_proj_ver_edit_page.php' );
 	<div class="space-10"></div>
 	<div id="manage-proj-version-update-div" class="form-container">
 	<form id="manage-proj-version-update-form" method="post" action="manage_proj_ver_update.php">
-		<div class="widget-box widget-color-blue2">
+		<div class="widget-box widget-color-main">
 			<div class="widget-header widget-header-small">
 				<h4 class="widget-title lighter">
 					<i class="ace-icon fa fa-share-alt"></i>

--- a/manage_tags_page.php
+++ b/manage_tags_page.php
@@ -126,7 +126,7 @@ print_manage_menu( 'manage_tags_page.php' );
 
 <div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-tags"></i>
@@ -188,7 +188,7 @@ print_manage_menu( 'manage_tags_page.php' );
 <?php if( $t_can_edit ) { ?>
 <div class="space-10"></div>
 	<form id="manage-tags-create-form" method="post" action="tag_create.php">
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-tag"></i>

--- a/manage_user_create_page.php
+++ b/manage_user_create_page.php
@@ -61,7 +61,7 @@ print_manage_menu( 'manage_user_create_page.php' );
 <div class="space-10"></div>
 <div id="manage-user-create-div" class="form-container">
 	<form id="manage-user-create-form" method="post" action="manage_user_create.php">
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-user"></i>

--- a/manage_user_edit_page.php
+++ b/manage_user_edit_page.php
@@ -100,7 +100,7 @@ print_manage_menu( 'manage_user_page.php' );
 <!-- USER INFO -->
 <div id="edit-user-div" class="form-container">
 	<form id="edit-user-form" method="post" action="manage_user_update.php">
-		<div class="widget-box widget-color-blue2">
+		<div class="widget-box widget-color-main">
 			<div class="widget-header widget-header-small">
 				<h4 class="widget-title lighter">
 					<i class="ace-icon fa fa-user"></i>
@@ -308,7 +308,7 @@ if( $t_reset || $t_unlock || $t_delete || $t_impersonate ) {
 	!user_is_administrator( $t_user_id ) ) {
 ?>
 <div class="space-10"></div>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 <h4 class="widget-title lighter">
 <i class="ace-icon fa fa-user"></i>

--- a/manage_user_page.php
+++ b/manage_user_page.php
@@ -245,7 +245,7 @@ while( $t_row = db_fetch_array( $t_result ) ) {
 
 $t_user_count = count( $t_users );
 ?>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 <h4 class="widget-title lighter">
 	<i class="ace-icon fa fa-users"></i>

--- a/my_view_inc.php
+++ b/my_view_inc.php
@@ -265,7 +265,7 @@ $t_bug_string = $t_bug_count == 1 ? 'bug' : 'bugs';
 
 # -- ====================== BUG LIST ========================= --
 ?>
-<div id="<?php echo $t_box_title ?>" class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
+<div id="<?php echo $t_box_title ?>" class="widget-box widget-color-main <?php echo $t_block_css ?>">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-list-alt"></i>

--- a/news_edit_page.php
+++ b/news_edit_page.php
@@ -97,7 +97,7 @@ layout_page_begin( 'main_page.php' );
 <div class="space-10"></div>
 <div id="news-update-div" class="form-container">
 	<form id="news-update-form" method="post" action="news_update.php">
-		<div class="widget-box widget-color-blue2">
+		<div class="widget-box widget-color-main">
 			<div class="widget-header widget-header-small">
 				<h4 class="widget-title lighter">
 					<i class="ace-icon fa fa-edit"></i>

--- a/news_list_page.php
+++ b/news_list_page.php
@@ -55,7 +55,7 @@ layout_page_begin( 'main_page.php' );
 ?>
 
 <div class="col-md-12 col-xs-12">
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-archive"></i>

--- a/news_menu_page.php
+++ b/news_menu_page.php
@@ -57,7 +57,7 @@ layout_page_begin( 'main_page.php' );
 <div class="col-md-12 col-xs-12">
 	<div id="news-add-div" class="form-container">
 	<form id="news-add-form" method="post" action="news_add.php">
-		<div class="widget-box widget-color-blue2">
+		<div class="widget-box widget-color-main">
 			<div class="widget-header widget-header-small">
 				<h4 class="widget-title lighter">
 					<i class="ace-icon fa fa-edit"></i>
@@ -129,7 +129,7 @@ if( news_get_count( helper_get_current_project(), current_user_is_administrator(
 	<div class="space-10"></div>
 	<div id="news-edit-div" class="form-container">
 	<form id="news-edit-form" method="post" action="news_edit_page.php">
-		<div class="widget-box widget-color-blue2">
+		<div class="widget-box widget-color-main">
 			<div class="widget-header widget-header-small">
 				<h4 class="widget-title lighter">
 					<i class="ace-icon fa fa-edit"></i>

--- a/plugins/MantisCoreFormatting/pages/config.php
+++ b/plugins/MantisCoreFormatting/pages/config.php
@@ -40,7 +40,7 @@ print_manage_menu( 'manage_plugin_page.php' );
 <form id="formatting-config-form" action="<?php echo plugin_page( 'config_edit' )?>" method="post">
 <?php echo form_security_field( 'plugin_format_config_edit' ) ?>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-text-width"></i>

--- a/plugins/MantisGraph/pages/category_graph.php
+++ b/plugins/MantisGraph/pages/category_graph.php
@@ -43,7 +43,7 @@ $t_metrics = create_category_summary();
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-bar-chart-o"></i>

--- a/plugins/MantisGraph/pages/developer_graph.php
+++ b/plugins/MantisGraph/pages/developer_graph.php
@@ -40,7 +40,7 @@ $t_series_name = lang_get( 'bugs' );
 ?>
 
 <div class="col-md-12 col-xs-12">
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-bar-chart-o"></i>

--- a/plugins/MantisGraph/pages/issues_trend_graph.php
+++ b/plugins/MantisGraph/pages/issues_trend_graph.php
@@ -38,7 +38,7 @@ print_summary_submenu();
 ?>
 
 <div class="col-md-12 col-xs-12">
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-bar-chart-o"></i>

--- a/plugins/MantisGraph/pages/issues_trend_page.php
+++ b/plugins/MantisGraph/pages/issues_trend_page.php
@@ -60,7 +60,7 @@ $t_types = array(
 <div class="col-md-12 col-xs-12">
     <div class="space-10"></div>
     <form id="graph_form" method="post" action="<?php echo plugin_page( 'issues_trend_page.php' ); ?>" class="form-inline">
-        <div class="widget-box widget-color-blue2">
+        <div class="widget-box widget-color-main">
         <div class="widget-body">
         <div class="widget-main no-padding">
             <div class="table-responsive">

--- a/plugins/MantisGraph/pages/priority_graph.php
+++ b/plugins/MantisGraph/pages/priority_graph.php
@@ -43,7 +43,7 @@ $t_metrics = create_bug_enum_summary( lang_get( 'priority_enum_string' ), 'prior
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-bar-chart-o"></i>

--- a/plugins/MantisGraph/pages/reporter_graph.php
+++ b/plugins/MantisGraph/pages/reporter_graph.php
@@ -40,7 +40,7 @@ $t_series_name = lang_get( 'bugs' );
 ?>
 
 <div class="col-md-12 col-xs-12">
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-bar-chart-o"></i>

--- a/plugins/MantisGraph/pages/resolution_graph.php
+++ b/plugins/MantisGraph/pages/resolution_graph.php
@@ -43,7 +43,7 @@ $t_metrics = create_bug_enum_summary( lang_get( 'resolution_enum_string' ), 'res
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-bar-chart-o"></i>

--- a/plugins/MantisGraph/pages/severity_graph.php
+++ b/plugins/MantisGraph/pages/severity_graph.php
@@ -42,7 +42,7 @@ $t_metrics = create_bug_enum_summary( lang_get( 'severity_enum_string' ), 'sever
     <div class="col-md-12 col-xs-12">
         <div class="space-10"></div>
 
-        <div class="widget-box widget-color-blue2">
+        <div class="widget-box widget-color-main">
             <div class="widget-header widget-header-small">
                 <h4 class="widget-title lighter">
                     <i class="ace-icon fa fa-bar-chart-o"></i>

--- a/plugins/MantisGraph/pages/status_graph.php
+++ b/plugins/MantisGraph/pages/status_graph.php
@@ -41,7 +41,7 @@ $t_metrics = create_bug_status_summary();
     <div class="col-md-12 col-xs-12">
         <div class="space-10"></div>
 
-        <div class="widget-box widget-color-blue2">
+        <div class="widget-box widget-color-main">
             <div class="widget-header widget-header-small">
                 <h4 class="widget-title lighter">
                     <i class="ace-icon fa fa-bar-chart-o"></i>

--- a/plugins/XmlImportExport/pages/config_page.php
+++ b/plugins/XmlImportExport/pages/config_page.php
@@ -16,7 +16,7 @@ print_manage_menu( 'manage_plugin_page.php' );
 <div class="form-container">
 <form action="<?php echo plugin_page( 'config' ) ?>" method="post">
 <fieldset>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
     <h4 class="widget-title lighter">
         <i class="ace-icon fa fa-exchange"></i>

--- a/plugins/XmlImportExport/pages/import.php
+++ b/plugins/XmlImportExport/pages/import.php
@@ -56,7 +56,7 @@ if( ALL_PROJECTS == $t_project_id ) {
 
 <input type="hidden" name="project_id" value="<?php echo $t_project_id;?>" />
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 <h4 class="widget-title lighter">
 <i class="ace-icon fa fa-upload"></i>

--- a/proj_doc_add_page.php
+++ b/proj_doc_add_page.php
@@ -64,7 +64,7 @@ print_doc_menu('proj_doc_add_page.php');
 <div class="form-container">
 <form method="post" enctype="multipart/form-data" action="proj_doc_add.php">
 	<?php echo form_security_field( 'proj_doc_add' ) ?>
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-upload"></i>

--- a/proj_doc_edit_page.php
+++ b/proj_doc_edit_page.php
@@ -86,7 +86,7 @@ print_doc_menu();
 <form method="post" enctype="multipart/form-data" action="proj_doc_update.php">
 <?php echo form_security_field( 'proj_doc_update' ) ?>
 <input type="hidden" name="file_id" value="<?php echo $t_file_id ?>"/>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 		<h4 class="widget-title lighter">
 			<i class="ace-icon fa fa-edit"></i>

--- a/proj_doc_page.php
+++ b/proj_doc_page.php
@@ -114,7 +114,7 @@ print_doc_menu( 'proj_doc_page.php' );
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-file"></i>

--- a/query_store_page.php
+++ b/query_store_page.php
@@ -58,7 +58,7 @@ layout_page_header();
 layout_page_begin();
 ?>
 <div class="col-md-12 col-xs-12">
-<div id="save-filter" class="widget-box widget-color-blue2">
+<div id="save-filter" class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-filter"></i>

--- a/roadmap_page.php
+++ b/roadmap_page.php
@@ -93,7 +93,7 @@ function print_version_header( array $p_version_row ) {
 	$t_block_css = $t_collapse_block ? 'collapsed' : '';
 	$t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 
-	echo '<div id="' . $t_block_id . '" class="widget-box widget-color-blue2 ' . $t_block_css . '">';
+	echo '<div id="' . $t_block_id . '" class="widget-box widget-color-main ' . $t_block_css . '">';
 	echo '<div class="widget-header widget-header-small">';
 	echo '<h4 class="widget-title lighter">';
 	echo '<i class="ace-icon fa fa-road"></i>';

--- a/summary_page.php
+++ b/summary_page.php
@@ -131,7 +131,7 @@ print_summary_submenu();
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-bar-chart-o"></i>

--- a/tag_update_page.php
+++ b/tag_update_page.php
@@ -78,7 +78,7 @@ layout_page_begin();
 <div class="col-md-12 col-xs-12">
 	<div class="space-10"></div>
 	<form method="post" action="tag_update.php">
-	<div class="widget-box widget-color-blue2">
+	<div class="widget-box widget-color-main">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<i class="ace-icon fa fa-tag"></i>

--- a/tag_view_page.php
+++ b/tag_view_page.php
@@ -73,7 +73,7 @@ layout_page_begin();
 
 <div class="col-md-12 col-xs-12">
 <div class="space-10"></div>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 <h4 class="widget-title lighter">
 	<i class="ace-icon fa fa-tag"></i>

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -87,7 +87,7 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 <div class="space-10"></div>
 <form id="bug_action" method="post" action="bug_actiongroup_page.php">
 <?php # CSRF protection not required here - form does not result in modifications ?>
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 	<div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-columns"></i>

--- a/view_filters_page.php
+++ b/view_filters_page.php
@@ -113,7 +113,7 @@ $t_filter = filter_ensure_valid_filter( $t_filter );
 		}
 	?>
 
-		<div class="widget-box widget-color-blue2">
+		<div class="widget-box widget-color-main">
 			<div class="widget-header widget-header-small">
 				<h4 class="widget-title lighter">
 					<i class="ace-icon fa fa-filter"></i>

--- a/view_user_page.php
+++ b/view_user_page.php
@@ -76,7 +76,7 @@ layout_page_header();
 layout_page_begin();
 ?>
 <div class="col-md-12 col-xs-12">
-<div class="widget-box widget-color-blue2">
+<div class="widget-box widget-color-main">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<i class="ace-icon fa fa-user"></i>


### PR DESCRIPTION
Rename current widget-color-blue2 css class to a more generic class
name.
Move widget color definitions to ace-mantis.css for easier
customization.

Fixes: #22575