### PR TITLE
Style logo in login related pages

### DIFF
--- a/lost_pwd_page.php
+++ b/lost_pwd_page.php
@@ -71,11 +71,7 @@ layout_login_page_begin();
 <div class="col-md-offset-3 col-md-6 col-sm-10 col-sm-offset-1">
 <div id="lost-password-div" class="login-container">
 	<div class="space-12 hidden-480"></div>
-	<a href="<?php echo config_get( 'logo_url' ) ?>">
-		<h1 class="center white">
-			<img src="<?php echo helper_mantis_url( config_get( 'logo_image' ) ); ?>">
-		</h1>
-	</a>
+	<?php layout_login_page_logo() ?>
 	<div class="space-24 hidden-480"></div>
 	<div class="position-relative">
 	<div class="signup-box visible widget-box no-border" id="login-box">

--- a/signup.php
+++ b/signup.php
@@ -93,11 +93,7 @@ layout_login_page_begin();
 	<div class="col-md-offset-3 col-md-6 col-sm-10 col-sm-offset-1">
 		<div class="login-container">
 			<div class="space-12 hidden-480"></div>
-			<a href="<?php echo config_get( 'logo_url' ) ?>">
-				<h1 class="center white">
-					<img src="<?php echo helper_mantis_url( config_get( 'logo_image' ) ); ?>">
-				</h1>
-			</a>
+			<?php layout_login_page_logo() ?>
 			<div class="space-24 hidden-480"></div>
 
 			<div class="position-relative">

--- a/signup_page.php
+++ b/signup_page.php
@@ -64,11 +64,7 @@ $t_public_key = crypto_generate_uri_safe_nonce( 64 );
 <div class="col-md-offset-3 col-md-6 col-sm-10 col-sm-offset-1">
     <div class="login-container">
 	<div class="space-12 hidden-480"></div>
-	<a href="<?php echo config_get( 'logo_url' ) ?>">
-		<h1 class="center white">
-			<img src="<?php echo helper_mantis_url( config_get( 'logo_image' ) ); ?>">
-		</h1>
-	</a>
+	<?php layout_login_page_logo() ?>
 	<div class="space-24 hidden-480"></div>
 
 	<div class="position-relative">

--- a/verify.php
+++ b/verify.php
@@ -97,11 +97,7 @@ layout_login_page_begin();
 <div class="col-md-offset-4 col-md-4 col-sm-8 col-sm-offset-1">
 	<div class="login-container">
 		<div class="space-12 hidden-480"></div>
-		<a href="<?php echo config_get( 'logo_url' ) ?>">
-			<h1 class="center white">
-				<img src="<?php echo helper_mantis_url( config_get( 'logo_image' ) ); ?>">
-			</h1>
-		</a>
+		<?php layout_login_page_logo() ?>
 		<div class="space-24 hidden-480"></div>
 
 		<?php


### PR DESCRIPTION
Apply same style than login page for logo layout in lost-password,
sign-up and verify pages.

Related issue: #23382

Continuation for PR #1192