### PR TITLE
Fixes and improvements for the install page

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -671,7 +671,12 @@ if( !$g_database_upgrade ) {
 		echo "<tr>\n\t<td>\n";
 		echo "\t\t" . $t_prefix_labels[$t_key] . "\n";
 		echo "\t</td>\n\t<td>\n\t\t";
-		echo '<input id="' . $t_key . '" name="' . $t_key . '" type="text" value="' . $f_db_table_prefix . '">';
+		echo '<input id="' . $t_key . '" name="' . $t_key . '" type="text" class="db-table-prefix" value="' . $f_db_table_prefix . '">';
+		if( $t_key != 'db_table_suffix' ) {
+			$t_id_sample = $t_key. '_sample';
+			echo "\n&nbsp;", '<label for="' . $t_id_sample . '">Sample table name:</label>';
+			echo "\n", '<input id="' . $t_id_sample . '" type="text" size="40" disabled>';
+		}
 		echo "\n\t</td>\n</tr>\n\n";
 	}
 

--- a/admin/install.php
+++ b/admin/install.php
@@ -493,24 +493,26 @@ if( 2 == $t_install_state ) {
 		);
 ?>
 </tr>
-</table>
-<?php
-	}?>
-</table>
-</div>
-</div>
-</div>
-</div>
-</div>
 
 <?php
-	if( false == $g_failed ) {
-		$t_install_state++;
-	} else {
-		$t_install_state--; # a check failed, redisplay the questions
-	}
+		if( false == $g_failed ) {
+			$t_install_state++;
+		} else {
+			$t_install_state--; # a check failed, redisplay the questions
+		}
+	} # end if db open
 } # end 2 == $t_install_state
+?>
 
+</table>
+</table>
+</div>
+</div>
+</div>
+</div>
+</div>
+
+<?php
 # system checks have passed, get the database information
 if( 1 == $t_install_state ) {
 	?>

--- a/admin/install.php
+++ b/admin/install.php
@@ -594,7 +594,7 @@ if( !$g_database_upgrade ) {
 		Hostname (for Database Server)
 	</td>
 	<td>
-		<input name="hostname" type="textbox" value="<?php echo string_attribute( $f_hostname ) ?>">
+		<input name="hostname" type="text" value="<?php echo string_attribute( $f_hostname ) ?>">
 	</td>
 </tr>
 
@@ -604,7 +604,7 @@ if( !$g_database_upgrade ) {
 		Username (for Database)
 	</td>
 	<td>
-		<input name="db_username" type="textbox" value="<?php echo string_attribute( $f_db_username ) ?>">
+		<input name="db_username" type="text" value="<?php echo string_attribute( $f_db_username ) ?>">
 	</td>
 </tr>
 
@@ -627,7 +627,7 @@ if( !$g_database_upgrade ) {
 		Database name (for Database)
 	</td>
 	<td>
-		<input name="database_name" type="textbox" value="<?php echo string_attribute( $f_database_name ) ?>">
+		<input name="database_name" type="text" value="<?php echo string_attribute( $f_database_name ) ?>">
 	</td>
 </tr>
 <?php
@@ -640,7 +640,7 @@ if( !$g_database_upgrade ) {
 		Admin Username (to <?php echo( !$g_database_upgrade ) ? 'create Database' : 'update Database'?> if required)
 	</td>
 	<td>
-		<input name="admin_username" type="textbox" value="<?php echo string_attribute( $f_admin_username ) ?>">
+		<input name="admin_username" type="text" value="<?php echo string_attribute( $f_admin_username ) ?>">
 	</td>
 </tr>
 
@@ -669,7 +669,7 @@ if( !$g_database_upgrade ) {
 		echo "<tr>\n\t<td>\n";
 		echo "\t\t" . $t_prefix_labels[$t_key] . "\n";
 		echo "\t</td>\n\t<td>\n\t\t";
-		echo '<input id="' . $t_key . '" name="' . $t_key . '" type="textbox" value="' . $f_db_table_prefix . '">';
+		echo '<input id="' . $t_key . '" name="' . $t_key . '" type="text" value="' . $f_db_table_prefix . '">';
 		echo "\n\t</td>\n</tr>\n\n";
 	}
 

--- a/admin/install.php
+++ b/admin/install.php
@@ -672,10 +672,16 @@ if( !$g_database_upgrade ) {
 		echo "\t\t" . $t_prefix_labels[$t_key] . "\n";
 		echo "\t</td>\n\t<td>\n\t\t";
 		echo '<input id="' . $t_key . '" name="' . $t_key . '" type="text" class="db-table-prefix" value="' . $f_db_table_prefix . '">';
+		echo "\n&nbsp;";
 		if( $t_key != 'db_table_suffix' ) {
 			$t_id_sample = $t_key. '_sample';
-			echo "\n&nbsp;", '<label for="' . $t_id_sample . '">Sample table name:</label>';
+			echo '<label for="' . $t_id_sample . '">Sample table name:</label>';
 			echo "\n", '<input id="' . $t_id_sample . '" type="text" size="40" disabled>';
+		} else {
+			echo '<span id="oracle_size_warning" >';
+			echo "On Oracle < 12cR2, max length for identifiers is 30 chars. "
+				. "Keep pre/suffixes as short as possible to avoid problems.";
+			echo '<span>';
 		}
 		echo "\n\t</td>\n</tr>\n\n";
 	}

--- a/js/install.js
+++ b/js/install.js
@@ -30,8 +30,10 @@ $('#db_type').change(
 		var db;
 		if ($(this).val() == 'oci8') {
 			db = 'oci8';
+			$('#oracle_size_warning').show();
 		} else {
 			db = 'other';
+			$('#oracle_size_warning').hide();
 		}
 
 		$('#default_' + db + ' span').each(

--- a/js/install.js
+++ b/js/install.js
@@ -46,7 +46,33 @@ $('#db_type').change(
 				target.data('defval', $(el).text());
 			}
 		);
+
+		update_sample_table_names();
 	}
 ).change();
 
+/**
+ * Populate sample table names based on given prefix/suffix
+ */
+$('.db-table-prefix').on('input', update_sample_table_names);
+
+update_sample_table_names();
 });
+
+function update_sample_table_names() {
+	var prefix = $('#db_table_prefix').val().trim();
+	if(prefix && prefix.substr(-1) != '_') {
+		prefix += '_';
+	}
+	var suffix = $('#db_table_suffix').val().trim();
+	if(suffix && suffix.substr(0,1) != '_') {
+		suffix = '_' + suffix;
+	}
+	var plugin = $('#db_table_plugin_prefix').val().trim();
+	if(plugin && plugin.substr(-1) != '_') {
+		plugin += '_';
+	}
+
+	$('#db_table_prefix_sample').val(prefix + '<CORE TABLE>' + suffix);
+	$('#db_table_plugin_prefix_sample').val(prefix + plugin + '<PLUGIN>_<TABLE>' + suffix);
+}


### PR DESCRIPTION
- display of input text boxes with Modern UI style
- Installation Options section's title was displayed under _Checking Installation, instead of above the options themselves
- add dynamic table name preview based on prefix/suffix settings
- add warning message about Oracle identifier size limit

Fixes [#22850](https://mantisbt.org/bugs/view.php?id=22850) and [#22851](https://mantisbt.org/bugs/view.php?id=22851)