### PR TITLE
Don’t show completely empty notes

### DIFF
--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -477,6 +477,12 @@ function bugnote_get_all_visible_bugnotes( $p_bug_id, $p_user_bugnote_order, $p_
 			# If the access level specified is not enough to see time tracking information
 			# then reset it to 0.
 			if( !$t_time_tracking_visible ) {
+				# If the time tracking is the only data in the note, then skip it.
+				if( is_blank( $t_bugnote->note ) ) {
+					continue;
+				}
+
+				# otherwise, don't return the time tracking information so that it is not visible.
 				$t_bugnote->time_tracking = 0;
 			}
 


### PR DESCRIPTION
For time tracking notes with no text, if user doesn’t have access
to time tracking information, then an empty note is displayed.
This fix hides the note in such case.

Fixes #22635