### PR TITLE
Honor HTTP_X_FORWARDED_PROTO for Gravatar

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -181,11 +181,7 @@ unset( $t_local_config );
 $t_protocol = 'http';
 $t_host = 'localhost';
 if( isset ( $_SERVER['SCRIPT_NAME'] ) ) {
-	if( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) ) {
-		$t_protocol= $_SERVER['HTTP_X_FORWARDED_PROTO'];
-	} else if( !empty( $_SERVER['HTTPS'] ) && ( strtolower( $_SERVER['HTTPS'] ) != 'off' ) ) {
-		$t_protocol = 'https';
-	}
+	$t_protocol = http_is_protocol_https() ? 'https' : 'http';
 
 	# $_SERVER['SERVER_PORT'] is not defined in case of php-cgi.exe
 	if( isset( $_SERVER['SERVER_PORT'] ) ) {

--- a/core.php
+++ b/core.php
@@ -131,6 +131,22 @@ function require_lib( $p_library_name ) {
 }
 
 /**
+ * Checks to see if script was queried through the HTTPS protocol
+ * @return boolean True if protocol is HTTPS
+ */
+function http_is_protocol_https() {
+	if( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) ) {
+		return strtolower( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) == 'https';
+	}
+
+	if( !empty( $_SERVER['HTTPS'] ) && ( strtolower( $_SERVER['HTTPS'] ) != 'off' ) ) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * Define an autoload function to automatically load classes when referenced
  *
  * @param string $p_class Class name being autoloaded.

--- a/core/http_api.php
+++ b/core/http_api.php
@@ -36,22 +36,6 @@ require_api( 'config_api.php' );
 $g_csp = array();
 
 /**
- * Checks to see if script was queried through the HTTPS protocol
- * @return boolean True if protocol is HTTPS
- */
-function http_is_protocol_https() {
-	if( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) ) {
-		return strtolower( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) == 'https';
-	}
-
-	if( !empty( $_SERVER['HTTPS'] ) && ( strtolower( $_SERVER['HTTPS'] ) != 'off' ) ) {
-		return true;
-	}
-
-	return false;
-}
-
-/**
  * Check to see if the client is using Microsoft Internet Explorer so we can
  * enable quirks and hacky non-standards-compliant workarounds.
  * @return boolean True if Internet Explorer is detected as the user agent

--- a/core/http_api.php
+++ b/core/http_api.php
@@ -40,7 +40,15 @@ $g_csp = array();
  * @return boolean True if protocol is HTTPS
  */
 function http_is_protocol_https() {
-	return !empty( $_SERVER['HTTPS'] ) && ( utf8_strtolower( $_SERVER['HTTPS'] ) != 'off' );
+	if( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) ) {
+		return strtolower( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) == 'https';
+	}
+
+	if( !empty( $_SERVER['HTTPS'] ) && ( strtolower( $_SERVER['HTTPS'] ) != 'off' ) ) {
+		return true;
+	}
+
+	return false;
 }
 
 /**


### PR DESCRIPTION
When behind a proxy/load balancer and HTTP_X_FORWARDED_PROTO indicates
that MantisBT is accessed via https, make sure all resources are loaded via https.

Fixes #22689