### PR TITLE
Deprecate access_has_any_project()

### DIFF
--- a/core/access_api.php
+++ b/core/access_api.php
@@ -417,12 +417,27 @@ function access_ensure_project_level( $p_access_level, $p_project_id = null, $p_
 
 /**
  * Check whether the user has the specified access level for any project project
+ *
+ * Warning: this function may mislead into incorrect validations. Usually you want to
+ * check that a user meets a threshold for any project, but that threshold may be configured
+ * differently for each project, and the user may also have different access levels in each
+ * project due to private projects assignment.
+ * In that scenario, $p_access_level can't be a static threshold, but a "threshold identifier"
+ * instead, that must be evaluated for each project.
+ * Function "access_has_any_project_level()" provides that functionality, also covers the basic
+ * usage of this function.
+ * For such reasons, this function has been deprecated.
+ *
  * @param integer      $p_access_level Integer representing access level.
  * @param integer|null $p_user_id      Integer representing user id, defaults to null to use current user.
  * @return boolean whether user has access level specified
  * @access public
+ * @deprecated	access_has_any_project_level() should be used in preference to this function (since verrsion 2.6)
  */
 function access_has_any_project( $p_access_level, $p_user_id = null ) {
+	error_parameters( __FUNCTION__ . '()', 'access_has_any_project_level()' );
+	trigger_error( ERROR_DEPRECATED_SUPERSEDED, DEPRECATED );
+
 	# Short circuit the check in this case
 	if( NOBODY == $p_access_level ) {
 		return false;

--- a/core/bug_group_action_api.php
+++ b/core/bug_group_action_api.php
@@ -189,7 +189,7 @@ function bug_group_action_get_commands( array $p_project_ids = null ) {
 		}
 
 		if( !isset( $t_commands['COPY'] ) &&
-			access_has_any_project( config_get( 'report_bug_threshold', null, null, $t_project_id ) ) ) {
+			access_has_any_project_level( 'report_bug_threshold' ) ) {
 			$t_commands['COPY'] = lang_get( 'actiongroup_menu_copy' );
 		}
 

--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -1079,7 +1079,8 @@ function print_column_selection( BugData $p_bug, $p_columns_target = COLUMNS_TAR
 	global $g_checkboxes_exist;
 
 	echo '<td class="column-selection">';
-	if( access_has_any_project( config_get( 'report_bug_threshold', null, null, $p_bug->project_id ) ) ||
+	if( # check report_bug_threshold for the actions "copy" or "move" into any other project
+		access_has_any_project_level( 'report_bug_threshold' ) ||
 		# !TODO: check if any other projects actually exist for the bug to be moved to
 		access_has_project_level( config_get( 'move_bug_threshold', null, null, $p_bug->project_id ), $p_bug->project_id ) ||
 		# !TODO: factor in $g_auto_set_status_to_assigned == ON

--- a/core/filter_form_api.php
+++ b/core/filter_form_api.php
@@ -2375,7 +2375,7 @@ function filter_form_draw_inputs( $p_filter, $p_for_screen = true, $p_static = f
 	$t_show_build = $t_show_product_version && ( config_get( 'enable_product_build' ) == ON );
 
 	# overload handler_id setting if user isn't supposed to see them (ref #6189)
-	if( !access_has_any_project( config_get( 'view_handler_threshold' ) ) ) {
+	if( !access_has_any_project_level( 'view_handler_threshold' ) ) {
 		$t_filter[FILTER_PROPERTY_HANDLER_ID] = array(
 			META_FILTER_ANY,
 		);

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -792,12 +792,14 @@ function layout_print_sidebar( $p_active_sidebar_page = null ) {
 		if( access_has_global_level( config_get( 'manage_site_threshold' ) ) ) {
 			layout_sidebar_menu( 'manage_overview_page.php', 'manage_link', 'fa-gears', $p_active_sidebar_page );
 		} else {
-			$t_show_access = min( config_get( 'manage_user_threshold' ), config_get( 'manage_project_threshold' ), config_get( 'manage_custom_fields_threshold' ) );
-			if( access_has_global_level( $t_show_access ) || access_has_any_project( $t_show_access ) ) {
-				if( access_has_global_level( config_get( 'manage_user_threshold' ) ) ) {
+			$t_show_manage_user = access_has_global_level( config_get( 'manage_user_threshold' ) );
+			$t_show_manage_custom_fields = access_has_global_level( config_get( 'manage_custom_fields_threshold' ) );
+			$t_show_manage_project = access_has_any_project_level( 'manage_project_threshold' );
+			if( $t_show_manage_user || $t_show_manage_custom_fields || $t_show_manage_project ) {
+				if( $t_show_manage_user ) {
 					$t_link = 'manage_user_page.php';
 				} else {
-					if( access_has_project_level( config_get( 'manage_project_threshold' ), $t_current_project ) && ( $t_current_project <> ALL_PROJECTS ) ) {
+					if( $t_show_manage_project && ( $t_current_project <> ALL_PROJECTS ) ) {
 						$t_link = 'manage_proj_edit_page.php?project_id=' . $t_current_project;
 					} else {
 						$t_link = 'manage_proj_page.php';


### PR DESCRIPTION
This function may mislead into incorrect validations. Usually you want
to check that a user meets a threshold for any project, but that
threshold may be configured differently for each project, and the user
may also have different access levels in each project due to private
projects assignment.
In that scenario, $p_access_level can't be a static threshold, but a
"threshold identifier" instead, that must be evaluated for each project.
Function "access_has_any_project_level()" provides that functionality,
also covers the basic usage of this function.
For such reasons, this function has been deprecated.

Fixes: #21654
