### PR TITLE
Move assigned projects outside of form

### DIFF
--- a/account_page.php
+++ b/account_page.php
@@ -289,27 +289,28 @@ if( !empty( $t_projects ) ) {
 		<div class="widget-body">
 			<div class="widget-main no-padding">
 				<div class="table-responsive">
-					<table class="table table-bordered table-condensed table-striped">
+					<table class="table table-striped table-bordered table-condensed table-hover">
+						<thead>
+							<tr>
+								<th><?php echo lang_get( 'name' ) ?></th>
+								<th><?php echo lang_get( 'access_level' ) ?></th>
+								<th><?php echo lang_get( 'view_status' ) ?></th>
+								<th><?php echo lang_get( 'description' ) ?></th>
+							</tr>
+						</thead>
 						<?php
+						foreach( $t_projects as $t_project_id => $t_project ) {
+							$t_project_name = string_attribute( $t_project['name'] );
+							$t_access_level = get_enum_element( 'access_levels', $t_project['access_level'] );
+							$t_view_state = get_enum_element( 'project_view_state', $t_project['view_state'] );
+							$t_description = string_display_links( project_get_field( $t_project_id, 'description' ) );
 							echo '<tr>';
-							echo '<td class="category">' . lang_get( 'assigned_projects' ) . '</td>';
-							echo '<td>';
-							foreach( $t_projects AS $t_project_id => $t_project ) {
-								$t_project_name = string_attribute( $t_project['name'] );
-								$t_view_state = $t_project['view_state'];
-								$t_access_level = $t_project['access_level'];
-								$t_access_level = get_enum_element( 'access_levels', $t_access_level );
-								$t_view_state = get_enum_element( 'project_view_state', $t_view_state );
-
-								echo '<div class="col-md-3 col-xs-6 no-padding">' . $t_project_name . '</div>'
-										. '<div class="col-md-9 col-xs-6">'
-										. '<span class="label label-default">' . $t_access_level . '</span>'
-										. '<span class="bold padding-left-4">' . $t_view_state . '</span></div>';
-								echo '<div class="clearfix"></div>';
-								echo '<div class="space-4"></div>';
-							}
-							echo '</td>';
+							echo '<td>' . $t_project_name . '</td>';
+							echo '<td>' . $t_access_level . '</td>';
+							echo '<td>' . $t_view_state . '</td>';
+							echo '<td>' . $t_description . '</td>';
 							echo '</tr>';
+						}
 						?>
 					</table>
 				</div>

--- a/account_page.php
+++ b/account_page.php
@@ -258,27 +258,6 @@ print_account_menu( 'account_page.php' );
 					<?php echo get_enum_element( 'access_levels', current_user_get_access_level() ); ?>
 				</td>
 			</tr>
-			<?php
-			$t_projects = user_get_assigned_projects( auth_get_current_user_id() );
-			if( count( $t_projects ) > 0 ) {
-				echo '<tr>';
-				echo '<td class="category">' . lang_get( 'assigned_projects' ) . '</td>';
-				echo '<td>';
-				foreach( $t_projects AS $t_project_id=>$t_project ) {
-					$t_project_name = string_attribute( $t_project['name'] );
-					$t_view_state = $t_project['view_state'];
-					$t_access_level = $t_project['access_level'];
-					$t_access_level = get_enum_element( 'access_levels', $t_access_level );
-					$t_view_state = get_enum_element( 'project_view_state', $t_view_state );
-
-					echo '<div class="col-md-3 col-xs-6 no-padding">' . $t_project_name . '</div> <div class="col-md-9 col-xs-6"><span class="label label-default">' . $t_access_level . '</span><span class="bold padding-left-4">' . $t_view_state . '</span></div>';
-					echo '<div class="clearfix"></div>';
-					echo '<div class="space-4"></div>';
-				}
-				echo '</td>';
-				echo '</tr>';
-			}
-			?>
 				</fieldset>
 			</table>
 		</div>
@@ -293,6 +272,51 @@ print_account_menu( 'account_page.php' );
 	<?php } ?>
 	</div>
 </div>
+
+<?php
+$t_projects = user_get_assigned_projects( auth_get_current_user_id() );
+if( !empty( $t_projects ) ) {
+?>
+	<div class="space-10"></div>
+
+	<div class="widget-box widget-color-blue2">
+		<div class="widget-header widget-header-small">
+			<h4 class="widget-title lighter">
+				<i class="ace-icon fa fa-user"></i>
+				<?php echo lang_get( 'assigned_projects' ) ?>
+			</h4>
+		</div>
+		<div class="widget-body">
+			<div class="widget-main no-padding">
+				<div class="table-responsive">
+					<table class="table table-bordered table-condensed table-striped">
+						<?php
+							echo '<tr>';
+							echo '<td class="category">' . lang_get( 'assigned_projects' ) . '</td>';
+							echo '<td>';
+							foreach( $t_projects AS $t_project_id => $t_project ) {
+								$t_project_name = string_attribute( $t_project['name'] );
+								$t_view_state = $t_project['view_state'];
+								$t_access_level = $t_project['access_level'];
+								$t_access_level = get_enum_element( 'access_levels', $t_access_level );
+								$t_view_state = get_enum_element( 'project_view_state', $t_view_state );
+
+								echo '<div class="col-md-3 col-xs-6 no-padding">' . $t_project_name . '</div>'
+										. '<div class="col-md-9 col-xs-6">'
+										. '<span class="label label-default">' . $t_access_level . '</span>'
+										. '<span class="bold padding-left-4">' . $t_view_state . '</span></div>';
+								echo '<div class="clearfix"></div>';
+								echo '<div class="space-4"></div>';
+							}
+							echo '</td>';
+							echo '</tr>';
+						?>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+<?php } ?>
 
 	</form>
 </div>

--- a/account_page.php
+++ b/account_page.php
@@ -282,7 +282,7 @@ if( !empty( $t_projects ) ) {
 	<div class="widget-box widget-color-blue2">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
-				<i class="ace-icon fa fa-user"></i>
+				<i class="ace-icon fa fa-puzzle-piece"></i>
 				<?php echo lang_get( 'assigned_projects' ) ?>
 			</h4>
 		</div>

--- a/manage_proj_page.php
+++ b/manage_proj_page.php
@@ -97,26 +97,26 @@ print_manage_menu( 'manage_proj_page.php' );
 	<table class="table table-striped table-bordered table-condensed table-hover">
 		<thead>
 			<tr>
-				<td><?php
+				<th><?php
 					print_manage_project_sort_link( 'manage_proj_page.php', lang_get( 'name' ), 'name', $t_direction, $f_sort );
 					print_sort_icon( $t_direction, $f_sort, 'name' ); ?>
-				</td>
-				<td><?php
+				</th>
+				<th><?php
 					print_manage_project_sort_link( 'manage_proj_page.php', lang_get( 'status' ), 'status', $t_direction, $f_sort );
 					print_sort_icon( $t_direction, $f_sort, 'status' ); ?>
-				</td>
-				<td><?php
+				</th>
+				<th><?php
 					print_manage_project_sort_link( 'manage_proj_page.php', lang_get( 'enabled' ), 'enabled', $t_direction, $f_sort );
 					print_sort_icon( $t_direction, $f_sort, 'enabled' ); ?>
-				</td>
-				<td><?php
+				</th>
+				<th><?php
 					print_manage_project_sort_link( 'manage_proj_page.php', lang_get( 'view_status' ), 'view_state', $t_direction, $f_sort );
 					print_sort_icon( $t_direction, $f_sort, 'view_state' ); ?>
-				</td>
-				<td><?php
+				</th>
+				<th><?php
 					print_manage_project_sort_link( 'manage_proj_page.php', lang_get( 'description' ), 'description', $t_direction, $f_sort );
 					print_sort_icon( $t_direction, $f_sort, 'description' ); ?>
-				</td>
+				</th>
 			</tr>
 		</thead>
 

--- a/manage_user_edit_page.php
+++ b/manage_user_edit_page.php
@@ -311,7 +311,7 @@ if( $t_reset || $t_unlock || $t_delete || $t_impersonate ) {
 <div class="widget-box widget-color-blue2">
 <div class="widget-header widget-header-small">
 <h4 class="widget-title lighter">
-<i class="ace-icon fa fa-user"></i>
+<i class="ace-icon fa fa-puzzle-piece"></i>
 <?php echo lang_get('add_user_title') ?>
 </h4>
 </div>


### PR DESCRIPTION
Move the list of assigned projects outside of the form in account_page.
This list is not editable, so it must not be part of the form.

Fixes: #21552


![seleccion_151](https://cloud.githubusercontent.com/assets/14123811/24322252/f6ece604-115f-11e7-8539-a4cbb6438df5.png)
