### PR TITLE
Add config parameter to control format of email notifications

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -705,6 +705,12 @@ $g_email_separator2 = str_pad('', 70, '-');
  */
 $g_email_padding_length	= 28;
 
+/**
+ * enable HTML format in emails
+ * @global integer $g_enable_html_email
+ */
+$g_enable_html_email = OFF;
+
 ###########################
 # MantisBT Version String #
 ###########################

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -1300,7 +1300,12 @@ function email_send( EmailData $p_email_data ) {
 			break;
 	}
 
-	$t_mail->IsHTML( false );              # set email format to plain text
+	if( ON == config_get( 'enable_html_email' ) ) {
+		$t_mail->IsHTML( true );              # set email format to HTML
+	} else {
+		$t_mail->IsHTML( false );              # set email format to plain text
+	}
+
 	$t_mail->WordWrap = 80;              # set word wrap to 80 characters
 	$t_mail->CharSet = $t_email_data->metadata['charset'];
 	$t_mail->Host = config_get( 'smtp_host' );


### PR DESCRIPTION
The markdown(MD) format within the plain text email notifications are causing confusions for our non-technical users who heavily depend on emails to know about issues. So we think that converting the MD to HTML in emails may help them greatly. We are working on a plugin which converts markdown text in email notifications to HTML format. Currently only the textarea fields (description, additional information, steps to reproduce, and notes) are converted.

The 'g_enable_html_email` parameter tells PHPMailer that it needs to use text/html as the Content-Type. The default value for this configuration parameter is OFF, so existing plain/text emails won't be affected.

Please review the PR and let us know your feedback.