### PR TITLE
db_get_table() also check suffix for legacy-style names

### DIFF
--- a/core/database_api.php
+++ b/core/database_api.php
@@ -911,8 +911,8 @@ function db_time_queries() {
  * @return string containing full database table name (with prefix and suffix)
  */
 function db_get_table( $p_name ) {
-	if( strpos( $p_name, 'mantis_' ) === 0 ) {
-		$t_table = substr( $p_name, 7, strpos( $p_name, '_table' ) - 7 );
+	if( preg_match( '/^mantis_(.*)_table$/', $p_name, $t_matches ) ) {
+		$t_table = $t_matches[1];
 		error_parameters(
 			__FUNCTION__ . "( '$p_name' )",
 			__FUNCTION__ . "( '$t_table' )"


### PR DESCRIPTION
If $db_table_plugin_prefix contains 'mantis', db_get_table() function
will incorrectly process a plugin's tables as if they were legacy tables
(i.e. 'Mantis 1.2 style', with a 'mantis_' prefix).

If $db_table_suffix also is not set to '_table', then the generated table
name will be incorrect (e.g. with the Source Integration plugin,
changeset table will be generated as 'mantis_Source_ch_suffix' instead
of 'mantis_mantis_Source_changeset_suffix'), causing the installation by
plugin_upgrade() to fail and invalid tables to be created.

We now use a regex to check for legacy tables, verifying that it ends
with '_table' in addition to beginning with 'mantis_'. This basically
reverts commit 38bc02483eb58a3708e4f419bfa7c02b6c6900db (issue #16038).

Note on performance: while preg_match() is slower than strpos(), it is
actually more efficient to use that, considering that we would need a
second function call to check for the suffix, as well as a substr() call
to extract the table name, while preg_match() does it all at once.

Fixes [#20168](https://mantisbt.org/bugs/view.php?id=20168)

This will be backported to 1.3.x after merge