### PR TITLE
Allow caching of generated js/css files

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -214,6 +214,16 @@ function html_css() {
 		html_css_link( config_get( 'css_rtl_include_file' ) );
 	}
 	foreach( $g_stylesheets_included as $t_stylesheet_path ) {
+		# status_config.php is a special css file, dynamically generated.
+		# Add a hash to the query string to differentiate content based on its
+		# relevant properties. This allows a browser to cache them separately and force
+		# a reload when the content may differ.
+		if( $t_stylesheet_path == 'status_config.php' ) {
+			$t_stylesheet_path = helper_url_combine(
+				helper_mantis_url( 'css/status_config.php' ),
+				'cache_key=' . helper_generate_cache_key( array( 'user' ) )
+			);
+		}
 		html_css_link( $t_stylesheet_path );
 	}
 
@@ -297,8 +307,19 @@ function require_js( $p_script_path ) {
  */
 function html_head_javascript() {
 	global $g_scripts_included;
-	echo "\t" . '<script type="text/javascript" src="' . helper_mantis_url( 'javascript_config.php' ) . '"></script>' . "\n";
-	echo "\t" . '<script type="text/javascript" src="' . helper_mantis_url( 'javascript_translations.php' ) . '"></script>' . "\n";
+	# Add a hash to the query string to differentiate content based on its
+	# relevant properties. This allows a browser to cache them separately and force
+	# a reload when the content may differ.
+	$t_javascript_translations = helper_url_combine(
+		helper_mantis_url( 'javascript_translations.php' ),
+		'cache_key=' . helper_generate_cache_key( array( 'lang' ) )
+	);
+	$t_javascript_config = helper_url_combine(
+		helper_mantis_url( 'javascript_config.php' ),
+		'cache_key=' . helper_generate_cache_key( array( 'user' ) )
+	);
+	echo "\t" . '<script type="text/javascript" src="' . $t_javascript_config . '"></script>' . "\n";
+	echo "\t" . '<script type="text/javascript" src="' . $t_javascript_translations . '"></script>' . "\n";
 
 	if ( config_get_global( 'cdn_enabled' ) == ON ) {
 		# JQuery

--- a/css/status_config.php
+++ b/css/status_config.php
@@ -28,8 +28,19 @@
 # Prevent output of HTML in the content if errors occur
 define( 'DISABLE_INLINE_ERROR_REPORTING', true );
 
+$t_allow_caching = isset( $_GET['cache_key'] );
+if( $t_allow_caching ) {
+	# Suppress default headers. This allows caching as defined in server configuration
+	$g_bypass_headers = true;
+}
+
 @require_once( dirname( dirname( __FILE__ ) ) . '/core.php' );
 require_api( 'config_api.php' );
+
+if( $t_allow_caching ) {
+	# if standard headers were bypassed, add security headers, at least
+	http_security_headers();
+}
 
 /**
  * Send correct MIME Content-Type header for css content.

--- a/javascript_config.php
+++ b/javascript_config.php
@@ -27,8 +27,19 @@
 # Prevent output of HTML in the content if errors occur
 define( 'DISABLE_INLINE_ERROR_REPORTING', true );
 
+$t_allow_caching = isset( $_GET['cache_key'] );
+if( $t_allow_caching ) {
+	# Suppress default headers. This allows caching as defined in server configuration
+	$g_bypass_headers = true;
+}
+
 require_once( 'core.php' );
 require_api( 'config_api.php' );
+
+if( $t_allow_caching ) {
+	# if standard headers were bypassed, add security headers, at least
+	http_security_headers();
+}
 
 /**
  * Print array of configuration option->values for javascript.

--- a/javascript_translations.php
+++ b/javascript_translations.php
@@ -28,8 +28,19 @@
 # Prevent output of HTML in the content if errors occur
 define( 'DISABLE_INLINE_ERROR_REPORTING', true );
 
+$t_allow_caching = isset( $_GET['cache_key'] );
+if( $t_allow_caching ) {
+	# Suppress default headers. This allows caching as defined in server configuration
+	$g_bypass_headers = true;
+}
+
 require_once( 'core.php' );
 require_api( 'lang_api.php' );
+
+if( $t_allow_caching ) {
+	# if standard headers were bypassed, add security headers, at least
+	http_security_headers();
+}
 
 /**
  * Print Language translation for javascript

--- a/plugin.php
+++ b/plugin.php
@@ -27,11 +27,21 @@
  * @uses plugin_api.php
  */
 
+$t_allow_caching = isset( $_GET['cache_key'] );
+if( $t_allow_caching ) {
+	# Suppress default headers. This allows caching as defined in server configuration
+	$g_bypass_headers = true;
+}
+
 require_once( 'core.php' );
 require_api( 'config_api.php' );
 require_api( 'constant_inc.php' );
 require_api( 'gpc_api.php' );
 require_api( 'plugin_api.php' );
+
+if( $t_allow_caching ) {
+	http_security_headers();
+}
 
 $t_plugin_path = config_get( 'plugin_path' );
 


### PR DESCRIPTION
Allow client caching of dynamically generated css and js files.
Default headers disable explicitly caching of application pages, but
these generated files don't change usually between page loads.
By disabling default headers, the cacheability is defined by the server
configuration.

The included files are referenced by a URL built with
dummy parameters that allows cache busting on the browser cached copy,
based on the variables that may result in a different content, for
example, after changing logged user, language...

Fixes: #23324