### PR TITLE
Cache all needed projects for navbar layout

### DIFF
--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1492,6 +1492,8 @@ function filter_get_bug_rows_query_clauses( array $p_filter, $p_project_id = nul
 		$t_private_and_public_project_ids = array();
 		$t_limited_projects = array();
 
+		# make sure the project rows are cached, as they will be used to check access levels.
+		project_cache_array_rows( $t_project_ids );
 		foreach( $t_project_ids as $t_pid ) {
 			# limit reporters to visible projects
 			if( ( ON === $t_limit_reporters ) && ( !access_has_project_level( access_threshold_min_level( config_get( 'report_bug_threshold', null, $t_user_id, $t_pid ) ) + 1, $t_pid, $t_user_id ) ) ) {

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -615,9 +615,13 @@ function layout_navbar_button_bar() {
  */
 function layout_navbar_projects_list( $p_project_id = null, $p_include_all_projects = true, $p_filter_project_id = null, $p_trace = false, $p_can_report_only = false ) {
 	$t_user_id = auth_get_current_user_id();
+
+	# Cache all needed projects
+	project_cache_array_rows( user_get_all_accessible_projects( $t_user_id ) );
+
+	# Get top level projects
 	$t_project_ids = user_get_accessible_projects( $t_user_id );
 	$t_can_report = true;
-	project_cache_array_rows( $t_project_ids );
 
 	if( $p_include_all_projects && $p_filter_project_id !== ALL_PROJECTS ) {
 		echo ALL_PROJECTS == $p_project_id ? '<li class="active">' : '<li>';


### PR DESCRIPTION
Reduce DB query count by caching all needed projects for the navbar layout.

Fixes: #23237

After:
![seleccion_231](https://user-images.githubusercontent.com/14123811/29414021-b11cc79a-835e-11e7-8e2f-6598f4a3f2e4.png)

Before:
![seleccion_230](https://user-images.githubusercontent.com/14123811/29414033-b8c346e0-835e-11e7-8046-d1d30de74cae.png)

