### PR TITLE
Fixed #23157: phpMailer SMTP Verify Peer

### DIFF
--- a/config/config_inc.php.sample
+++ b/config/config_inc.php.sample
@@ -51,9 +51,15 @@ $g_anonymous_account		= '';
 
 # --- Email Configuration ---
 $g_phpMailer_method		= PHPMAILER_METHOD_MAIL; # or PHPMAILER_METHOD_SMTP, PHPMAILER_METHOD_SENDMAIL
-$g_smtp_host			= 'localhost';			# used with PHPMAILER_METHOD_SMTP
-$g_smtp_username		= '';					# used with PHPMAILER_METHOD_SMTP
-$g_smtp_password		= '';					# used with PHPMAILER_METHOD_SMTP
+
+# used with PHPMAILER_METHOD_SMTP
+$g_smtp_host			= 'localhost';
+$g_smtp_username		= '';
+$g_smtp_password		= '';
+# $g_smtp_connection_mode = ''; # Valid values are '' (no encryption), 'ssl' or 'tls'
+# $g_smtp_port = 25; # default unencrypted: 25  default tls: 587
+# $g_smtp_ssl_verify_peer = true; # Can be set to false to allow self-signed certs from mail server.
+
 $g_webmaster_email      = 'webmaster@example.com';
 $g_from_email           = 'noreply@example.com';	# the "From: " field in emails
 $g_return_path_email    = 'admin@example.com';	# the return address for bounced mail

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -680,6 +680,14 @@ $g_smtp_connection_mode = '';
  */
 $g_smtp_port = 25;
 
+/** 
+ * When sending e-mail via ssl or tls, the mail server you are sending to may be
+ * using a self-signed certificate. If so then you must set this value to false
+ * otherwise mantis will silently fail to send your e-mails.
+ * @global bool $g_smtp_ssl_verify_peer
+ */
+$g_smtp_ssl_verify_peer = true;
+
 /**
  * It is recommended to use a cronjob or a scheduler task to send emails. The
  * cronjob should typically run every 5 minutes.  If no cronjob is used,then

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -1293,6 +1293,13 @@ function email_send( EmailData $p_email_data ) {
 			}
 			else {
 				$t_mail->SMTPSecure = config_get( 'smtp_connection_mode' );
+					
+				// Specify additonal options for ssl/tls protocols.
+				$t_mail->SMTPOptions = array (
+					'ssl' => array(
+						'verify_peer' => config_get( 'smtp_ssl_verify_peer' )
+					)
+				);
 			}
 
 			$t_mail->Port = config_get( 'smtp_port' );


### PR DESCRIPTION
This will add an additional config option for sending ssl/tls smtp e-mails in php 5.6.