### PR TITLE
Fixes #19368 - If a float custom field is empty, display it as an emp…

### DIFF
--- a/core/cfdefs/cfdef_standard.php
+++ b/core/cfdefs/cfdef_standard.php
@@ -210,7 +210,7 @@ function cfdef_print_textarea( $p_value ) {
  * @param string $p_value The custom field value.
  */
 function cfdef_print_numeric( $p_value ) {
-	echo (int)$p_value;
+	echo is_numeric( $p_value ) ? (int)$p_value : '';
 }
 
 /**
@@ -218,7 +218,7 @@ function cfdef_print_numeric( $p_value ) {
  * @param string $p_value The custom field value.
  */
 function cfdef_print_float( $p_value ) {
-	echo (float)$p_value;
+	echo is_numeric( $p_value ) ? (float)$p_value : '';
 }
 
 /**


### PR DESCRIPTION
…ty string, rather than zero.  Courtesy of Game Creek Video.