### PR TITLE
Show file added event in timeline

### DIFF
--- a/core/classes/IssueFileAddedTimelineEvent.class.php
+++ b/core/classes/IssueFileAddedTimelineEvent.class.php
@@ -1,0 +1,58 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Timeline event class for adding files to issues.
+ * @copyright Copyright 2014 MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ * @package MantisBT
+ */
+
+/**
+ * Timeline event class for creation of issues.
+ *
+ * @package MantisBT
+ * @subpackage classes
+ */
+class IssueFileAddedTimelineEvent extends TimelineEvent {
+	private $issue_id;
+
+	/**
+	 * @param integer $p_timestamp Timestamp representing the time the event occurred.
+	 * @param integer $p_user_id   An user identifier.
+	 * @param integer $p_issue_id  A issue identifier.
+	 */
+	public function __construct( $p_timestamp, $p_user_id, $p_issue_id ) {
+		parent::__construct( $p_timestamp, $p_user_id );
+
+		$this->issue_id = $p_issue_id;
+	}
+
+	/**
+	 * Returns html string to display
+	 * @return string
+	 */
+	public function html() {
+		$t_show_summary = config_get( 'timeline_show_issue_summary' );
+		$t_link = string_get_bug_view_link( $this->issue_id, true, false, $t_show_summary );
+		
+		$t_html = $this->html_start( 'fa-plus' );
+		$t_html .= '<div class="action">' . sprintf( lang_get( 'timeline_issue_file_added' ), user_get_name( $this->user_id ), $t_link ) . '</div>';
+		$t_html .= $this->html_end();
+
+		return $t_html;
+	}
+}

--- a/core/classes/IssueFileAddedTimelineEvent.class.php
+++ b/core/classes/IssueFileAddedTimelineEvent.class.php
@@ -46,8 +46,7 @@ class IssueFileAddedTimelineEvent extends TimelineEvent {
 	 * @return string
 	 */
 	public function html() {
-		$t_show_summary = config_get( 'timeline_show_issue_summary' );
-		$t_link = string_get_bug_view_link( $this->issue_id, true, false, $t_show_summary );
+		$t_link = string_get_bug_view_link( $this->issue_id );
 		
 		$t_html = $this->html_start( 'fa-plus' );
 		$t_html .= '<div class="action">' . sprintf( lang_get( 'timeline_issue_file_added' ), user_get_name( $this->user_id ), $t_link ) . '</div>';

--- a/core/timeline_api.php
+++ b/core/timeline_api.php
@@ -60,21 +60,22 @@ function timeline_events( $p_start_time, $p_end_time, $p_max_events, $p_filter =
 	$t_previous_history_event = null;
 	while ( $t_history_event = history_get_event_from_row( $t_result, /* $p_user_id */ auth_get_current_user_id(), /* $p_check_access_to_issue */ true ) ) {
 		$t_event = null;
-		$t_user_id = $t_history_event['userid'];
+		$t_user_id = (int)$t_history_event['userid'];
 		$t_timestamp = $t_history_event['date'];
 		$t_issue_id = $t_history_event['bug_id'];
+		$t_type = $t_history_event['type'];
 
 		if ( $t_previous_history_event != null ) {  //check repeated event
-			if (    $t_previous_history_event['userid'] == $t_history_event['userid']
-				 && $t_previous_history_event['date'] == $t_history_event['date']
-				 && $t_previous_history_event['bug_id'] == $t_history_event['bug_id']
-				 && $t_previous_history_event['type'] == $t_history_event['type']	
+			if (    $t_previous_history_event['userid'] == $t_user_id
+				 && $t_previous_history_event['date'] == $t_timestamp
+				 && $t_previous_history_event['bug_id'] == $t_issue_id
+				 && $t_previous_history_event['type'] == $t_type
 			) {
 				continue;
 			}
 		}
 		
-		switch( $t_history_event['type'] ) {
+		switch( $t_type ) {
 			case NEW_BUG:
 				$t_event = new IssueCreatedTimelineEvent( $t_timestamp, $t_user_id, $t_issue_id );
 				break;
@@ -85,14 +86,14 @@ function timeline_events( $p_start_time, $p_end_time, $p_max_events, $p_filter =
 			case BUG_MONITOR:
 				# Skip monitors added for others due to reminders, only add monitor events where added
 				# user is the same as the logged in user.
-				if( (int)$t_history_event['old_value'] == (int)$t_history_event['userid'] ) {
+				if( (int)$t_history_event['old_value'] == $t_user_id ) {
 					$t_event = new IssueMonitorTimelineEvent( $t_timestamp, $t_user_id, $t_issue_id, true );
 				}
 				break;
 			case BUG_UNMONITOR:
 				# Skip removing other users from monitoring list, only add unmonitor events where removed
 				# user is the same as the logged in user.
-				if( (int)$t_history_event['old_value'] == (int)$t_history_event['userid'] ) {
+				if( (int)$t_history_event['old_value'] == $t_user_id ) {
 					$t_event = new IssueMonitorTimelineEvent( $t_timestamp, $t_user_id, $t_issue_id, false );
 				}
 				break;

--- a/core/timeline_api.php
+++ b/core/timeline_api.php
@@ -65,10 +65,11 @@ function timeline_events( $p_start_time, $p_end_time, $p_max_events, $p_filter =
 		$t_issue_id = $t_history_event['bug_id'];
 
 		if ( $t_previous_history_event != null ) {  //check repeated event
-			if ( $t_previous_history_event['userid'] == $t_history_event['userid'] &&
-				 $t_previous_history_event['date'] == $t_history_event['date'] &&
-				 $t_previous_history_event['bug_id'] == $t_history_event['bug_id'] &&
-				 $t_previous_history_event['type'] == $t_history_event['type']	) {
+			if (    $t_previous_history_event['userid'] == $t_history_event['userid']
+				 && $t_previous_history_event['date'] == $t_history_event['date']
+				 && $t_previous_history_event['bug_id'] == $t_history_event['bug_id']
+				 && $t_previous_history_event['type'] == $t_history_event['type']	
+			) {
 				continue;
 			}
 		}

--- a/core/timeline_api.php
+++ b/core/timeline_api.php
@@ -113,8 +113,7 @@ function timeline_events( $p_start_time, $p_end_time, $p_max_events, $p_filter =
 				}
 				break;
 			case FILE_ADDED:
- 				$t_bugnote_id = $t_history_event['old_value'];
-				$t_event = new IssueFileAddedTimelineEvent( $t_timestamp, $t_user_id, $t_issue_id, $t_bugnote_id );
+				$t_event = new IssueFileAddedTimelineEvent( $t_timestamp, $t_user_id, $t_issue_id );
  				break;
 		}
 

--- a/lang/strings_chinese_traditional.txt
+++ b/lang/strings_chinese_traditional.txt
@@ -1230,6 +1230,7 @@ $s_month_october = '10 月';
 $s_month_november = '11 月';
 $s_month_december = '12 月';
 $s_timeline_issue_created = '<span class="username">%1$s</span> 已建立問題 <span class="issue_id">%2$s</span>';
+$s_timeline_issue_file_added = '<span class="username">%1$s</span> 已新增檔案於議題 <span class="issue_id">%2$s</span>';
 $s_timeline_issue_note_created = '<span class="username">%1$s</span> 已說明問題 <span class="issue_id">%2$s</span>';
 $s_timeline_issue_monitor = '<span class="username">%1$s</span> 正在監視問題 <span class="issue_id">%2$s</span>';
 $s_timeline_issue_unmonitor = '<span class="username">%1$s</span> 停止監視問題 <span class="issue_id">%2$s</span>';

--- a/lang/strings_chinese_traditional.txt
+++ b/lang/strings_chinese_traditional.txt
@@ -1230,7 +1230,6 @@ $s_month_october = '10 月';
 $s_month_november = '11 月';
 $s_month_december = '12 月';
 $s_timeline_issue_created = '<span class="username">%1$s</span> 已建立問題 <span class="issue_id">%2$s</span>';
-$s_timeline_issue_file_added = '<span class="username">%1$s</span> 已新增檔案於議題 <span class="issue_id">%2$s</span>';
 $s_timeline_issue_note_created = '<span class="username">%1$s</span> 已說明問題 <span class="issue_id">%2$s</span>';
 $s_timeline_issue_monitor = '<span class="username">%1$s</span> 正在監視問題 <span class="issue_id">%2$s</span>';
 $s_timeline_issue_unmonitor = '<span class="username">%1$s</span> 停止監視問題 <span class="issue_id">%2$s</span>';

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1592,6 +1592,7 @@ $s_month_december = 'December';
 
 # Timeline Feature Strings
 $s_timeline_issue_created = '<span class="username">%1$s</span> created issue <span class="issue_id">%2$s</span>';
+$s_timeline_issue_file_added = '<span class="username">%1$s</span> added attachment in issue <span class="issue_id">%2$s</span>';
 $s_timeline_issue_note_created = '<span class="username">%1$s</span> commented on issue <span class="issue_id">%2$s</span>';
 $s_timeline_issue_monitor = '<span class="username">%1$s</span> is monitoring issue <span class="issue_id">%2$s</span>';
 $s_timeline_issue_unmonitor = '<span class="username">%1$s</span> stopped monitoring issue <span class="issue_id">%2$s</span>';

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1592,7 +1592,7 @@ $s_month_december = 'December';
 
 # Timeline Feature Strings
 $s_timeline_issue_created = '<span class="username">%1$s</span> created issue <span class="issue_id">%2$s</span>';
-$s_timeline_issue_file_added = '<span class="username">%1$s</span> added attachment in issue <span class="issue_id">%2$s</span>';
+$s_timeline_issue_file_added = '<span class="username">%1$s</span> added attachment(s) to issue <span class="issue_id">%2$s</span>';
 $s_timeline_issue_note_created = '<span class="username">%1$s</span> commented on issue <span class="issue_id">%2$s</span>';
 $s_timeline_issue_monitor = '<span class="username">%1$s</span> is monitoring issue <span class="issue_id">%2$s</span>';
 $s_timeline_issue_unmonitor = '<span class="username">%1$s</span> stopped monitoring issue <span class="issue_id">%2$s</span>';


### PR DESCRIPTION
Add an new event

I had added a new event for class TimelineEevent. In order to show events for file added in issue in the timeline.

Also I prevent events that have same issue id, user id, event type, and timestamp to show multiple times in timeline. Such that when multiple files are added to issue at a time. There will be only one timeline event for this.

A new item $s_timeline_issue_file_added is introduce in the language file. But I am only able to add the translation for English and Traditional Chinese.