### PR TITLE
Move notify user checkbox outside the form

### DIFF
--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -967,7 +967,7 @@ $s_account_deleted_msg = 'Account deleted...';
 $s_delete_account_sure_msg = 'Are you sure you wish to delete this account?';
 
 # manage_user_edit_page.php
-$s_notify_user = 'Notify User';
+$s_notify_user = 'Notify user of this change';
 
 # manage_user_prune.php
 $s_accounts_pruned_msg = 'All accounts that have never logged in and are older than 1 week have been removed';

--- a/manage_user_edit_page.php
+++ b/manage_user_edit_page.php
@@ -195,18 +195,6 @@ print_manage_menu( 'manage_user_page.php' );
 					</label>
 				</td>
 			</tr>
-			<?php
-			if( config_get( 'enable_email_notification' ) == ON ) { ?>
-				<tr>
-					<td class="category"> <?php echo lang_get( 'notify_user' ) ?> </td>
-					<td>
-						<label>
-							<input type="checkbox" class="ace" id="send-email" name="send_email_notification" checked="checked" ?>
-							<span class="lbl"></span>
-						</label>
-					</td>
-				</tr>
-			<?php } ?>
 
 			<?php event_signal( 'EVENT_MANAGE_USER_UPDATE_FORM', array( $t_user['id'] ) ); ?>
 
@@ -219,6 +207,14 @@ print_manage_menu( 'manage_user_page.php' );
 
 		<div class="widget-toolbox padding-8 clearfix">
 			<input type="submit" class="btn btn-primary btn-white btn-round" value="<?php echo lang_get( 'update_user_button' ) ?>" />
+			<?php
+			if( config_get( 'enable_email_notification' ) == ON ) { ?>
+				&nbsp;
+				<label class="inline">
+					<input type="checkbox" class="ace" id="send-email" name="send_email_notification" checked="checked">
+					<span class="lbl"> <?php echo lang_get( 'notify_user' ) ?></span>
+				</label>
+			<?php } ?>
 		</div>
 		</div>
 		</div>


### PR DESCRIPTION
On manage user page, the "notify user" checkbox is not part of the user
data, and is only used to trigger a notification if the form is saved.
Move the item outside the form, next to the update button to better
match the context of the action.

Fixes: #21695

Before:
![seleccion_233](https://user-images.githubusercontent.com/14123811/29499227-f8853b0c-860c-11e7-9520-bae44921409a.png)

After:
![seleccion_232](https://user-images.githubusercontent.com/14123811/29499229-ff281a42-860c-11e7-8260-38d3e3c85f57.png)
