### PR TITLE
Show a warning when changing field type

### DIFF
--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -1477,3 +1477,20 @@ function string_custom_field_value_for_email( $p_value, $p_type ) {
 	}
 	return $p_value;
 }
+
+/**
+ * Returns true if there is data stored for a custom field id.
+ * Empty values are ignored
+ * @param integer $p_field_id	Custom field id
+ * @return boolean		True, if non-empty values exist
+ */
+function custom_field_has_data( $p_field_id ) {
+	db_param_push();
+	$t_query = 'SELECT COUNT(*) FROM {custom_field_string}'
+			. ' WHERE field_id=' . db_param()
+			. ' AND value<>\'\'';
+	$t_result = db_query( $t_query, array( (int)$p_field_id ) );
+	$t_count = db_result( $t_result );
+
+	return $t_count > 0;
+}

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1341,6 +1341,7 @@ $s_kb = 'KB';
 $s_attachment_missing = 'Attachment missing';
 $s_attachment_count = 'Attachment count';
 $s_view_attachments_for_issue = 'View %1$d attachment(s) for issue #%2$d';
+$s_warning_update_custom_field_type = '<strong>Warning:</strong> Custom field "%1$s" already has stored values. Changing field type may cause errors and unexpected behaviour if existing values are not consistent with the field\'s new type. To proceed, click the button below';
 
 # PHPMailer
 $s_phpmailer_language = 'en';

--- a/manage_custom_field_update.php
+++ b/manage_custom_field_update.php
@@ -71,6 +71,11 @@ $t_values['require_resolved']	= gpc_get_bool( 'require_resolved' );
 $t_values['require_closed']		= gpc_get_bool( 'require_closed' );
 $t_values['filter_by']			= gpc_get_bool( 'filter_by' );
 
+$t_def = custom_field_get_definition( $f_field_id );
+if( $t_def['type'] != $t_values['type'] && custom_field_has_data( $f_field_id ) ) {
+	helper_ensure_confirmed( sprintf( lang_get( 'warning_update_custom_field_type' ), $t_def['name'] ), lang_get( 'update' ) );
+}
+
 custom_field_update( $f_field_id, $t_values );
 
 form_security_purge( 'manage_custom_field_update' );


### PR DESCRIPTION
Show a warning when updating type for a custom field, for which already exists stored
values.

Related issue: #23270