### PR TITLE
Fix order of activities with same timestamp

### DIFF
--- a/core/bug_activity_api.php
+++ b/core/bug_activity_api.php
@@ -187,6 +187,11 @@ function bug_activity_sort( &$p_entries ) {
 			return $t_order == 'DESC' ? -1 : 1;
 		}
 
+		# same timestamp and same type, probably came from cloning an issue
+		if( $a['timestamp'] == $b['timestamp'] && $a['type'] == $b['type'] ) {
+			return (int)$a['id'] - (int)$b['id'];
+		}
+
 		if( $a['user_id'] < $b['user_id'] ) {
 			return -1;
 		}


### PR DESCRIPTION
When activities of the same type have the same timestamp, for example
when created from cloning issues, use the element id for sorting.

Fixes: #22441