### PR TITLE
Fix rendering of on-page debug logs in modern ui

### DIFF
--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -1008,8 +1008,8 @@ function layout_page_content_begin() {
  * @return null
  */
 function layout_page_content_end() {
-    # Print table of log events
-    log_print_to_page();
+	# Print table of log events
+	log_print_to_page();
 
 	echo '</div>' , "\n";
 }

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -1008,6 +1008,9 @@ function layout_page_content_begin() {
  * @return null
  */
 function layout_page_content_end() {
+    # Print table of log events
+    log_print_to_page();
+
 	echo '</div>' , "\n";
 }
 
@@ -1207,9 +1210,6 @@ function layout_footer() {
 		echo '</address>' . "\n";
 		echo '</div>' . "\n";
 	}
-
-	# Print table of log events
-	log_print_to_page();
 
 	layout_footer_end();
 }

--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -184,19 +184,19 @@ function log_print_to_page() {
 		$t_total_event_count = count( $g_log_events );
 
 
-        echo "<div class=\"space-10\"></div>";
-        echo "\t<div class=\"row\">\n";
+		echo "<div class=\"space-10\"></div>";
+		echo "\t<div class=\"row\">\n";
 		echo "\t<div class=\"col-xs-12\">\n";
 
-        echo "\t<div class=\"widget-box widget-color-red\">\n";
-	    echo "\t<div class=\"widget-header widget-header-small\">\n";
-	    echo "\t<h4 class=\"widget-title lighter\">\n";
+		echo "\t<div class=\"widget-box widget-color-red\">\n";
+		echo "\t<div class=\"widget-header widget-header-small\">\n";
+		echo "\t<h4 class=\"widget-title lighter\">\n";
 		echo "\t<i class=\"ace-icon fa fa-flag-o\"></i>\n";
 		echo "Debug Log";
-        echo "</h4>\n";
-	    echo "</div>\n";
+		echo "</h4>\n";
+		echo "</div>\n";
 
-	    echo "\t<div class=\"widget-body\">\n";
+		echo "\t<div class=\"widget-body\">\n";
 
 		echo "\n\n<!--Mantis Debug Log Output-->";
 		if( $t_total_event_count == 0 ) {
@@ -204,7 +204,7 @@ function log_print_to_page() {
 			return;
 		}
 
-        echo "<div class=\"widget-main no-padding\">";
+		echo "<div class=\"widget-main no-padding\">";
 		echo "<div class=\"table-responsive\">\n";
 		echo "<table class=\"table table-bordered table-condensed table-striped\" id=\"log-event-list\">\n";
 		echo "\t<thead>\n";

--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -183,21 +183,36 @@ function log_print_to_page() {
 		$t_total_queries_count = 0;
 		$t_total_event_count = count( $g_log_events );
 
-		echo "\t<hr />\n";
+
+        echo "<div class=\"space-10\"></div>";
+        echo "\t<div class=\"row\">\n";
+		echo "\t<div class=\"col-xs-12\">\n";
+
+        echo "\t<div class=\"widget-box widget-color-red\">\n";
+	    echo "\t<div class=\"widget-header widget-header-small\">\n";
+	    echo "\t<h4 class=\"widget-title lighter\">\n";
+		echo "\t<i class=\"ace-icon fa fa-flag-o\"></i>\n";
+		echo "Debug Log";
+        echo "</h4>\n";
+	    echo "</div>\n";
+
+	    echo "\t<div class=\"widget-body\">\n";
+
 		echo "\n\n<!--Mantis Debug Log Output-->";
 		if( $t_total_event_count == 0 ) {
 			echo "<!--END Mantis Debug Log Output-->\n\n";
 			return;
 		}
 
-		echo "<hr />\n";
-		echo "<table id=\"log-event-list\">\n";
+        echo "<div class=\"widget-main no-padding\">";
+		echo "<div class=\"table-responsive\">\n";
+		echo "<table class=\"table table-bordered table-condensed table-striped\" id=\"log-event-list\">\n";
 		echo "\t<thead>\n";
 		echo "\t\t<tr>\n";
-		echo "\t\t\t<th>" . lang_get( 'log_page_number' ) . "</th>\n";
-		echo "\t\t\t<th>" . lang_get( 'log_page_time' ) . "</th>\n";
-		echo "\t\t\t<th>" . lang_get( 'log_page_caller' ) . "</th>\n";
-		echo "\t\t\t<th>" . lang_get( 'log_page_event' ) . "</th>\n";
+		echo "\t\t\t<th class=\"small-caption\">" . lang_get( 'log_page_number' ) . "</th>\n";
+		echo "\t\t\t<th class=\"small-caption\">" . lang_get( 'log_page_time' ) . "</th>\n";
+		echo "\t\t\t<th class=\"small-caption\">" . lang_get( 'log_page_caller' ) . "</th>\n";
+		echo "\t\t\t<th class=\"small-caption\">" . lang_get( 'log_page_event' ) . "</th>\n";
 		echo "\t\t</tr>\n";
 		echo "\t</thead>\n";
 		echo "\t<tbody>\n";
@@ -230,27 +245,28 @@ function log_print_to_page() {
 					if( $t_log_event[2][2] ) {
 						$t_query_duplicate_class = ' class="duplicate-query"';
 					}
-					echo "\t\t<tr " . $t_query_duplicate_class . '><td>' . $t_level . '-' . $t_count[$t_log_event[1]] . '</td><td>' . $t_log_event[2][1] . '</td><td>' . string_html_specialchars( $t_log_event[3] ) . '</td><td>' . string_html_specialchars( $t_log_event[2][0] ) . "</td></tr>\n";
+					echo "\t\t<tr " . $t_query_duplicate_class . '><td class="small">' . $t_level . '-' . $t_count[$t_log_event[1]] . '</td><td class="small">' . $t_log_event[2][1] . '</td><td class="small">' . string_html_specialchars( $t_log_event[3] ) . '</td><td class="small">' . string_html_specialchars( $t_log_event[2][0] ) . "</td></tr>\n";
 					break;
 				default:
-					echo "\t\t<tr><td>" . $t_level . '-' . $t_count[$t_log_event[1]] . '</td><td>' . $t_log_event[2][1] . '</td><td>' . string_html_specialchars( $t_log_event[3] ) . '</td><td>' . string_html_specialchars( $t_log_event[2][0] ) . "</td></tr>\n";
+					echo "\t\t<tr><td class=\"small\">" . $t_level . '-' . $t_count[$t_log_event[1]] . '</td><td class="small">' . $t_log_event[2][1] . '</td><td class="small">' . string_html_specialchars( $t_log_event[3] ) . '</td><td class="small">' . string_html_specialchars( $t_log_event[2][0] ) . "</td></tr>\n";
 			}
 		}
 
 		# output any summary data
 		if( $t_unique_queries_count != 0 ) {
 			$t_unique_queries_executed = sprintf( lang_get( 'unique_queries_executed' ), $t_unique_queries_count );
-			echo "\t\t<tr><td>" . $g_log_levels[LOG_DATABASE] . '</td><td colspan="3">' . $t_unique_queries_executed . "</td></tr>\n";
+			echo "\t\t<tr><td class=\"small\">" . $g_log_levels[LOG_DATABASE] . '</td><td colspan="3" class="small">' . $t_unique_queries_executed . "</td></tr>\n";
 		}
 		if( $t_total_queries_count != 0 ) {
 			$t_total_queries_executed = sprintf( lang_get( 'total_queries_executed' ), $t_total_queries_count );
-			echo "\t\t<tr><td>" . $g_log_levels[LOG_DATABASE] . '</td><td colspan="3">' . $t_total_queries_executed . "</td></tr>\n";
+			echo "\t\t<tr><td class=\"small\">" . $g_log_levels[LOG_DATABASE] . '</td><td colspan="3" class="small">' . $t_total_queries_executed . "</td></tr>\n";
 		}
 		if( $t_total_query_execution_time != 0 ) {
 			$t_total_query_time = sprintf( lang_get( 'total_query_execution_time' ), $t_total_query_execution_time );
-			echo "\t\t<tr><td>" . $g_log_levels[LOG_DATABASE] . '</td><td colspan="3">' . $t_total_query_time . "</td></tr>\n";
+			echo "\t\t<tr><td class=\"small\">" . $g_log_levels[LOG_DATABASE] . '</td><td colspan="3" class="small">' . $t_total_query_time . "</td></tr>\n";
 		}
 		echo "\t</tbody>\n\t</table>\n";
+		echo "</div></div></div></div></div></div>\n";
 
 		echo "<!--END Mantis Debug Log Output-->\n\n";
 	}


### PR DESCRIPTION
Fixes #22672

Here is what it looks like after applying this fix:

<img width="540" alt="screen shot 2017-04-05 at 2 30 44 pm" src="https://cloud.githubusercontent.com/assets/1354889/24728030/1cfd185e-1a0d-11e7-9925-f8577b931ca6.png">
