### PR TITLE
Add user timeline to view user page

### DIFF
--- a/core/history_api.php
+++ b/core/history_api.php
@@ -279,6 +279,7 @@ function history_query_result( array $p_query_options ) {
 		$t_query .= ' WHERE ' . implode( ' AND ', $t_where );
 	}
 
+	# Order history lines by date. Use the storing sequence as 2nd order field for lines with the same date.
 	$t_query .= ' ORDER BY {bug_history}.date_modified ' . $t_history_order . ', {bug_history}.id ' . $t_history_order;
 	$t_result = db_query( $t_query, $t_params );
 	return $t_result;
@@ -291,8 +292,12 @@ function history_query_result( array $p_query_options ) {
  * @param  integer $p_end_time       The end time to filter by, or null for all.
  * @param  string  $p_history_order  The sort order.
  * @return database result to pass into history_get_event_from_row().
+ * @deprecated		Use history_query_result() instead
  */
 function history_get_range_result_filter( $p_filter, $p_start_time = null, $p_end_time = null, $p_history_order = null ) {
+	error_parameters( __FUNCTION__ . '()', 'history_query_result()' );
+	trigger_error( ERROR_DEPRECATED_SUPERSEDED, DEPRECATED );
+
 	$t_query_options = array();
 	if ( $p_history_order !== null ) {
 		$t_query_options['order'] = $p_history_order;
@@ -316,8 +321,12 @@ function history_get_range_result_filter( $p_filter, $p_start_time = null, $p_en
  * @param  integer $p_end_time       The end time to filter by, or null for all.
  * @param  string  $p_history_order  The sort order.
  * @return IteratorAggregate|boolean database result to pass into history_get_event_from_row().
+ * @deprecated		Use history_query_result() instead
  */
 function history_get_range_result( $p_bug_id = null, $p_start_time = null, $p_end_time = null, $p_history_order = null ) {
+	error_parameters( __FUNCTION__ . '()', 'history_query_result()' );
+	trigger_error( ERROR_DEPRECATED_SUPERSEDED, DEPRECATED );
+
 	$t_query_options = array();
 	if ( $p_history_order !== null ) {
 		$t_query_options['order'] = $p_history_order;
@@ -475,14 +484,12 @@ function history_get_event_from_row( $p_result, $p_user_id = null, $p_check_acce
 function history_get_raw_events_array( $p_bug_id, $p_user_id = null, $p_start_time = null, $p_end_time = null ) {
 	$t_user_id = (( null === $p_user_id ) ? auth_get_current_user_id() : $p_user_id );
 
-	# grab history and display by date_modified then field_name
-	# @@@ by MASC I guess it's better by id then by field_name. When we have more history lines with the same
-	# date, it's better to respect the storing order otherwise we should risk to mix different information
-	# I give you an example. We create a child of a bug with different custom fields. In the history of the child
-	# bug we will find the line related to the relationship mixed with the custom fields (the history is creted
-	# for the new bug with the same timestamp...)
-
-	$t_result = history_get_range_result( $p_bug_id, $p_start_time, $p_end_time );
+	$t_query_options = array(
+		'bug_id' => $p_bug_id,
+		'start_time' => $p_start_time,
+		'end_time' => $p_end_time
+		);
+	$t_result = history_query_result( $t_query_options );
 
 	$t_raw_history = array();
 

--- a/core/timeline_api.php
+++ b/core/timeline_api.php
@@ -37,19 +37,24 @@ require_api( 'history_api.php' );
  * @param integer $p_start_time Timestamp representing start time of the period.
  * @param integer $p_end_time   Timestamp representing end time of the period.
  * @param integer $p_max_events The maximum number of events to return or 0 for unlimited.
- * @param type $p_filter		Filter array to use for filtering bugs
+ * @param array $p_filter		Filter array to use for filtering bugs, or null for no limit.
+ * @param integer $p_user_id	A user id, to limit timeline to a user's history, or null for no limit.
  * @return array
  */
-function timeline_events( $p_start_time, $p_end_time, $p_max_events, $p_filter = null ) {
+function timeline_events( $p_start_time, $p_end_time, $p_max_events, $p_filter = null, $p_user_id = null ) {
 	$t_timeline_events = array();
 
-	if( null === $p_filter ) {
-		# create an empty filter, to match all bugs
-		$t_filter = filter_ensure_valid_filter( array() );
-		# Override the default hide status, to show all bugs
-		$t_filter[FILTER_PROPERTY_HIDE_STATUS] = array( META_FILTER_NONE );
+	$t_query_options = array();
+	$t_query_options['start_time'] = $p_start_time;
+	$t_query_options['end_time'] = $p_end_time;
+	$t_query_options['order'] = 'DESC';
+	if( null !== $p_filter ) {
+		$t_query_options['filter'] = $p_filter;
 	}
-	$t_result = history_get_range_result_filter( $t_filter, $p_start_time, $p_end_time, 'DESC' );
+	if( null !== $p_user_id ) {
+		$t_query_options['user_id'] = $p_user_id;
+	}
+	$t_result = history_query_result( $t_query_options );
 	$t_count = 0;
 
 	while ( $t_history_event = history_get_event_from_row( $t_result, /* $p_user_id */ auth_get_current_user_id(), /* $p_check_access_to_issue */ true ) ) {

--- a/core/timeline_inc.php
+++ b/core/timeline_inc.php
@@ -19,17 +19,38 @@ require_api( 'timeline_api.php' );
 
 define( 'MAX_EVENTS', 50 );
 
+# Variables that are defined in parent script:
+#
+# $g_timeline_filter	Filter array to be used to get timeline event
+#						If undefined, it's initialized as null.
+# $g_timeline_user		User id to limit timeline scope.
+#						If undefined, it's initialized as null.
+#
+
+if( !isset( $g_timeline_filter ) ) {
+	$g_timeline_filter = null;
+}
+if( !isset( $g_timeline_user ) ) {
+	$g_timeline_user = null;
+}
+
 $f_days = gpc_get_int( 'days', 0 );
 $f_all = gpc_get_int( 'all', 0 );
 $t_max_events = $f_all ? 0 : MAX_EVENTS + 1;
 
 $t_end_time = time() - ( $f_days * SECONDS_PER_DAY );
 $t_start_time = $t_end_time - ( 7 * SECONDS_PER_DAY );
-$t_events = timeline_events( $t_start_time, $t_end_time, $t_max_events );
+$t_events = timeline_events( $t_start_time, $t_end_time, $t_max_events, $g_timeline_filter, $g_timeline_user );
 
 $t_collapse_block = is_collapsed( 'timeline' );
 $t_block_css = $t_collapse_block ? 'collapsed' : '';
 $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
+
+$t_url_page = $_SERVER["PHP_SELF"];
+$t_url_params = $_GET;
+if( isset( $t_url_params['all'] ) ) {
+	unset( $t_url_params['all'] );
+}
 ?>
 
 <div id="timeline" class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
@@ -57,14 +78,16 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 				echo '&#160;&#160;';
 
 				echo '<div class="btn-group">';
-				echo ' <a class="btn btn-primary btn-xs btn-white btn-round" href="my_view_page.php?days=' .
-					( $f_days + 7 ) . '">' . lang_get( 'prev' ) . '</a>';
+				$t_url_params['days'] = $f_days + 7;
+				$t_href = $t_url_page . '?' . http_build_query( $t_url_params );
+				echo ' <a class="btn btn-primary btn-xs btn-white btn-round" href="' . $t_href . '">' . lang_get( 'prev' ) . '</a>';
 
 				$t_next_days = ( $f_days - 7 ) > 0 ? $f_days - 7 : 0;
 
 				if( $t_next_days != $f_days ) {
-					echo ' <a class="btn btn-primary btn-xs btn-white btn-round" href="my_view_page.php?days=' .
-						$t_next_days . '">' . lang_get( 'next' ) . '</a>';
+					$t_url_params['days'] = $t_next_days;
+					$t_href = $t_url_page . '?' . http_build_query( $t_url_params );
+					echo ' <a class="btn btn-primary btn-xs btn-white btn-round" href="' . $t_href . '">' . lang_get( 'next' ) . '</a>';
 				}
 				echo '</div>';
 ?>
@@ -82,8 +105,9 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 		timeline_print_events( $t_events );
 		echo '<div class="widget-toolbox">';
 		echo '<div class="btn-toolbar">';
-		echo '<a class="btn btn-primary btn-sm btn-white btn-round" href="my_view_page.php?days='
-			. $f_days . '&amp;all=1">' . lang_get( 'timeline_more' ) . '</a>';
+		$t_url_params['all'] = 1;
+		$t_href = $t_url_page . '?' . helper_url_query_string( $t_url_params );
+		echo '<a class="btn btn-primary btn-sm btn-white btn-round" href="' . $t_href . '">' . lang_get( 'timeline_more' ) . '</a>';
 		echo '</div>';
 		echo '</div>';
 	} else {

--- a/my_view_page.php
+++ b/my_view_page.php
@@ -151,7 +151,13 @@ while (list ($t_box_title, $t_box_display) = each ($t_boxes)) {
 
 <?php if( $t_timeline_view_threshold_access ) { ?>
 <div class="col-md-5 col-xs-12">
-	<?php include( $g_core_path . 'timeline_inc.php' ); ?>
+	<?php
+		# Build a simple filter that gets all bugs for current project
+		$g_timeline_filter = array();
+		$g_timeline_filter[FILTER_PROPERTY_HIDE_STATUS] = array( META_FILTER_NONE );
+		$g_timeline_filter = filter_ensure_valid_filter( $g_timeline_filter );
+		include( $g_core_path . 'timeline_inc.php' );
+	?>
 	<div class="space-10"></div>
 </div>
 <?php }

--- a/view_user_page.php
+++ b/view_user_page.php
@@ -161,8 +161,6 @@ if( $t_timeline_view_threshold_access ) {
 	$g_timeline_filter[FILTER_PROPERTY_HIDE_STATUS] = array( META_FILTER_NONE );
 	$g_timeline_filter = filter_ensure_valid_filter( $g_timeline_filter );
 	$g_timeline_user = $f_user_id;
-	# Override current project, to let timeline show events for all-projects
-	$g_project_override = ALL_PROJECTS;
 	?>
 	<div class="col-md-5 col-xs-12">
 		<?php include( $g_core_path . 'timeline_inc.php' ); ?>

--- a/view_user_page.php
+++ b/view_user_page.php
@@ -74,8 +74,10 @@ $u_realname = user_get_realname( $u_id );
 layout_page_header();
 
 layout_page_begin();
+$t_timeline_view_threshold_access = access_has_project_level( config_get( 'timeline_view_threshold' ) );
+$t_timeline_view_class = ( $t_timeline_view_threshold_access ) ? "col-md-7" : "col-md-12";
 ?>
-<div class="col-md-12 col-xs-12">
+<div class="<?php echo $t_timeline_view_class ?> col-xs-12">
 <div class="widget-box widget-color-blue2">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
@@ -151,5 +153,22 @@ layout_page_begin();
 </div>
 </div>
 </div>
+
+<?php
+if( $t_timeline_view_threshold_access ) {
+	# Build a filter to show all bugs in current projects
+	$g_timeline_filter = array();
+	$g_timeline_filter[FILTER_PROPERTY_HIDE_STATUS] = array( META_FILTER_NONE );
+	$g_timeline_filter = filter_ensure_valid_filter( $g_timeline_filter );
+	$g_timeline_user = $f_user_id;
+	# Override current project, to let timeline show events for all-projects
+	$g_project_override = ALL_PROJECTS;
+	?>
+	<div class="col-md-5 col-xs-12">
+		<?php include( $g_core_path . 'timeline_inc.php' ); ?>
+		<div class="space-10"></div>
+	</div>
+<?php } ?>
+
 <?php
 layout_page_end();


### PR DESCRIPTION
Display a timeline widget in "view user page", showing recent actions performed by the specific user.

The timeline is showed if access level is met by $t_timeline_view_threshold_access.
Issues that are shown are retrieved by joining with a filter, so that the only events displayed are those related to issues that the viewing user has access to.

Currently, the user timeline search is forced to All-projects. It's open to discussion if this information must be a global scope, or should be limited by current project selection.

These changes needed some refactoring of timeline_inc, timeline_api and history_api, to allow decoupling from my_view page, and user specific search.

![seleccion_153](https://cloud.githubusercontent.com/assets/14123811/24332301/a1116684-1244-11e7-8f79-1ac3a3538386.png)

Fixes: #22585