### PR TITLE
Lost password email validation fix

### DIFF
--- a/core/current_user_api.php
+++ b/core/current_user_api.php
@@ -192,7 +192,7 @@ function current_user_get_all_accessible_subprojects( $p_project_id ) {
  * @access public
  */
 function current_user_is_administrator() {
-	return user_is_administrator( auth_get_current_user_id() );
+	return auth_is_user_authenticated() && user_is_administrator( auth_get_current_user_id() );
 }
 
 /**


### PR DESCRIPTION
This was caused when:
- anonymous authentication is OFF.
- email address is left empty.

This caused calling auth_get_current_user_id() when no user is authenticated
which causes user to get redirected to login page and then get directed to
lost password action page, which then complains that there is no valid form
security token.

The correct behvior is to prompt an error message that email address is invalid.

Fixes #22746