### PR TITLE
Leave xmlhttprequest.php for backward compatibility

### DIFF
--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -545,7 +545,7 @@ define( 'LOG_NONE', 0 );            # no logging
 define( 'LOG_EMAIL', 1 );           # all emails sent
 define( 'LOG_EMAIL_RECIPIENT', 2 ); # details of email recipient determination
 define( 'LOG_FILTERING', 4 );       # logging for filtering.
-define( 'LOG_AJAX', 8 );            # logging for AJAX / XmlHttpRequests
+define( 'LOG_AJAX', 8 );            # logging for AJAX
 define( 'LOG_LDAP', 16 );           # logging for LDAP
 define( 'LOG_DATABASE', 32 );       # logging for Database
 define( 'LOG_WEBSERVICE', 64 );     # logging for Web Service Requests

--- a/xmlhttprequest.php
+++ b/xmlhttprequest.php
@@ -40,7 +40,7 @@ $f_entrypoint = gpc_get_string( 'entrypoint' );
 
 $t_function = 'xmlhttprequest_' . $f_entrypoint;
 if( function_exists( $t_function ) ) {
-	log_event( LOG_AJAX, 'Calling {' . $t_function . '}...' );
+	log_event( LOG_AJAX, 'DEPRECATED: Calling {' . $t_function . '}. Use REST API instead.' );
 	call_user_func( $t_function );
 } else {
 	log_event( LOG_AJAX, 'Unknown function for entry point = ' . $t_function );

--- a/xmlhttprequest.php
+++ b/xmlhttprequest.php
@@ -1,0 +1,48 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * WARNING: This approach for doing AJAX calls is now deprecated in favor of the
+ * new REST API.
+ *
+ * @package MantisBT
+ * @copyright Copyright 2000 - 2002  Kenzaburo Ito - kenito@300baud.org
+ * @copyright Copyright 2002  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ *
+ * @uses core.php
+ * @uses authentication_api.php
+ * @uses gpc_api.php
+ * @uses logging_api.php
+ */
+
+require_once( 'core.php' );
+require_api( 'authentication_api.php' );
+require_api( 'gpc_api.php' );
+require_api( 'logging_api.php' );
+
+auth_ensure_user_authenticated();
+
+$f_entrypoint = gpc_get_string( 'entrypoint' );
+
+$t_function = 'xmlhttprequest_' . $f_entrypoint;
+if( function_exists( $t_function ) ) {
+	log_event( LOG_AJAX, 'Calling {' . $t_function . '}...' );
+	call_user_func( $t_function );
+} else {
+	log_event( LOG_AJAX, 'Unknown function for entry point = ' . $t_function );
+	echo 'unknown entry point';
+}


### PR DESCRIPTION
Re-adding xmlhttprequest.php for plugins.  However, plugins should
be updated to use the new REST API approach.

This should fix the Snippets plugin that was broken by remote of this
page.

Fixes #22593