### PR TITLE
Add option to show summary of issues instead of ID in timeline

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -3618,6 +3618,10 @@ $g_my_view_boxes = array(
  */
 $g_my_view_boxes_fixed_position = ON;
 
+/**
+ * Toggle whether 'Timeline' boxes show summary of issue after issue ID
+ */
+$g_timeline_show_issue_summary = OFF;
 
 #############
 # RSS Feeds #

--- a/core/classes/IssueAssignedTimelineEvent.class.php
+++ b/core/classes/IssueAssignedTimelineEvent.class.php
@@ -49,15 +49,21 @@ class IssueAssignedTimelineEvent extends TimelineEvent {
 	 * @return string
 	 */
 	public function html() {
+		$t_show_summary = config_get( 'timeline_show_issue_summary' );
+		if ( $t_show_summary ) {
+			$t_link = string_get_bug_view_link_with_summary( $this->issue_id );
+		} else {
+			$t_link = string_get_bug_view_link( $this->issue_id );
+		}
 		if( $this->user_id == $this->handler_id ) {
 			$t_html = $this->html_start( 'fa-flag-o' );
-			$t_string = sprintf( lang_get( 'timeline_issue_assigned_to_self' ), user_get_name( $this->user_id ), string_get_bug_view_link( $this->issue_id ) );
+			$t_string = sprintf( lang_get( 'timeline_issue_assigned_to_self' ), user_get_name( $this->user_id ), $t_link );
 		} else if( $this->handler_id != NO_USER ) {
 			$t_html = $this->html_start( 'fa-hand-o-right' );
-			$t_string = sprintf( lang_get( 'timeline_issue_assigned' ), user_get_name( $this->user_id ), string_get_bug_view_link( $this->issue_id ), user_get_name( $this->handler_id ) );
+			$t_string = sprintf( lang_get( 'timeline_issue_assigned' ), user_get_name( $this->user_id ), $t_link, user_get_name( $this->handler_id ) );
 		} else {
             $t_html = $this->html_start( 'fa-flag-o' );
-			$t_string = sprintf( lang_get( 'timeline_issue_unassigned' ), user_get_name( $this->user_id ), string_get_bug_view_link( $this->issue_id ) );
+			$t_string = sprintf( lang_get( 'timeline_issue_unassigned' ), user_get_name( $this->user_id ), $t_link );
 		}
 
 		$t_html .= '<div class="action">' . $t_string . '</div>';

--- a/core/classes/IssueCreatedTimelineEvent.class.php
+++ b/core/classes/IssueCreatedTimelineEvent.class.php
@@ -46,8 +46,14 @@ class IssueCreatedTimelineEvent extends TimelineEvent {
 	 * @return string
 	 */
 	public function html() {
+		$t_show_summary = config_get( 'timeline_show_issue_summary' );
+		if ( $t_show_summary ) {
+			$t_link = string_get_bug_view_link_with_summary( $this->issue_id );
+		} else {
+			$t_link = string_get_bug_view_link( $this->issue_id );
+		}
 		$t_html = $this->html_start( 'fa-plus' );
-		$t_html .= '<div class="action">' . sprintf( lang_get( 'timeline_issue_created' ), user_get_name( $this->user_id ), string_get_bug_view_link( $this->issue_id ) ) . '</div>';
+		$t_html .= '<div class="action">' . sprintf( lang_get( 'timeline_issue_created' ), user_get_name( $this->user_id ), $t_link ) . '</div>';
 		$t_html .= $this->html_end();
 
 		return $t_html;

--- a/core/classes/IssueMonitorTimelineEvent.class.php
+++ b/core/classes/IssueMonitorTimelineEvent.class.php
@@ -49,10 +49,16 @@ class IssueMonitorTimelineEvent extends TimelineEvent {
 	 * @return string
 	 */
 	public function html() {
+		$t_show_summary = config_get( 'timeline_show_issue_summary' );
+		if ( $t_show_summary ) {
+			$t_link = string_get_bug_view_link_with_summary( $this->issue_id );
+		} else {
+			$t_link = string_get_bug_view_link( $this->issue_id );
+		}
 		$t_string = $this->monitor ? lang_get( 'timeline_issue_monitor' ) : lang_get( 'timeline_issue_unmonitor' );
 
 		$t_html = $this->html_start( 'fa-eye' );
-		$t_html .= '<div class="action">' . sprintf( $t_string, user_get_name( $this->user_id ), string_get_bug_view_link( $this->issue_id ) ) . '</div>';
+		$t_html .= '<div class="action">' . sprintf( $t_string, user_get_name( $this->user_id ), $t_link ) . '</div>';
 		$t_html .= $this->html_end();
 
 		return $t_html;

--- a/core/classes/IssueNoteCreatedTimelineEvent.class.php
+++ b/core/classes/IssueNoteCreatedTimelineEvent.class.php
@@ -49,8 +49,14 @@ class IssueNoteCreatedTimelineEvent extends TimelineEvent {
 	 * @return string
 	 */
 	public function html() {
+		$t_show_summary = config_get( 'timeline_show_issue_summary' );
+		if ( $t_show_summary ) {
+			$t_link = string_get_bug_view_link_with_summary( $this->issue_id );
+		} else {
+			$t_link = string_get_bug_view_link( $this->issue_id );
+		}
 		$t_html = $this->html_start( 'fa-comment-o' );
-		$t_html .= '<div class="action">' . sprintf( lang_get( 'timeline_issue_note_created' ), user_get_name( $this->user_id ), string_get_bug_view_link( $this->issue_id ) ) . '</div>';
+		$t_html .= '<div class="action">' . sprintf( lang_get( 'timeline_issue_note_created' ), user_get_name( $this->user_id ), $t_link ) . '</div>';
 		$t_html .= $this->html_end();
 
 		return $t_html;

--- a/core/classes/IssueStatusChangeTimelineEvent.class.php
+++ b/core/classes/IssueStatusChangeTimelineEvent.class.php
@@ -91,13 +91,19 @@ class IssueStatusChangeTimelineEvent extends TimelineEvent {
 	 * @return string
 	 */
 	public function html() {
+		$t_show_summary = config_get( 'timeline_show_issue_summary' );
+		if ( $t_show_summary ) {
+			$t_link = string_get_bug_view_link_with_summary( $this->issue_id );
+		} else {
+			$t_link = string_get_bug_view_link( $this->issue_id );
+		}
 		switch( $this->type ) {
 			case IssueStatusChangeTimelineEvent::RESOLVED:
                 $t_html = $this->html_start( 'fa-thumbs-o-up' );
 				$t_string = sprintf(
 					lang_get( 'timeline_issue_resolved' ),
 					user_get_name( $this->user_id ),
-					string_get_bug_view_link( $this->issue_id )
+					$t_link
 				);
 				break;
 			case IssueStatusChangeTimelineEvent::CLOSED:
@@ -105,7 +111,7 @@ class IssueStatusChangeTimelineEvent extends TimelineEvent {
 				$t_string = sprintf(
 					lang_get( 'timeline_issue_closed' ),
 					user_get_name( $this->user_id ),
-					string_get_bug_view_link( $this->issue_id )
+					$t_link
 				);
 				break;
 			case IssueStatusChangeTimelineEvent::REOPENED:
@@ -113,7 +119,7 @@ class IssueStatusChangeTimelineEvent extends TimelineEvent {
 				$t_string = sprintf(
 					lang_get( 'timeline_issue_reopened' ),
 					user_get_name( $this->user_id ),
-					string_get_bug_view_link( $this->issue_id )
+					$t_link
 				);
 				break;
 			case IssueStatusChangeTimelineEvent::IGNORED:

--- a/core/classes/IssueTagTimelineEvent.class.php
+++ b/core/classes/IssueTagTimelineEvent.class.php
@@ -52,6 +52,12 @@ class IssueTagTimelineEvent extends TimelineEvent {
 	 * @return string
 	 */
 	public function html() {
+		$t_show_summary = config_get( 'timeline_show_issue_summary' );
+		if ( $t_show_summary ) {
+			$t_link = string_get_bug_view_link_with_summary( $this->issue_id );
+		} else {
+			$t_link = string_get_bug_view_link( $this->issue_id );
+		}
 		$t_string = $this->tag ? lang_get( 'timeline_issue_tagged' ) : lang_get( 'timeline_issue_untagged' );
 		$t_tag_row = tag_get_by_name( $this->tag_name );
 
@@ -60,7 +66,7 @@ class IssueTagTimelineEvent extends TimelineEvent {
 			. sprintf(
 				$t_string,
 				user_get_name( $this->user_id ),
-				string_get_bug_view_link( $this->issue_id ),
+				$t_link,
 				$t_tag_row ? tag_get_link( $t_tag_row ) : $this->tag_name
 			)
 			. '</div>';

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -677,6 +677,41 @@ function string_get_bug_view_link( $p_bug_id, $p_detail_info = true, $p_fqdn = f
 /**
  * return an href anchor that links to a bug VIEW page for the given bug
  * @param integer $p_bug_id      A bug identifier.
+ * @param boolean $p_detail_info Whether to include more detailed information (e.g. title attribute / project) in the returned string.
+ * @param boolean $p_fqdn        Whether to return an absolute or relative link.
+ * @return string
+ */
+function string_get_bug_view_link_with_summary( $p_bug_id, $p_detail_info = true, $p_fqdn = false ) {
+	if( bug_exists( $p_bug_id ) ) {
+		$t_link = '<a href="';
+		if( $p_fqdn ) {
+			$t_link .= config_get_global( 'path' );
+		} else {
+			$t_link .= config_get_global( 'short_path' );
+		}
+		$t_link .= string_get_bug_view_url( $p_bug_id ) . '"';
+		if( $p_detail_info ) {
+			$t_summary = string_attribute( bug_get_field( $p_bug_id, 'summary' ) );
+			$t_project_id = bug_get_field( $p_bug_id, 'project_id' );
+			$t_status = string_attribute( get_enum_element( 'status', bug_get_field( $p_bug_id, 'status' ), $t_project_id ) );
+			$t_link .= ' title="' . bug_format_id( $p_bug_id ) . ': [' . $t_status . '] ' . $t_summary . '"';
+
+			$t_resolved = bug_get_field( $p_bug_id, 'status' ) >= config_get( 'bug_resolved_status_threshold', null, null, $t_project_id );
+			if( $t_resolved ) {
+				$t_link .= ' class="resolved"';
+			}
+		}
+		$t_link .= '>' . $t_summary . '</a>';
+	} else {
+		$t_link = bug_format_id( $p_bug_id );
+	}
+
+	return $t_link;
+}
+
+/**
+ * return an href anchor that links to a bug VIEW page for the given bug
+ * @param integer $p_bug_id      A bug identifier.
  * @param integer $p_bugnote_id  A bugnote identifier.
  * @param boolean $p_detail_info Whether to include more detailed information (e.g. title attribute / project) in the returned string.
  * @param boolean $p_fqdn        Whether to return an absolute or relative link.


### PR DESCRIPTION
It was hard for our team to know which issue was updated by just reading the issue IDs in timeline. We needed to mouse over each ID to see the summary and recognized the issue. I have added an option to change the IDs in timeline to summary of issues. Hope this can help someone has a similar need.

The changes are summarize as:

1. A new function *string_get_bug_view_link_with_summary()* is created. This function return a hyperlink to issue with summary as text.
2. And a new configuration *$g_timeline_show_issue_summary* is created. In order to change timeline display the summary in issue links.
3. Every derived TimelineEvent class reads the configuration and call the *string_get_bug_view_link_with_summary()* or *the original string_get_bug_view_link()*