### PR TITLE
Check if admin dir has been disabled via .htaccess

### DIFF
--- a/login_page.php
+++ b/login_page.php
@@ -141,11 +141,22 @@ $t_warnings = array();
 $t_upgrade_required = false;
 
 if( config_get_global( 'admin_checks' ) == ON ) {
-	# Check if the admin directory is accessible
-	$t_admin_dir = dirname( __FILE__ ) . '/admin';
-	$t_admin_dir_is_accessible = @file_exists( $t_admin_dir . '/.' );
+	# Check if admin directory is accessible as URL by retrieving HTTP headers.
+	# Note: using file_get_contents is faster than get_headers() which does a
+	# GET by default, and avoids changing the default stream context.
+	$t_admin_url = config_get_global('path') . 'admin/';
+	$context = stream_context_create( array(
+		'http' => array( 'method' => 'HEAD', 'follow_location' => 0 )
+	) );
+	@file_get_contents($t_admin_url, NULL, $context );
+	$t_admin_dir_is_accessible = strpos( $http_response_header[0], '200' ) !== false;
+
 	if( $t_admin_dir_is_accessible ) {
 		$t_warnings[] = lang_get( 'warning_admin_directory_present' );
+	} else {
+		# Check if admin directory is accessible at filesystem level
+		$t_admin_dir = dirname( __FILE__ ) . '/admin';
+		$t_admin_dir_is_accessible = @file_exists( $t_admin_dir . '/.' );
 	}
 
 	# Generate a warning if default user administrator/root is valid.


### PR DESCRIPTION
Verifies if the directory is accessible by retrieving the HTTP headers
via a HEAD request and checking the HTTP status code instead of checking
if it can be read at filesystem level.

Fixes [#23211](http://www.mantisbt.org/bugs/view.php?id=23211)