### PR TITLE
Fix HTML syntax error

### DIFF
--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -340,7 +340,7 @@ if( $t_show_reporter || $t_show_handler || $t_show_due_date ) {
 			}
 			echo '<input ' . helper_get_tab_index() . ' type="text" id="due_date" name="due_date" class="datetimepicker input-sm" size="16" ' .
 				'data-picker-locale="' . lang_get_current_datetime_locale() .  '" data-picker-format="' . config_get( 'datetime_picker_format' ) . '" ' .
-				'" maxlength="16" value="' . $t_date_to_display . '" />';
+				'maxlength="16" value="' . $t_date_to_display . '" />';
 			echo '<i class="fa fa-calendar fa-xlg datetimepicker"></i>';
 		} else {
 			if( !date_is_null( $t_bug->due_date ) ) {


### PR DESCRIPTION
470adca85fd8d004068f97b29ef94625041ed094 left a single `"` that was causing display errors on some browsers. I removed it. 