### PR TITLE
Missing "echo" in date-picker-locale attrib in due date field

### DIFF
--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -242,7 +242,7 @@ layout_page_begin();
 		</th>
 		<td>
 			<input type="text" id="due_date" name="due_date" class="datetimepicker input-sm" size="16" maxlength="20"
-				data-picker-locale="<?php lang_get_current_datetime_locale() ?>"
+				data-picker-locale="<?php echo lang_get_current_datetime_locale() ?>"
 				data-picker-format="<?php echo convert_date_format_to_momentjs( config_get( 'normal_date_format' ) ) ?>"
 				<?php helper_get_tab_index() ?> value="<?php echo $t_date_to_display ?>" />
 			<i class="fa fa-calendar fa-xlg datetimepicker"></i>


### PR DESCRIPTION
Including missing "echo" in attribute in due date field, related to https://www.mantisbt.org/bugs/view.php?id=22700