### PR TITLE
Remove unused code and generation of unused CSS code

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -4513,7 +4513,6 @@ $g_public_config_names = array(
 	'status_enum_string',
 	'status_enum_workflow',
 	'status_icon_arr',
-	'status_legend_position',
 	'stop_on_errors',
 	'store_reminders',
 	'stored_query_create_shared_threshold',

--- a/css/status_config.php
+++ b/css/status_config.php
@@ -91,8 +91,3 @@ foreach( $t_statuses as $t_id => $t_label ) {
 			. " { color: {$t_colors[$t_label]}; background-color: {$t_colors[$t_label]}; }\n";
 	}
 }
-
-# Status legend width class
-$t_color_count = count( $t_colors );
-$t_color_width = ( $t_color_count > 0 ? ( round( 100/$t_color_count ) ) : 0 );
-echo ".status-legend-width { width: $t_color_width%; }\n";


### PR DESCRIPTION
The following kind of CSS is no longer needed since status legend
and status_legend_position have been obsoleted.

.status-legend-width { width: 14%; }

Fixes #23150