### PR TITLE
Focus on current project selection

### DIFF
--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -531,7 +531,7 @@ function layout_navbar_projects_menu() {
 	}
 
 	if( $t_show_project_selector ) {
-		echo '<li class="grey">' . "\n";
+		echo '<li class="grey" id="dropdown_projects_menu">' . "\n";
 		echo '<a data-toggle="dropdown" href="#" class="dropdown-toggle">' . "\n";
 
 		$t_current_project_id = helper_get_current_project();

--- a/js/common.js
+++ b/js/common.js
@@ -374,6 +374,10 @@ $(document).ready( function() {
 			$('tr[id=bugnote-attach-files]').show();
 		}
 	});
+
+	$(document).on('shown.bs.dropdown', '#dropdown_projects_menu', function() {
+		$(this).find(".dropdown-menu li.active a").focus();
+	 });
 });
 
 function setBugLabel() {


### PR DESCRIPTION
To follow the expected behaviour of a standard dropdown selection list,
make the list to be scrolled and focused on the currently selected
project.

Fixes: #23248