### PR TITLE
Remove generation of unused CSS code

### DIFF
--- a/css/status_config.php
+++ b/css/status_config.php
@@ -81,7 +81,6 @@ switch( $t_referer_page ) {
 $t_status_string = config_get( 'status_enum_string' );
 $t_statuses = MantisEnum::getAssocArrayIndexedByValues( $t_status_string );
 $t_colors = config_get( 'status_colors' );
-$t_status_percents = auth_is_user_authenticated() ? get_percentage_by_status() : array();
 
 foreach( $t_statuses as $t_id => $t_label ) {
 	$t_css_class = html_get_status_css_class( $t_id );
@@ -90,12 +89,6 @@ foreach( $t_statuses as $t_id => $t_label ) {
 	if( array_key_exists( $t_label, $t_colors ) ) {
 		echo '.' . $t_css_class
 			. " { color: {$t_colors[$t_label]}; background-color: {$t_colors[$t_label]}; }\n";
-	}
-
-	# Status percentage width class
-	if( array_key_exists( $t_id, $t_status_percents ) ) {
-		echo '.' . str_replace( 'color', 'percentage', $t_css_class )
-			. " { width: {$t_status_percents[$t_id]}%; }\n";
 	}
 }
 


### PR DESCRIPTION
The following kind of CSS is no longer need since
status_percentage_legend has been obsoleted.

.status-10-percentage { width: 11%; }

Fixes #23141

I didn't remove function get_percentage_by_status() for the moment as we might need it for other purposes (e.g. enhancements on summary page, ...)
