### PR TITLE
Fixes markdown formating for notes column

### DIFF
--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -534,7 +534,9 @@ function bugnote_get_all_visible_as_string( $p_bug_id, $p_user_bugnote_order, $p
 		$t_note_string .= "\n" . $t_note->note . "\n";
 
 		if ( !empty( $t_output ) ) {
-			$t_output .= "---\n";
+			# Use a marker that doesn't confuse markdown parser.
+			# `---` or `===` would mark previous line as a header.
+			$t_output .= "=-=\n";
 		}
 
 		$t_output .= $t_note_string;


### PR DESCRIPTION
The 3 dashes marked the notes above it as a markdown header.  Fix is to just use a newline.

Fixes #22867

*Before:*

![notes_column_with_markdown](https://cloud.githubusercontent.com/assets/6446/26042784/e0ab3cc4-38ec-11e7-9bae-0ef73dc757d7.png)

*After:*

![notes_column_with_markdown_fix](https://cloud.githubusercontent.com/assets/6446/26042799/02f3ce4a-38ed-11e7-80f3-0d16a774d418.png)
