### PR TITLE
Filter load save refactor

### DIFF
--- a/api/soap/mc_filter_api.php
+++ b/api/soap/mc_filter_api.php
@@ -236,14 +236,10 @@ function mc_filter_get_issue_headers( $p_username, $p_password, $p_project_id, $
 	$t_orig_page_number = $p_page_number < 1 ? 1 : $p_page_number;
 	$t_page_count = 0;
 	$t_bug_count = 0;
-	$t_filter = filter_db_get_filter( $p_filter_id );
-	$t_filter_detail = explode( '#', $t_filter, 2 );
-	if( !isset( $t_filter_detail[1] ) ) {
+	$t_filter = filter_get( $p_filter_id, null );
+	if( null === $t_filter ) {
 		return ApiObjectFactory::faultServerError( 'Invalid Filter' );
 	}
-	$t_filter = json_decode( $t_filter_detail[1], true );
-	$t_filter = filter_ensure_valid_filter( $t_filter );
-
 	$t_result = array();
 	$t_rows = filter_get_bug_rows( $p_page_number, $p_per_page, $t_page_count, $t_bug_count, $t_filter, $p_project_id );
 

--- a/api/soap/mc_filter_api.php
+++ b/api/soap/mc_filter_api.php
@@ -127,7 +127,7 @@ function mc_filter_get( $p_username, $p_password, $p_project_id, $p_filter_id = 
 function mci_filter_delete( $p_filter_id ) {
 	$t_user_id = auth_get_current_user_id();
 
-	$t_filter = filter_cache_row( $p_filter_id, /* trigger_errors */ false );
+	$t_filter = filter_get_row( $p_filter_id );
 	if( !$t_filter ) {
 		return ApiObjectFactory::faultNotFound( 'Filter not found' );
 	}

--- a/api/soap/mc_filter_api.php
+++ b/api/soap/mc_filter_api.php
@@ -172,7 +172,12 @@ function mc_filter_get_issues( $p_username, $p_password, $p_project_id, $p_filte
 		return mci_fault_access_denied( $t_user_id );
 	}
 
-	$t_filter = filter_load( $p_filter_id, $t_user_id );
+	if( is_numeric( $p_filter_id ) ) {
+		$t_filter = filter_get( $p_filter_id );
+	} else {
+		$t_filter = filter_standard_get( $p_filter_id, $t_user_id );
+	}
+
 	if( $t_filter === null ) {
 		return ApiObjectFactory::faultNotFound( "Unknown filter '$p_filter_id'" );
 	}

--- a/core/current_user_api.php
+++ b/core/current_user_api.php
@@ -236,9 +236,9 @@ function current_user_ensure_unprotected() {
  * @access public
  */
 function current_user_get_bug_filter( $p_project_id = null ) {
-	$f_tmp_key = gpc_get_string( 'filter', 0 );
+	$f_tmp_key = gpc_get_string( 'filter', null );
 
-	if( 0 !== $f_tmp_key ) {
+	if( null !== $f_tmp_key ) {
 		$t_filter = filter_temporary_get( $f_tmp_key, filter_get_default() );
 	} else {
 		$t_user_id = auth_get_current_user_id();

--- a/core/current_user_api.php
+++ b/core/current_user_api.php
@@ -249,8 +249,6 @@ function current_user_get_bug_filter( $p_project_id = null ) {
 			$t_filter = json_decode( $t_token, true );
 		}
 		$t_filter = filter_ensure_valid_filter( $t_filter );
-	} else if( !filter_is_cookie_valid() ) {
-		$t_filter = filter_get_default();
 	} else {
 		$t_user_id = auth_get_current_user_id();
 		$t_filter = user_get_bug_filter( $t_user_id, $p_project_id );

--- a/core/current_user_api.php
+++ b/core/current_user_api.php
@@ -28,7 +28,6 @@
  * @uses filter_api.php
  * @uses gpc_api.php
  * @uses helper_api.php
- * @uses tokens_api.php
  * @uses user_api.php
  * @uses user_pref_api.php
  * @uses utility_api.php
@@ -39,7 +38,6 @@ require_api( 'constant_inc.php' );
 require_api( 'filter_api.php' );
 require_api( 'gpc_api.php' );
 require_api( 'helper_api.php' );
-require_api( 'tokens_api.php' );
 require_api( 'user_api.php' );
 require_api( 'user_pref_api.php' );
 require_api( 'utility_api.php' );
@@ -238,17 +236,10 @@ function current_user_ensure_unprotected() {
  * @access public
  */
 function current_user_get_bug_filter( $p_project_id = null ) {
-	$f_filter_token = gpc_get( 'filter', null );
+	$f_tmp_key = gpc_get_string( 'filter', 0 );
 
-	if( null !== $f_filter_token && token_exists( (int)$f_filter_token ) ) {
-		# If the token id exists, try to load the value
-		# At this point, only one value can exists for each token type and user
-		# so read the token based on type, regardless of the id that was provided
-		$t_token = token_get_value( TOKEN_FILTER );
-		if( null != $t_token ) {
-			$t_filter = json_decode( $t_token, true );
-		}
-		$t_filter = filter_ensure_valid_filter( $t_filter );
+	if( 0 !== $f_tmp_key ) {
+		$t_filter = filter_temporary_get( $f_tmp_key, filter_get_default() );
 	} else {
 		$t_user_id = auth_get_current_user_id();
 		$t_filter = user_get_bug_filter( $t_user_id, $p_project_id );

--- a/core/current_user_api.php
+++ b/core/current_user_api.php
@@ -239,7 +239,11 @@ function current_user_get_bug_filter( $p_project_id = null ) {
 	$f_tmp_key = gpc_get_string( 'filter', null );
 
 	if( null !== $f_tmp_key ) {
-		$t_filter = filter_temporary_get( $f_tmp_key, filter_get_default() );
+		$t_filter = filter_temporary_get( $f_tmp_key, null );
+		# if filter doesn't exist or can't be loaded, return a default filter (doesn't throw error)
+		if( null === $t_filter ) {
+			$t_filter = filter_get_default();
+		}
 	} else {
 		$t_user_id = auth_get_current_user_id();
 		$t_filter = user_get_bug_filter( $t_user_id, $p_project_id );

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -951,6 +951,10 @@ function filter_get_default() {
 
 /**
  * Deserialize filter string
+ * Expected strings have this format: "<version>#<json string>" where:
+ * - <version> is the versio number of the filter structure used. See constant FILTER_VERSION
+ * - # is a separator
+ * - <json string> is the json encoded filter array.
  * @param string $p_serialized_filter Serialized filter string.
  * @return mixed $t_filter array
  * @see filter_ensure_valid_filter
@@ -959,6 +963,10 @@ function filter_deserialize( $p_serialized_filter ) {
 	if( is_blank( $p_serialized_filter ) ) {
 		return false;
 	}
+
+	#@TODO cproensa, we could accept a pure json array, without version prefix
+	# in this case, the filter version field inside the array is to be used
+	# and if not present, set the current filter version
 
 	# check to see if new cookie is needed
 	$t_setting_arr = explode( '#', $p_serialized_filter, 2 );

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2585,7 +2585,11 @@ function filter_draw_selection_area( $p_page_number, $p_for_screen = true, $p_ex
 
 	if( access_has_project_level( config_get( 'stored_query_create_threshold' ) ) ) { ?>
 		<form class="form-inline pull-left" method="post" name="save_query" action="query_store_page.php">
-			<?php # CSRF protection not required here - form does not result in modifications ?>
+			<?php # CSRF protection not required here - form does not result in modifications
+			if( filter_is_temporary( $t_filter ) ) {
+				echo '<input type="hidden" name="filter" value="' . filter_get_temporary_key( $t_filter ) . '" />';
+			}
+			?>
 			<input type="submit" name="save_query_button" class="btn btn-primary btn-white btn-sm btn-round"
 				value="<?php echo lang_get( 'save_query' )?>" />
 		</form>
@@ -2593,7 +2597,7 @@ function filter_draw_selection_area( $p_page_number, $p_for_screen = true, $p_ex
 	}
 	if( count( $t_stored_queries_arr ) > 0 ) { ?>
 		<form id="filter-queries-form" class="form-inline pull-left padding-left-8"  method="get" name="list_queries<?php echo $t_form_name_suffix;?>" action="view_all_set.php">
-			<?php # CSRF protection not required here - form does not result in modifications ?>
+			<?php # CSRF protection not required here - form does not result in modifications?>
 			<input type="hidden" name="type" value="3" />
 			<select name="source_query_id">
 				<option value="-1"></option>

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -3778,13 +3778,22 @@ function filter_get( $p_filter_id, array $p_default = null ) {
 	return $t_filter;
 }
 
+/**
+ * Updates a filter's properties with those from another filter that is referenced
+ * by it's source-id property.
+ * This is used when an anonymous filter was created from a named filter. As long
+ * as this anonymous filter is not modified, it must be keep in sync with the
+ * referenced filter (source_id), because the source filter may have been modified
+ * at a later time.
+ * This is a side effect of always using anonymous filters even when selecting a
+ * named filter to be applied as current.
+ *
+ * @param array $p_filter	Original filter array
+ * @return array	Updated filter array
+ */
 function filter_update_source_properties( array $p_filter ) {
 	# Check if the filter references a named filter
 	# This property only makes sense, and should be available on unnamed filters
-	# Note that an unnamed filter is used as a working copy for the user. This logic
-	# allows for automatic updating of a current filter when the user had selected
-	# a named filter and that filter has changed. Otherwise the updates in base filter
-	# wuould not reflect in the user's current filter
 	if( isset( $p_filter['_filter_id'] ) ) {
 		$t_filter_id = $p_filter['_filter_id'];
 	} else {
@@ -3799,7 +3808,7 @@ function filter_update_source_properties( array $p_filter ) {
 			if( is_array( $t_new_filter ) ) {
 				# update the referenced stored filter id for the new loaded filter
 				$t_new_filter['_source_query_id'] = $t_source_query_id;
-				$p_filter = filter_copy_runtime_properties( $p_filter, $t_new_filter );
+				$p_filter = filter_copy_runtime_properties( $t_new_filter, $p_filter );
 			} else {
 				# If the unserialez data is not an array, the some error happened, eg, invalid format
 				unset( $p_filter['_source_query_id'] );
@@ -3935,7 +3944,13 @@ function filter_clean_runtime_properties( array $p_filter ) {
 	return $p_filter;
 }
 
-function filter_copy_runtime_properties( array $p_filter_from, array $p_filter_to ) {
+/**
+ * Copy the runtime properties from one filter into another.
+ * @param array $p_filter_to	Destination filter array
+ * @param array $p_filter_from	Filter array from which properties are copied
+ * @return array	Updated filter array
+ */
+function filter_copy_runtime_properties( array $p_filter_to, array $p_filter_from ) {
 	if( isset( $p_filter_from['_temporary_key'] ) ) {
 		$p_filter_to['_temporary_key'] = $p_filter_from['_temporary_key'];
 	}

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -557,6 +557,30 @@ function filter_ensure_fields( array $p_filter_arr ) {
 }
 
 /**
+ * A wrapper to compare filter version syntax
+ * Note: Currently, filter versions hve this syntax: "vN",  * where N is a integer number.
+ * @param string $p_version1    First version number
+ * @param string $p_version2    Second version number
+ * @param string $p_operator    Comparison test, if provided. As expected by version_compare()
+ */
+function filter_version_compare( $p_version1, $p_version2, $p_operator = null ) {
+	return version_compare( $p_version1, $p_version2, $p_operator );
+}
+
+/**
+ * Upgrade a filter array to the current filter structure, by converting properties
+ * that have changed from previous filter versions
+ * @param array $p_filter	Filter array to upgrade
+ */
+function filter_version_upgrade( array $p_filter ) {
+	# This is a stub for future version upgrades
+
+	# After conversions are made, update filter value to current version
+	$p_filter['_version'] = FILTER_VERSION;
+	return $p_filter;
+}
+
+/**
  * Make sure that our filters are entirely correct and complete (it is possible that they are not).
  * We need to do this to cover cases where we don't have complete control over the filters given.
  * @param array $p_filter_arr A Filter definition.
@@ -567,11 +591,9 @@ function filter_ensure_valid_filter( array $p_filter_arr ) {
 	if( !isset( $p_filter_arr['_version'] ) ) {
 		$p_filter_arr['_version'] = FILTER_VERSION;
 	}
-	$t_cookie_vers = (int)substr( $p_filter_arr['_version'], 1 );
-	$t_current_version = (int)substr( FILTER_VERSION, 1 );
-	if( $t_current_version > $t_cookie_vers ) {
-		# if the version is old, update it
-		$p_filter_arr['_version'] = FILTER_VERSION;
+
+	if( filter_version_compare( $p_filter_arr['_version'], FILTER_VERSION, '<' ) ) {
+		$p_filter_arr = filter_version_upgrade( $p_filter_arr );
 	}
 
 	$p_filter_arr = filter_ensure_fields( $p_filter_arr );
@@ -989,7 +1011,6 @@ function filter_deserialize( $p_serialized_filter ) {
 	# Set the filter version that was loaded in the array
 	$t_filter_array['_version'] = $t_setting_arr[0];
 
-	#@TODO cproensa, write stub for filter version specific conversions, inside filter_ensure_valid_filter
 	return filter_ensure_valid_filter( $t_filter_array );
 }
 

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1004,40 +1004,6 @@ function filter_serialize( $p_filter_array ) {
 }
 
 /**
- * Check if the filter cookie exists and is of the correct version.
- * @return boolean
- */
-function filter_is_cookie_valid() {
-	$t_view_all_cookie_id = gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' );
-	$t_view_all_cookie = filter_db_get_filter_string( $t_view_all_cookie_id );
-
-	# check to see if the cookie does not exist
-	if( is_blank( $t_view_all_cookie ) ) {
-		return false;
-	}
-
-	# check to see if new cookie is needed
-	$t_setting_arr = explode( '#', $t_view_all_cookie, 2 );
-	if( ( $t_setting_arr[0] == 'v1' ) || ( $t_setting_arr[0] == 'v2' ) || ( $t_setting_arr[0] == 'v3' ) || ( $t_setting_arr[0] == 'v4' ) ) {
-		return false;
-	}
-
-	# We shouldn't need to do this anymore, as filters from v5 onwards should cope with changing
-	# filter indices dynamically
-	$t_filter_cookie_arr = array();
-	if( isset( $t_setting_arr[1] ) ) {
-		$t_filter_cookie_arr = json_decode( $t_setting_arr[1], true );
-	} else {
-		return false;
-	}
-	if( $t_filter_cookie_arr['_version'] != FILTER_VERSION ) {
-		return false;
-	}
-
-	return true;
-}
-
-/**
  * Get the filter db row $p_filter_id
  * using the cached row if it's available
  * @global array $g_cache_filter_db_rows

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -562,6 +562,7 @@ function filter_ensure_fields( array $p_filter_arr ) {
  * @param string $p_version1    First version number
  * @param string $p_version2    Second version number
  * @param string $p_operator    Comparison test, if provided. As expected by version_compare()
+ * @return mixed	As returned by version_compare()
  */
 function filter_version_compare( $p_version1, $p_version2, $p_operator = null ) {
 	return version_compare( $p_version1, $p_version2, $p_operator );
@@ -571,6 +572,7 @@ function filter_version_compare( $p_version1, $p_version2, $p_operator = null ) 
  * Upgrade a filter array to the current filter structure, by converting properties
  * that have changed from previous filter versions
  * @param array $p_filter	Filter array to upgrade
+ * @return array	Updgraded filter array
  */
 function filter_version_upgrade( array $p_filter ) {
 	# This is a stub for future version upgrades
@@ -583,9 +585,8 @@ function filter_version_upgrade( array $p_filter ) {
 /**
  * Make sure that our filters are entirely correct and complete (it is possible that they are not).
  * We need to do this to cover cases where we don't have complete control over the filters given.
- * @param array $p_filter_arr A Filter definition.
- * @return array
- * @todo function needs to be abstracted
+ * @param array $p_filter_arr	A filter array
+ * @return array	Validated filter array
  */
 function filter_ensure_valid_filter( array $p_filter_arr ) {
 	if( !isset( $p_filter_arr['_version'] ) ) {
@@ -3860,7 +3861,7 @@ function filter_temporary_get( $p_filter_key, $p_default = null ) {
  * its key if it was loaded as a temporary filter.
  * If neither key is found, a new one will be created
  * @param array $p_filter     Filter array
- * @param type $p_filter_key  Key to update, or null
+ * @param string $p_filter_key  Key to update, or null
  * @return string	The key used for storing the filter.
  */
 function filter_temporary_set( array $p_filter, $p_filter_key = null ) {

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1001,7 +1001,7 @@ function filter_serialize( $p_filter_array ) {
  */
 function filter_is_cookie_valid() {
 	$t_view_all_cookie_id = gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' );
-	$t_view_all_cookie = filter_db_get_filter( $t_view_all_cookie_id );
+	$t_view_all_cookie = filter_db_get_filter_string( $t_view_all_cookie_id );
 
 	# check to see if the cookie does not exist
 	if( is_blank( $t_view_all_cookie ) ) {
@@ -2811,7 +2811,7 @@ function filter_db_set_for_current_user( $p_project_id, $p_is_public, $p_name, $
  * @param integer $p_user_id   A valid user identifier.
  * @return mixed
  */
-function filter_db_get_filter( $p_filter_id, $p_user_id = null ) {
+function filter_db_get_filter_string( $p_filter_id, $p_user_id = null ) {
 	$c_filter_id = (int)$p_filter_id;
 
 	if( !filter_is_accessible( $c_filter_id, $p_user_id ) ) {
@@ -3745,7 +3745,7 @@ function filter_get( $p_filter_id, array $p_default = null ) {
 	$t_trigger_error = func_num_args() == 1;
 
 	# This function checks for user access
-	$t_filter_string = filter_db_get_filter( $p_filter_id );
+	$t_filter_string = filter_db_get_filter_string( $p_filter_id );
 	# If value is false, it either doesn't exists or is not accesible
 	if( !$t_filter_string ) {
 		if( $t_trigger_error ) {
@@ -3768,7 +3768,7 @@ function filter_get( $p_filter_id, array $p_default = null ) {
 		# check if filter id is a proper named filter, and is accesible
 		if( filter_is_named_filter( $t_source_query_id ) && filter_is_accessible( $t_source_query_id ) ){
 			# replace filter with the referenced one
-			$t_filter = filter_deserialize( filter_db_get_filter( $t_source_query_id ) );
+			$t_filter = filter_deserialize( filter_db_get_filter_string( $t_source_query_id ) );
 			# update the referenced stored filter id for the new loaded filter
 			$t_filter['_source_query_id'] = $t_source_query_id;
 		} else {

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2824,42 +2824,6 @@ function filter_db_get_filter_string( $p_filter_id, $p_user_id = null ) {
 }
 
 /**
- * Load a filter from db or a standard filter.
- *
- * @param string|integer $p_filter_id The filter id or standard filter.
- * @param integer|null $p_user_id The user id or null for logged in user.
- * @return null filter not found, false invalid filter, otherwise the filter.
- */
-function filter_load( $p_filter_id, $p_user_id = null ) {
-	if( is_numeric( $p_filter_id ) ) {
-		$t_filter = filter_get( $p_filter_id, null );
-	} else {
-		$p_filter_id = strtolower( $p_filter_id );
-		$t_project_id = helper_get_current_project();
-		$t_user_id = auth_get_current_user_id();
-
-		switch( $p_filter_id ) {
-			case FILTER_STANDARD_ASSIGNED:
-				$t_filter = filter_create_assigned_to_unresolved( $t_project_id, $t_user_id );
-				break;
-			case FILTER_STANDARD_UNASSIGNED:
-				$t_filter = filter_create_assigned_to_unresolved( $t_project_id, NO_USER );
-				break;
-			case FILTER_STANDARD_REPORTED:
-				$t_filter = filter_create_reported_by( $t_project_id, $t_user_id );
-				break;
-			case FILTER_STANDARD_MONITORED:
-				$t_filter = filter_create_monitored_by( $t_project_id, $t_user_id );
-				break;
-			default:
-				return null;
-		}
-	}
-
-	return filter_ensure_valid_filter( $t_filter );
-}
-
-/**
  * get current filter for given project and user
  * @param integer $p_project_id A project identifier.
  * @param integer $p_user_id    A valid user identifier.
@@ -3137,7 +3101,7 @@ function filter_create_recently_modified( $p_days, $p_filter = null ) {
 	$p_filter[FILTER_PROPERTY_LAST_UPDATED_START_DAY] = $t_date->format( 'j' );
 	$p_filter[FILTER_PROPERTY_LAST_UPDATED_START_MONTH] = $t_date->format( 'n' );
 	$p_filter[FILTER_PROPERTY_LAST_UPDATED_START_YEAR] = $t_date->format( 'Y' );
-	return $p_filter;
+	return filter_ensure_valid_filter( $p_filter );
 }
 
 /**
@@ -3774,6 +3738,41 @@ function filter_get( $p_filter_id, array $p_default = null ) {
 	$t_filter['_filter_id'] = $p_filter_id;
 
 	$t_filter = filter_update_source_properties( $t_filter );
+
+	return $t_filter;
+}
+
+/**
+ * Return a standard filter
+ * @param string $p_filter_name     The name of the filter
+ * @param integer|null $p_user_id   A user id to build this filter. Null for current user
+ * @return null|boolean|array       null filter not found, false invalid filter, otherwise the filter.
+ */
+function filter_standard_get( $p_filter_name, $p_user_id = null ) {
+	$p_filter_name = strtolower( $p_filter_name );
+	$t_project_id = helper_get_current_project();
+	if( null === $p_user_id ) {
+		$t_user_id = auth_get_current_user_id();
+	} else {
+		$t_user_id = $p_user_id;
+	}
+
+	switch( $p_filter_name ) {
+		case FILTER_STANDARD_ASSIGNED:
+			$t_filter = filter_create_assigned_to_unresolved( $t_project_id, $t_user_id );
+			break;
+		case FILTER_STANDARD_UNASSIGNED:
+			$t_filter = filter_create_assigned_to_unresolved( $t_project_id, NO_USER );
+			break;
+		case FILTER_STANDARD_REPORTED:
+			$t_filter = filter_create_reported_by( $t_project_id, $t_user_id );
+			break;
+		case FILTER_STANDARD_MONITORED:
+			$t_filter = filter_create_monitored_by( $t_project_id, $t_user_id );
+			break;
+		default:
+			return null;
+	}
 
 	return $t_filter;
 }

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2443,20 +2443,6 @@ function filter_cache_result( array $p_rows, array $p_id_array_lastmod ) {
 }
 
 /**
- * Mainly based on filter_draw_selection_area2() but adds the support for the collapsible
- * filter display.
- * @param integer $p_page_number Page number.
- * @param boolean $p_for_screen  Whether output is for screen view.
- * @return void
- * @see filter_draw_selection_area2
- */
-function filter_draw_selection_area( $p_page_number, $p_for_screen = true ) {
-	echo '<div class="col-md-12 col-xs-12">';
-	filter_draw_selection_area2( $p_page_number, $p_for_screen, true );
-	echo '</div>';
-}
-
-/**
  * Prints the filter selection area for both the bug list view screen and
  * the bug list print screen. This function was an attempt to make it easier to
  * add new filters and rearrange them on screen for both pages.
@@ -2465,7 +2451,7 @@ function filter_draw_selection_area( $p_page_number, $p_for_screen = true ) {
  * @param boolean $p_expanded    Whether to display expanded.
  * @return void
  */
-function filter_draw_selection_area2( $p_page_number, $p_for_screen = true, $p_expanded = true ) {
+function filter_draw_selection_area( $p_page_number, $p_for_screen = true, $p_expanded = true ) {
 	$t_form_name_suffix = $p_expanded ? '_open' : '_closed';
 
 	$t_filter = current_user_get_bug_filter();
@@ -2486,7 +2472,7 @@ function filter_draw_selection_area2( $p_page_number, $p_for_screen = true, $p_e
 		$t_view_all_set_type = 5;
 	}
 	?>
-
+	<div class="col-md-12 col-xs-12">
 	<div class="filter-box">
 		<form method="post" name="filters<?php echo $t_form_name_suffix?>" id="filters_form<?php echo $t_form_name_suffix?>" action="<?php echo $t_action;?>">
 		<?php # CSRF protection not required here - form does not result in modifications ?>
@@ -2595,6 +2581,7 @@ function filter_draw_selection_area2( $p_page_number, $p_for_screen = true, $p_e
 		filter_form_draw_inputs( $t_filter, $p_for_screen, false, 'view_filters_page.php' );
 		?>
 
+		</div>
 		</div>
 		</div>
 		<?php

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -99,11 +99,6 @@ $g_filter = null;
 # indexed by filter_id, contains the filter rows as read from db table
 $g_cache_filter_db_rows = array();
 
-# @global array $g_cache_filter_db_serialized
-# indexed by filter_id, contains the serialized filter strings
-$g_cache_filter_db_serialized = array();
-
-
 /**
  * Initialize the filter API with the current filter.
  * @param array $p_filter The filter to set as the current filter.
@@ -2817,28 +2812,14 @@ function filter_db_set_for_current_user( $p_project_id, $p_is_public, $p_name, $
  * @return mixed
  */
 function filter_db_get_filter( $p_filter_id, $p_user_id = null ) {
-	global $g_cache_filter_db_serialized;
 	$c_filter_id = (int)$p_filter_id;
 
 	if( !filter_is_accessible( $c_filter_id, $p_user_id ) ) {
 		return null;
 	}
 
-	if( isset( $g_cache_filter_db_serialized[$c_filter_id] ) ) {
-		if( $g_cache_filter_db_serialized[$c_filter_id] === false ) {
-			return null;
-		}
-		return $g_cache_filter_db_serialized[$c_filter_id];
-	}
-
 	$t_filter_row = filter_get_row( $c_filter_id );
-	if( $t_filter_row ) {
-		$g_cache_filter_db_serialized[$c_filter_id] = $t_filter_row['filter_string'];
-	} else {
-		$g_cache_filter_db_serialized[$c_filter_id] = false;
-	}
-
-	return $g_cache_filter_db_serialized[$c_filter_id];
+	return $t_filter_row['filter_string'];
 }
 
 /**

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2850,18 +2850,7 @@ function filter_db_get_filter( $p_filter_id, $p_user_id = null ) {
  */
 function filter_load( $p_filter_id, $p_user_id = null ) {
 	if( is_numeric( $p_filter_id ) ) {
-		$p_filter_id = (int)$p_filter_id;
-		$t_filter = filter_db_get_filter( $p_filter_id );
-		if( $t_filter === null ) {
-			return null;
-		}
-
-		$t_filter_detail = explode( '#', $t_filter, 2 );
-		if( !isset( $t_filter_detail[1] ) ) {
-			return false;
-		}
-
-		$t_filter = json_decode( $t_filter_detail[1], true );
+		$t_filter = filter_get( $p_filter_id, null );
 	} else {
 		$p_filter_id = strtolower( $p_filter_id );
 		$t_project_id = helper_get_current_project();

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -3033,7 +3033,7 @@ function filter_db_delete_current_filters() {
  * @param boolean $p_public			Public flag for filter
  * @return array	Array of filter ids and names
  */
-function filter_db_get_queries( $p_project_id = null, $p_user_id = null, $p_public = null ) {
+function filter_db_get_named_filters( $p_project_id = null, $p_user_id = null, $p_public = null ) {
 	db_param_push();
 	$t_params = array();
 	$t_query = 'SELECT id, name FROM {filters} WHERE project_id >= ' . db_param();

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -972,20 +972,20 @@ function filter_deserialize( $p_serialized_filter ) {
 		return false;
 	}
 
-	# We shouldn't need to do this anymore, as filters from v5 onwards should cope with changing
-	# filter indices dynamically
-	$t_filter_array = array();
+	# filters from v5 onwards should cope with changing filter indices dynamically
+
+	# Decode json string. If an error happens, eg, invalid format, returns false.
 	if( isset( $t_setting_arr[1] ) ) {
 		$t_filter_array = json_decode( $t_setting_arr[1], true );
 	} else {
 		return false;
 	}
-	if( $t_filter_array['_version'] != FILTER_VERSION ) {
-		# if the version is not new enough, update it using defaults
-		return filter_ensure_valid_filter( $t_filter_array );
-	}
 
-	return $t_filter_array;
+	# Set the filter version that was loaded in the array
+	$t_filter_array['_version'] = $t_setting_arr[0];
+
+	#@TODO cproensa, write stub for filter version specific conversions, inside filter_ensure_valid_filter
+	return filter_ensure_valid_filter( $t_filter_array );
 }
 
 /**

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -3827,7 +3827,7 @@ function filter_temporary_get( $p_filter_key, $p_default = null ) {
 		return filter_ensure_valid_filter( $t_filter );
 	} else {
 		if( $t_trigger_error ) {
-			error_parameters( $p_filter_id );
+			error_parameters( $p_filter_key );
 			trigger_error( ERROR_FILTER_NOT_FOUND, ERROR );
 		} else {
 			return $p_default;

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -3765,6 +3765,11 @@ function filter_get( $p_filter_id, array $p_default = null ) {
 		}
 	}
 	$t_filter = filter_deserialize( $t_filter_string );
+	# If the unserialez data is not an array, the some error happened, eg, invalid format
+	if( !is_array( $t_filter ) ) {
+		# Don't throw error, otherwise the user could not recover navigation easily
+		return filter_get_default();
+	}
 	$t_filter = filter_clean_runtime_properties( $t_filter );
 	$t_filter['_filter_id'] = $p_filter_id;
 
@@ -3791,9 +3796,14 @@ function filter_update_source_properties( array $p_filter ) {
 		if( filter_is_named_filter( $t_source_query_id ) && filter_is_accessible( $t_source_query_id ) ){
 			# replace filter with the referenced one
 			$t_new_filter = filter_deserialize( filter_db_get_filter_string( $t_source_query_id ) );
-			# update the referenced stored filter id for the new loaded filter
-			$t_new_filter['_source_query_id'] = $t_source_query_id;
-			$p_filter = filter_copy_runtime_properties( $p_filter, $t_new_filter );
+			if( is_array( $t_new_filter ) ) {
+				# update the referenced stored filter id for the new loaded filter
+				$t_new_filter['_source_query_id'] = $t_source_query_id;
+				$p_filter = filter_copy_runtime_properties( $p_filter, $t_new_filter );
+			} else {
+				# If the unserialez data is not an array, the some error happened, eg, invalid format
+				unset( $p_filter['_source_query_id'] );
+			}
 		} else {
 			# If the filter id is not valid, clean the referenced filter id
 			unset( $p_filter['_source_query_id'] );

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -3866,9 +3866,8 @@ function filter_temporary_get( $p_filter_key, $p_default = null ) {
  */
 function filter_temporary_set( array $p_filter, $p_filter_key = null ) {
 	if( null === $p_filter_key ) {
-		if( isset( $p_filter['_temporary_key'] ) ) {
-			$t_filter_key = $p_filter['_temporary_key'];
-		} else {
+		$t_filter_key = filter_get_temporary_key( $p_filter );
+		if( !$t_filter_key ) {
 			$t_filter_key = uniqid();
 		}
 	} else {
@@ -3886,7 +3885,7 @@ function filter_temporary_set( array $p_filter, $p_filter_key = null ) {
  * Get the temporary key of the filter, if was loaded from temporary session store
  * Return null otherwise
  * @param array $p_filter	Filter array
- * @return string	Key associated with this filter, null if none
+ * @return string|null	Key associated with this filter, null if none
  */
 function filter_get_temporary_key( array $p_filter ) {
 	if( isset( $p_filter['_temporary_key'] ) ) {
@@ -3913,7 +3912,7 @@ function filter_is_temporary( array $p_filter ) {
  * If a filter is provided that does not contain the key proeprty, an empty
  * string is returned.
  * @param array|string $p_key_or_filter	Either a string key, or a filter array
- * @return string	Formatted parameter string, or empty
+ * @return string|null	Formatted parameter string, or null
  */
 function filter_get_temporary_key_param( $p_key_or_filter ) {
 	if( is_array( $p_key_or_filter ) ) {
@@ -3924,7 +3923,7 @@ function filter_get_temporary_key_param( $p_key_or_filter ) {
 	if( $t_key ) {
 		return 'filter=' . $t_key;
 	} else {
-		return '';
+		return null;
 	}
 }
 

--- a/core/filter_form_api.php
+++ b/core/filter_form_api.php
@@ -2387,8 +2387,10 @@ function filter_form_draw_inputs( $p_filter, $p_for_screen = true, $p_static = f
 		if( $p_static) {
 			return $p_label;
 		} else {
-			if( $t_source_query_id > 0 ) {
-				$t_data_filter_id = ' data-filter_id="' . $t_source_query_id . '"';
+			if( filter_is_temporary( $t_filter ) ) {
+				$t_data_filter_id = ' data-filter="' . filter_get_temporary_key( $t_filter ) . '"';
+			} elseif ( isset( $t_filter['_filter_id'] ) ) {
+				$t_data_filter_id = ' data-filter_id="' . $t_filter['_filter_id'] . '"';
 			} else {
 				$t_data_filter_id = '';
 			}

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1520,7 +1520,7 @@ function print_small_button( $p_link, $p_url_text, $p_new_window = false ) {
  * @param string  $p_text           The displayed text for the link.
  * @param integer $p_page_no        The page number to link to.
  * @param integer $p_page_cur       The current page number.
- * @param integer $p_temp_filter_key Temporary filter id.
+ * @param integer $p_temp_filter_key Temporary filter key.
  * @return void
  */
 function print_page_link( $p_page_url, $p_text = '', $p_page_no = 0, $p_page_cur = 0, $p_temp_filter_key = null ) {
@@ -1548,7 +1548,7 @@ function print_page_link( $p_page_url, $p_text = '', $p_page_no = 0, $p_page_cur
  * @param integer $p_start          The first page number.
  * @param integer $p_end            The last page number.
  * @param integer $p_current        The current page number.
- * @param integer $p_temp_filter_key Temporary filter id.
+ * @param integer $p_temp_filter_key Temporary filter key.
  * @return void
  */
 function print_page_links( $p_page, $p_start, $p_end, $p_current, $p_temp_filter_key = null ) {

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1317,6 +1317,12 @@ function print_formatted_severity_string( BugData $p_bug ) {
  * @return void
  */
 function print_view_bug_sort_link( $p_string, $p_sort_field, $p_sort, $p_dir, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
+	# @TODO cproensa, $g_filter is needed to get the temporary id, since the
+	# actual filter is not providede as parameter. Ideally, we should not
+	# rely in this global variable, but at the moment is not possible without
+	# a rewrite of these print functions.
+	global $g_filter;
+
 	switch( $p_columns_target ) {
 		case COLUMNS_TARGET_PRINT_PAGE:
 		case COLUMNS_TARGET_VIEW_PAGE:
@@ -1333,7 +1339,8 @@ function print_view_bug_sort_link( $p_string, $p_sort_field, $p_sort, $p_dir, $p
 			}
 			$t_sort_field = rawurlencode( $p_sort_field );
 			$t_print_parameter = ( $p_columns_target == COLUMNS_TARGET_PRINT_PAGE ) ? '&print=1' : '';
-			print_link( 'view_all_set.php?sort_add=' . $t_sort_field . '&dir_add=' . $p_dir . '&type=2' . $t_print_parameter, $p_string );
+			$t_filter_parameter = filter_is_temporary( $g_filter ) ? filter_get_temporary_key_param( $g_filter ) . '&' : '';
+			print_link( 'view_all_set.php?' . $t_filter_parameter . 'sort_add=' . $t_sort_field . '&dir_add=' . $p_dir . '&type=2' . $t_print_parameter, $p_string );
 			break;
 		default:
 			echo $p_string;
@@ -1513,10 +1520,10 @@ function print_small_button( $p_link, $p_url_text, $p_new_window = false ) {
  * @param string  $p_text           The displayed text for the link.
  * @param integer $p_page_no        The page number to link to.
  * @param integer $p_page_cur       The current page number.
- * @param integer $p_temp_filter_id Temporary filter id.
+ * @param integer $p_temp_filter_key Temporary filter id.
  * @return void
  */
-function print_page_link( $p_page_url, $p_text = '', $p_page_no = 0, $p_page_cur = 0, $p_temp_filter_id = 0 ) {
+function print_page_link( $p_page_url, $p_text = '', $p_page_no = 0, $p_page_cur = 0, $p_temp_filter_key = null ) {
 	if( is_blank( $p_text ) ) {
 		$p_text = $p_page_no;
 	}
@@ -1524,8 +1531,8 @@ function print_page_link( $p_page_url, $p_text = '', $p_page_no = 0, $p_page_cur
 	if( ( 0 < $p_page_no ) && ( $p_page_no != $p_page_cur ) ) {
 		echo '<li class="pull-right"> ';
 		$t_delimiter = ( strpos( $p_page_url, '?' ) ? '&' : '?' );
-		if( $p_temp_filter_id !== 0 ) {
-			print_link( $p_page_url . $t_delimiter . 'filter=' . $p_temp_filter_id . '&page_number=' . $p_page_no, $p_text );
+		if( $p_temp_filter_key ) {
+			print_link( $p_page_url . $t_delimiter . 'filter=' . $p_temp_filter_key . '&page_number=' . $p_page_no, $p_text );
 		} else {
 			print_link( $p_page_url . $t_delimiter . 'page_number=' . $p_page_no, $p_text );
 		}
@@ -1541,11 +1548,16 @@ function print_page_link( $p_page_url, $p_text = '', $p_page_no = 0, $p_page_cur
  * @param integer $p_start          The first page number.
  * @param integer $p_end            The last page number.
  * @param integer $p_current        The current page number.
- * @param integer $p_temp_filter_id Temporary filter id.
+ * @param integer $p_temp_filter_key Temporary filter id.
  * @return void
  */
-function print_page_links( $p_page, $p_start, $p_end, $p_current, $p_temp_filter_id = 0 ) {
+function print_page_links( $p_page, $p_start, $p_end, $p_current, $p_temp_filter_key = null ) {
 	$t_items = array();
+
+	# @TODO cproensa
+	# passing the temporary filter id to build ad-hoc url parameter is weak
+	# ideally, we should pass a parameters array which is appended to all generated links
+	# those parameters are provided as needed by the main page calling this functions
 
 	# Check if we have more than one page,
 	#  otherwise return without doing anything.
@@ -1565,11 +1577,11 @@ function print_page_links( $p_page, $p_start, $p_end, $p_current, $p_temp_filter
 	print( '<ul class="pagination small no-margin"> ' );
 
 	# Next and Last links
-	print_page_link( $p_page, $t_last, $p_end, $p_current, $p_temp_filter_id );
+	print_page_link( $p_page, $t_last, $p_end, $p_current, $p_temp_filter_key );
 	if( $p_current < $p_end ) {
-		print_page_link( $p_page, $t_next, $p_current + 1, $p_current, $p_temp_filter_id );
+		print_page_link( $p_page, $t_next, $p_current + 1, $p_current, $p_temp_filter_key );
 	} else {
-		print_page_link( $p_page, $t_next, null, null, $p_temp_filter_id );
+		print_page_link( $p_page, $t_next, null, null, $p_temp_filter_key );
 	}
 
 	# Page numbers ...
@@ -1590,11 +1602,9 @@ function print_page_links( $p_page, $p_start, $p_end, $p_current, $p_temp_filter
 			array_push( $t_items, '<li class="active pull-right"><a>' . $i . '</a></li>' );
 		} else {
 			$t_delimiter = ( strpos( $p_page, '?' ) ? '&' : '?' ) ;
-			if( $p_temp_filter_id !== 0 ) {
-				array_push( $t_items, '<li class="pull-right"><a href="' . $p_page . $t_delimiter . 'filter=' . $p_temp_filter_id . '&amp;page_number=' . $i . '">' . $i . '</a></li>' );
-			} else {
-				array_push( $t_items, '<li class="pull-right"><a href="' . $p_page . $t_delimiter . 'page_number=' . $i . '">' . $i . '</a></li>' );
-			}
+			$t_filter_param = filter_get_temporary_key_param( $p_temp_filter_key );
+			$t_filter_param .= $t_filter_param === null ? : '&amp;';
+			array_push( $t_items, '<li class="pull-right"><a href="' . $p_page . $t_delimiter . $t_filter_param . 'page_number=' . $i . '">' . $i . '</a></li>' );
 		}
 	}
 	echo implode( '&#160;', $t_items );
@@ -1605,8 +1615,8 @@ function print_page_links( $p_page, $p_start, $p_end, $p_current, $p_temp_filter
 
 
 	# First and previous links
-	print_page_link( $p_page, $t_prev, $p_current - 1, $p_current, $p_temp_filter_id );
-	print_page_link( $p_page, $t_first, 1, $p_current, $p_temp_filter_id );
+	print_page_link( $p_page, $t_prev, $p_current - 1, $p_current, $p_temp_filter_key );
+	print_page_link( $p_page, $t_first, 1, $p_current, $p_temp_filter_key );
 
 	print( ' </ul>' );
 }

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1469,7 +1469,6 @@ function user_get_bug_filter( $p_user_id, $p_project_id = null ) {
 		# check if filter id is a proper stored filter, and is accesible
 		if( filter_is_named_filter( $t_source_query_id ) && filter_is_accessible( $t_source_query_id ) ){
 			# the actual stored filter can be retrieved
-			$t_filter_row = filter_cache_row( $t_source_query_id, /* trigger_errors */ false );
 			$t_filter = filter_deserialize( filter_db_get_filter( $t_source_query_id ) );
 			# update the referenced stored filter id
 			$t_filter['_source_query_id'] = $t_source_query_id;

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1455,31 +1455,8 @@ function user_get_bug_filter( $p_user_id, $p_project_id = null ) {
 		$t_project_id = $p_project_id;
 	}
 
-	$t_view_all_cookie_id = filter_db_get_project_current( $t_project_id, $p_user_id );
-	$t_view_all_cookie = filter_db_get_filter( $t_view_all_cookie_id, $p_user_id );
-
-	$t_filter = filter_deserialize( $t_view_all_cookie );
-	if( !$t_filter ) {
-		return filter_get_default();
-	}
-
-	# when the user specific filter references a stored filter id, get that filter instead
-	if( isset( $t_filter['_source_query_id'] ) && $t_view_all_cookie_id != $t_filter['_source_query_id'] ) {
-		$t_source_query_id = $t_filter['_source_query_id'];
-		# check if filter id is a proper stored filter, and is accesible
-		if( filter_is_named_filter( $t_source_query_id ) && filter_is_accessible( $t_source_query_id ) ){
-			# the actual stored filter can be retrieved
-			$t_filter = filter_deserialize( filter_db_get_filter( $t_source_query_id ) );
-			# update the referenced stored filter id
-			$t_filter['_source_query_id'] = $t_source_query_id;
-		} else {
-			# If the filter id is not valid, clean the referenced filter id
-			unset( $t_filter['_source_query_id'] );
-		}
-	}
-	$t_filter = filter_ensure_valid_filter( $t_filter );
-
-	return $t_filter;
+	$t_filter_id = filter_db_get_project_current( $t_project_id, $p_user_id );
+	return filter_get( $t_filter_id );
 }
 
 /**

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1455,8 +1455,14 @@ function user_get_bug_filter( $p_user_id, $p_project_id = null ) {
 		$t_project_id = $p_project_id;
 	}
 
+	# Currently we use the filters saved in db as "current" special filters,
+	# to track the active settings for filters in use.
 	$t_filter_id = filter_db_get_project_current( $t_project_id, $p_user_id );
-	return filter_get( $t_filter_id );
+	if( $t_filter_id ) {
+		return filter_get( $t_filter_id );
+	} else {
+		return filter_get_default();
+	}
 }
 
 /**

--- a/issues_rss.php
+++ b/issues_rss.php
@@ -172,17 +172,18 @@ if( $f_username !== null ) {
 }
 $t_show_sticky = null;
 
+# Override current user
+current_user_set( $t_user_id );
+
 if( $f_filter_id == 0 ) {
 	$t_custom_filter = filter_get_default();
 	$t_custom_filter['sort'] = $c_sort_field;
 } else {
 	# null will be returned if the user doesn't have access right to access the filter.
-	$t_custom_filter = filter_db_get_filter( $f_filter_id, $t_user_id );
+	$t_custom_filter = filter_get( $f_filter_id, null );
 	if( null === $t_custom_filter ) {
 		access_denied();
 	}
-
-	$t_custom_filter = filter_deserialize( $t_custom_filter );
 }
 
 $t_issues = filter_get_bug_rows( $t_page_number, $t_issues_per_page, $t_page_count, $t_issues_count,

--- a/js/common.js
+++ b/js/common.js
@@ -122,12 +122,16 @@ $(document).ready( function() {
 		event.preventDefault();
 		var fieldID = $(this).attr('id');
 		var filter_id = $(this).data('filter_id');
+		var filter_tmp_id = $(this).data('filter');
 		var targetID = fieldID + '_target';
 		var viewType = $('#filters_form_open input[name=view_type]').val();
 		$('#' + targetID).html('<span class="dynamic-filter-loading">' + translations['loading'] + "</span>");
 		var params = 'view_type=' + viewType + '&filter_target=' + fieldID;
 		if( undefined !== filter_id ) {
 			params += '&filter_id=' + filter_id;
+		}
+		if( undefined !== filter_tmp_id ) {
+			params += '&filter=' + filter_tmp_id;
 		}
 		$.ajax({
 			url: 'return_dynamic_filters.php',

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1659,7 +1659,6 @@ $MANTIS_ERROR[ERROR_GPC_ARRAY_UNEXPECTED] = 'A string was expected but an array 
 $MANTIS_ERROR[ERROR_GPC_NOT_NUMBER] = 'A number was expected for %1$s.';
 $MANTIS_ERROR[ERROR_BUG_NOT_FOUND] = 'Issue %1$d not found.';
 $MANTIS_ERROR[ERROR_FILTER_NOT_FOUND] = 'Filter %1$s not found.';
-$MANTIS_ERROR[ERROR_FILTER_TOO_OLD] = 'The filter you are trying to use is too old to be upgraded. Please re-create it.';
 $MANTIS_ERROR[ERROR_EMAIL_INVALID] = 'Invalid e-mail address.';
 $MANTIS_ERROR[ERROR_EMAIL_DISPOSABLE] = 'It is not allowed to use disposable e-mail addresses.';
 $MANTIS_ERROR[ERROR_USER_PROFILE_NOT_FOUND] = 'Profile not found.';

--- a/manage_filter_edit_page.php
+++ b/manage_filter_edit_page.php
@@ -70,12 +70,9 @@ if( null === $f_filter_id ) {
 	trigger_error( ERROR_EMPTY_FIELD, ERROR );
 }
 
-$t_filter_string = filter_db_get_filter( $f_filter_id );
-if( !$t_filter_string ) {
+$t_filter = filter_get( $f_filter_id, null );
+if( null === $t_filter ) {
 	access_denied();
-} else {
-	$t_filter = filter_deserialize( $t_filter_string );
-	$t_filter['_source_query_id'] = $f_filter_id;
 }
 
 $f_view_type = gpc_get_string( 'view_type', $t_filter['_view_type'] );

--- a/manage_filter_edit_page.php
+++ b/manage_filter_edit_page.php
@@ -76,7 +76,6 @@ if( !$t_filter_string ) {
 } else {
 	$t_filter = filter_deserialize( $t_filter_string );
 	$t_filter['_source_query_id'] = $f_filter_id;
-	filter_cache_row( $f_filter_id );
 }
 
 $f_view_type = gpc_get_string( 'view_type', $t_filter['_view_type'] );

--- a/manage_filter_edit_update.php
+++ b/manage_filter_edit_update.php
@@ -45,7 +45,6 @@ if( !$t_filter_string ) {
 	access_denied();
 } else {
 	$t_filter = filter_deserialize( $t_filter_string );
-	filter_cache_row( $f_filter_id );
 }
 
 $f_filter_name = gpc_get_string( 'filter_name', null );

--- a/manage_filter_edit_update.php
+++ b/manage_filter_edit_update.php
@@ -40,11 +40,9 @@ if( null === $f_filter_id ) {
 	trigger_error( ERROR_EMPTY_FIELD, ERROR );
 }
 
-$t_filter_string = filter_db_get_filter( $f_filter_id );
-if( !$t_filter_string ) {
+$t_filter = filter_get( $f_filter_id, null );
+if( null === $t_filter ) {
 	access_denied();
-} else {
-	$t_filter = filter_deserialize( $t_filter_string );
 }
 
 $f_filter_name = gpc_get_string( 'filter_name', null );

--- a/manage_filter_page.php
+++ b/manage_filter_page.php
@@ -60,10 +60,10 @@ if( !access_has_project_level( config_get( 'stored_query_use_threshold' ) ) ) {
 }
 
 $t_filter_ids_available =
-		filter_db_get_queries( ALL_PROJECTS, $t_user_id, false ) +
-		filter_db_get_queries( ALL_PROJECTS, null, true ) +
-		filter_db_get_queries( $t_project_id, $t_user_id, false ) +
-		filter_db_get_queries( $t_project_id, null, true )
+		filter_db_get_named_filters( ALL_PROJECTS, $t_user_id, false ) +
+		filter_db_get_named_filters( ALL_PROJECTS, null, true ) +
+		filter_db_get_named_filters( $t_project_id, $t_user_id, false ) +
+		filter_db_get_named_filters( $t_project_id, null, true )
 		;
 filter_cache_rows( $t_filter_ids_available );
 

--- a/print_all_bug_page.php
+++ b/print_all_bug_page.php
@@ -72,21 +72,11 @@ $t_num_of_columns = count( $t_columns );
 
 # Initialize the filter from the cookie, use default if not set
 $t_cookie_value_id = gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' );
-$t_cookie_value = filter_db_get_filter( $t_cookie_value_id );
-if( is_blank( $t_cookie_value ) ) {
-	$t_filter_cookie_arr = filter_get_default();
-} else {
-	# check to see if new cookie is needed
-	if( !filter_is_cookie_valid() ) {
-		print_header_redirect( 'view_all_set.php?type=0&print=1' );
-	}
-	$t_setting_arr = explode( '#', $t_cookie_value, 2 );
-	$t_filter_cookie_arr = json_decode( $t_setting_arr[1], true );
-}
+$t_filter = filter_get( $t_cookie_value_id, filter_get_default() );
 
-$f_highlight_changed = $t_filter_cookie_arr[FILTER_PROPERTY_HIGHLIGHT_CHANGED];
-$f_sort              = $t_filter_cookie_arr[FILTER_PROPERTY_SORT_FIELD_NAME];
-$f_dir               = $t_filter_cookie_arr[FILTER_PROPERTY_SORT_DIRECTION];
+$f_highlight_changed = $t_filter[FILTER_PROPERTY_HIGHLIGHT_CHANGED];
+$f_sort              = $t_filter[FILTER_PROPERTY_SORT_FIELD_NAME];
+$f_dir               = $t_filter[FILTER_PROPERTY_SORT_DIRECTION];
 $t_project_id        = helper_get_current_project();
 
 # This replaces the actual search that used to be here
@@ -197,7 +187,7 @@ $f_export = implode( ',', $f_bug_arr );
 </tr>
 <tr class="row-category">
 	<?php
-		$t_sort_properties = filter_get_visible_sort_properties_array( $t_filter_cookie_arr, COLUMNS_TARGET_PRINT_PAGE );
+		$t_sort_properties = filter_get_visible_sort_properties_array( $t_filter, COLUMNS_TARGET_PRINT_PAGE );
 		foreach( $t_columns as $t_column ) {
 			helper_call_custom_function( 'print_column_title', array( $t_column, COLUMNS_TARGET_PRINT_PAGE, $t_sort_properties ) );
 		}

--- a/print_all_bug_page.php
+++ b/print_all_bug_page.php
@@ -70,9 +70,8 @@ $t_project_id 			= 0;
 $t_columns = helper_get_columns_to_view( COLUMNS_TARGET_PRINT_PAGE );
 $t_num_of_columns = count( $t_columns );
 
-# Initialize the filter from the cookie, use default if not set
-$t_cookie_value_id = gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' );
-$t_filter = filter_get( $t_cookie_value_id, filter_get_default() );
+# Get the filter in use
+$t_filter = current_user_get_bug_filter();
 
 $f_highlight_changed = $t_filter[FILTER_PROPERTY_HIGHLIGHT_CHANGED];
 $f_sort              = $t_filter[FILTER_PROPERTY_SORT_FIELD_NAME];

--- a/print_all_bug_page.php
+++ b/print_all_bug_page.php
@@ -72,6 +72,7 @@ $t_num_of_columns = count( $t_columns );
 
 # Get the filter in use
 $t_filter = current_user_get_bug_filter();
+filter_init( $t_filter );
 
 $f_highlight_changed = $t_filter[FILTER_PROPERTY_HIGHLIGHT_CHANGED];
 $f_sort              = $t_filter[FILTER_PROPERTY_SORT_FIELD_NAME];
@@ -146,14 +147,20 @@ $f_export = implode( ',', $f_bug_arr );
 		array( 'print_all_bug_page_word', 'html', 'target="_blank"', 'fa-internet-explorer', 'Word View' ) );
 
 	foreach ( $t_icons as $t_icon ) {
-		echo '<a href="' . $t_icon[0] . '.php?' . FILTER_PROPERTY_SEARCH. '=' . $t_search .
-			'&amp;' . FILTER_PROPERTY_SORT_FIELD_NAME . '=' . $f_sort .
-			'&amp;' . FILTER_PROPERTY_SORT_DIRECTION . '=' . $t_new_dir .
-			'&amp;type_page=' . $t_icon[1] .
-			'&amp;export=' . $f_export .
-			'&amp;show_flag=' . $t_show_flag .
-			'" ' . $t_icon[2] . '>' .
-			'<i class="fa ' . $t_icon[3] . '" alt="' . $t_icon[4] . '"></i></a> ';
+		$t_params = array(
+			FILTER_PROPERTY_SEARCH => $t_search,
+			FILTER_PROPERTY_SORT_FIELD_NAME => $f_sort,
+			FILTER_PROPERTY_SORT_DIRECTION => $t_new_dir,
+			'type_page' => $t_icon[1],
+			'export' => $f_export,
+			'show_flag' => $t_show_flag,
+		);
+		if( filter_is_temporary( $t_filter ) ) {
+			$t_params['filter'] = filter_get_temporary_key( $t_filter );
+		}
+
+		echo '<a href="' . $t_icon[0] . '.php?' . http_build_query( $t_params ) . '" ' . $t_icon[2] . '>'
+			. '<i class="fa ' . $t_icon[3] . '" alt="' . $t_icon[4] . '"></i></a> ';
 	}
 ?>
 
@@ -162,7 +169,13 @@ $f_export = implode( ',', $f_bug_arr );
 </table>
 </form>
 
-<form method="post" action="print_all_bug_page.php">
+<?php
+$t_form_url = 'print_all_bug_page.php';
+if( filter_is_temporary( $t_filter ) ) {
+	$t_form_url .='?' . filter_get_temporary_key_param( $t_filter );
+}
+?>
+<form method="post" action="<?php echo $t_form_url ?>">
 <?php # CSRF protection not required here - form does not result in modifications ?>
 
 <table id="buglist" class="table table-striped table-bordered table-condensed no-margin">

--- a/query_store.php
+++ b/query_store.php
@@ -97,10 +97,19 @@ $t_filter = current_user_get_bug_filter();
 if( isset( $t_filter['_source_query_id'] ) ) {
 	unset( $t_filter['_source_query_id'] );
 }
-$t_filter_string = filter_serialize( $t_filter );
 
-$t_new_row_id = filter_db_set_for_current_user( $t_project_id, $f_is_public,
-												$f_query_name, $t_filter_string );
+# Check that the user has permission to create stored filters
+if( !access_has_project_level( config_get( 'stored_query_create_threshold' ) ) ) {
+	access_denied();
+}
+
+# ensure that we're not making this filter public if we're not allowed
+if( !access_has_project_level( config_get( 'stored_query_create_shared_threshold' ) ) ) {
+	$f_is_public = false;
+}
+
+$t_filter_string = filter_serialize( $t_filter );
+$t_new_row_id = filter_db_create_filter( $t_filter_string, auth_get_current_user_id(), $t_project_id, $f_query_name , $f_is_public );
 
 form_security_purge( 'query_store' );
 

--- a/query_store.php
+++ b/query_store.php
@@ -89,11 +89,10 @@ if( $f_all_projects ) {
 	$t_project_id = 0;
 }
 
-$t_filter_id = gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' );
-$t_filter = filter_get( $t_filter_id, null );
-if( null === $t_filter ) {
-	access_denied();
-}
+# Get the filter in use
+# @TODO cproensa maybe we should pass the exact (current) filter id
+$t_filter = current_user_get_bug_filter();
+
 # named filters must not reference source query id
 if( isset( $t_filter['_source_query_id'] ) ) {
 	unset( $t_filter['_source_query_id'] );

--- a/query_store.php
+++ b/query_store.php
@@ -90,7 +90,6 @@ if( $f_all_projects ) {
 }
 
 # Get the filter in use
-# @TODO cproensa maybe we should pass the exact (current) filter id
 $t_filter = current_user_get_bug_filter();
 
 # named filters must not reference source query id

--- a/query_store.php
+++ b/query_store.php
@@ -117,5 +117,15 @@ if( $t_new_row_id == -1 ) {
 		. urlencode( lang_get( 'query_store_error' ) );
 	print_header_redirect( $t_query_redirect_url );
 } else {
-	print_header_redirect( 'view_all_bug_page.php' );
+	# Build a redirect to view_all_set to load the filter that was saved.
+	# This will make the filter name appear as selected in the filter selection box.
+	$t_params = array(
+		'type' => 3,
+		'source_query_id' => $t_new_row_id
+	);
+	if( filter_is_temporary( $t_filter ) ) {
+		$t_params['filter'] = filter_get_temporary_key( $t_filter );
+	}
+	$t_redirect = 'view_all_set.php?' . http_build_query( $t_params );
+	print_header_redirect( $t_redirect );
 }

--- a/query_store.php
+++ b/query_store.php
@@ -104,7 +104,7 @@ if( !access_has_project_level( config_get( 'stored_query_create_threshold' ) ) )
 
 # ensure that we're not making this filter public if we're not allowed
 if( !access_has_project_level( config_get( 'stored_query_create_shared_threshold' ) ) ) {
-	$f_is_public = false;
+	access_denied();
 }
 
 $t_filter_string = filter_serialize( $t_filter );

--- a/query_store.php
+++ b/query_store.php
@@ -89,9 +89,12 @@ if( $f_all_projects ) {
 	$t_project_id = 0;
 }
 
-$t_filter_string = filter_db_get_filter( gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' ) );
+$t_filter_id = gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' );
+$t_filter = filter_get( $t_filter_id, null );
+if( null === $t_filter ) {
+	access_denied();
+}
 # named filters must not reference source query id
-$t_filter = filter_deserialize( $t_filter_string );
 if( isset( $t_filter['_source_query_id'] ) ) {
 	unset( $t_filter['_source_query_id'] );
 }

--- a/query_store_page.php
+++ b/query_store_page.php
@@ -66,13 +66,13 @@ layout_page_begin();
 	</h4>
 </div>
 <?php
-$t_query_to_store = filter_db_get_filter( gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' ) );
+$t_query_to_store = filter_db_get_filter_string( gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' ) );
 $t_query_arr = filter_db_get_available_queries();
 
 # Let's just see if any of the current filters are the
 # same as the one we're about the try and save
 foreach( $t_query_arr as $t_id => $t_name ) {
-	if( filter_db_get_filter( $t_id ) == $t_query_to_store ) {
+	if( filter_db_get_filter_string( $t_id ) == $t_query_to_store ) {
 		print lang_get( 'query_exists' ) . ' (' . $t_name . ')<br />';
 	}
 }

--- a/query_store_page.php
+++ b/query_store_page.php
@@ -123,7 +123,11 @@ if( access_has_project_level( config_get( 'stored_query_create_shared_threshold'
 </form>
 <div class="space-10"></div>
 <form action="view_all_bug_page.php">
-<?php # CSRF protection not required here - form does not result in modifications ?>
+<?php # CSRF protection not required here - form does not result in modifications
+if( filter_is_temporary( $t_filter ) ) {
+	echo '<input type="hidden" name="filter" value="' . filter_get_temporary_key( $t_filter ) . '" />';
+}
+?>
 <input type="submit" class="btn btn-primary btn-white btn-round" value="<?php print lang_get( 'go_back' ); ?>" />
 </form>
 </div>

--- a/query_store_page.php
+++ b/query_store_page.php
@@ -66,7 +66,8 @@ layout_page_begin();
 	</h4>
 </div>
 <?php
-$t_query_to_store = filter_db_get_filter_string( gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' ) );
+$t_current_filter_id = filter_db_get_project_current( helper_get_current_project() );
+$t_query_to_store = filter_db_get_filter_string( $t_current_filter_id );
 $t_query_arr = filter_db_get_available_queries();
 
 # Let's just see if any of the current filters are the

--- a/query_store_page.php
+++ b/query_store_page.php
@@ -66,8 +66,11 @@ layout_page_begin();
 	</h4>
 </div>
 <?php
-$t_current_filter_id = filter_db_get_project_current( helper_get_current_project() );
-$t_query_to_store = filter_db_get_filter_string( $t_current_filter_id );
+$t_filter = current_user_get_bug_filter();
+# We are comparing filters as serialized stringsd
+# filter_serialize will remove runtime properties, so they can compare
+# @TODO cproensa, implement a better method to compare filters? is it used besides here?
+$t_query_to_store = filter_serialize( $t_filter );
 $t_query_arr = filter_db_get_available_queries();
 
 # Let's just see if any of the current filters are the
@@ -87,7 +90,12 @@ if( $t_error_msg != null ) {
 <div class="widget-body">
 	<div class="widget-main center">
 <form method="post" action="query_store.php" class="form-inline">
-<?php echo form_security_field( 'query_store' ) ?>
+<?php
+echo form_security_field( 'query_store' );
+if( filter_is_temporary( $t_filter ) ) {
+	echo '<input type="hidden" name="filter" value="' . filter_get_temporary_key( $t_filter ) . '" />';
+}
+?>
 <div class="space-10"></div>
 <label class="bold inline"> <?php echo lang_get( 'query_name_label' ) . lang_get( 'word_separator' ); ?> </label>
 <input type="text" name="query_name" class="input-sm" />

--- a/return_dynamic_filters.php
+++ b/return_dynamic_filters.php
@@ -64,18 +64,15 @@ $f_filter_id = gpc_get( 'filter_id', null );
 if( null === $f_filter_id ) {
 	$t_filter = current_user_get_bug_filter();
 } else {
-	$c_filter_id = (int)$f_filter_id;
-	$t_filter_string = filter_db_get_filter( $c_filter_id );
-	if( !$t_filter_string ) {
+	$t_filter = filter_get( $f_filter_id, null );
+	if( null === $t_filter ) {
 		trigger_error( ERROR_ACCESS_DENIED, ERROR );
-	} else {
-		$t_filter = filter_deserialize( $t_filter_string );
-		$t_filter['_source_query_id'] = $f_filter_id;
 	}
 }
 
 $f_view_type = gpc_get_string( 'view_type', $t_filter['_view_type'] );
 $t_filter['_view_type'] = $f_view_type;
+# call to filter_ensure_valid_filter to clean up after adding unsafe values from gpc vars
 $t_filter = filter_ensure_valid_filter( $t_filter );
 
 /**

--- a/return_dynamic_filters.php
+++ b/return_dynamic_filters.php
@@ -61,13 +61,13 @@ if( !auth_is_user_authenticated() ) {
 compress_enable();
 
 $f_filter_id = gpc_get( 'filter_id', null );
-if( null === $f_filter_id ) {
-	$t_filter = current_user_get_bug_filter();
-} else {
+if( null !== $f_filter_id ) {
 	$t_filter = filter_get( $f_filter_id, null );
 	if( null === $t_filter ) {
 		trigger_error( ERROR_ACCESS_DENIED, ERROR );
 	}
+} else {
+	$t_filter = current_user_get_bug_filter();
 }
 
 $f_view_type = gpc_get_string( 'view_type', $t_filter['_view_type'] );

--- a/return_dynamic_filters.php
+++ b/return_dynamic_filters.php
@@ -71,7 +71,6 @@ if( null === $f_filter_id ) {
 	} else {
 		$t_filter = filter_deserialize( $t_filter_string );
 		$t_filter['_source_query_id'] = $f_filter_id;
-		filter_cache_row( $c_filter_id );
 	}
 }
 

--- a/search.php
+++ b/search.php
@@ -148,13 +148,9 @@ $t_my_filter['_view_type'] = FILTER_VIEW_TYPE_ADVANCED;
 
 $t_setting_arr = filter_ensure_valid_filter( $t_my_filter );
 
-$t_settings_serialized = json_encode( $t_setting_arr );
-$t_settings_string = FILTER_VERSION . '#' . $t_settings_serialized;
-
-# Store the filter string in the database: its the current filter, so some values won't change
-$t_project_id = helper_get_current_project();
-$t_project_id = ( $t_project_id * -1 );
-$t_row_id = filter_db_set_for_current_user( $t_project_id, false, '', $t_settings_string );
+# set the filter for use, for current user
+# Note: This will overwrite the filter in use/default for current project and user.
+filter_set_project_filter( $t_setting_arr );
 
 # redirect to print_all or view_all page
 if( $f_print ) {

--- a/search.php
+++ b/search.php
@@ -156,9 +156,6 @@ $t_project_id = helper_get_current_project();
 $t_project_id = ( $t_project_id * -1 );
 $t_row_id = filter_db_set_for_current_user( $t_project_id, false, '', $t_settings_string );
 
-# set cookie values
-gpc_set_cookie( config_get_global( 'view_all_cookie' ), $t_row_id, time()+config_get_global( 'cookie_time_length' ), config_get_global( 'cookie_path' ) );
-
 # redirect to print_all or view_all page
 if( $f_print ) {
 	$t_redirect_url = 'print_all_bug_page.php';

--- a/search.php
+++ b/search.php
@@ -150,7 +150,7 @@ $t_setting_arr = filter_ensure_valid_filter( $t_my_filter );
 
 # set the filter for use, for current user
 # Note: This will overwrite the filter in use/default for current project and user.
-filter_set_project_filter( $t_setting_arr );
+$t_temporary_key = filter_temporary_set( $t_setting_arr );
 
 # redirect to print_all or view_all page
 if( $f_print ) {
@@ -158,5 +158,6 @@ if( $f_print ) {
 } else {
 	$t_redirect_url = 'view_all_bug_page.php';
 }
+$t_redirect_url .= '?' . filter_get_temporary_key_param( $t_temporary_key );
 
 print_header_redirect( $t_redirect_url );

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -135,8 +135,8 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 		</div>
 		<div class="btn-group pull-right"><?php
 			# -- Page number links --
-			$f_filter	= gpc_get_int( 'filter', 0);
-			print_page_links( 'view_all_bug_page.php', 1, $t_page_count, (int)$f_page_number, $f_filter );
+			$f_tmp_filter	= gpc_get_string( 'filter', 0);
+			print_page_links( 'view_all_bug_page.php', 1, $t_page_count, (int)$f_page_number, $f_tmp_filter );
 			?>
 		</div>
 	</div>
@@ -235,8 +235,8 @@ write_bug_rows( $t_rows );
 			</div>
 			<div class="btn-group pull-right">
 				<?php
-					$f_filter = gpc_get_int('filter', 0);
-					print_page_links('view_all_bug_page.php', 1, $t_page_count, (int)$f_page_number, $f_filter);
+					$f_tmp_filter = gpc_get_string('filter', 0);
+					print_page_links('view_all_bug_page.php', 1, $t_page_count, (int)$f_page_number, $f_tmp_filter);
 				?>
 			</div>
 <?php # -- ====================== end of MASS BUG MANIPULATION ========================= -- ?>

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -135,8 +135,8 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 		</div>
 		<div class="btn-group pull-right"><?php
 			# -- Page number links --
-			$f_tmp_filter	= gpc_get_string( 'filter', 0);
-			print_page_links( 'view_all_bug_page.php', 1, $t_page_count, (int)$f_page_number, $f_tmp_filter );
+			$t_tmp_filter_key = filter_get_temporary_key( $t_filter );
+			print_page_links( 'view_all_bug_page.php', 1, $t_page_count, (int)$f_page_number, $t_tmp_filter_key );
 			?>
 		</div>
 	</div>
@@ -235,8 +235,8 @@ write_bug_rows( $t_rows );
 			</div>
 			<div class="btn-group pull-right">
 				<?php
-					$f_tmp_filter = gpc_get_string('filter', 0);
-					print_page_links('view_all_bug_page.php', 1, $t_page_count, (int)$f_page_number, $f_tmp_filter);
+					$t_tmp_filter_key = filter_get_temporary_key( $t_filter );
+					print_page_links('view_all_bug_page.php', 1, $t_page_count, (int)$f_page_number, $t_tmp_filter_key );
 				?>
 			</div>
 <?php # -- ====================== end of MASS BUG MANIPULATION ========================= -- ?>

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -111,10 +111,12 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 		<div class="btn-toolbar">
 			<div class="btn-group pull-left">
 		<?php
+			$t_filter_param = filter_get_temporary_key_param( $t_filter );
+			$t_filter_param = ( empty( $t_filter_param ) ? '' : '?' ) . $t_filter_param;
 			# -- Print and Export links --
-			print_small_button( 'print_all_bug_page.php', lang_get( 'print_all_bug_page_link' ) );
-			print_small_button( 'csv_export.php', lang_get( 'csv_export' ) );
-			print_small_button( 'excel_xml_export.php', lang_get( 'excel_export' ) );
+			print_small_button( 'print_all_bug_page.php' . $t_filter_param, lang_get( 'print_all_bug_page_link' ) );
+			print_small_button( 'csv_export.php' . $t_filter_param, lang_get( 'csv_export' ) );
+			print_small_button( 'excel_xml_export.php' . $t_filter_param, lang_get( 'excel_export' ) );
 
 			$t_event_menu_options = $t_links = event_signal('EVENT_MENU_FILTER');
 

--- a/view_all_set.php
+++ b/view_all_set.php
@@ -35,7 +35,6 @@
  * @uses html_api.php
  * @uses logging_api.php
  * @uses print_api.php
- * @uses tokens_api.php
  * @uses utility_api.php
  */
 
@@ -52,7 +51,6 @@ require_api( 'helper_api.php' );
 require_api( 'html_api.php' );
 require_api( 'logging_api.php' );
 require_api( 'print_api.php' );
-require_api( 'tokens_api.php' );
 require_api( 'utility_api.php' );
 
 auth_ensure_user_authenticated();
@@ -174,7 +172,7 @@ if( $f_print ) {
 }
 
 if( $f_temp_filter ) {
-	$t_token_id = token_set( TOKEN_FILTER, json_encode( $t_setting_arr ) );
-	$t_redirect_url = $t_redirect_url . '?filter=' . $t_token_id;
+	$t_temp_key = filter_temporary_set( $t_setting_arr );
+	$t_redirect_url = $t_redirect_url . '?filter=' . $t_temp_key;
 }
 print_header_redirect( $t_redirect_url );

--- a/view_all_set.php
+++ b/view_all_set.php
@@ -75,36 +75,6 @@ if( ( $f_type == 3 ) && ( $f_source_query_id == -1 ) ) {
 	$f_type = 0;
 }
 
-#   array contents
-#   --------------
-#	 0: version
-#	 1: $f_show_category
-#	 2: $f_show_severity
-#	 3: $f_show_status
-#	 4: $f_per_page
-#	 5: $f_highlight_changed
-#	 6: $f_hide_closed
-#	 7: $f_reporter_id
-#	 8: $f_handler_id
-#	 9: $f_sort
-#	10: $f_dir
-#	11: $f_start_month
-#	12: $f_start_day
-#	13: $f_start_year
-#	14: $f_end_month
-#	15: $f_end_day
-#	16: $f_end_year
-#	17: $f_search
-#	18: $f_hide_resolved
-#	19: $f_show_resolution
-#	20: $f_show_build
-#	21: $f_show_version
-#	22: $f_do_filter_by_date
-#	23: $f_custom_field
-#	24: $f_relationship_type
-# 	25: $f_relationship_bug
-# 	26: $f_show_profile
-
 # Get the filter in use
 $t_setting_arr = current_user_get_bug_filter();
 

--- a/view_all_set.php
+++ b/view_all_set.php
@@ -74,6 +74,11 @@ $t_setting_arr = current_user_get_bug_filter();
 $t_temp_filter = $f_make_temporary || filter_is_temporary( $t_setting_arr );
 $t_previous_temporary_key = filter_get_temporary_key( $t_setting_arr );
 
+# If user is anonymous, force the creation of a temporary filter
+if( current_user_is_anonymous() ) {
+	$t_temp_filter = true;
+}
+
 
 # Clear the source query id.  Since we have entered new filter criteria.
 if( isset( $t_setting_arr['_source_query_id'] ) ) {

--- a/view_all_set.php
+++ b/view_all_set.php
@@ -105,15 +105,8 @@ if( ( $f_type == 3 ) && ( $f_source_query_id == -1 ) ) {
 # 	25: $f_relationship_bug
 # 	26: $f_show_profile
 
-# Set new filter values.  These are stored in a cookie
-$t_cookie_name = config_get_global( 'view_all_cookie' );
-$t_cookie_filter_id = gpc_get_cookie( $t_cookie_name, null );
-if( null === $t_cookie_filter_id ) {
-	# no cookie found, set it
-	$f_type = 1;
-} else {
-	$t_setting_arr = filter_get( $t_cookie_filter_id, filter_get_default() );
-}
+# Get the filter in use
+$t_setting_arr = current_user_get_bug_filter();
 
 # Clear the source query id.  Since we have entered new filter criteria.
 if( isset( $t_setting_arr['_source_query_id'] ) ) {
@@ -144,7 +137,6 @@ switch( $f_type ) {
 		$t_setting_arr = filter_get( $f_source_query_id, null );
 		if( null === $t_setting_arr ) {
 			# couldn't get the filter, if we were trying to use the filter, clear it and reload
-			gpc_clear_cookie( $t_cookie_name );
 			error_proceed_url( 'view_all_set.php?type=0' );
 			trigger_error( ERROR_FILTER_NOT_FOUND, ERROR );
 			exit;
@@ -204,11 +196,10 @@ $t_settings_string = filter_serialize( $t_setting_arr );
 if( !$f_temp_filter ) {
 	# Store the filter string in the database: its the current filter, so some values won't change
 	$t_project_id = helper_get_current_project();
+	# saving a current filter, a negative project id is a hack to indicate that
+	# it's a current filter, for this project and user
 	$t_project_id = ( $t_project_id * -1 );
-	$t_row_id = filter_db_set_for_current_user( $t_project_id, false, '', $t_settings_string );
-
-	# set cookie values
-	gpc_set_cookie( $t_cookie_name, $t_row_id, time()+config_get_global( 'cookie_time_length' ), config_get_global( 'cookie_path' ) );
+	filter_db_set_for_current_user( $t_project_id, false, '', $t_settings_string );
 }
 
 # redirect to print_all or view_all page

--- a/view_all_set.php
+++ b/view_all_set.php
@@ -60,6 +60,10 @@ $f_source_query_id		= gpc_get_int( 'source_query_id', -1 );
 $f_print				= gpc_get_bool( 'print' );
 $f_make_temporary		= gpc_get_bool( 'temporary' );
 
+if( $f_make_temporary && $f_type < 0 ) {
+	$f_type = 1;
+}
+
 if( $f_type < 0 ) {
 	print_header_redirect( 'view_all_bug_page.php' );
 }

--- a/view_all_set.php
+++ b/view_all_set.php
@@ -160,16 +160,10 @@ switch( $f_type ) {
 
 $t_setting_arr = filter_ensure_valid_filter( $t_setting_arr );
 
-$t_settings_string = filter_serialize( $t_setting_arr );
-
 # If only using a temporary filter, don't store it in the database
 if( !$f_temp_filter ) {
 	# Store the filter string in the database: its the current filter, so some values won't change
-	$t_project_id = helper_get_current_project();
-	# saving a current filter, a negative project id is a hack to indicate that
-	# it's a current filter, for this project and user
-	$t_project_id = ( $t_project_id * -1 );
-	filter_db_set_for_current_user( $t_project_id, false, '', $t_settings_string );
+	filter_set_project_filter( $t_setting_arr );
 }
 
 # redirect to print_all or view_all page

--- a/view_filters_page.php
+++ b/view_filters_page.php
@@ -72,14 +72,11 @@ if( null === $f_filter_id ) {
 	$t_filter = current_user_get_bug_filter();
 	$t_named_filter = false;
 } else {
-	$c_filter_id = (int)$f_filter_id;
-	$t_filter_string = filter_db_get_filter( $c_filter_id );
-	if( !$t_filter_string ) {
+	$t_filter = filter_get( $f_filter_id, null );
+	if( null === $t_filter ) {
 		access_denied();
-	} else {
-		$t_filter = filter_deserialize( $t_filter_string );
-		$t_named_filter = true;
 	}
+	$t_named_filter = true;
 }
 
 $f_for_screen = gpc_get_bool( 'for_screen', true );

--- a/view_filters_page.php
+++ b/view_filters_page.php
@@ -79,7 +79,6 @@ if( null === $f_filter_id ) {
 	} else {
 		$t_filter = filter_deserialize( $t_filter_string );
 		$t_named_filter = true;
-		filter_cache_row( $c_filter_id );
 	}
 }
 


### PR DESCRIPTION
This PR is cleaning and rewriting the filters functionality that deals with loading and storing filters.

Mainly:
- Clean up duplicated or unneeded code, rename some functions and variables to better match the current concepts
- Encapsulate the logic for loading and savig filters from database, which previously was duplicated in several places, doing ad-hoc un/serialization.
- Remove the usage of cookies to track filters
- Remove the usage of token table to track temporary filters
- Implement temporary filters stored in user session.
- Ensure that temporary filters are tracked through most of the actions in view_all_page

Directly fixes:
0008167: Filter settings saved when using Anonymous account
0008204: Filters not remembered when clicking through from "My View"

Some background on how filters worked so far:

There is a cookie "view_all_cookie". In the first implementation of filters, long time ago, this cookie would store the filter properties on client side.
Then (around 2004), stored filters were created. Also the filters table would store the user filter properties for the in-use filter settings. Now the cookie only stores a filter id from that table.
The rows in filter table that stores "in use" filters are stored with negative project ids, as a hack to not mix with proper stored filters. This way a user can have a different working filter "remembered" for each project.
*However, i dont't think that really was working now, because i see the cookie id always the same, even after changing projects.*

Additionally, there are temporary filters, which is a filter that is not to be stored in database (as the "working" filters for each project). The solution was to use the tokens table, where the TOKEN_FILTER entry for each user, stores the serialized data of a temporary filter. 
To use a temporary filter, a parameter "filter" was passed around with the token id (but not everywhere, so far this only worked for pagination).
Using tokens also have the disadvantage that only one token value can exist for each user. The token id actually was not used, as the token values is nos accessible by token_id, just by "fetching the value for said token type"

On top of that, said "working" filters and temporary filters as token, only support *one* filter for each scenario, per user. So we have the case of anonymous user, or any other concurrent login, that is interfering each other, as all of the real users are modifying the same filter.

What This PR changes:

- Remove use of the cookie. There's no need for it, since whenever we need the working "filter", go directly to filters table.
- Remove use of the filter token. Since this was not optimal, storing temporary filters has been implemented in session data.
- A real filter key is used so that multiple temporary filters can exists for each user session. The filter is now tracked through most of the actions in view_all_page, modifications to the temporary filter are kept to that temp filter, saving a temp filter now actually saves it, etc.

However, using a non-temporary filter still uses the filters table "unique per project" working filters.
For solving the anonymous user scenario, all the filters are forced to be temporary for this user.

It mainly affects to temporary data, so there should not be any significant issue with backwards compatibility
As always, some bugs and typos can happen. Testing is needed...


_Some potential changes, to be evaluated:_

All the filters used could be temporary. This has a better experience overall, when several open tabs track different filter properties, and does not interfere between them. The database (unnamed) filters could be redefined as "default filters" for each project, where the user, supported by some UI element, be able to set a filter to be the deafult for each project (currently the user cannot control how or when these last-used filters are loaded, and can be confusing)

When using the temporary filters, a new copy can be made after each modification. This means having a new array, with different id, stored for each filter change. This allows compatibility with browser navigation, where for example, going back in the browser after a filter change, recovers the state of the previous filter/view. On the bad side, this would increase session storage, and would be better once we have implemented the plan to store filters only as the modified properties, not the whole array.


