### PR TITLE
Changes for print_form_button()

### DIFF
--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -426,7 +426,7 @@ while( $t_row = db_fetch_array( $t_result ) ) {
 
 ?>
 <!-- Repeated Info Rows -->
-			<tr>
+			<tr class="visible-on-hover-toggle">
 				<td>
 					<?php echo ($v_user_id == 0) ? lang_get( 'all_users' ) : string_display_line( user_get_name( $v_user_id ) ) ?>
 				</td>
@@ -439,7 +439,7 @@ while( $t_row = db_fetch_array( $t_result ) ) {
 	if( $t_read_write_access ) {
 ?>
 <td class="center">
-	<div class="btn-group inline">
+	<div class="btn-group inline visible-on-hover">
 <?php
 		if( config_can_delete( $v_config_id ) ) {
 			# Update button (will populate edit form at page bottom)

--- a/bugnote_view_inc.php
+++ b/bugnote_view_inc.php
@@ -153,7 +153,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 			$t_time_tracking_hhmm = '';
 		}
 ?>
-<tr class="bugnote" id="c<?php echo $t_activity['id'] ?>">
+<tr class="bugnote visible-on-hover-toggle" id="c<?php echo $t_activity['id'] ?>">
 		<td class="category">
 		<div class="pull-left padding-2"><?php print_avatar( $t_activity['user_id'], 'bugnote', 80 ); ?>
 		</div>
@@ -199,7 +199,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 		?>
 		<div class="clearfix"></div>
 		<div class="space-2"></div>
-		<div class="btn-group-sm">
+		<div class="btn-group visible-on-hover">
 		<?php
 			# show edit button if the user is allowed to edit this bugnote
 			if( $t_activity['can_edit'] ) {

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1401,7 +1401,7 @@ function print_manage_project_sort_link( $p_page, $p_string, $p_field, $p_dir, $
  * @see form_security_token()
  * @return void
  */
-function print_form_button( $p_action_page, $p_label, $p_args_to_post = null, $p_security_token = null, $p_class = '' ) {
+function print_form_button( $p_action_page, $p_label, array $p_args_to_post = null, $p_security_token = null, $p_class = '' ) {
 	$t_form_name = explode( '.php', $p_action_page, 2 );
 	# TODO: ensure all uses of print_button supply arguments via $p_args_to_post (POST)
 	# instead of via $p_action_page (GET). Then only add the CSRF form token if
@@ -1412,18 +1412,14 @@ function print_form_button( $p_action_page, $p_label, $p_args_to_post = null, $p
 		echo form_security_field( $t_form_name[0], $p_security_token );
 	}
 	if( $p_class !== '') {
-		echo '<input type="submit" class="' . $p_class . '" value="', $p_label, '" />';
+		$t_class = $p_class;
 	} else {
-		echo '<input type="submit" class="btn btn-primary btn-xs btn-white btn-round" value="', $p_label, '" />';
+		$t_class = 'btn btn-primary btn-xs btn-white btn-round';
 	}
-
-	if( $p_args_to_post !== null ) {
-		foreach( $p_args_to_post as $t_var => $t_value ) {
-			echo '<input type="hidden" name="' . $t_var .
-				'" value="' . htmlentities( $t_value ) . '" />';
-		}
+	echo '<button type="submit" class="' . $t_class . '">' . $p_label . '</button>';
+	if( $p_args_to_post ) {
+		print_hidden_inputs( $p_args_to_post );
 	}
-
 	echo '</fieldset>';
 	echo '</form>';
 }

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1406,7 +1406,7 @@ function print_form_button( $p_action_page, $p_label, array $p_args_to_post = nu
 	# TODO: ensure all uses of print_button supply arguments via $p_args_to_post (POST)
 	# instead of via $p_action_page (GET). Then only add the CSRF form token if
 	# arguments are being sent via the POST method.
-	echo '<form method="post" action="', htmlspecialchars( $p_action_page ), '" class="form-inline inline">';
+	echo '<form method="post" action="', htmlspecialchars( $p_action_page ), '" class="form-inline inline single-button-form">';
 	echo '<fieldset>';
 	if( $p_security_token !== OFF ) {
 		echo form_security_field( $t_form_name[0], $p_security_token );

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1406,7 +1406,7 @@ function print_form_button( $p_action_page, $p_label, array $p_args_to_post = nu
 	# TODO: ensure all uses of print_button supply arguments via $p_args_to_post (POST)
 	# instead of via $p_action_page (GET). Then only add the CSRF form token if
 	# arguments are being sent via the POST method.
-	echo '<form method="post" action="', htmlspecialchars( $p_action_page ), '" class="form-inline">';
+	echo '<form method="post" action="', htmlspecialchars( $p_action_page ), '" class="form-inline inline">';
 	echo '<fieldset>';
 	if( $p_security_token !== OFF ) {
 		echo form_security_field( $t_form_name[0], $p_security_token );

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -503,6 +503,9 @@ input.typeahead.scrollable ~ .tt-menu {
   margin-bottom: 10px;
 }
 
+.btn-group .single-button-form {
+	margin: 0 1px 0 0;
+}
 
 /* Small devices (tablets, 768px and up) */
 @media (min-width: 768px) {

--- a/js/common.js
+++ b/js/common.js
@@ -378,6 +378,21 @@ $(document).ready( function() {
 	$(document).on('shown.bs.dropdown', '#dropdown_projects_menu', function() {
 		$(this).find(".dropdown-menu li.active a").focus();
 	 });
+
+	/**
+	 * Manage visiblity on hover trigger objects
+	 */
+	if( $('.visible-on-hover-toggle').length ) {
+		$('.visible-on-hover-toggle').hover(
+			function(e){ // handlerIn
+				$(e.currentTarget).find('.visible-on-hover').removeClass('invisible');
+			},
+			function(e){ // handlerOut
+				$(e.currentTarget).find('.visible-on-hover').addClass('invisible');
+			}
+		);
+		$('.visible-on-hover').addClass('invisible');
+	}
 });
 
 function setBugLabel() {


### PR DESCRIPTION
Some proposals for buttons generated from print_form_button(), and buttons layout in general.

- Use `button` tag, instead of `input`, as the former can include icons. We use intensively these buttons in manage pages, one or several in each row of a table. Having the full text for all buttons add clutter to the page, so at some point they could be changed to icons
- Buttons generated from print_form_button() are not inlined by themselves, as they are placed as standalone forms, which have block display style. This does not correspond to the behavoiur of standard button or inputs, which are inline elements by default.
- Buttons generated from print_form_button() does not show spacing between them, whereas standard buttons in a form do have some margin.
- Experiment with a visibility toggle for some manage buttons, when these buttons are used for actions on every row in a table. By making them visible only when hovering on its relevant container, the page may look cleaner.
