### PR TITLE
Fix CSV and Excel export when markdown is enabled

### DIFF
--- a/core/cfdefs/cfdef_standard.php
+++ b/core/cfdefs/cfdef_standard.php
@@ -31,7 +31,8 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_STRING] = array (
 	'#function_value_to_database' => 'db_mysql_fix_utf8',
 	'#function_database_to_value' => null,
 	'#function_print_input' => 'cfdef_input_textbox',
-	'#function_string_value' => null,
+	'#function_print_value' => null,
+	'#function_string_value' => 'cfdef_prepare_string',
 	'#function_string_value_for_email' => null,
 );
 
@@ -46,7 +47,8 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_TEXTAREA] = array (
 	'#function_value_to_database' => 'db_mysql_fix_utf8',
 	'#function_database_to_value' => null,
 	'#function_print_input' => 'cfdef_input_textarea',
-	'#function_string_value' => null,
+	'#function_print_value' => 'cfdef_print_textarea',
+	'#function_string_value' => 'cfdef_prepare_string',
 	'#function_string_value_for_email' => null,
 );
 
@@ -60,7 +62,8 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_NUMERIC] = array (
 	'#function_value_to_database' => null,
 	'#function_database_to_value' => null,
 	'#function_print_input' => 'cfdef_input_textbox',
-	'#function_string_value' => null,
+	'#function_print_value' => 'cfdef_print_numeric',
+	'#function_string_value' => 'cfdef_prepare_numeric',
 	'#function_string_value_for_email' => null,
 );
 
@@ -74,7 +77,8 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_FLOAT] = array (
 	'#function_value_to_database' => null,
 	'#function_database_to_value' => null,
 	'#function_print_input' => 'cfdef_input_textbox',
-	'#function_string_value' => null,
+	'#function_print_value' => 'cfdef_print_float',
+	'#function_string_value' => 'cfdef_prepare_float',
 	'#function_string_value_for_email' => null,
 );
 
@@ -88,6 +92,7 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_ENUM] = array (
 	'#function_value_to_database' => null,
 	'#function_database_to_value' => null,
 	'#function_print_input' => 'cfdef_input_list',
+	'#function_print_value' => null,
 	'#function_string_value' => 'cfdef_prepare_list_value',
 	'#function_string_value_for_email' => 'cfdef_prepare_list_value_for_email',
 );
@@ -102,6 +107,7 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_EMAIL] = array (
 	'#function_value_to_database' => null,
 	'#function_database_to_value' => null,
 	'#function_print_input' => 'cfdef_input_textbox',
+	'#function_print_value' => null,
 	'#function_string_value' => 'cfdef_prepare_email_value',
 	'#function_string_value_for_email' => 'cfdef_prepare_email_value_for_email',
 );
@@ -116,6 +122,7 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_CHECKBOX] = array (
 	'#function_value_to_database' => 'cfdef_prepare_list_value_to_database',
 	'#function_database_to_value' => 'cfdef_prepare_list_database_to_value',
 	'#function_print_input' => 'cfdef_input_checkbox',
+	'#function_print_value' => null,
 	'#function_string_value' => 'cfdef_prepare_list_value',
 	'#function_string_value_for_email' => 'cfdef_prepare_list_value_for_email',
 );
@@ -130,6 +137,7 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_RADIO] = array (
 	'#function_value_to_database' => null,
 	'#function_database_to_value' => null,
 	'#function_print_input' => 'cfdef_input_radio',
+	'#function_print_value' => null,
 	'#function_string_value' => 'cfdef_prepare_list_value',
 	'#function_string_value_for_email' => 'cfdef_prepare_list_value_for_email',
 );
@@ -144,6 +152,7 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_LIST] = array (
 	'#function_value_to_database' => null,
 	'#function_database_to_value' => null,
 	'#function_print_input' => 'cfdef_input_list',
+	'#function_print_value' => null,
 	'#function_string_value' => 'cfdef_prepare_list_value',
 	'#function_string_value_for_email' => 'cfdef_prepare_list_value_for_email',
 );
@@ -158,6 +167,7 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_MULTILIST] = array (
 	'#function_value_to_database' => 'cfdef_prepare_list_value_to_database',
 	'#function_database_to_value' => 'cfdef_prepare_list_database_to_value',
 	'#function_print_input' => 'cfdef_input_list',
+	'#function_print_value' => null,
 	'#function_string_value' => 'cfdef_prepare_list_value',
 	'#function_string_value_for_email' => 'cfdef_prepare_list_value_for_email',
 );
@@ -173,6 +183,7 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_DATE] = array (
 	'#function_database_to_value' => null,
 	'#function_default_to_value' => 'cfdef_prepare_date_default',
 	'#function_print_input' => 'cfdef_input_date',
+	'#function_print_value' => null,
 	'#function_string_value' => 'cfdef_prepare_date_value',
 	'#function_string_value_for_email' => 'cfdef_prepare_date_value_for_email',
 );
@@ -184,6 +195,59 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_DATE] = array (
  */
 function cfdef_prepare_list_database_to_value( $p_value ) {
 	return rtrim( ltrim( $p_value, '|' ), '|' );
+}
+
+/**
+ * Print value of text area custom field with sanitization and link processing.
+ * @param string $p_value The custom field value.
+ */
+function cfdef_print_textarea( $p_value ) {
+	echo string_display_links( $p_value );
+}
+
+/**
+ * Print value of numeric custom field with sanitization and link processing.
+ * @param string $p_value The custom field value.
+ */
+function cfdef_print_numeric( $p_value ) {
+	echo (int)$p_value;
+}
+
+/**
+ * Print value of float custom field with sanitization and link processing.
+ * @param string $p_value The custom field value.
+ */
+function cfdef_print_float( $p_value ) {
+	echo (float)$p_value;
+}
+
+/**
+ * Prepare value for custom fields of type numeric.
+ * @param string $p_value The string value.
+ * @return int The numeric value.
+ */
+function cfdef_prepare_numeric( $p_value ) {
+	$t_value = (int)$p_value;
+	return $t_value;
+}
+
+/**
+ * Prepare value for custom fields of type float.
+ * @param string $p_value The string value.
+ * @return float The float value.
+ */
+function cfdef_prepare_float( $p_value ) {
+	$t_value = (float)$p_value;
+	return $t_value;
+}
+
+/**
+ * Prepare value for custom fields of type string.
+ * @param string $p_value The string value.
+ * @return string The string value.
+ */
+function cfdef_prepare_string( $p_value ) {
+	return $p_value;
 }
 
 /**

--- a/core/classes/MantisColumn.class.php
+++ b/core/classes/MantisColumn.class.php
@@ -79,5 +79,22 @@ abstract class MantisColumn {
 	 * @return void
 	 */
 	abstract public function display( BugData $p_bug, $p_columns_target );
+
+	/**
+	 * Function to return column value for a given bug row.  This should be overridden
+	 * to provide value without processing for html display or escaping for a specific target
+	 * output.  Default implementation is to capture display output for backward compatibility
+	 * with target COLUMNS_TARGET_CSV_PAGE.  The output will be escaped by calling code to the
+	 * appropriate format.
+	 *
+	 * @param BugData $p_bug            A BugData object.
+	 * @param integer $p_columns_target Column display target.
+	 * @return string The column value.
+	 */
+	public function value( BugData $p_bug, $p_columns_target ) {
+		ob_start();
+		$this->display( $p_bug, COLUMNS_TARGET_CSV_PAGE );
+		return ob_get_clean();
+	}
 }
 

--- a/core/csv_api.php
+++ b/core/csv_api.php
@@ -134,6 +134,48 @@ function csv_get_columns() {
 }
 
 /**
+ * Gets the formatted value for the specified issue id, project and custom field.
+ * @param integer $p_issue_id     The issue id.
+ * @param integer $p_project_id   The project id.
+ * @param string  $p_custom_field The custom field name (without 'custom_' prefix).
+ * @return string The custom field value.
+ */
+function csv_format_custom_field( $p_issue_id, $p_project_id, $p_custom_field ) {
+	$t_field_id = custom_field_get_id_from_name( $p_custom_field );
+
+	if( $t_field_id === false ) {
+		$t_value = '@' . $p_custom_field . '@';
+	} else if( custom_field_is_linked( $t_field_id, $p_project_id ) ) {
+		$t_def = custom_field_get_definition( $t_field_id );
+		$t_value = string_custom_field_value( $t_def, $t_field_id, $p_issue_id );
+	} else {
+		# field is not linked to project
+		$t_value = '';
+	}
+
+	return csv_escape_string( $t_value );
+}
+
+/**
+ * Gets the formatted value for the specified plugin column value.
+ * @param string  $p_column The plugin column name.
+ * @param BugData $p_bug    A bug object to print the column for - needed for the display function of the plugin column.
+ * @return string The plugin column value.
+ */
+function csv_format_plugin_column_value( $p_column, BugData $p_bug ) {
+	$t_plugin_columns = columns_get_plugin_columns();
+
+	if( !isset( $t_plugin_columns[$p_column] ) ) {
+		$t_value = '';
+	} else {
+		$t_column_object = $t_plugin_columns[$p_column];
+		$t_value = $t_column_object->value( $p_bug );
+	}
+
+	return csv_escape_string( $t_value );
+}
+
+/**
  * returns the formatted bug id
  * @param BugData $p_bug A BugData object.
  * @return string csv formatted bug id

--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -1430,11 +1430,13 @@ function string_custom_field_value( array $p_def, $p_field_id, $p_bug_id ) {
 	if( $t_custom_field_value === null ) {
 		return '';
 	}
+
 	global $g_custom_field_type_definition;
 	if( isset( $g_custom_field_type_definition[$p_def['type']]['#function_string_value'] ) ) {
 		return call_user_func( $g_custom_field_type_definition[$p_def['type']]['#function_string_value'], $t_custom_field_value );
 	}
-	return string_display_links( $t_custom_field_value );
+
+	return $t_custom_field_value;
 }
 
 /**
@@ -1447,7 +1449,17 @@ function string_custom_field_value( array $p_def, $p_field_id, $p_bug_id ) {
  * @access public
  */
 function print_custom_field_value( array $p_def, $p_field_id, $p_bug_id ) {
-	echo string_custom_field_value( $p_def, $p_field_id, $p_bug_id );
+	$t_custom_field_value = custom_field_get_value( $p_field_id, $p_bug_id );
+	if( $t_custom_field_value === null ) {
+		return;
+	}
+
+	global $g_custom_field_type_definition;
+	if( isset( $g_custom_field_type_definition[$p_def['type']]['#function_print_value'] ) ) {
+		return call_user_func( $g_custom_field_type_definition[$p_def['type']]['#function_print_value'], $t_custom_field_value );
+	}
+
+	echo string_display_line_links( $t_custom_field_value );
 }
 
 /**

--- a/core/excel_api.php
+++ b/core/excel_api.php
@@ -512,12 +512,13 @@ function excel_format_custom_field( $p_issue_id, $p_project_id, $p_custom_field 
 
 	if( custom_field_is_linked( $t_field_id, $p_project_id ) ) {
 		$t_def = custom_field_get_definition( $t_field_id );
+		$t_value = string_custom_field_value( $t_def, $t_field_id, $p_issue_id );
 
-		if ( $t_def['type'] == CUSTOM_FIELD_TYPE_NUMERIC ) {
-			return excel_prepare_number( string_custom_field_value( $t_def, $t_field_id, $p_issue_id ) );
+		if ( $t_def['type'] == CUSTOM_FIELD_TYPE_NUMERIC && is_numeric( $t_value ) ) {
+			return excel_prepare_number( $t_value );
 		}
 
-		return excel_prepare_string( string_custom_field_value( $t_def, $t_field_id, $p_issue_id ) );
+		return excel_prepare_string( $t_value );
 	}
 
 	# field is not linked to project
@@ -534,14 +535,13 @@ function excel_format_plugin_column_value( $p_column, BugData $p_bug ) {
 	$t_plugin_columns = columns_get_plugin_columns();
 
 	if( !isset( $t_plugin_columns[$p_column] ) ) {
-		return excel_prepare_string( '' );
+		$t_value = '';
 	} else {
 		$t_column_object = $t_plugin_columns[$p_column];
-		ob_start();
-		$t_column_object->display( $p_bug, COLUMNS_TARGET_EXCEL_PAGE );
-		$t_value = ob_get_clean();
-		return excel_prepare_string( $t_value );
+		$t_value = $t_column_object->value( $p_bug );
 	}
+
+	return excel_prepare_string( $t_value );
 }
 
 /**

--- a/csv_export.php
+++ b/csv_export.php
@@ -148,16 +148,19 @@ do {
 				$t_first_column = false;
 			}
 
-			if( column_get_custom_field_name( $t_column ) !== null || column_is_plugin_column( $t_column ) ) {
-				ob_start();
-				$t_column_value_function = 'print_column_value';
-				helper_call_custom_function( $t_column_value_function, array( $t_column, $t_row, COLUMNS_TARGET_CSV_PAGE ) );
-				$t_value = ob_get_clean();
-
-				echo csv_escape_string( $t_value );
+			$t_custom_field = column_get_custom_field_name( $t_column );
+			if( $t_custom_field !== null ) {
+				echo csv_format_custom_field( $t_row->id, $t_row->project_id, $t_custom_field );
+			} else if( column_is_plugin_column( $t_column ) ) {
+				echo csv_format_plugin_column_value( $t_column, $t_row );
 			} else {
 				$t_function = 'csv_format_' . $t_column;
-				echo $t_function( $t_row );
+				if( function_exists( $t_function ) ) {
+					echo $t_function( $t_row );
+				} else {
+					# Field is unknown
+					echo '';
+				}
 			}
 		}
 

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -147,7 +147,12 @@ do {
 				echo excel_format_plugin_column_value( $t_column, $t_row );
 			} else {
 				$t_function = 'excel_format_' . $t_column;
-				echo $t_function( $t_row );
+				if( function_exists( $t_function ) ) {
+					echo $t_function( $t_row );
+				} else {
+					# field is unknown
+					echo '';
+				}
 			}
 		}
 


### PR DESCRIPTION
The output for CSV and Excel included paragraph html tags which polluted
the output and corrupted Excel output when there are numeric custom fields.

This was caused by calling html processing when getting the value of custom fields.

The fix is to have the retrieval of custom field values not process it for any output
and have the calling code do the appropriate processing. The code also now does
processing based on the custom field type rather than treating types all as string.

Fixes #22428