### PR TITLE
REST and SOAP API Improvements

### DIFF
--- a/api/rest/index.php
+++ b/api/rest/index.php
@@ -55,6 +55,7 @@ require_once( $t_restcore_dir . 'config_rest.php' );
 require_once( $t_restcore_dir . 'internal_rest.php' );
 require_once( $t_restcore_dir . 'issues_rest.php' );
 require_once( $t_restcore_dir . 'lang_rest.php' );
+require_once( $t_restcore_dir . 'projects_rest.php' );
 require_once( $t_restcore_dir . 'users_rest.php' );
 
 event_signal( 'EVENT_REST_API_ROUTES', array( array( 'app' => $g_app ) ) );

--- a/api/rest/restcore/issues_rest.php
+++ b/api/rest/restcore/issues_rest.php
@@ -40,11 +40,43 @@ $g_app->group('/issues', function() use ( $g_app ) {
  * @return \Slim\Http\Response The augmented response.
  */
 function rest_issue_get( \Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
-	# Username and password below are ignored, since middleware already done the auth.
-	$t_result = mc_issue_get( /* username */ '', /* password */ '', $p_request->getParam( 'id' ) );
+	$t_issue_id = $p_request->getParam( 'id' );
 
-	if( ApiObjectFactory::isFault( $t_result ) ) {
-		return $p_response->withStatus( $t_result->status_code, $t_result->fault_string );
+	if( !is_blank( $t_issue_id ) ) {
+		# Get Issue By Id
+
+		# Username and password below are ignored, since middleware already done the auth.
+		$t_issue = mc_issue_get( /* username */ '', /* password */ '', $t_issue_id );
+
+		if( ApiObjectFactory::isFault( $t_issue ) ) {
+			return $p_response->withStatus( $t_result->status_code, $t_result->fault_string );
+		}
+
+		$t_result = array( 'issues' => array( $t_issue ) );
+	} else {
+		$t_page_number = $p_request->getParam( 'page', 1 );
+		$t_page_size = $p_request->getParam( 'page_size', 50 );
+
+		# Get a set of issues
+		$t_project_id = (int)$p_request->getParam( 'project_id', ALL_PROJECTS );
+		if( $t_project_id != ALL_PROJECTS && !project_exists( $t_project_id ) ) {
+			# TODO: What's best was to escape $t_project?
+			$t_message = "Project '$t_project_id' doesn't exist";
+			return $p_response->withStatus( HTTP_STATUS_NOT_FOUND, $t_message );
+		}
+
+		$t_filter_id = (int)$p_request->getParam( 'filter_id', 0 );
+		if( $t_filter_id !== 0 ) {
+			# TODO: we should have a better way to do this.
+			global $g_project_override;
+			$g_project_override = $t_project_id;
+
+			$t_issues = mc_filter_get_issues( '', '', $t_project_id, $t_filter_id, $t_page_number, $t_page_size );
+		} else {
+			$t_issues = mc_project_get_issues( '', '', $t_project_id, $t_page_number, $t_page_size );
+		}
+
+		$t_result = array( 'issues' => $t_issues );
 	}
 
 	return $p_response->withStatus( HTTP_STATUS_SUCCESS )->withJson( $t_result );

--- a/api/rest/restcore/projects_rest.php
+++ b/api/rest/restcore/projects_rest.php
@@ -1,0 +1,55 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * A webservice interface to Mantis Bug Tracker
+ *
+ * @package MantisBT
+ * @copyright Copyright MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ */
+
+$g_app->group('/projects', function() use ( $g_app ) {
+	$g_app->get( '', 'rest_projects_get' );
+	$g_app->get( '/', 'rest_projects_get' );
+});
+
+/**
+ * A method to get list of projects accessible to user with all their related information.
+ *
+ * @param \Slim\Http\Request $p_request   The request.
+ * @param \Slim\Http\Response $p_response The response.
+ * @param array $p_args Arguments
+ * @return \Slim\Http\Response The augmented response.
+ */
+function rest_projects_get( \Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
+	$t_user_id = auth_get_current_user_id();
+	$t_lang = mci_get_user_lang( $t_user_id );
+
+	$t_project_ids = user_get_accessible_projects( $t_user_id, /* disabled */ false );
+	$t_projects = array();
+
+	foreach( $t_project_ids as $t_project_id ) {
+		$t_project = mci_project_get( $t_project_id, $t_lang, /* detail */ true );
+		$t_projects[] = $t_project;
+	}
+
+	$t_result = array( 'projects' => $t_projects );
+
+	return $p_response->withStatus( HTTP_STATUS_SUCCESS )->withJson( $t_result );
+}
+
+

--- a/api/rest/restcore/users_rest.php
+++ b/api/rest/restcore/users_rest.php
@@ -35,7 +35,7 @@ $g_app->group('/users', function() use ( $g_app ) {
  * @return \Slim\Http\Response The augmented response.
  */
 function rest_user_get_me( \Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
-	$t_result = mci_user_get( '', '', auth_get_current_user_id() );
+	$t_result = mci_user_get( auth_get_current_user_id() );
 	return $p_response->withStatus( HTTP_STATUS_SUCCESS )->withJson( $t_result );
 }
 

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -230,19 +230,17 @@ function mc_login( $p_username, $p_password ) {
 		return mci_fault_login_failed();
 	}
 
-	return mci_user_get( $p_username, $p_password, $t_user_id );
+	return mci_user_get( $t_user_id );
 }
 
 /**
  * Given an id, this method returns the user.
  * When calling this method make sure that the caller has the right to retrieve
  * information about the target user.
- * @param string  $p_username Login username.
- * @param string  $p_password Login password.
  * @param integer $p_user_id  A valid user identifier.
  * @return array array of user data for the supplied user id
  */
-function mci_user_get( $p_username, $p_password, $p_user_id ) {
+function mci_user_get( $p_user_id ) {
 	$t_user_data = array();
 
 	# if user doesn't exist, then mci_account_get_array_by_id() will throw.

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -701,6 +701,49 @@ function mci_user_get_accessible_subprojects( $p_user_id, $p_parent_project_id, 
 }
 
 /**
+ * Convert version into appropriate format for SOAP/REST.
+ *
+ * @param string $p_version The version
+ * @return array|null|string The converted version
+ */
+function mci_get_version( $p_version ) {
+	if( ApiObjectFactory::$soap ) {
+		return mci_null_if_empty( $p_version );
+	}
+
+	if( is_blank( $p_version ) ) {
+		return null;
+	}
+
+	return array( 'name' => $p_version );
+}
+
+/**
+ * Returns the category name, possibly null if no category is assigned
+ *
+ * @param integer $p_category_id A category identifier.
+ * @return string
+ */
+function mci_get_category( $p_category_id ) {
+	if( ApiObjectFactory::$soap ) {
+		if( $p_category_id == 0 ) {
+			return null;
+		}
+
+		return mci_null_if_empty( category_get_name( $p_category_id ) );
+	}
+
+	if( $p_category_id == 0 ) {
+		return null;
+	}
+
+	return array(
+		'id' => $p_category_id,
+		'name' => mci_null_if_empty( category_get_name( $p_category_id ) ),
+	);
+}
+
+/**
  * Convert a category name to a category id for a given project
  * @param string|array $p_category Category name or array with id and/or name.
  * @param integer $p_project_id    Project id.

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -704,18 +704,27 @@ function mci_user_get_accessible_subprojects( $p_user_id, $p_parent_project_id, 
  * Convert version into appropriate format for SOAP/REST.
  *
  * @param string $p_version The version
+ * @param int $p_project_id The project id
  * @return array|null|string The converted version
  */
-function mci_get_version( $p_version ) {
-	if( ApiObjectFactory::$soap ) {
-		return mci_null_if_empty( $p_version );
+function mci_get_version( $p_version, $p_project_id ) {
+	$t_version_id = version_get_id( $p_version, $p_project_id );
+	if( $t_version_id === false ) {
+		return null;
 	}
 
 	if( is_blank( $p_version ) ) {
 		return null;
 	}
 
-	return array( 'name' => $p_version );
+	if( ApiObjectFactory::$soap ) {
+		return $p_version;
+	}
+
+	return array(
+		'id' => (int)$t_version_id,
+		'name' => $p_version,
+	);
 }
 
 /**

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -263,7 +263,7 @@ function mci_user_get( $p_username, $p_password, $p_user_id ) {
 			'name' => MantisEnum::getLabel( config_get( 'access_levels_enum_string' ), $t_access_level ),
 		);
 
-		$t_project_ids = user_get_accessible_projects( $p_user_id, /* disabled */ true );
+		$t_project_ids = user_get_accessible_projects( $p_user_id, /* disabled */ false );
 		$t_projects = array();
 		foreach( $t_project_ids as $t_project_id ) {
 			$t_projects[] = mci_project_get( $t_project_id );

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -668,20 +668,6 @@ function mci_get_mantis_path() {
 }
 
 /**
- * Given a enum string and num, return the appropriate localized string
- * @param string $p_enum_name Enumeration name.
- * @param string $p_val       Enumeration value.
- * @param string $p_lang      Language string.
- * @return string
- */
-function mci_get_enum_element( $p_enum_name, $p_val, $p_lang ) {
-	$t_enum_string = config_get( $p_enum_name . '_enum_string' );
-	$t_localized_enum_string = lang_get( $p_enum_name . '_enum_string', $p_lang );
-
-	return MantisEnum::getLocalizedLabel( $t_enum_string, $t_localized_enum_string, $p_val );
-}
-
-/**
  * Gets the sub-projects that are accessible to the specified user / project.
  * @param integer $p_user_id           User id.
  * @param integer $p_parent_project_id Parent Project id.

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -247,6 +247,7 @@ function mci_user_get( $p_user_id ) {
 	if( ApiObjectFactory::$soap ) {
 		$t_user_data['account_data'] = mci_account_get_array_by_id( $p_user_id );
 		$t_user_data['access_level'] = access_get_global_level( $p_user_id );
+		$t_user_data['timezone'] = user_pref_get_pref( $p_user_id, 'timezone' );
 	} else {
 		$t_account_data = mci_account_get_array_by_id( $p_user_id );
 		foreach( $t_account_data as $t_key => $t_value ) {

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -736,7 +736,8 @@ function mci_get_version( $p_version, $p_project_id ) {
 function mci_get_category( $p_category_id ) {
 	if( ApiObjectFactory::$soap ) {
 		if( $p_category_id == 0 ) {
-			return null;
+			# This should be really null, but will leaving it to avoid changing the behavior
+			return '';
 		}
 
 		return mci_null_if_empty( category_get_name( $p_category_id ) );

--- a/api/soap/mc_enum_api.php
+++ b/api/soap/mc_enum_api.php
@@ -280,13 +280,17 @@ function mci_validate_enum_access( $p_username, $p_password ) {
 function mci_enum_get_array_by_id( $p_enum_id, $p_enum_type, $p_lang ) {
 	$t_result = array();
 	$t_result['id'] = (int)$p_enum_id;
-	$t_result['name'] = mci_get_enum_element( $p_enum_type, $p_enum_id, $p_lang );
 
-	if( !ApiObjectFactory::$soap ) {
-		$t_enum_name = $p_enum_type . '_enum_string';
-		$t_enum_string_value = config_get( $t_enum_name );
-		$t_enum_localized_value = lang_get( $t_enum_name );
+	$t_enum_name = $p_enum_type . '_enum_string';
+	$t_enum_string_value = config_get( $t_enum_name );
+	$t_enum_localized_value = lang_get( $t_enum_name, $p_lang );
 
+	if( ApiObjectFactory::$soap ) {
+		# Soap API returns the localized label as the name
+		$t_result['name'] = MantisEnum::getLocalizedLabel( $t_enum_string_value, $t_enum_localized_value, $p_enum_id );
+	} else {
+		$t_enum_array = MantisEnum::getAssocArrayIndexedByValues( $t_enum_string_value );
+		$t_result['name'] = $t_enum_array[$p_enum_id];
 		$t_result['label'] = MantisEnum::getLocalizedLabel( $t_enum_string_value, $t_enum_localized_value, $p_enum_id );
 
 		if( $p_enum_type == 'status' ) {

--- a/api/soap/mc_enum_api.php
+++ b/api/soap/mc_enum_api.php
@@ -288,6 +288,11 @@ function mci_enum_get_array_by_id( $p_enum_id, $p_enum_type, $p_lang ) {
 		$t_enum_localized_value = lang_get( $t_enum_name );
 
 		$t_result['label'] = MantisEnum::getLocalizedLabel( $t_enum_string_value, $t_enum_localized_value, $p_enum_id );
+
+		if( $p_enum_type == 'status' ) {
+			$t_status_colors = config_get( 'status_colors' );
+			$t_result['color'] = $t_status_colors[$t_result['name']];
+		}
 	}
 
 	return $t_result;

--- a/api/soap/mc_enum_api.php
+++ b/api/soap/mc_enum_api.php
@@ -281,6 +281,15 @@ function mci_enum_get_array_by_id( $p_enum_id, $p_enum_type, $p_lang ) {
 	$t_result = array();
 	$t_result['id'] = (int)$p_enum_id;
 	$t_result['name'] = mci_get_enum_element( $p_enum_type, $p_enum_id, $p_lang );
+
+	if( !ApiObjectFactory::$soap ) {
+		$t_enum_name = $p_enum_type . '_enum_string';
+		$t_enum_string_value = config_get( $t_enum_name );
+		$t_enum_localized_value = lang_get( $t_enum_name );
+
+		$t_result['label'] = MantisEnum::getLocalizedLabel( $t_enum_string_value, $t_enum_localized_value, $p_enum_id );
+	}
+
 	return $t_result;
 }
 

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -1519,10 +1519,10 @@ function mci_issue_data_as_array( BugData $p_issue_data, $p_user_id, $p_lang ) {
 
 	$t_issue['project'] = mci_project_as_array_by_id( $p_issue_data->project_id );
 	$t_issue['category'] = mci_get_category( $p_issue_data->category_id );
-	$t_issue['version'] = mci_get_version( $p_issue_data->version );
-	$t_issue['fixed_in_version'] = mci_get_version( $p_issue_data->fixed_in_version );
+	$t_issue['version'] = mci_get_version( $p_issue_data->version, $p_issue_data->project_id );
+	$t_issue['fixed_in_version'] = mci_get_version( $p_issue_data->fixed_in_version, $p_issue_data->project_id );
 	if( access_has_bug_level( config_get( 'roadmap_view_threshold' ), $t_id ) ) {
-		$t_issue['target_version'] = mci_get_version( $p_issue_data->target_version );
+		$t_issue['target_version'] = mci_get_version( $p_issue_data->target_version, $p_issue_data->project_id );
 	}
 
 	$t_issue['reporter'] = mci_account_get_array_by_id( $p_issue_data->reporter_id );

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -846,7 +846,10 @@ function mc_issue_add( $p_username, $p_password, $p_issue ) {
 	}
 
 	if( isset( $p_issue['tags'] ) && is_array( $p_issue['tags'] ) ) {
-		mci_tag_set_for_issue( $t_issue_id, $p_issue['tags'], $t_user_id );
+		$t_tags_result = mci_tag_set_for_issue( $t_issue_id, $p_issue['tags'], $t_user_id );
+		if( ApiObjectFactory::isFault( $t_tags_result ) ) {
+			return $t_tags_result;
+		}
 	}
 
 	email_bug_added( $t_issue_id );

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -132,31 +132,6 @@ function mc_issue_get_history( $p_username, $p_password, $p_issue_id ) {
 }
 
 /**
- * Returns the category name, possibly null if no category is assigned
- *
- * @param integer $p_category_id A category identifier.
- * @return string
- */
-function mci_get_category( $p_category_id ) {
-	if( ApiObjectFactory::$soap ) {
-		if( $p_category_id == 0 ) {
-			return '';
-		}
-
-		return mci_null_if_empty( category_get_name( $p_category_id ) );
-	}
-
-	if( $p_category_id == 0 ) {
-		return array( 'category' => null );
-	}
-
-	return array(
-		'id' => $p_category_id,
-		'name' => mci_null_if_empty( category_get_name( $p_category_id ) ),
-	);
-}
-
-/**
  * Get due date for a given bug
  * @param BugData $p_bug A BugData object.
  * @return soapval the value to be encoded as the due date
@@ -1542,6 +1517,12 @@ function mci_issue_data_as_array( BugData $p_issue_data, $p_user_id, $p_lang ) {
 
 	$t_issue['project'] = mci_project_as_array_by_id( $p_issue_data->project_id );
 	$t_issue['category'] = mci_get_category( $p_issue_data->category_id );
+	$t_issue['version'] = mci_get_version( $p_issue_data->version );
+	$t_issue['fixed_in_version'] = mci_get_version( $p_issue_data->fixed_in_version );
+	if( access_has_bug_level( config_get( 'roadmap_view_threshold' ), $t_id ) ) {
+		$t_issue['target_version'] = mci_get_version( $p_issue_data->target_version );
+	}
+
 	$t_issue['reporter'] = mci_account_get_array_by_id( $p_issue_data->reporter_id );
 
 	if( !empty( $p_issue_data->handler_id ) &&
@@ -1582,17 +1563,6 @@ function mci_issue_data_as_array( BugData $p_issue_data, $p_user_id, $p_lang ) {
 	$t_updated_at = ApiObjectFactory::datetime( $p_issue_data->last_updated );
 
 	if( ApiObjectFactory::$soap ) {
-		# TODO: create mci_get_version
-		$t_issue['version'] = mci_null_if_empty( $p_issue_data->version );
-
-		# TODO: create mci_get_version
-		$t_issue['fixed_in_version'] = mci_null_if_empty( $p_issue_data->fixed_in_version );
-
-		# TODO: create mci_get_version
-		if( access_has_bug_level( config_get( 'roadmap_view_threshold' ), $t_id ) ) {
-			$t_issue['target_version'] = mci_null_if_empty( $p_issue_data->target_version );
-		}
-
 		if( config_get( 'enable_profiles' ) != OFF ) {
 			$t_issue['profile_id'] = (int)$p_issue_data->profile_id;
 		}
@@ -1611,22 +1581,6 @@ function mci_issue_data_as_array( BugData $p_issue_data, $p_user_id, $p_lang ) {
 			if ((int)$p_issue_data->profile_id != 0) {
 				$t_issue['profile'] = mci_profile_as_array_by_id($p_issue_data->profile_id);
 			}
-		}
-
-		# TODO: create mci_get_version
-		if( !is_blank( $p_issue_data->version ) ) {
-			$t_issue['version'] = array( 'name' => $p_issue_data->version );
-		}
-
-		# TODO: create mci_get_version()
-		if( !is_blank( $p_issue_data->fixed_in_version ) ) {
-			$t_issue['fixed_in_version'] = array( 'name' => $p_issue_data->fixed_in_version );
-		}
-
-		# TODO: Create mci_get_version()
-		if( !is_blank( $p_issue_data->target_version ) &&
-			access_has_bug_level( config_get( 'roadmap_view_threshold' ), $t_id ) ) {
-			$t_issue['target_version'] = array('name' => $p_issue_data->target_version);
 		}
 
 		$t_issue['sticky'] = (bool)$p_issue_data->sticky;

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -610,13 +610,13 @@ function mci_issue_handler_access_check( $p_user_id, $p_project_id, $p_old_handl
 		}
 
 		if( !access_has_project_level( config_get( 'handle_bug_threshold' ), $p_project_id, $p_new_handler_id ) ) {
-			return mci_fault_access_denied( 'User \'' . $p_new_handler_id . '\' does not have access right to handle issues' );
+			return mci_fault_access_denied( $p_user_id, 'User does not have access right to handle issues' );
 		}
 	}
 
 	if( $p_old_handler_id != $p_new_handler_id ) {
 		if( !access_has_project_level( config_get( 'update_bug_assign_threshold' ), $p_project_id, $p_user_id ) ) {
-			return mci_fault_access_denied( 'User \'' . $p_user_id . '\' does not have access right to assign issues' );
+			return mci_fault_access_denied( $p_user_id, 'User does not have access right to assign issues' );
 		}
 	}
 
@@ -689,7 +689,7 @@ function mc_issue_add( $p_username, $p_password, $p_issue ) {
 	}
 
 	if( !access_has_project_level( config_get( 'report_bug_threshold' ), $t_project_id, $t_user_id ) ) {
-		return mci_fault_access_denied( 'User \'' . $t_user_id . '\' does not have access right to report issues' );
+		return mci_fault_access_denied( $t_user_id, 'User does not have access right to report issues' );
 	}
 
 	$t_access_check_result = mci_issue_handler_access_check( $t_user_id, $t_project_id, /* old */ 0, /* new */ $t_handler_id );

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -378,7 +378,7 @@ function mci_issue_get_notes( $p_issue_id ) {
 					$t_type = 'reminder';
 					break;
 				case TIME_TRACKING:
-					$t_type = 'timelog';
+					$t_type = $t_has_time_tracking_access ? 'timelog' : 'note';
 					break;
 			}
 

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -474,7 +474,14 @@ function mci_issue_get_notes( $p_issue_id ) {
 			}
 
 			$t_bugnote['type'] = $t_type;
-			$t_bugnote['attr'] = $t_value->note_attr;
+
+			if( !is_blank( $t_value->note_attr ) ) {
+				$t_bugnote['attr'] = $t_value->note_attr;
+			}
+
+			if( isset( $t_bugnote['time_tracking'] ) && ( $t_bugnote['time_tracking'] == 0 || $t_type != 'timelog' ) ) {
+				unset( $t_bugnote['time_tracking'] );
+			}
 
 			$t_bugnote['created_at'] = ApiObjectFactory::datetimeString( $t_created_at );
 			$t_bugnote['updated_at'] = ApiObjectFactory::datetimeString( $t_modified_at );

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -643,6 +643,18 @@ function mc_issue_add( $p_username, $p_password, $p_issue ) {
 		$p_issue = ApiObjectFactory::objectToArray( $p_issue );
 	}
 
+	if( !isset( $p_issue['summary'] ) )  {
+		return ApiObjectFactory::faultBadRequest( 'Summary not specified' );
+	}
+
+	if( !isset( $p_issue['description'] ) )  {
+		return ApiObjectFactory::faultBadRequest( 'Description not specified' );
+	}
+
+	if( !isset( $p_issue['project'] ) )  {
+		return ApiObjectFactory::faultBadRequest( 'Project not specified' );
+	}
+
 	$t_project = $p_issue['project'];
 
 	$t_project_id = mci_get_project_id( $t_project );

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -138,11 +138,22 @@ function mc_issue_get_history( $p_username, $p_password, $p_issue_id ) {
  * @return string
  */
 function mci_get_category( $p_category_id ) {
-	if( $p_category_id == 0 ) {
-		return '';
+	if( ApiObjectFactory::$soap ) {
+		if( $p_category_id == 0 ) {
+			return '';
+		}
+
+		return mci_null_if_empty( category_get_name( $p_category_id ) );
 	}
 
-	return mci_null_if_empty( category_get_name( $p_category_id ) );
+	if( $p_category_id == 0 ) {
+		return array( 'category' => null );
+	}
+
+	return array(
+		'id' => $p_category_id,
+		'name' => mci_null_if_empty( category_get_name( $p_category_id ) ),
+	);
 }
 
 /**
@@ -1527,6 +1538,7 @@ function mci_issue_data_as_array( BugData $p_issue_data, $p_user_id, $p_lang ) {
 	$t_issue['additional_information'] = mci_null_if_empty( mci_sanitize_xml_string( $t_additional_information ) );
 
 	$t_issue['project'] = mci_project_as_array_by_id( $p_issue_data->project_id );
+	$t_issue['category'] = mci_get_category( $p_issue_data->category_id );
 	$t_issue['reporter'] = mci_account_get_array_by_id( $p_issue_data->reporter_id );
 
 	if( !empty( $p_issue_data->handler_id ) ) {
@@ -1553,7 +1565,6 @@ function mci_issue_data_as_array( BugData $p_issue_data, $p_user_id, $p_lang ) {
 	$t_updated_at = ApiObjectFactory::datetime( $p_issue_data->last_updated );
 
 	if( ApiObjectFactory::$soap ) {
-		$t_issue['category'] = mci_get_category( $p_issue_data->category_id );
 		$t_issue['version'] = mci_null_if_empty( $p_issue_data->version );
 		$t_issue['fixed_in_version'] = mci_null_if_empty( $p_issue_data->fixed_in_version );
 		$t_issue['target_version'] = mci_null_if_empty( $p_issue_data->target_version );
@@ -1566,11 +1577,6 @@ function mci_issue_data_as_array( BugData $p_issue_data, $p_user_id, $p_lang ) {
 		if( (int)$p_issue_data->profile_id != 0 ) {
 			$t_issue['profile'] = mci_profile_as_array_by_id( $p_issue_data->profile_id );
 		}
-
-		$t_issue['category'] = array(
-			'id' => $p_issue_data->category_id,
-			'name' => mci_get_category( $p_issue_data->category_id )
-		);
 
 		if( !is_blank( $p_issue_data->version ) ) {
 			$t_issue['version'] = array( 'name' => $p_issue_data->version );

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -761,7 +761,8 @@ function mc_issue_add( $p_username, $p_password, $p_issue ) {
 		$t_bug_data->sticky = $p_issue['sticky'];
 	}
 
-	if( isset( $p_issue['due_date'] ) && access_has_global_level( config_get( 'due_date_update_threshold' ) ) ) {
+	if( isset( $p_issue['due_date'] ) &&
+		access_has_project_level( config_get( 'due_date_update_threshold' ), $t_bug_data->project_id ) ) {
 		$t_bug_data->due_date = strtotime( $p_issue['due_date'] );
 	} else {
 		$t_bug_data->due_date = date_get_null();
@@ -1007,7 +1008,8 @@ function mc_issue_update( $p_username, $p_password, $p_issue_id, stdClass $p_iss
 		$t_bug_data->sticky = $p_issue['sticky'];
 	}
 
-	if( isset( $p_issue['due_date'] ) && access_has_global_level( config_get( 'due_date_update_threshold' ) ) ) {
+	if( isset( $p_issue['due_date'] ) &&
+		access_has_project_level( config_get( 'due_date_update_threshold' ), $t_bug_data->project_id ) ) {
 		$t_bug_data->due_date = strtotime( $p_issue['due_date'] );
 	} else {
 		$t_bug_data->due_date = date_get_null();

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "Mantis Bug Tracker",
     "type": "project",
     "require": {
-        "slim/slim": "^3.0"
+        "slim/slim": "^3.0",
+        "guzzlehttp/guzzle": "^6.2"
     },
     "license": "GPL v2",
     "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7d5e97c6512f88e4f73e260712e38892",
+    "content-hash": "03a882052f1704dd022892733868bc05",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -36,6 +36,184 @@
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
             "time": "2017-02-14T19:40:03+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/8d6c6cc55186db87b7dc5009827429ba4e9dc006",
+                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.4",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2017-02-28T22:50:30+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20T10:07:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2017-03-20T17:10:46+00:00"
         },
         {
             "name": "nikic/fast-route",

--- a/tests/bootstrap.php.sample
+++ b/tests/bootstrap.php.sample
@@ -57,3 +57,17 @@ $GLOBALS['MANTIS_TESTSUITE_PROJECT_ID'] = 1;
  */
 date_default_timezone_set('America/Los_Angeles');
 
+/**
+ * Enable REST API Tests
+ */
+$GLOBALS['MANTIS_TESTSUITE_REST_ENABLED'] = true;
+
+/**
+ * The base url for Mantis REST APIs
+ */
+$GLOBALS['MANTIS_TESTSUITE_REST_HOST'] = 'http://localhost/mantisbt/api/rest';
+
+/**
+ * The API token to use
+ */
+$GLOBALS['MANTIS_TESTSUITE_API_TOKEN'] = '';

--- a/tests/bootstrap.php.sample
+++ b/tests/bootstrap.php.sample
@@ -51,3 +51,9 @@ $GLOBALS['MANTIS_TESTSUITE_EMAIL'] = 'root@localhost';
  * @name MANTIS_TESTSUITE_PROJECT_ID
  */
 $GLOBALS['MANTIS_TESTSUITE_PROJECT_ID'] = 1;
+
+/**
+ * Set default timestamp to avoid errors in some test environments
+ */
+date_default_timezone_set('America/Los_Angeles');
+

--- a/tests/rest/AllTests.php
+++ b/tests/rest/AllTests.php
@@ -42,9 +42,6 @@ class RestAllTests extends PHPUnit_Framework_TestSuite
 	 * @return void
 	 */
 	protected function setUp() {
-		if( !extension_loaded( 'curl' ) ) {
-			$this->markTestSuiteSkipped( 'The CURL extension is not available.' );
-		}
 	}
 
 	/**

--- a/tests/rest/AllTests.php
+++ b/tests/rest/AllTests.php
@@ -1,0 +1,61 @@
+<?php
+# Mantis - a php based bugtracking system
+
+# Mantis is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Mantis is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Mantis.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mantis Webservice Tests
+ *
+ * @package Tests
+ * @subpackage UnitTests
+ * @copyright Copyright MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ */
+
+/**
+ * Test config
+ */
+require_once __DIR__ . '/RestIssueAddTest.php';
+
+/**
+ * Soap Test Suite
+ * @package    Tests
+ * @subpackage UnitTests
+ * @copyright Copyright 2002  MantisBT Team   - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ */
+class RestAllTests extends PHPUnit_Framework_TestSuite
+{
+	/**
+	 * setUp
+	 * @return void
+	 */
+	protected function setUp() {
+		if( !extension_loaded( 'curl' ) ) {
+			$this->markTestSuiteSkipped( 'The CURL extension is not available.' );
+		}
+	}
+
+	/**
+	 * Initializes REST Test Suite
+	 * @return RestAllTests
+	 */
+	public static function suite() {
+		$t_suite = new RestAllTests( 'REST API' );
+
+		$t_suite->addTestSuite( 'RestIssueAddTest' );
+
+		return $t_suite;
+	}
+}

--- a/tests/rest/RestBase.php
+++ b/tests/rest/RestBase.php
@@ -1,0 +1,221 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mantis Webservice Tests
+ *
+ * @package Tests
+ * @subpackage UnitTests
+ * @copyright Copyright MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ */
+
+$t_root_path = dirname( dirname( dirname( __FILE__ ) ) ) . DIRECTORY_SEPARATOR;
+
+# MantisBT constants
+require_once ( $t_root_path . DIRECTORY_SEPARATOR . 'core/constant_inc.php' );
+
+/**
+ * Base class for REST API test cases
+ *
+ * @requires extension curl
+ * @group REST
+ */
+class RestBase extends PHPUnit_Framework_TestCase {
+	/**
+	 * @var string Base path for REST API
+	 */
+	protected $base_path = '';
+
+	/**
+	 * @var string Username
+	 */
+	protected $userName = 'administrator';
+
+	/**
+	 * @var string The API token to use for authentication
+	 */
+	protected $token = '';
+
+	/**
+	 * @var string Email address
+	 */
+	protected $email = 'root@localhost';
+
+	/**
+	 * @var int User ID
+	 */
+	protected $userId = '1';
+
+	/**
+	 * @var int Project ID
+	 */
+	protected $projectId = 1;
+
+	/**
+	 * @var array Array of Issue IDs to delete
+	 */
+	private $issueIdsToDelete = array();
+
+	/**
+	 * setUp
+	 * @return void
+	 */
+	protected function setUp() {
+		if( !isset( $GLOBALS['MANTIS_TESTSUITE_REST_ENABLED'] ) ||
+			!$GLOBALS['MANTIS_TESTSUITE_REST_ENABLED'] ) {
+			$this->markTestSkipped( 'The REST API tests are disabled.' );
+		}
+
+		$this->assertTrue( array_key_exists( 'MANTIS_TESTSUITE_REST_HOST', $GLOBALS ) &&
+			!empty( $GLOBALS['MANTIS_TESTSUITE_REST_HOST'] ),
+			"You must define 'MANTIS_TESTSUITE_REST_HOST' in your bootstrap file" );
+
+		$this->base_path = trim( $GLOBALS['MANTIS_TESTSUITE_REST_HOST'], '/' );
+
+		if( array_key_exists( 'MANTIS_TESTSUITE_USERNAME', $GLOBALS ) ) {
+			$this->userName = $GLOBALS['MANTIS_TESTSUITE_USERNAME'];
+		} else {
+			$this->userName = 'administrator';
+		}
+
+		$this->assertTrue( array_key_exists( 'MANTIS_TESTSUITE_API_TOKEN', $GLOBALS ) &&
+			!empty( $GLOBALS['MANTIS_TESTSUITE_API_TOKEN'] ),
+			"You must define 'MANTIS_TESTSUITE_API_TOKEN' in your bootstrap file" );
+
+		$this->token = $GLOBALS['MANTIS_TESTSUITE_API_TOKEN'];
+
+		if( array_key_exists( 'MANTIS_TESTSUITE_PROJECT_ID', $GLOBALS ) ) {
+			$this->projectId = $GLOBALS['MANTIS_TESTSUITE_PROJECT_ID'];
+		} else {
+			$this->projectId = 1;
+		}
+	}
+
+	/**
+	 * tearDown
+	 * @return void
+	 */
+	protected function tearDown() {
+		foreach ( $this->issueIdsToDelete as $t_issue_id_to_delete ) {
+			$this->delete( '/issues', 'id=' . $t_issue_id_to_delete );
+		}
+	}
+
+	protected function delete( $p_relative_path, $p_query_string ) {
+		$t_curl = curl_init();
+
+		curl_setopt_array( $t_curl, array(
+			CURLOPT_URL => $this->base_path . $p_relative_path . '?' . $p_query_string,
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_ENCODING => "",
+			CURLOPT_MAXREDIRS => 10,
+			CURLOPT_TIMEOUT => 30,
+			CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+			CURLOPT_CUSTOMREQUEST => "DELETE",
+			CURLOPT_HTTPHEADER => array(
+				'authorization: ' . $this->token,
+				'cache-control: no-cache',
+			),
+		));
+
+		$t_response = curl_exec( $t_curl );
+		$t_error = curl_error( $t_curl );
+
+		curl_close( $t_curl );
+
+		if ( $t_error ) {
+			return "cURL Error #:" . $t_error;
+		}
+
+		return $t_response;
+	}
+
+	/**
+	 * @param string $p_relative_path The relative path under `/api/rest/` e.g. `/issues`.
+	 * @param string $p_payload The payload object, it will be json encoded before sending.
+	 * @return mixed|string The response object.
+	 */
+	protected function post( $p_relative_path, $p_payload ) {
+		$t_curl = curl_init();
+
+		curl_setopt_array( $t_curl, array(
+			CURLOPT_URL => $this->base_path . $p_relative_path,
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_ENCODING => '',
+			CURLOPT_MAXREDIRS => 0,
+			CURLOPT_TIMEOUT => 30,
+			CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+			CURLOPT_CUSTOMREQUEST => 'POST',
+			CURLOPT_POSTFIELDS => json_encode( $p_payload ),
+			CURLOPT_HTTPHEADER => array(
+				'authorization: ' . $this->token,
+				'cache-control: no-cache',
+				'content-type: application/json',
+			),
+		));
+
+		$t_response = curl_exec( $t_curl );
+		$t_error = curl_error( $t_curl );
+		file_put_contents( '/tmp/response.txt', $this->base_path . $p_relative_path . ' ' . $this->token . ' ' . var_export( json_encode( $p_payload ), true ) . ' ' . var_export( $t_response, true ) . ' ' . var_export( $t_error, true ) );
+		if( $t_response == false ) {
+			return 'cURL Error #:' . $t_error;
+		}
+
+		curl_close( $t_curl );
+
+		return json_decode( $t_response, true );
+	}
+
+	/**
+	 * return integer The default project id.
+	 * @return integer
+	 */
+	protected function getProjectId() {
+		return $this->projectId;
+	}
+
+	/**
+	 * return string The default category.
+	 * @return string
+	 */
+	protected function getCategory() {
+		return 'General';
+	}
+
+	/**
+	 * getIssueToAdd
+	 * @param string $p_test_case Test case identifier.
+	 * @return array
+	 */
+	protected function getIssueToAdd( $p_test_case ) {
+		return array(
+				'summary' => $p_test_case . ': test issue: ' . rand( 1, 1000000 ),
+				'description' => 'description of test issue.',
+				'project' => array( 'id' => $this->getProjectId() ),
+				'category' => array( 'name' => $this->getCategory() ) );
+	}
+
+	/**
+	 * Registers an issue for deletion after the test method has run
+	 *
+	 * @param integer $p_issue_id Issue identifier.
+	 * @return void
+	 */
+	protected function deleteAfterRun( $p_issue_id ) {
+		$this->issueIdsToDelete[] = $p_issue_id;
+	}
+}

--- a/tests/rest/RestBase.php
+++ b/tests/rest/RestBase.php
@@ -23,10 +23,8 @@
  * @link http://www.mantisbt.org
  */
 
-$t_root_path = dirname( dirname( dirname( __FILE__ ) ) ) . DIRECTORY_SEPARATOR;
-
-# MantisBT constants
-require_once ( $t_root_path . DIRECTORY_SEPARATOR . 'core/constant_inc.php' );
+require_once( __DIR__ . '/../../vendor/autoload.php' );
+require_once ( __DIR__ . '/../../core/constant_inc.php' );
 
 /**
  * Base class for REST API test cases
@@ -116,32 +114,16 @@ class RestBase extends PHPUnit_Framework_TestCase {
 	}
 
 	protected function delete( $p_relative_path, $p_query_string ) {
-		$t_curl = curl_init();
-
-		curl_setopt_array( $t_curl, array(
-			CURLOPT_URL => $this->base_path . $p_relative_path . '?' . $p_query_string,
-			CURLOPT_RETURNTRANSFER => true,
-			CURLOPT_ENCODING => "",
-			CURLOPT_MAXREDIRS => 10,
-			CURLOPT_TIMEOUT => 30,
-			CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-			CURLOPT_CUSTOMREQUEST => "DELETE",
-			CURLOPT_HTTPHEADER => array(
-				'authorization: ' . $this->token,
-				'cache-control: no-cache',
+		$t_client = new \GuzzleHttp\Client();
+		$t_options = array(
+			'allow_redirects' => false,
+			'http_errors' => false,
+			'headers' => array(
+				'Authorization' => $this->token,
 			),
-		));
+		);
 
-		$t_response = curl_exec( $t_curl );
-		$t_error = curl_error( $t_curl );
-
-		curl_close( $t_curl );
-
-		if ( $t_error ) {
-			return "cURL Error #:" . $t_error;
-		}
-
-		return $t_response;
+		return $t_client->request( 'DELETE', $this->base_path . $p_relative_path . '?' . $p_query_string, $t_options );
 	}
 
 	/**
@@ -150,34 +132,17 @@ class RestBase extends PHPUnit_Framework_TestCase {
 	 * @return mixed|string The response object.
 	 */
 	protected function post( $p_relative_path, $p_payload ) {
-		$t_curl = curl_init();
-
-		curl_setopt_array( $t_curl, array(
-			CURLOPT_URL => $this->base_path . $p_relative_path,
-			CURLOPT_RETURNTRANSFER => true,
-			CURLOPT_ENCODING => '',
-			CURLOPT_MAXREDIRS => 0,
-			CURLOPT_TIMEOUT => 30,
-			CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-			CURLOPT_CUSTOMREQUEST => 'POST',
-			CURLOPT_POSTFIELDS => json_encode( $p_payload ),
-			CURLOPT_HTTPHEADER => array(
-				'authorization: ' . $this->token,
-				'cache-control: no-cache',
-				'content-type: application/json',
+		$t_client = new \GuzzleHttp\Client();
+		$t_options = array(
+			'allow_redirects' => false,
+			'http_errors' => false,
+			'json' => $p_payload,
+			'headers' => array(
+				'Authorization' => $this->token,
 			),
-		));
+		);
 
-		$t_response = curl_exec( $t_curl );
-		$t_error = curl_error( $t_curl );
-		file_put_contents( '/tmp/response.txt', $this->base_path . $p_relative_path . ' ' . $this->token . ' ' . var_export( json_encode( $p_payload ), true ) . ' ' . var_export( $t_response, true ) . ' ' . var_export( $t_error, true ) );
-		if( $t_response == false ) {
-			return 'cURL Error #:' . $t_error;
-		}
-
-		curl_close( $t_curl );
-
-		return json_decode( $t_response, true );
+		return $t_client->request( 'POST', $this->base_path . $p_relative_path, $t_options );
 	}
 
 	/**

--- a/tests/rest/RestIssueAddTest.php
+++ b/tests/rest/RestIssueAddTest.php
@@ -36,24 +36,24 @@ class RestIssueAddTest extends RestBase {
 		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueWithMinimalFields' );
 		$t_response = $this->post( '/issues', $t_issue_to_add );
 
-		$this->assertTrue( is_array( $t_response ) );
-		$this->assertTrue( isset( $t_response['issue'] ) );
+		$this->assertEquals( 201, $t_response->getStatusCode() );
+		$t_body = json_decode( $t_response->getBody(), true );
+		$t_issue = $t_body['issue'];
+		# file_put_contents( '/tmp/response.txt', var_export( $t_body, true ) );
 
-		$t_issue = $t_response['issue'];
-
-		$this->assertTrue( isset( $t_issue['id'] ) );
-		$this->assertTrue( is_numeric($t_issue['id'] ) );
-		$this->assertEquals( $t_issue_to_add['summary'], $t_issue['summary'] );
-		$this->assertEquals( $t_issue_to_add['description'], $t_issue['description'] );
-		$this->assertEquals( $t_issue_to_add['category']['name'], $t_issue['category']['name'] );
-		$this->assertEquals( $t_issue_to_add['project']['id'], $t_issue['project']['id'] );
-		$this->assertEquals( $this->userName, $t_issue['reporter']['name'] );
+		$this->assertTrue( isset( $t_issue['id'] ), 'id set' );
+		$this->assertTrue( is_numeric($t_issue['id'] ), 'id is numeric' );
+		$this->assertEquals( $t_issue_to_add['summary'], $t_issue['summary'], 'summary' );
+		$this->assertEquals( $t_issue_to_add['description'], $t_issue['description'], 'description' );
+		$this->assertEquals( $t_issue_to_add['category']['name'], $t_issue['category']['name'], 'category name' );
+		$this->assertEquals( $t_issue_to_add['project']['id'], $t_issue['project']['id'], 'project id' );
+		$this->assertEquals( $this->userName, $t_issue['reporter']['name'], 'reporter name' );
 
 		# Verify Status
-		$this->assertEquals( 10, $t_issue['status']['id'] );
-		$this->assertEquals( '#fcbdbd', $t_issue['status']['color'] );
-		$this->assertEquals( 'new', $t_issue['status']['name'] );
-		$this->assertEquals( 'new', $t_issue['status']['label'] );
+		$this->assertEquals( 10, $t_issue['status']['id'], 'status id' );
+		$this->assertEquals( '#fcbdbd', $t_issue['status']['color'], 'status color' );
+		$this->assertEquals( 'new', $t_issue['status']['name'], 'status name' );
+		$this->assertEquals( 'new', $t_issue['status']['label'], 'status label' );
 
 		# Verify Resolution
 		$this->assertEquals( 10, $t_issue['resolution']['id'], 'resolution id' );
@@ -84,7 +84,7 @@ class RestIssueAddTest extends RestBase {
 		$this->assertTrue( isset( $t_issue['created_at'] ), 'created at' );
 		$this->assertTrue( isset( $t_issue['updated_at'] ), 'updated at' );
 
-		$this->deleteAfterRun( $t_response['issue']['id'] );
+		$this->deleteAfterRun( $t_issue['id'] );
 	}
 
 	public function testCreateIssueWithEnumIds() {
@@ -99,10 +99,9 @@ class RestIssueAddTest extends RestBase {
 
 		$t_response = $this->post( '/issues', $t_issue_to_add );
 
-		$this->assertTrue( is_array( $t_response ) );
-		$this->assertTrue( isset( $t_response['issue'] ) );
-
-		$t_issue = $t_response['issue'];
+		$this->assertEquals( 201, $t_response->getStatusCode() );
+		$t_body = json_decode( $t_response->getBody(), true );
+		$t_issue = $t_body['issue'];
 
 		$this->assertTrue( isset( $t_issue['id'] ) );
 		$this->assertTrue( is_numeric($t_issue['id'] ) );
@@ -142,7 +141,7 @@ class RestIssueAddTest extends RestBase {
 		$this->assertTrue( isset( $t_issue['created_at'] ), 'created at' );
 		$this->assertTrue( isset( $t_issue['updated_at'] ), 'updated at' );
 
-		$this->deleteAfterRun( $t_response['issue']['id'] );
+		$this->deleteAfterRun( $t_issue['id'] );
 	}
 
 	public function testCreateIssueNoSummary() {
@@ -151,7 +150,7 @@ class RestIssueAddTest extends RestBase {
 
 		$t_response = $this->post( '/issues', $t_issue_to_add );
 
-		$this->assertFalse( is_array( $t_response ) );
+		$this->assertEquals( 400, $t_response->getStatusCode() );
 	}
 
 	public function testCreateIssueNoDescription() {
@@ -160,7 +159,7 @@ class RestIssueAddTest extends RestBase {
 
 		$t_response = $this->post( '/issues', $t_issue_to_add );
 
-		$this->assertFalse( is_array( $t_response ) );
+		$this->assertEquals( 400, $t_response->getStatusCode() );
 	}
 
 	public function testCreateIssueNoCategory() {
@@ -169,7 +168,7 @@ class RestIssueAddTest extends RestBase {
 
 		$t_response = $this->post( '/issues', $t_issue_to_add );
 
-		$this->assertFalse( is_array( $t_response ) );
+		$this->assertEquals( 400, $t_response->getStatusCode() );
 	}
 
 	public function testCreateIssueNoProject() {
@@ -178,6 +177,6 @@ class RestIssueAddTest extends RestBase {
 
 		$t_response = $this->post( '/issues', $t_issue_to_add );
 
-		$this->assertFalse( is_array( $t_response ) );
+		$this->assertEquals( 400, $t_response->getStatusCode() );
 	}
 }

--- a/tests/rest/RestIssueAddTest.php
+++ b/tests/rest/RestIssueAddTest.php
@@ -282,6 +282,56 @@ class RestIssueAddTest extends RestBase {
 		$this->assertEquals( 400, $t_response->getStatusCode() );
 	}
 
+	public function testCreateIssueWithTags() {
+		# TODO: Create/cleanup tags once supported by the API, till then use dump from official bug tracker
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueWithTags' );
+		$t_issue_to_add['tags'] = array( array( 'name' => 'modern-ui' ), array( 'name' => 'patch' ) );
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertEquals( 201, $t_response->getStatusCode() );
+		$t_body = json_decode( $t_response->getBody(), true );
+		$t_issue = $t_body['issue'];
+
+		$this->assertTrue( isset( $t_issue['tags'] ), 'tags set' );
+		$this->assertEquals( 'modern-ui', $t_issue['tags'][0]['name'] );
+		$this->assertEquals( 'patch', $t_issue['tags'][1]['name'] );
+
+		$this->deleteAfterRun( $t_issue['id'] );
+	}
+
+	public function testCreateIssueWithTagNameNotFound() {
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueWithTagsNotFound' );
+		$t_issue_to_add['tags'] = array( array( 'name' => 'tag-not-found' ) );
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		# TODO: 404 is returned here after issue is created.  We can improve this later.
+		$this->assertEquals( 404, $t_response->getStatusCode() );
+		$t_body = json_decode( $t_response->getBody(), true );
+		$t_issue = $t_body['issue'];
+
+		$this->assertFalse( isset( $t_issue['tags'] ), 'tags set' );
+
+		$this->deleteAfterRun( $t_issue['id'] );
+	}
+
+	public function testCreateIssueWithTagIdNotFound() {
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueWithTagsNotFound' );
+		$t_issue_to_add['tags'] = array( array( 'id' => 100000 ) );
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		# TODO: 404 is returned here after issue is created.  We can improve this later.
+		$this->assertEquals( 404, $t_response->getStatusCode() );
+		$t_body = json_decode( $t_response->getBody(), true );
+		$t_issue = $t_body['issue'];
+
+		$this->assertFalse( isset( $t_issue['tags'] ), 'tags set' );
+
+		$this->deleteAfterRun( $t_issue['id'] );
+	}
+
 	public function testCreateIssueNoSummary() {
 		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueNoSummary' );
 		unset( $t_issue_to_add['summary'] );

--- a/tests/rest/RestIssueAddTest.php
+++ b/tests/rest/RestIssueAddTest.php
@@ -144,6 +144,144 @@ class RestIssueAddTest extends RestBase {
 		$this->deleteAfterRun( $t_issue['id'] );
 	}
 
+	public function testCreateIssueWithVersionString() {
+		# TODO: Use version APIs to get create/get test values from DB.  For now use data from dump of official bugtracker
+		$t_version_name = '1.3.2';
+		$t_target_version_name = '2.0.x';
+		$t_fixed_in_version_name = '2.0.0-beta.3';
+
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueWithVersionString' );
+		$t_issue_to_add['version'] = $t_version_name;
+		$t_issue_to_add['target_version'] = $t_target_version_name;
+		$t_issue_to_add['fixed_in_version'] = $t_fixed_in_version_name;
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertEquals( 201, $t_response->getStatusCode() );
+		$t_body = json_decode( $t_response->getBody(), true );
+		$t_issue = $t_body['issue'];
+
+		$this->assertTrue( isset( $t_issue['version'] ), 'version id set' );
+		$this->assertTrue( isset( $t_issue['version']['id'] ), 'version id set' );
+		$this->assertTrue( isset( $t_issue['version']['name'] ), 'version name set' );
+		$this->assertEquals( $t_version_name, $t_issue['version']['name'] );
+		$this->assertEquals( $t_target_version_name, $t_issue['target_version']['name'] );
+		$this->assertEquals( $t_fixed_in_version_name, $t_issue['fixed_in_version']['name'] );
+
+		$this->deleteAfterRun( $t_issue['id'] );
+	}
+
+	public function testCreateIssueWithVersionObjectName() {
+		# TODO: Use version APIs to get create/get test values from DB.  For now use data from dump of official bugtracker
+		$t_version_name = '1.3.2';
+
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueWithVersionObjectName' );
+		$t_issue_to_add['version'] = array( 'name' => $t_version_name );
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertEquals( 201, $t_response->getStatusCode() );
+		$t_body = json_decode( $t_response->getBody(), true );
+		$t_issue = $t_body['issue'];
+
+		$this->assertTrue( isset( $t_issue['version'] ), 'version id set' );
+		$this->assertTrue( isset( $t_issue['version']['id'] ), 'version id set' );
+		$this->assertTrue( is_numeric( $t_issue['version']['id'] ), 'version id numeric' );
+		$this->assertTrue( isset( $t_issue['version']['name'] ), 'version name set' );
+		$this->assertEquals( $t_version_name, $t_issue['version']['name'] );
+		$this->assertFalse( isset( $t_issue['target_version'] ), 'target_version set' );
+		$this->assertFalse( isset( $t_issue['fixed_in_version'] ), 'fixed_in_version set' );
+
+		$this->deleteAfterRun( $t_issue['id'] );
+	}
+
+	public function testCreateIssueWithVersionObjectId() {
+		# TODO: Use version APIs to get create/get test values from DB.  For now use data from dump of official bugtracker
+		$t_version_name = '1.3.2';
+		$t_version_id = 255;
+
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueWithVersionObjectId' );
+		$t_issue_to_add['version'] = array( 'id' => $t_version_id );
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertEquals( 201, $t_response->getStatusCode() );
+		$t_body = json_decode( $t_response->getBody(), true );
+		$t_issue = $t_body['issue'];
+
+		$this->assertTrue( isset( $t_issue['version'] ), 'version set' );
+		$this->assertTrue( isset( $t_issue['version']['id'] ), 'version id set' );
+		$this->assertTrue( is_numeric( $t_issue['version']['id'] ), 'version id numeric' );
+		$this->assertTrue( isset( $t_issue['version']['name'] ), 'version name set' );
+		$this->assertEquals( $t_version_name, $t_issue['version']['name'], 'version name' );
+		$this->assertEquals( $t_version_id, $t_issue['version']['id'], 'version id' );
+		$this->assertFalse( isset( $t_issue['target_version'] ), 'target_version set' );
+		$this->assertFalse( isset( $t_issue['fixed_in_version'] ), 'fixed_in_version set' );
+
+		$this->deleteAfterRun( $t_issue['id'] );
+	}
+
+	public function testCreateIssueWithVersionObjectIdAndMistatchingName() {
+		# TODO: Use version APIs to get create/get test values from DB.  For now use data from dump of official bugtracker
+		# Here we are using id for '1.3.2' and name for '1.3.1'.  ID should be used.
+		$t_wrong_version_name = '1.3.1';
+		$t_correct_version_name = '1.3.2';
+		$t_version_id = 255;  # '1.3.2'
+
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueWithVersionObjectIdAndMistatchingName' );
+		$t_issue_to_add['version'] = array( 'id' => $t_version_id, 'name' => $t_wrong_version_name );
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertEquals( 201, $t_response->getStatusCode() );
+		$t_body = json_decode( $t_response->getBody(), true );
+		$t_issue = $t_body['issue'];
+
+		$this->assertTrue( isset( $t_issue['version'] ), 'version id set' );
+		$this->assertTrue( isset( $t_issue['version']['id'] ), 'version id set' );
+		$this->assertTrue( is_numeric( $t_issue['version']['id'] ), 'version id numeric' );
+		$this->assertTrue( isset( $t_issue['version']['name'] ), 'version name set' );
+		$this->assertEquals( $t_correct_version_name, $t_issue['version']['name'], 'version name' );
+		$this->assertEquals( $t_version_id, $t_issue['version']['id'], 'version id' );
+		$this->assertFalse( isset( $t_issue['target_version'] ), 'target_version set' );
+		$this->assertFalse( isset( $t_issue['fixed_in_version'] ), 'fixed_in_version set' );
+
+		$this->deleteAfterRun( $t_issue['id'] );
+	}
+
+	public function testCreateIssueWithVersionObjectIdNotFound() {
+		# Test case assumes webservice_error_when_version_not_found = ON.
+		$t_version_id = 10000;
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueWithVersionObjectIdNotFound' );
+		$t_issue_to_add['version'] = array( 'id' => $t_version_id );
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertEquals( 400, $t_response->getStatusCode() );
+	}
+
+	public function testCreateIssueWithVersionObjectNameNotFound() {
+		# Test case assumes webservice_error_when_version_not_found = ON.
+		$t_version_name = 'VersionNotFound';
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueWithVersionObjectNameNotFound' );
+		$t_issue_to_add['version'] = array( 'name' => $t_version_name );
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertEquals( 400, $t_response->getStatusCode() );
+	}
+
+	public function testCreateIssueWithVersionStringNotFound() {
+		# Test case assumes webservice_error_when_version_not_found = ON.
+		$t_version_name = 'VersionNotFound';
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueWithVersionObjectNameNotFound' );
+		$t_issue_to_add['version'] = $t_version_name;
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertEquals( 400, $t_response->getStatusCode() );
+	}
+
 	public function testCreateIssueNoSummary() {
 		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueNoSummary' );
 		unset( $t_issue_to_add['summary'] );

--- a/tests/rest/RestIssueAddTest.php
+++ b/tests/rest/RestIssueAddTest.php
@@ -1,0 +1,183 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mantis Webservice Tests
+ *
+ * @package Tests
+ * @subpackage UnitTests
+ * @copyright Copyright MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ */
+
+require_once 'RestBase.php';
+
+/**
+ * Test fixture for issue creation webservice methods.
+ *
+ * @requires extension curl
+ * @group REST
+ */
+class RestIssueAddTest extends RestBase {
+	public function testCreateIssueWithMinimalFields() {
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueWithMinimalFields' );
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertTrue( is_array( $t_response ) );
+		$this->assertTrue( isset( $t_response['issue'] ) );
+
+		$t_issue = $t_response['issue'];
+
+		$this->assertTrue( isset( $t_issue['id'] ) );
+		$this->assertTrue( is_numeric($t_issue['id'] ) );
+		$this->assertEquals( $t_issue_to_add['summary'], $t_issue['summary'] );
+		$this->assertEquals( $t_issue_to_add['description'], $t_issue['description'] );
+		$this->assertEquals( $t_issue_to_add['category']['name'], $t_issue['category']['name'] );
+		$this->assertEquals( $t_issue_to_add['project']['id'], $t_issue['project']['id'] );
+		$this->assertEquals( $this->userName, $t_issue['reporter']['name'] );
+
+		# Verify Status
+		$this->assertEquals( 10, $t_issue['status']['id'] );
+		$this->assertEquals( '#fcbdbd', $t_issue['status']['color'] );
+		$this->assertEquals( 'new', $t_issue['status']['name'] );
+		$this->assertEquals( 'new', $t_issue['status']['label'] );
+
+		# Verify Resolution
+		$this->assertEquals( 10, $t_issue['resolution']['id'], 'resolution id' );
+		$this->assertEquals( 'open', $t_issue['resolution']['name'], 'resolution name' );
+		$this->assertEquals( 'open', $t_issue['resolution']['label'], 'resolution label' );
+
+		# Verify View State
+		$this->assertEquals( 10, $t_issue['view_state']['id'], 'view state id' );
+		$this->assertEquals( 'public', $t_issue['view_state']['name'], 'view state name' );
+		$this->assertEquals( 'public', $t_issue['view_state']['label'], 'view state label' );
+
+		# Verify Priority
+		$this->assertEquals( 30, $t_issue['priority']['id'], 'priority id' );
+		$this->assertEquals( 'normal', $t_issue['priority']['name'], 'priority name' );
+		$this->assertEquals( 'normal', $t_issue['priority']['label'], 'priority label' );
+
+		# Verify Severity
+		$this->assertEquals( 50, $t_issue['severity']['id'], 'severity id' );
+		$this->assertEquals( 'minor', $t_issue['severity']['name'], 'severity name' );
+		$this->assertEquals( 'minor', $t_issue['severity']['label'], 'severity label' );
+
+		# Verify Reproducibility
+		$this->assertEquals( 70, $t_issue['reproducibility']['id'], 'reproducibility id' );
+		$this->assertEquals( 'have not tried', $t_issue['reproducibility']['name'], 'reproducibility name' );
+		$this->assertEquals( 'have not tried', $t_issue['reproducibility']['label'], 'reproducibility label' );
+
+		$this->assertEquals( false, $t_issue['sticky'], 'sticky' );
+		$this->assertTrue( isset( $t_issue['created_at'] ), 'created at' );
+		$this->assertTrue( isset( $t_issue['updated_at'] ), 'updated at' );
+
+		$this->deleteAfterRun( $t_response['issue']['id'] );
+	}
+
+	public function testCreateIssueWithEnumIds() {
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueWithEnumIds' );
+		$t_issue_to_add['status']['id'] = 50; # assigned
+		$t_issue_to_add['resolution']['id'] = 30; # reopened
+		$t_issue_to_add['view_state']['id'] = 50; # private
+		$t_issue_to_add['priority']['id'] = 40; # high
+		$t_issue_to_add['severity']['id'] = 10; # feature
+		$t_issue_to_add['reproducibility']['id'] = 10; # always
+		$t_issue_to_add['sticky'] = true;
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertTrue( is_array( $t_response ) );
+		$this->assertTrue( isset( $t_response['issue'] ) );
+
+		$t_issue = $t_response['issue'];
+
+		$this->assertTrue( isset( $t_issue['id'] ) );
+		$this->assertTrue( is_numeric($t_issue['id'] ) );
+
+		# Verify Status
+		$this->assertEquals( 50, $t_issue['status']['id'] );
+		$this->assertEquals( '#c2dfff', $t_issue['status']['color'] );
+		$this->assertEquals( 'assigned', $t_issue['status']['name'] );
+		$this->assertEquals( 'assigned', $t_issue['status']['label'] );
+
+		# Verify Resolution
+		$this->assertEquals( 30, $t_issue['resolution']['id'], 'resolution id' );
+		$this->assertEquals( 'reopened', $t_issue['resolution']['name'], 'resolution name' );
+		$this->assertEquals( 'reopened', $t_issue['resolution']['label'], 'resolution label' );
+
+		# Verify View State
+		$this->assertEquals( 50, $t_issue['view_state']['id'], 'view state id' );
+		$this->assertEquals( 'private', $t_issue['view_state']['name'], 'view state name' );
+		$this->assertEquals( 'private', $t_issue['view_state']['label'], 'view state label' );
+
+		# Verify Priority
+		$this->assertEquals( 40, $t_issue['priority']['id'], 'priority id' );
+		$this->assertEquals( 'high', $t_issue['priority']['name'], 'priority name' );
+		$this->assertEquals( 'high', $t_issue['priority']['label'], 'priority label' );
+
+		# Verify Severity
+		$this->assertEquals( 10, $t_issue['severity']['id'], 'severity id' );
+		$this->assertEquals( 'feature', $t_issue['severity']['name'], 'severity name' );
+		$this->assertEquals( 'feature', $t_issue['severity']['label'], 'severity label' );
+
+		# Verify Reproducibility
+		$this->assertEquals( 10, $t_issue['reproducibility']['id'], 'reproducibility id' );
+		$this->assertEquals( 'always', $t_issue['reproducibility']['name'], 'reproducibility name' );
+		$this->assertEquals( 'always', $t_issue['reproducibility']['label'], 'reproducibility label' );
+
+		$this->assertEquals( true, $t_issue['sticky'], 'sticky' );
+		$this->assertTrue( isset( $t_issue['created_at'] ), 'created at' );
+		$this->assertTrue( isset( $t_issue['updated_at'] ), 'updated at' );
+
+		$this->deleteAfterRun( $t_response['issue']['id'] );
+	}
+
+	public function testCreateIssueNoSummary() {
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueNoSummary' );
+		unset( $t_issue_to_add['summary'] );
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertFalse( is_array( $t_response ) );
+	}
+
+	public function testCreateIssueNoDescription() {
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueNoDescription' );
+		unset( $t_issue_to_add['description'] );
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertFalse( is_array( $t_response ) );
+	}
+
+	public function testCreateIssueNoCategory() {
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueNoCategory' );
+		unset( $t_issue_to_add['category'] );
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertFalse( is_array( $t_response ) );
+	}
+
+	public function testCreateIssueNoProject() {
+		$t_issue_to_add = $this->getIssueToAdd( 'RestIssueAddTest.testCreateIssueNoProject' );
+		unset( $t_issue_to_add['project'] );
+
+		$t_response = $this->post( '/issues', $t_issue_to_add );
+
+		$this->assertFalse( is_array( $t_response ) );
+	}
+}

--- a/tests/soap/FilterTest.php
+++ b/tests/soap/FilterTest.php
@@ -583,12 +583,13 @@ class FilterTest extends SoapBase {
         $t_issue_to_add['resolution'] = array( 'id' => FIXED );
         $t_issue_to_add['sticky'] = true;
         $t_issue_to_add['view_state'] = array( 'id' => VS_PUBLIC );
-        $t_issue_to_add['fixed_in_version'] = 'test_69';
-        $t_issue_to_add['target_version'] = 'test_70';
         $t_issue_to_add['platform'] = 'test_plaform';
         $t_issue_to_add['os'] = 'test_os';
         $t_issue_to_add['os_build'] = 'test_6';
 
+        # Must use valid versions for this to work.
+		# $t_issue_to_add['fixed_in_version'] = 'test_69';
+		# $t_issue_to_add['target_version'] = 'test_70';
 
         $t_issue_id = $this->client->mc_issue_add( $this->userName, $this->password, $t_issue_to_add );
 
@@ -608,8 +609,9 @@ class FilterTest extends SoapBase {
                            'sort_direction' => 'DESC',
                            'sticky' => true,
                            'view_state' => array( VS_PUBLIC ),
-                           'fixed_in_version' => array( 'test_69' ),
-                           'target_version' => array( 'test_70' ),
+                           # These versions must exist for this to work
+                           # 'fixed_in_version' => array( 'test_69' ),
+                           # 'target_version' => array( 'test_70' ),
                            'platform' => array( 'test_plaform' ),
                            'os' => array( 'test_os' ),
                            'os_build' => array( 'test_6' )

--- a/tests/soap/IssueAddTest.php
+++ b/tests/soap/IssueAddTest.php
@@ -81,14 +81,24 @@ class IssueAddTest extends SoapBase {
 		$this->assertEquals( 70, $t_issue->reproducibility->id );
 		$this->assertEquals( 'have not tried', $t_issue->reproducibility->name );
 		$this->assertEquals( 0, $t_issue->sponsorship_total );
-		$this->assertEquals( 10, $t_issue->projection->id );
-		$this->assertEquals( 'none', $t_issue->projection->name );
-		$this->assertEquals( 10, $t_issue->eta->id );
-		$this->assertEquals( 'none', $t_issue->eta->name );
+
+		if( $this->client->mc_config_get_string( $this->userName, $this->password, 'enable_projection' ) ) {
+			$this->assertEquals( 10, $t_issue->projection->id );
+			$this->assertEquals( 'none', $t_issue->projection->name );
+		} else {
+			$this->assertFalse( isset( $t_issue->projection ) );
+		}
+
+		if( $this->client->mc_config_get_string( $this->userName, $this->password, 'enable_eta' ) ) {
+			$this->assertEquals( 10, $t_issue->eta->id );
+			$this->assertEquals( 'none', $t_issue->eta->name );
+		} else {
+			$this->assertFalse( isset( $t_issue->eta ) );
+		}
+
 		$this->assertEquals( 10, $t_issue->resolution->id );
 		$this->assertEquals( 'open', $t_issue->resolution->name );
 		$this->assertEquals( false, $t_issue->sticky );
-
 	}
 
 	/**
@@ -127,8 +137,17 @@ class IssueAddTest extends SoapBase {
 	public function testCreateIssueWithRareFields() {
 		$t_issue_to_add = $this->getIssueToAdd( 'IssueAddTest.testCreateIssueWithRareFields' );
 
-		$t_issue_to_add['projection'] = array( 'id' => 90 );    # redesign
-		$t_issue_to_add['eta'] = array( 'id' => 60 );           # > 1 month
+		$t_eta_enabled = $this->client->mc_config_get_string( $this->userName, $this->password, 'enable_eta' );
+		$t_projection_enabled = $this->client->mc_config_get_string( $this->userName, $this->password, 'enable_projection' );
+
+		if( $t_projection_enabled ) {
+			$t_issue_to_add['projection'] = array( 'id' => 90 );    # redesign
+		}
+
+		if( $t_eta_enabled ) {
+			$t_issue_to_add['eta'] = array( 'id' => 60 );           # > 1 month
+		}
+
 		$t_issue_to_add['resolution'] = array( 'id' => 80 );    # suspended
 		$t_issue_to_add['status'] = array( 'id' => 40 );        # confirmed
 		$t_issue_to_add['fixed_in_version'] = 'fixed version';
@@ -145,13 +164,21 @@ class IssueAddTest extends SoapBase {
 		$t_issue = $this->client->mc_issue_get( $this->userName, $this->password, $t_issue_id );
 
 		# explicitly specified fields
-		$this->assertEquals( $t_issue_to_add['projection']['id'], $t_issue->projection->id );
-		$this->assertEquals( $t_issue_to_add['eta']['id'], $t_issue->eta->id );
+		if( $t_projection_enabled ) {
+			$this->assertEquals( $t_issue_to_add['projection']['id'], $t_issue->projection->id );
+		}
+
+		if( $t_eta_enabled ) {
+			$this->assertEquals( $t_issue_to_add['eta']['id'], $t_issue->eta->id );
+		}
+
 		$this->assertEquals( $t_issue_to_add['resolution']['id'], $t_issue->resolution->id );
 		$this->assertEquals( $t_issue_to_add['status']['id'], $t_issue->status->id );
-		$this->assertEquals( $t_issue_to_add['fixed_in_version'], $t_issue->fixed_in_version );
-		$this->assertEquals( $t_issue_to_add['target_version'], $t_issue->target_version );
 		$this->assertEquals( $t_issue_to_add['sticky'], $t_issue->sticky );
+
+		# Since versions are not defined, they are not going to be set
+		$this->assertFalse( isset( $t_issue->fixed_in_version ) );
+		$this->assertFalse( isset( $t_issue->target_version ) );
 
 		$t_read_dt = DateTime::createFromFormat( DateTime::ISO8601, $t_issue->last_updated );
 

--- a/tests/soap/IssueAddTest.php
+++ b/tests/soap/IssueAddTest.php
@@ -150,9 +150,11 @@ class IssueAddTest extends SoapBase {
 
 		$t_issue_to_add['resolution'] = array( 'id' => 80 );    # suspended
 		$t_issue_to_add['status'] = array( 'id' => 40 );        # confirmed
-		$t_issue_to_add['fixed_in_version'] = 'fixed version';
-		$t_issue_to_add['target_version'] = 'target version';
 		$t_issue_to_add['sticky'] = true;
+
+		# Must use valid versions for this to work.
+		# $t_issue_to_add['fixed_in_version'] = 'fixed version';
+		# $t_issue_to_add['target_version'] = 'target version';
 
 		$t_dt = DateTime::createFromFormat( 'U', time() );
 		$t_issue_to_add['last_updated'] = $t_dt->format( DateTime::ISO8601 );

--- a/tests/soap/IssueUpdateTest.php
+++ b/tests/soap/IssueUpdateTest.php
@@ -80,10 +80,21 @@ class IssueUpdateTest extends SoapBase {
 		$this->assertEquals( 70, $t_issue->reproducibility->id );
 		$this->assertEquals( 'have not tried', $t_issue->reproducibility->name );
 		$this->assertEquals( 0, $t_issue->sponsorship_total );
-		$this->assertEquals( 10, $t_issue->projection->id );
-		$this->assertEquals( 'none', $t_issue->projection->name );
-		$this->assertEquals( 10, $t_issue->eta->id );
-		$this->assertEquals( 'none', $t_issue->eta->name );
+
+		if( $this->client->mc_config_get_string( $this->userName, $this->password, 'enable_projection' ) ) {
+			$this->assertEquals( 10, $t_issue->projection->id );
+			$this->assertEquals( 'none', $t_issue->projection->name );
+		} else {
+			$this->assertFalse( isset( $t_issue->projection ) );
+		}
+
+		if( $this->client->mc_config_get_string( $this->userName, $this->password, 'enable_eta' ) ) {
+			$this->assertEquals( 10, $t_issue->eta->id );
+			$this->assertEquals( 'none', $t_issue->eta->name );
+		} else {
+			$this->assertFalse( isset( $t_issue->eta ) );
+		}
+
 		$this->assertEquals( 10, $t_issue->resolution->id );
 		$this->assertEquals( 'open', $t_issue->resolution->name );
 	}
@@ -132,10 +143,21 @@ class IssueUpdateTest extends SoapBase {
 		$this->assertEquals( 70, $t_issue->reproducibility->id );
 		$this->assertEquals( 'have not tried', $t_issue->reproducibility->name );
 		$this->assertEquals( 0, $t_issue->sponsorship_total );
-		$this->assertEquals( 10, $t_issue->projection->id );
-		$this->assertEquals( 'none', $t_issue->projection->name );
-		$this->assertEquals( 10, $t_issue->eta->id );
-		$this->assertEquals( 'none', $t_issue->eta->name );
+
+		if( $this->client->mc_config_get_string( $this->userName, $this->password, 'enable_projection' ) ) {
+			$this->assertEquals( 10, $t_issue->projection->id );
+			$this->assertEquals( 'none', $t_issue->projection->name );
+		} else {
+			$this->assertFalse( isset( $t_issue->projection ) );
+		}
+
+		if( $this->client->mc_config_get_string( $this->userName, $this->password, 'enable_eta' ) ) {
+			$this->assertEquals( 10, $t_issue->eta->id );
+			$this->assertEquals( 'none', $t_issue->eta->name );
+		} else {
+			$this->assertFalse( isset( $t_issue->eta ) );
+		}
+
 		$this->assertEquals( 10, $t_issue->resolution->id );
 		$this->assertEquals( 'open', $t_issue->resolution->name );
 	}
@@ -330,7 +352,13 @@ class IssueUpdateTest extends SoapBase {
 	 * @return void
 	 */
 	public function testUpdateWithRareFields() {
-		$this->skipIfTimeTrackingIsNotEnabled();
+		if( !$this->client->mc_config_get_string( $this->userName, $this->password, 'enable_product_build' ) ) {
+			$this->markTestSkipped( 'Product build is not enabled' );
+		}
+
+		if( !$this->client->mc_config_get_string( $this->userName, $this->password, 'allow_freetext_in_profile_fields' ) ) {
+			$this->markTestSkipped( '`allow_freetext_in_profile_fields` is not enabled' );
+		}
 
 		$t_issue_to_add = $this->getIssueToAdd( 'IssueUpdateTest.testUpdateWithRareFields' );
 

--- a/tests/soap/LoginTest.php
+++ b/tests/soap/LoginTest.php
@@ -66,7 +66,7 @@ class LoginTest extends SoapBase {
 		$this->assertEquals( $this->userName, $t_user_data->account_data->name, 'name' );
 		$this->assertEquals( $this->userId, $t_user_data->account_data->id, 'id' );
 		$this->assertEquals( $this->email, $t_user_data->account_data->email, 'email' );
-		$this->assertEquals( false, empty( $t_user_data->timezone ), 'timezone' );
+		$this->assertFalse( empty( $t_user_data->timezone ), 'timezone' );
 		$this->assertEquals( 90, (integer)$t_user_data->access_level, 'access_level' );
 	}
 


### PR DESCRIPTION
It is recommended to review this PR one commit at a time to follow the chain of changes.

**REST API**
- Support getting multiple issues with pagination.  This can be based on filter or project.  Whether returning a single issue (by id) or a batch of issues, the same response format is now used which has `issues` array.
- Setup framework for testing REST API + tests for issue creation.
- When time tracking is not visible, return note type as `note` rather than `timelog` if it has a hidden time.
- Return versions as an object with id and name rather than just a string.
- Enum name should be the English (from config) value.
- Added enum `label` which has the localized version of the enum name.
- Fix some error messages that were not correctly reflecting the error case.
- Include status color as part of status info on issues.
- Use `created_at` rather than `date_submitted`.
- Use `updated_at` rather than `last_updated`.
- Make `sticky` a boolean rather than a string.
- Don't include `sponsorship_total`.

**SOAP and REST**

- Added some config option checks that were missing from SOAP/REST API (e.g. eta enabled, projection enabled, profile, build/platform/os, etc).
- Don't allow setting an undefined version when creating an issue.
- Do access checks based on bug/project rather than global access level for fields like due date.