### PR TITLE
Fix updating projects in filter edit.

### DIFF
--- a/manage_filter_edit_page.php
+++ b/manage_filter_edit_page.php
@@ -182,20 +182,20 @@ $t_filter_project_id = filter_get_field( $f_filter_id, 'project_id' );
 							</td>
 							<td>
 								<label class="inline">
-									<input type="radio" class="ace input-sm" name="project_id" value="<?php echo ALL_PROJECTS ?>" <?php check_checked( ALL_PROJECTS == $t_filter_project_id ) ?>>
+									<input type="radio" class="ace input-sm" name="filter_project_id" value="<?php echo ALL_PROJECTS ?>" <?php check_checked( ALL_PROJECTS == $t_filter_project_id ) ?>>
 									<span class="lbl"> <?php echo lang_get( 'all_projects' ) ?></span>
 								</label>
 								<br>
 								<?php if( ALL_PROJECTS != $t_filter_project_id ) { ?>
 								<label>
-									<input type="radio" class="ace input-sm" name="project_id" value="<?php echo $t_filter_project_id ?>" <?php check_checked( ALL_PROJECTS != $t_filter_project_id ) ?>>
+									<input type="radio" class="ace input-sm" name="filter_project_id" value="<?php echo $t_filter_project_id ?>" <?php check_checked( ALL_PROJECTS != $t_filter_project_id ) ?>>
 									<span class="lbl"> <?php echo lang_get( 'stored_project' ) . ' (' . project_get_name( $t_filter_project_id ) . ')' ?></span>
 								</label>
 								<br>
 								<?php } ?>
 								<?php if( $t_filter_project_id != $t_current_project_id ) { ?>
 								<label>
-									<input type="radio" class="ace input-sm" name="project_id" value="<?php echo $t_current_project_id ?>">
+									<input type="radio" class="ace input-sm" name="filter_project_id" value="<?php echo $t_current_project_id ?>">
 									<span class="lbl"> <?php echo lang_get( 'current_project' ) . ' (' . project_get_name( $t_current_project_id ) . ')' ?></span>
 								</label>
 								<?php } ?>

--- a/manage_filter_edit_update.php
+++ b/manage_filter_edit_update.php
@@ -82,7 +82,7 @@ if( access_has_project_level( config_get( 'stored_query_create_shared_threshold'
 	$f_is_public = null;
 }
 
-$f_project_id = gpc_get_int( 'project_id', null );
+$f_project_id = gpc_get_int( 'filter_project_id', null );
 
 $t_editable = filter_db_can_delete_filter( $f_filter_id );
 if( !$t_editable ) {


### PR DESCRIPTION
Two form inputs with the same name was causing to not updating the
"projects" attribute when editing a filter.

Fixes: #23436