### PR TITLE
Fix regression of switching dates in filter to use date picker

### DIFF
--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -22,7 +22,7 @@
  * Mantis Version
  */
 define( 'MANTIS_VERSION', '2.4.0-dev' );
-define( 'FILTER_VERSION', 'v9' );
+define( 'FILTER_VERSION', 'v10' );
 
 # --- constants -------------------
 # magic numbers

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -3444,12 +3444,12 @@ function filter_print_view_type_toggle( $p_url, $p_view_type ) {
  */
 function filter_read_date_value( $p_filter, $p_date_field, $p_day_field, $p_month_field, $p_year_field )
 {
-    if( isset( $p_filter[$p_day_field] ) && isset( $p_filter[$p_month_field] ) && isset( $p_filter[$p_year_field] ) ) {
+    if( isset( $p_filter[$p_day_field] ) &&
+        isset( $p_filter[$p_month_field] ) &&
+        isset( $p_filter[$p_year_field] ) ) {
         $t_timestamp = mktime( 0, 0, 0, $p_filter[$p_month_field], $p_filter[$p_day_field], $p_filter[$p_year_field] );
-        log_event( LOG_FILTERING, 'Rafik: combined date value: ' . date( config_get( 'normal_date_format' ), $t_timestamp ));
         return date( config_get( 'normal_date_format' ), $t_timestamp );
 	} else {
-		log_event( LOG_FILTERING, 'Rafik: date value: ' . gpc_get_string( $p_date_field, $p_filter[$p_date_field] ));
 		return gpc_get_string( $p_date_field, $p_filter[$p_date_field] );
 	}
 }

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1510,8 +1510,8 @@ function filter_get_bug_rows_query_clauses( array $p_filter, $p_project_id = nul
 
 	# creation date filter
 	if( ( 'on' == $t_filter[FILTER_PROPERTY_FILTER_BY_DATE_SUBMITTED] )	) {
-		$t_start_string = filter_read_last_updated_start_date( $t_filter );
-		$t_end_string = filter_read_last_updated_end_date( $t_filter );
+		$t_start_string = filter_read_submitted_start_date( $t_filter );
+		$t_end_string = filter_read_submitted_end_date( $t_filter );
 
 		$t_where_params[] = strtotime( $t_start_string );
 		$t_where_params[] = strtotime( $t_end_string );
@@ -1521,8 +1521,8 @@ function filter_get_bug_rows_query_clauses( array $p_filter, $p_project_id = nul
 
 	# last update date filter
 	if( ( 'on' == $t_filter[FILTER_PROPERTY_FILTER_BY_LAST_UPDATED_DATE] ) ) {
-		$t_start_string = $t_filter[FILTER_PROPERTY_LAST_UPDATED_START_DATE];
-		$t_end_string = $t_filter[FILTER_PROPERTY_LAST_UPDATED_END_DATE];
+		$t_start_string = filter_read_last_updated_start_date( $t_filter );
+		$t_end_string = filter_read_last_updated_end_date( $t_filter );
 
 		$t_where_params[] = strtotime( $t_start_string );
 		$t_where_params[] = strtotime( $t_end_string );
@@ -3450,7 +3450,7 @@ function filter_read_date_value( $p_filter, $p_date_field, $p_day_field, $p_mont
         $t_timestamp = mktime( 0, 0, 0, $p_filter[$p_month_field], $p_filter[$p_day_field], $p_filter[$p_year_field] );
         return date( config_get( 'normal_date_format' ), $t_timestamp );
 	} else {
-		return gpc_get_string( $p_date_field, $p_filter[$p_date_field] );
+        return gpc_get_string( $p_date_field, $p_filter[$p_date_field] );
 	}
 }
 

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1516,8 +1516,8 @@ function filter_get_bug_rows_query_clauses( array $p_filter, $p_project_id = nul
 			&& is_string( $t_filter[FILTER_PROPERTY_START_DATE_SUBMITTED] )
 			&& is_string( $t_filter[FILTER_PROPERTY_END_DATE_SUBMITTED] )
 			) {
-		$t_start_string = $t_filter[FILTER_PROPERTY_START_DATE_SUBMITTED] . ' 00:00:00';
-		$t_end_string = $t_filter[FILTER_PROPERTY_END_DATE_SUBMITTED] . ' 23:59:59';
+		$t_start_string = $t_filter[FILTER_PROPERTY_START_DATE_SUBMITTED];
+		$t_end_string = $t_filter[FILTER_PROPERTY_END_DATE_SUBMITTED];
 
 		$t_where_params[] = strtotime( $t_start_string );
 		$t_where_params[] = strtotime( $t_end_string );
@@ -1530,8 +1530,8 @@ function filter_get_bug_rows_query_clauses( array $p_filter, $p_project_id = nul
 			&& is_string( $t_filter[FILTER_PROPERTY_LAST_UPDATED_START_DATE] )
 			&& is_string( $t_filter[FILTER_PROPERTY_LAST_UPDATED_END_DATE] )
 			) {
-		$t_start_string = $t_filter[FILTER_PROPERTY_LAST_UPDATED_START_DATE] . ' 00:00:00';
-		$t_end_string = $t_filter[FILTER_PROPERTY_LAST_UPDATED_END_DATE] . ' 23:59:59';
+		$t_start_string = $t_filter[FILTER_PROPERTY_LAST_UPDATED_START_DATE];
+		$t_end_string = $t_filter[FILTER_PROPERTY_LAST_UPDATED_END_DATE];
 
 		$t_where_params[] = strtotime( $t_start_string );
 		$t_where_params[] = strtotime( $t_end_string );

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -542,7 +542,7 @@ function filter_ensure_valid_filter( array $p_filter_arr ) {
 
 	$t_sort_fields = explode( ',', $p_filter_arr[FILTER_PROPERTY_SORT_FIELD_NAME] );
 	$t_dir_fields = explode( ',', $p_filter_arr[FILTER_PROPERTY_SORT_DIRECTION] );
-	# both arrays should be equal lenght, just in case
+	# both arrays should be equal length, just in case
 	$t_sort_fields_count = min( count( $t_sort_fields ), count( $t_dir_fields ) );
 
 	# clean up sort fields, remove invalid columns

--- a/core/filter_form_api.php
+++ b/core/filter_form_api.php
@@ -1228,13 +1228,16 @@ function print_filter_highlight_changed( array $p_filter = null ) {
 function print_filter_values_do_filter_by_date( array $p_filter ) {
 	$t_filter = $p_filter;
 	if( 'on' == $t_filter[FILTER_PROPERTY_FILTER_BY_DATE_SUBMITTED] ) {
-		echo '<input type="hidden" name="', FILTER_PROPERTY_FILTER_BY_DATE_SUBMITTED, '" value="', string_attribute( $t_filter[FILTER_PROPERTY_FILTER_BY_DATE_SUBMITTED] ), '" />';
-		echo '<input type="hidden" name="', FILTER_PROPERTY_START_DATE_SUBMITTED, '" value="', string_attribute( $t_filter[FILTER_PROPERTY_START_DATE_SUBMITTED] ), '" />';
-		echo '<input type="hidden" name="', FILTER_PROPERTY_END_DATE_SUBMITTED, '" value="', string_attribute( $t_filter[FILTER_PROPERTY_END_DATE_SUBMITTED] ), '" />';
+		$t_start_string = filter_read_submitted_start_date( $t_filter );
+		$t_end_string = filter_read_submitted_end_date( $t_filter );
 
-		echo $t_filter[FILTER_PROPERTY_START_DATE_SUBMITTED];
+		echo '<input type="hidden" name="', FILTER_PROPERTY_FILTER_BY_DATE_SUBMITTED, '" value="', string_attribute( $t_filter[FILTER_PROPERTY_FILTER_BY_DATE_SUBMITTED] ), '" />';
+		echo '<input type="hidden" name="', FILTER_PROPERTY_START_DATE_SUBMITTED, '" value="', $t_start_string, '" />';
+		echo '<input type="hidden" name="', FILTER_PROPERTY_END_DATE_SUBMITTED, '" value="', $t_end_string, '" />';
+
+		echo $t_start_string;
 		echo ' - ';
-		echo $t_filter[FILTER_PROPERTY_END_DATE_SUBMITTED];
+		echo $t_end_string;
 	} else {
 		echo lang_get( 'no' );
 	}
@@ -1288,7 +1291,7 @@ function print_filter_do_filter_by_date( $p_hide_checkbox = false, array $p_filt
 					' class="datetimepicker input-xs" ' . $t_menu_readonly .
 					' data-picker-locale="' . lang_get_current_datetime_locale() . '"' .
 					' data-picker-format="' . convert_date_format_to_momentjs( config_get( 'normal_date_format' ) ) . '"' .
-					' size="16" maxlength="20" value="' . $p_filter[FILTER_PROPERTY_START_DATE_SUBMITTED] . '" />';
+					' size="16" maxlength="20" value="' . filter_read_submitted_start_date( $p_filter ) . '" />';
 				echo '<i class="fa fa-calendar fa-xlg datetimepicker"></i>';
 				?>
 			</td>
@@ -1304,7 +1307,7 @@ function print_filter_do_filter_by_date( $p_hide_checkbox = false, array $p_filt
 					' class="datetimepicker input-xs" ' . $t_menu_readonly .
 					' data-picker-locale="' . lang_get_current_datetime_locale() . '"' .
 					' data-picker-format="' . convert_date_format_to_momentjs( config_get( 'normal_date_format' ) ) . '"' .
-					' size="16" maxlength="20" value="' . $p_filter[FILTER_PROPERTY_END_DATE_SUBMITTED] . '" />';
+					' size="16" maxlength="20" value="' . filter_read_submitted_end_date( $p_filter ) . '" />';
 				echo '<i class="fa fa-calendar fa-xlg datetimepicker"></i>';
 				?>
 			</td>
@@ -1321,13 +1324,16 @@ function print_filter_do_filter_by_date( $p_hide_checkbox = false, array $p_filt
 function print_filter_values_do_filter_by_last_updated_date( array $p_filter ) {
 	$t_filter = $p_filter;
 	if( 'on' == $t_filter[FILTER_PROPERTY_FILTER_BY_LAST_UPDATED_DATE] ) {
-		echo '<input type="hidden" name="', FILTER_PROPERTY_FILTER_BY_LAST_UPDATED_DATE, '" value="', string_attribute( $t_filter[FILTER_PROPERTY_FILTER_BY_LAST_UPDATED_DATE] ), '" />';
-		echo '<input type="hidden" name="', FILTER_PROPERTY_LAST_UPDATED_START_DATE, '" value="', string_attribute( $t_filter[FILTER_PROPERTY_LAST_UPDATED_START_DATE] ), '" />';
-		echo '<input type="hidden" name="', FILTER_PROPERTY_LAST_UPDATED_END_DATE, '" value="', string_attribute( $t_filter[FILTER_PROPERTY_LAST_UPDATED_END_DATE] ), '" />';
+		$t_start_string = filter_read_last_updated_start_date( $t_filter );
+		$t_end_string = filter_read_last_updated_end_date( $t_filter );
 
-		echo $t_filter[FILTER_PROPERTY_LAST_UPDATED_START_DATE];
+		echo '<input type="hidden" name="', FILTER_PROPERTY_FILTER_BY_LAST_UPDATED_DATE, '" value="', string_attribute( $t_filter[FILTER_PROPERTY_FILTER_BY_LAST_UPDATED_DATE] ), '" />';
+		echo '<input type="hidden" name="', FILTER_PROPERTY_LAST_UPDATED_START_DATE, '" value="', $t_start_string, '" />';
+		echo '<input type="hidden" name="', FILTER_PROPERTY_LAST_UPDATED_END_DATE, '" value="', $t_end_string, '" />';
+
+		echo $t_start_string;
 		echo ' - ';
-		echo $t_filter[FILTER_PROPERTY_LAST_UPDATED_END_DATE];
+		echo $t_end_string;
 	} else {
 		echo lang_get( 'no' );
 	}
@@ -1381,7 +1387,7 @@ function print_filter_do_filter_by_last_updated_date( $p_hide_checkbox = false, 
                     ' class="datetimepicker input-xs" ' . $t_menu_readonly .
                     ' data-picker-locale="' . lang_get_current_datetime_locale() . '"' .
                     ' data-picker-format="' . convert_date_format_to_momentjs( config_get( 'normal_date_format' ) ) . '"' .
-                    ' size="16" maxlength="20" value="' . $p_filter[FILTER_PROPERTY_LAST_UPDATED_START_DATE] . '" />';
+                    ' size="16" maxlength="20" value="' . filter_read_last_updated_start_date( $p_filter ) . '" />';
                 echo '<i class="fa fa-calendar fa-xlg datetimepicker"></i>';
 	            ?>
 			</td>
@@ -1397,7 +1403,7 @@ function print_filter_do_filter_by_last_updated_date( $p_hide_checkbox = false, 
 					' class="datetimepicker input-xs" ' . $t_menu_readonly .
 					' data-picker-locale="' . lang_get_current_datetime_locale() . '"' .
 					' data-picker-format="' . convert_date_format_to_momentjs( config_get( 'normal_date_format' ) ) . '"' .
-					' size="16" maxlength="20" value="' . $p_filter[FILTER_PROPERTY_LAST_UPDATED_END_DATE] . '" />';
+					' size="16" maxlength="20" value="' . filter_read_last_updated_end_date( $p_filter ) . '" />';
 				echo '<i class="fa fa-calendar fa-xlg datetimepicker"></i>';
 				?>
 			</td>


### PR DESCRIPTION
The extra time annotation was not supposed to be part of the change. As it made it to master, it broke filters with date_submitted & last_updated values set.

Fixes #22653
