### PR TITLE
Make tag view threshold work at project level

### DIFF
--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -176,7 +176,7 @@ $t_date_submitted = $t_show_date_submitted ? date( config_get( 'normal_date_form
 $t_show_last_updated = in_array( 'last_updated', $t_fields );
 $t_last_updated = $t_show_last_updated ? date( config_get( 'normal_date_format' ), $t_bug->last_updated ) : '';
 
-$t_show_tags = in_array( 'tags', $t_fields ) && access_has_global_level( config_get( 'tag_view_threshold' ) );
+$t_show_tags = in_array( 'tags', $t_fields ) && access_has_bug_level( config_get( 'tag_view_threshold' ), $t_bug_id );
 
 $t_bug_overdue = bug_is_overdue( $f_bug_id );
 

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1999,16 +1999,12 @@ function filter_get_bug_rows_query_clauses( array $p_filter, $p_project_id = nul
 
 	# tags
 	$c_tag_string = trim( $t_filter[FILTER_PROPERTY_TAG_STRING] );
-	$c_tag_select = trim( $t_filter[FILTER_PROPERTY_TAG_SELECT] );
-	if( is_blank( $c_tag_string ) && !is_blank( $c_tag_select ) && $c_tag_select != 0 && tag_exists( $c_tag_select ) ) {
-		$t_tag = tag_get( $c_tag_select );
-		$c_tag_string = $t_tag['name'];
-	}
+	$c_tag_select = (int)$t_filter[FILTER_PROPERTY_TAG_SELECT];
 
-	if( !is_blank( $c_tag_string ) ) {
+	if( !is_blank( $c_tag_string ) || $c_tag_select > 0 ) {
 		$t_tags = tag_parse_filters( $c_tag_string );
 
-		if( count( $t_tags ) ) {
+		if( count( $t_tags ) || $c_tag_select > 0 ) {
 
 			$t_projects_can_view_tags = access_project_array_filter( 'tag_view_threshold', $t_included_project_ids, $t_user_id );
 			if( !empty( $t_projects_can_view_tags ) ) {
@@ -2038,8 +2034,9 @@ function filter_get_bug_rows_query_clauses( array $p_filter, $p_project_id = nul
 					}
 				}
 
-				if( 0 < $t_filter[FILTER_PROPERTY_TAG_SELECT] && tag_exists( $t_filter[FILTER_PROPERTY_TAG_SELECT] ) ) {
-					$t_tags_any[] = tag_get( $t_filter[FILTER_PROPERTY_TAG_SELECT] );
+				# Add the tag id to the array, from filter field "tag_select"
+				if( 0 < $c_tag_select && tag_exists( $c_tag_select ) ) {
+					$t_tags_any[] = tag_get( $c_tag_select );
 				}
 
 				$t_tag_counter = 0;

--- a/core/filter_form_api.php
+++ b/core/filter_form_api.php
@@ -84,7 +84,7 @@ require_api( 'user_api.php' );
  * if the option is disabled, returns the current value and a hidden input for that value.
  * @param array $p_filter Filter array
  * @param string $p_filter_target Filter field name
- * @param boolean $p_show_inputs Whether to return a visible form input or a text value.
+ * @param boolean $p_show_inputs True to return a visible form input or false for a text value.
  * @return string The html content for the field requested
  */
 function filter_form_get_input( array $p_filter, $p_filter_target, $p_show_inputs = true ) {
@@ -1584,7 +1584,7 @@ function print_filter_values_tag_string( array $p_filter ) {
  */
 function print_filter_tag_string( array $p_filter = null ) {
 	global $g_filter;
-	if( !access_has_global_level( config_get( 'tag_view_threshold' ) ) ) {
+	if( !access_has_project_level( config_get( 'tag_view_threshold' ) ) ) {
 		return;
 	}
 	if( null === $p_filter ) {
@@ -2595,7 +2595,7 @@ function filter_form_draw_inputs( $p_filter, $p_for_screen = true, $p_static = f
 			null /* class */,
 			'relationship_type_filter_target' /* content id */
 			));
-	if( access_has_global_level( config_get( 'tag_view_threshold' ) ) ) {
+	if( access_has_project_level( config_get( 'tag_view_threshold' ) ) ) {
 		$t_row3->add_item( new TableFieldsItem(
 				$get_field_header( 'tag_string_filter', lang_get( 'tags' ) ),
 				filter_form_get_input( $t_filter, 'tag_string', $t_show_inputs ),


### PR DESCRIPTION
The part about filtering requires more work, as the query clauses needed to be rewritten to account for proper visibility.

commit f0a92c0ae58574aae44ca7d971d48809bf82ea31

    Check bug permissions to show tags
    
    Check for bug access level, instead of global, to show tags in bug view
    page.
    
    Fixes: #23216

commit e5743f4532b1dd5dd7fc6e4c08e6349b6da96421

    Check project level to show tags in filter
    
    Check project level, instead of global level, to show tags in the filter
    form.
    
    Fixes: #23216

commit 1e6fe3929a9a5c641ef4c1f522f5108fc189b4cd

    Refactor tags filter query
    
    Modify the query clauses to use JOINs.

commit 11e5c025ba0e03b4d65190e305d7c37f37ff21e0

    Refactor calculate included projects for filter
    
    Move the logic to calculate all the individual projects included in the
    filter search, into a separate function, to allow for reuse.

commit f3210ccd4263770ee159d20a6ea871ef9736219c

    Refactor access_has_any_project_level()
    
    Refactor access_has_any_project_level() with a more detailed access
    check function, that can return an array of projects that match the
    requested access.

commit 3b6deb2ef27c5e2df4c75d8421ba6e3cddb16897

    Use tag view permission in filter query
    
    Account for permissions in each project in the filter scope,
    to match tags only on those with proper access to view tags.
    
    Fixes: #23216
commit f9cfce73fede39f52949a3dc22e3f58743176443

    Fix query for related tags
    
    Refactor the related tags function to use a filter search for the tag,
    leaving the rd work for access and visibility checks to the filter api.
    
    Previous query was not correct as it was comparing project access level
    with bug view state. Also, it didn't account for view tags permissions
    for each project.
    
    Fixes: #21913

commit 95f0f381becb7fced6a980f1d6dbfc21615d656c

    Fix duplicated caluses for tags filter query
    
    Fix duplicating the filter query clauses when the filter field "tag
    select" is provided.


