### PR TITLE
Make `$g_anonymous_account` not case sensitive

### DIFF
--- a/core/user_api.php
+++ b/core/user_api.php
@@ -468,7 +468,7 @@ function user_is_protected( $p_user_id ) {
  * @access public
  */
 function user_is_anonymous( $p_user_id ) {
-	return auth_anonymous_enabled() && user_get_field( $p_user_id, 'username' ) == auth_anonymous_account();
+	return auth_anonymous_enabled() && strcasecmp( user_get_field( $p_user_id, 'username' ), auth_anonymous_account() ) == 0;
 }
 
 /**


### PR DESCRIPTION
If the case of this config option and the username mismatched,
the anonymous access worked, but the login button didn’t causing
normal users to not be able to login or signup.

Fixes #22928