### PR TITLE
Fix adding issues custom fields in REST API

### DIFF
--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -159,17 +159,15 @@ function mci_issue_set_custom_fields( $p_issue_id, array &$p_custom_fields = nul
 	if( isset( $p_custom_fields ) && is_array( $p_custom_fields ) ) {
 		foreach( $p_custom_fields as $t_custom_field ) {
 
-			# convert the rest api multi-dimensional array into a stdClass object
-			if( is_array($t_custom_field) ) {
-				$t_custom_field = json_decode(json_encode($t_custom_field));
+			if( is_object( $t_custom_field ) ) {
+				$t_custom_field = ApiObjectFactory::objectToArray( $t_custom_field );
 			}
 
-			$t_custom_field = ApiObjectFactory::objectToArray( $t_custom_field );
 			# Verify validity of custom field specification
 			$t_msg = 'Invalid Custom field specification';
 			$t_valid_cf = isset( $t_custom_field['field'] ) && isset( $t_custom_field['value'] );
 			if( $t_valid_cf ) {
-				$t_field = get_object_vars( $t_custom_field['field'] );
+				$t_field = get_object_vars( (object)$t_custom_field['field'] );
 				if( ( !isset( $t_field['id'] ) || $t_field['id'] == 0 ) && !isset( $t_field['name'] ) ) {
 					$t_valid_cf = false;
 					$t_msg .= ", either 'name' or 'id' != 0 or must be given.";
@@ -181,7 +179,7 @@ function mci_issue_set_custom_fields( $p_issue_id, array &$p_custom_fields = nul
 			}
 
 			# get custom field id from object ref
-			$t_custom_field_id = mci_get_custom_field_id_from_objectref( $t_custom_field['field'] );
+			$t_custom_field_id = mci_get_custom_field_id_from_objectref( (object)$t_custom_field['field'] );
 
 			if( $t_custom_field_id == 0 ) {
 				return ApiObjectFactory::faultNotFound( "Custom field '" . $t_field['name'] . "' not found." );

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -159,6 +159,11 @@ function mci_issue_set_custom_fields( $p_issue_id, array &$p_custom_fields = nul
 	if( isset( $p_custom_fields ) && is_array( $p_custom_fields ) ) {
 		foreach( $p_custom_fields as $t_custom_field ) {
 
+			# convert the rest api multi-dimensional array into a stdClass object
+			if( is_array($t_custom_field) ) {
+				$t_custom_field = json_decode(json_encode($t_custom_field));
+			}
+
 			$t_custom_field = ApiObjectFactory::objectToArray( $t_custom_field );
 			# Verify validity of custom field specification
 			$t_msg = 'Invalid Custom field specification';


### PR DESCRIPTION
Fix for the [23264](https://www.mantisbt.org/bugs/view.php?id=23264) issue - Custom fields not been saved when adding issue through the Rest API.

The REST API pass a multi-dimensional array of custom field values and the mci_issue_set_custom_fields function expect an stdClass object. 