### PR TITLE
Allow caching of generated js/css files

### DIFF
--- a/css/status_config.php
+++ b/css/status_config.php
@@ -28,8 +28,13 @@
 # Prevent output of HTML in the content if errors occur
 define( 'DISABLE_INLINE_ERROR_REPORTING', true );
 
+# Suppress default headers. This allows cachig as defined in server configuration
+$g_bypass_headers = true;
+
 @require_once( dirname( dirname( __FILE__ ) ) . '/core.php' );
 require_api( 'config_api.php' );
+
+http_security_headers();
 
 /**
  * Send correct MIME Content-Type header for css content.

--- a/javascript_config.php
+++ b/javascript_config.php
@@ -27,8 +27,13 @@
 # Prevent output of HTML in the content if errors occur
 define( 'DISABLE_INLINE_ERROR_REPORTING', true );
 
+# Suppress default headers. This allows cachig as defined in server configuration
+$g_bypass_headers = true;
+
 require_once( 'core.php' );
 require_api( 'config_api.php' );
+
+http_security_headers();
 
 /**
  * Print array of configuration option->values for javascript.

--- a/javascript_translations.php
+++ b/javascript_translations.php
@@ -28,8 +28,13 @@
 # Prevent output of HTML in the content if errors occur
 define( 'DISABLE_INLINE_ERROR_REPORTING', true );
 
+# Suppress default headers. This allows cachig as defined in server configuration
+$g_bypass_headers = true;
+
 require_once( 'core.php' );
 require_api( 'lang_api.php' );
+
+http_security_headers();
 
 /**
  * Print Language translation for javascript


### PR DESCRIPTION
Allow client caching of dynamically generated css and js filtes.
Default headers disable explicitly caching of application pages, but
these generated files don't change over time.
By disabling default headers, the cacheability is defined by the server
cconfiguration.

Fixes: #23324

Note i skipped the files deleted by #1178