### PR TITLE
Fix timetracking report with no category

### DIFF
--- a/core/billing_api.php
+++ b/core/billing_api.php
@@ -96,10 +96,13 @@ function billing_get_for_project( $p_project_id, $p_from, $p_to, $p_cost_per_hou
 
 	$t_query = 'SELECT bn.id id, bn.time_tracking minutes, bn.date_submitted as date_submitted, bnt.note note,
 			u.realname realname, b.project_id project_id, c.name bug_category, b.summary bug_summary, bn.bug_id bug_id, bn.reporter_id reporter_id
-			FROM {user} u, {bugnote} bn, {bug} b, {bugnote_text} bnt, {category} c
-			WHERE u.id = bn.reporter_id AND bn.time_tracking != 0 AND bn.bug_id = b.id AND bnt.id = bn.bugnote_text_id AND c.id=b.category_id
-			' . $t_project_where . $t_from_where . $t_to_where . '
-			ORDER BY bn.id';
+			FROM {user} u JOIN {bugnote} bn ON u.id = bn.reporter_id
+			JOIN {bug} b ON bn.bug_id = b.id
+			JOIN {bugnote_text} bnt ON bnt.id = bn.bugnote_text_id
+			LEFT OUTER JOIN {category} c ON c.id=b.category_id
+			WHERE bn.time_tracking != 0'
+			. $t_project_where . $t_from_where . $t_to_where
+			. ' ORDER BY bn.id';
 	$t_result = db_query( $t_query, $t_params );
 
 	$t_cost_per_min = $p_cost_per_hour / 60.0;


### PR DESCRIPTION
Don't require a category to be assigned to the bug as there is an option
to not require a category ($g_allow_no_category)

Fixes: #22158