### PR TITLE
Fix moving issues with attachments

### DIFF
--- a/core/file_api.php
+++ b/core/file_api.php
@@ -1084,7 +1084,7 @@ function file_move_bug_attachments( $p_bug_id, $p_project_id_to ) {
 			}
 			chmod( $t_disk_file_name_to, config_get( 'attachments_file_permissions' ) );
 			# Don't pop the parameters after query execution since we're in a loop
-			db_query( $t_query_disk_attachment_update, array( db_prepare_string( $t_path_to ), $c_bug_id, (int)$t_row['id'] ), false );
+			db_query( $t_query_disk_attachment_update, array( db_prepare_string( $t_path_to ), $c_bug_id, (int)$t_row['id'] ), -1, -1, false );
 		} else {
 			trigger_error( ERROR_FILE_DUPLICATE, ERROR );
 		}


### PR DESCRIPTION
Add missing parameters to db_query() call from file_move_bug_attachments()

Fixes [#21994](https://mantisbt.org/bugs/view.php?id=21994)
