### PR TITLE
Remove non-clickable arrows from sidebar menu items

### DIFF
--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -940,7 +940,6 @@ function layout_sidebar_menu( $p_page, $p_title, $p_icon, $p_active_sidebar_page
 	echo '<i class="menu-icon fa ' . $p_icon . '"></i> ' . "\n";
 	echo '<span class="menu-text"> ' . lang_get_defaulted( $p_title ) . ' </span>' . "\n";
 	echo '</a>' . "\n";
-	echo '<b class="arrow"></b>' . "\n";
 	echo '</li>' . "\n";
 }
 


### PR DESCRIPTION
On the collapsed sidebar menu items, the arrow shown when they are
hovered, places an arrea that is not clickable.
Remove the arrows since the UI value is small compared to the annoyance
as the user expects the whole area to be clikable.

Fixes: #22245