### PR TITLE
Make hover arrows clickable on collapsed sidebar menu

### DIFF
--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -187,6 +187,11 @@ pre {
     cursor: pointer !important;
 }
 
+/* Clickable hover arrows on collapsed sidebar #22245 */
+.nav-list li > .arrow {
+    pointer-events: none;
+}
+
 .fa-xlg {
     font-size: 1.6em;
     line-height: 0.73em;


### PR DESCRIPTION
An alternative approach to https://github.com/mantisbt/mantisbt/pull/1194

I tried latest Firefox, Chrome, IE and Edge.
Will have to check Safari this evening.

Looks quite good https://caniuse.com/#feat=pointer-events

Fixes #22245