### PR TITLE
Fixed #23136 Added new event to change email content-type

### DIFF
--- a/core/email_api.php
+++ b/core/email_api.php
@@ -1300,7 +1300,8 @@ function email_send( EmailData $p_email_data ) {
 			break;
 	}
 
-	$t_mail->IsHTML( false );              # set email format to plain text
+	# default email format is plain text
+	$t_mail->IsHTML( event_signal( 'EVENT_EMAIL_HTML_CONTENT' ) );	# default email format is plain text
 	$t_mail->WordWrap = 80;              # set word wrap to 80 characters
 	$t_mail->CharSet = $t_email_data->metadata['charset'];
 	$t_mail->Host = config_get( 'smtp_host' );

--- a/core/events_inc.php
+++ b/core/events_inc.php
@@ -149,4 +149,8 @@ event_declare_many( array(
 
 	# Authentication Events
 	'EVENT_AUTH_USER_FLAGS' => EVENT_TYPE_FIRST,
+
+	# Email Events
+	# Enable HTML Content-Type in email notifications
+	'EVENT_EMAIL_HTML_CONTENT' => EVENT_TYPE_CHAIN,
 ) );


### PR DESCRIPTION
Added a chain type event to modify the content-type of email notifications. This may help plugin developers to send HTML mails.

This is not a standalone event, and it may need another event to change the email body format. This is work in progress.

Please review and let me know your feedback.

