### PR TITLE
AJAX: Send HTTP 500 error for invalid entry point

### DIFF
--- a/xmlhttprequest.php
+++ b/xmlhttprequest.php
@@ -43,6 +43,12 @@ if( function_exists( $t_function ) ) {
 	log_event( LOG_AJAX, 'DEPRECATED: Calling {' . $t_function . '}. Use REST API instead.' );
 	call_user_func( $t_function );
 } else {
-	log_event( LOG_AJAX, 'Unknown function for entry point = ' . $t_function );
-	echo 'unknown entry point';
+	$t_msg = 'Unknown function for entry point: ' . $t_function;
+	log_event( LOG_AJAX, $t_msg );
+	header(
+		'HTTP/1.1 ' . HTTP_STATUS_BAD_REQUEST . ' ' . $t_msg,
+		false,
+		HTTP_STATUS_BAD_REQUEST
+	);
+	echo string_attribute( $t_msg );
 }


### PR DESCRIPTION
Sending an HTTP error code back to the caller instead of simply some
outputting arbitrary text message ensures that the client call actually
fails, without relying on failure being caused by mismatch in output
type, or detecting the error by parsing the output.

Fixes [#23184](https://mantisbt.org/bugs/view.php?id=23184)