### PR TITLE
Fix REST API auth with show_realname = ON

### DIFF
--- a/account_update.php
+++ b/account_update.php
@@ -68,7 +68,7 @@ if( !$t_account_verification ) {
 	# set a temporary cookie so the login information is passed between pages.
 	auth_set_cookies( $t_verify_user_id, false );
 	# fake login so the user can set their password
-	auth_attempt_script_login( user_get_field( $t_verify_user_id, 'username' ) );
+	auth_attempt_script_login( user_get_username( $t_verify_user_id ) );
 	$t_user_id = $t_verify_user_id;
 }
 
@@ -113,7 +113,7 @@ if( !( $t_ldap && config_get( 'use_ldap_realname' ) ) ) {
 	$t_realname = string_normalize( $f_realname );
 	if( $t_realname != user_get_field( $t_user_id, 'realname' ) ) {
 		# checks for problems with realnames
-		$t_username = user_get_field( $t_user_id, 'username' );
+		$t_username = user_get_username( $t_user_id );
 		user_ensure_realname_unique( $t_username, $t_realname );
 		$t_update_realname = true;
 	}

--- a/api/rest/restcore/AuthMiddleware.php
+++ b/api/rest/restcore/AuthMiddleware.php
@@ -36,7 +36,7 @@ class AuthMiddleware {
 			# Since authorization header is empty, check if user is authenticated by checking the cookie
 			# This mode is used when Web UI javascript calls into the API.
 			if( auth_is_user_authenticated() ) {
-				$t_username = user_get_name( auth_get_current_user_id() );
+				$t_username = user_get_field( auth_get_current_user_id(), 'username' );
 				$t_password = auth_get_current_user_cookie( /* auto-login-anonymous */ false );
 				$t_login_method = LOGIN_METHOD_COOKIE;
 			} else {

--- a/api/rest/restcore/AuthMiddleware.php
+++ b/api/rest/restcore/AuthMiddleware.php
@@ -36,7 +36,7 @@ class AuthMiddleware {
 			# Since authorization header is empty, check if user is authenticated by checking the cookie
 			# This mode is used when Web UI javascript calls into the API.
 			if( auth_is_user_authenticated() ) {
-				$t_username = user_get_field( auth_get_current_user_id(), 'username' );
+				$t_username = user_get_username( auth_get_current_user_id() );
 				$t_password = auth_get_current_user_cookie( /* auto-login-anonymous */ false );
 				$t_login_method = LOGIN_METHOD_COOKIE;
 			} else {

--- a/api/soap/mc_account_api.php
+++ b/api/soap/mc_account_api.php
@@ -45,7 +45,7 @@ function mci_account_get_array_by_id( $p_user_id ) {
 		$t_can_see_realname = access_has_project_level( config_get( 'show_user_realname_threshold' ) );
 		$t_can_see_email = access_has_project_level( config_get( 'show_user_email_threshold' ) );
 
-		$t_result['name'] = user_get_field( $p_user_id, 'username' );
+		$t_result['name'] = user_get_username( $p_user_id );
 
 		if ( $t_is_same_user || $t_can_manage || $t_can_see_realname ) {
 			$t_realname = user_get_realname( $p_user_id );

--- a/bug_reminder_page.php
+++ b/bug_reminder_page.php
@@ -131,7 +131,7 @@ layout_page_begin();
 			}
 
 			if( mention_enabled() ) {
-				echo '<br /><br />', sprintf( lang_get( 'reminder_mentions' ), '<strong>' . mentions_tag() . user_get_field( auth_get_current_user_id(), 'username' ) . '</strong>' );
+				echo '<br /><br />', sprintf( lang_get( 'reminder_mentions' ), '<strong>' . mentions_tag() . user_get_username( auth_get_current_user_id() ) . '</strong>' );
 			}
 		?>
 		</p>

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -1000,7 +1000,7 @@ function auth_reauthenticate() {
 		$t_anon_allowed = auth_anonymous_enabled();
 
 		$t_user_id = auth_get_current_user_id();
-		$t_username = user_get_field( $t_user_id, 'username' );
+		$t_username = user_get_username( $t_user_id );
 
 		# check for anonymous login
 		if( ON == $t_anon_allowed && $t_anon_account == $t_username ) {

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -506,7 +506,7 @@ function email_signup( $p_user_id, $p_confirm_hash, $p_admin_name = '' ) {
 	#  use same language as display for the email
 	#  lang_push( user_pref_get_language( $p_user_id ) );
 	# retrieve the username and email
-	$t_username = user_get_field( $p_user_id, 'username' );
+	$t_username = user_get_username( $p_user_id );
 	$t_email = user_get_email( $p_user_id );
 
 	# Build Welcome Message
@@ -552,7 +552,7 @@ function email_send_confirm_hash_url( $p_user_id, $p_confirm_hash ) {
 	lang_push( user_pref_get_language( $p_user_id ) );
 
 	# retrieve the username and email
-	$t_username = user_get_field( $p_user_id, 'username' );
+	$t_username = user_get_username( $p_user_id );
 	$t_email = user_get_email( $p_user_id );
 
 	$t_subject = '[' . config_get( 'window_title' ) . '] ' . lang_get( 'lost_password_subject' );

--- a/core/filter_form_api.php
+++ b/core/filter_form_api.php
@@ -196,7 +196,7 @@ function print_filter_reporter_id( array $p_filter = null ) {
 	#
 	if( ( ON === config_get( 'limit_reporters' ) ) && ( !access_has_project_level( access_threshold_min_level( config_get( 'report_bug_threshold' ) ) + 1 ) ) ) {
 		$t_id = auth_get_current_user_id();
-		$t_username = user_get_field( $t_id, 'username' );
+		$t_username = user_get_username( $t_id );
 		$t_realname = user_get_field( $t_id, 'realname' );
 		$t_display_name = string_attribute( $t_username );
 		if( ( isset( $t_realname ) ) && ( $t_realname > '' ) && ( ON == config_get( 'show_realname' ) ) ) {

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -135,7 +135,7 @@ function ldap_email( $p_user_id ) {
 		return $g_cache_ldap_email[(int)$p_user_id];
 	}
 
-	$t_username = user_get_field( $p_user_id, 'username' );
+	$t_username = user_get_username( $p_user_id );
 	$t_email = ldap_email_from_username( $t_username );
 
 	$g_cache_ldap_email[(int)$p_user_id] = $t_email;
@@ -167,7 +167,7 @@ function ldap_email_from_username( $p_username ) {
  * @return string real name.
  */
 function ldap_realname( $p_user_id ) {
-	$t_username = user_get_field( $p_user_id, 'username' );
+	$t_username = user_get_username( $p_user_id );
 	return ldap_realname_from_username( $t_username );
 }
 
@@ -293,7 +293,7 @@ function ldap_authenticate( $p_user_id, $p_password ) {
 		return false;
 	}
 
-	$t_username = user_get_field( $p_user_id, 'username' );
+	$t_username = user_get_username( $p_user_id );
 
 	return ldap_authenticate_by_username( $t_username, $p_password );
 }

--- a/core/rss_api.php
+++ b/core/rss_api.php
@@ -55,7 +55,7 @@ function rss_calculate_key( $p_user_id = null ) {
 		$t_user_id = $p_user_id;
 	}
 
-	$t_username = user_get_field( $t_user_id, 'username' );
+	$t_username = user_get_username( $t_user_id );
 	$t_password = user_get_field( $t_user_id, 'password' );
 	$t_cookie = user_get_field( $t_user_id, 'cookie_string' );
 

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -961,10 +961,19 @@ function user_get_realname( $p_user_id ) {
 }
 
 /**
- * return the username or a string "user<id>" if the user does not exist
- * if show_user_realname_threshold is set and real name is not empty, return it instead
+ * Return the user's name for display.
+ *
+ * The name is determined based on the following sequence:
+ * - if the user does not exist, returns the user ID prefixed by a localized
+ *   string (prefix_for_deleted_users, "user" by default);
+ * - if show_realname is ON and it is not empty, return the user's Real Name;
+ * - Otherwise, return the username
+ *
+ * NOTE: do not use this function to retrieve the user's username
+ * @see user_get_username()
  *
  * @param integer $p_user_id A valid user identifier.
+ *
  * @return string
  */
 function user_get_name( $p_user_id ) {

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -468,7 +468,7 @@ function user_is_protected( $p_user_id ) {
  * @access public
  */
 function user_is_anonymous( $p_user_id ) {
-	return auth_anonymous_enabled() && strcasecmp( user_get_field( $p_user_id, 'username' ), auth_anonymous_account() ) == 0;
+	return auth_anonymous_enabled() && strcasecmp( user_get_username( $p_user_id ), auth_anonymous_account() ) == 0;
 }
 
 /**
@@ -928,6 +928,16 @@ function user_get_email( $p_user_id ) {
 		$t_email = user_get_field( $p_user_id, 'email' );
 	}
 	return $t_email;
+}
+
+/**
+ * Lookup the user's login name (username)
+ *
+ * @param integer $p_user_id A valid user identifier.
+ * @return string
+ */
+function user_get_username( $p_user_id ) {
+	return user_get_field( $p_user_id, 'username' );
 }
 
 /**

--- a/verify.php
+++ b/verify.php
@@ -77,7 +77,7 @@ user_reset_failed_login_count_to_zero( $f_user_id );
 user_reset_lost_password_in_progress_count_to_zero( $f_user_id );
 
 # fake login so the user can set their password
-auth_attempt_script_login( user_get_field( $f_user_id, 'username' ) );
+auth_attempt_script_login( user_get_username( $f_user_id ) );
 
 user_increment_login_count( $f_user_id );
 


### PR DESCRIPTION
When accessing the webservice via browser as an authenticated user, and
$g_show_realname = ON, the request fails with HTTP 403 error.

This is due to using incorrect user_get_name() function to retrieve the
user's login name.

Calling user_get_field(<id>, 'username') instead.

Fixes [#23225](https://www.mantisbt.org/bugs/view.php?id=23225)