### PR TITLE
Add logging functionality for plugins

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -4137,7 +4137,7 @@ $g_stop_on_errors = OFF;
  * The available log channels are:
  *
  * LOG_NONE, LOG_EMAIL, LOG_EMAIL_RECIPIENT, LOG_EMAIL_VERBOSE, LOG_FILTERING,
- * LOG_AJAX, LOG_LDAP, LOG_DATABASE, LOG_WEBSERVICE, LOG_ALL
+ * LOG_AJAX, LOG_LDAP, LOG_DATABASE, LOG_WEBSERVICE, LOG_PLUGIN, LOG_ALL
  *
  * and can be combined using
  * {@link http://php.net/language.operators.bitwise PHP bitwise operators}

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -550,6 +550,7 @@ define( 'LOG_LDAP', 16 );           # logging for LDAP
 define( 'LOG_DATABASE', 32 );       # logging for Database
 define( 'LOG_WEBSERVICE', 64 );     # logging for Web Service Requests
 define( 'LOG_EMAIL_VERBOSE', 128 ); # logging for verbose email internals
+define( 'LOG_PLUGIN', 256 );        # logging for plugins
 
 # COLUMNS_TARGET_*
 define( 'COLUMNS_TARGET_VIEW_PAGE', 1 );

--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -122,7 +122,11 @@ function log_event( $p_level, $p_msg ) {
 				}
 			}
 		} else {
-			$t_caller .= ' ' . $t_backtrace[1]['function'] . '()';
+			if( isset(  $t_backtrace[1]['class'] ) ) {
+				$t_caller .= ' ' . $t_backtrace[1]['class'] . '::' . $t_backtrace[1]['function'] . '()';
+			} else {
+				$t_caller .= ' ' . $t_backtrace[1]['function'] . '()';
+			}
 		}
 	} else {
 		# or from a script directly?

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -35,6 +35,7 @@
  * @uses helper_api.php
  * @uses history_api.php
  * @uses lang_api.php
+ * @uses logging_api.php
  */
 
 require_api( 'access_api.php' );
@@ -46,6 +47,7 @@ require_api( 'event_api.php' );
 require_api( 'helper_api.php' );
 require_api( 'history_api.php' );
 require_api( 'lang_api.php' );
+require_api( 'logging_api.php' );
 
 # Cache variables #####
 
@@ -995,5 +997,22 @@ function plugin_init( $p_basename ) {
 		return true;
 	} else {
 		return false;
+	}
+}
+
+function plugin_log_event( $p_msg, $p_basename = null ) {
+	$t_current_plugin = plugin_get_current();
+	if( is_null( $p_basename ) ) {
+		$t_basename = $t_current_plugin;
+	} else {
+		$t_basename = $p_basename;
+	}
+
+	if( $t_basename != $t_current_plugin ) {
+		plugin_push_current( $t_basename );
+		log_event( LOG_PLUGIN, $p_msg);
+		plugin_pop_current();
+	} else {
+		log_event( LOG_PLUGIN, $p_msg);
 	}
 }

--- a/docbook/Admin_Guide/en-US/config/logging.xml
+++ b/docbook/Admin_Guide/en-US/config/logging.xml
@@ -256,6 +256,13 @@ $g_display_errors = array(
 						</listitem>
 					</varlistentry>
 					<varlistentry>
+						<term>LOG_PLUGIN</term>
+						<listitem>
+							<para>Enables logging from plugins.
+							</para>
+						</listitem>
+					</varlistentry>
+					<varlistentry>
 						<term>LOG_ALL</term>
 						<listitem>
 							<para>combines all of the above log levels


### PR DESCRIPTION
Add logging functionality for plugins
- Create a new loglevel LOG_PLUGIN to write logs specifically from plugins.
- Add function plugin_log_event() to wrap the log call for plugins.

Fixes: #22053

Print class name when logging backtrace caller info
If the caller function is a class method, print the class name alognside the function name in the log info.
Fixes: #23249