### PR TITLE
21225 close parent with unresolved children

### DIFF
--- a/bug_update.php
+++ b/bug_update.php
@@ -169,7 +169,13 @@ if ( !$t_reporter_reopening && !$t_reporter_closing ) {
 if( ( $t_resolve_issue || $t_close_issue ) &&
 	!relationship_can_resolve_bug( $f_bug_id )
 ) {
-	trigger_error( ERROR_BUG_RESOLVE_DEPENDANTS_BLOCKING, ERROR );
+
+	# this may be overridden with configuration to allow parents to close regardless of
+	# the status of any children
+	if ( OFF == config_get( 'allow_parent_of_unresolved_to_close' ) ) {
+		# retrieve all the relationships in which the bug is the source bug
+		trigger_error( ERROR_BUG_RESOLVE_DEPENDANTS_BLOCKING, ERROR );
+	}
 }
 
 # Validate any change to the status of the issue.

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -1317,6 +1317,13 @@ $g_default_bug_eta = ETA_NONE;
 $g_default_bug_relationship_clone = BUG_REL_NONE;
 
 /**
+ * Allow parent bug to close regardless of child status.  This defaults to OFF
+ * to preserve current functionality.
+ * @global integer $g_allow_parent_of_unresolved_to_close
+ */
+$g_allow_parent_of_unresolved_to_close = OFF;
+
+/**
  * Default for new bug relationships
  * @global integer $g_default_bug_relationship
  */
@@ -4228,6 +4235,7 @@ $g_public_config_names = array(
 	'allow_file_upload',
 	'allow_freetext_in_profile_fields',
 	'allow_no_category',
+        'allow_parent_of_unresolved_to_close',
 	'allow_permanent_cookie',
 	'allow_reporter_close',
 	'allow_reporter_reopen',

--- a/docbook/Admin_Guide/en-US/config/status.xml
+++ b/docbook/Admin_Guide/en-US/config/status.xml
@@ -228,6 +228,15 @@
 				</para>
 			</listitem>
 		</varlistentry>
+		<varlistentry>
+			<term>$g_allow_parent_of_unresolved_to_close</term>
+			<listitem>
+				<para>If set, no check is performed on the status of a bug's children,
+					which allows the parent to be closed whether or not the children
+					have been resolved. The default is OFF.
+				</para>
+			</listitem>
+		</varlistentry>
 	</variablelist>
 
 	<para>See also:


### PR DESCRIPTION
Allow parent bug to close regardless of child status.  This defaults to OFF to preserve current functionality.

Courtesy of Game Creek Video.