### PR TITLE
On group action page, show only allowed projects

### DIFF
--- a/bug_actiongroup_page.php
+++ b/bug_actiongroup_page.php
@@ -294,7 +294,8 @@ if( $t_multiple_projects ) {
 			switch( $f_action ) {
 				case 'COPY':
 				case 'MOVE':
-					print_project_option_list( null, false );
+					print_project_option_list( null /* $p_project_id */, false /* $p_include_all_projects */,
+							null /* $p_filter_project_id */, false /* $p_trace */, true /* $p_can_report_only */ );
 					break;
 				case 'ASSIGN':
 					print_assign_to_option_list( 0, $t_project_id );


### PR DESCRIPTION
On group action page, for "move" and "copy" actions, only allow the
selection of destination projects where the action can be performed.
Projects for which the user don't have report permission are now
disabled in the dropdown selection.

Fixes: #12444