### PR TITLE
Don't deliver unneeded JavaScript if Graphs plugin is enabled

### DIFF
--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -99,7 +99,7 @@ class MantisGraphPlugin extends MantisPlugin  {
 	 * @return void
 	 */
 	function csp_headers() {
-		if ( config_get_global( 'cdn_enabled' ) == ON ) {
+		if( config_get_global( 'cdn_enabled' ) == ON ) {
 			http_csp_add( 'script-src', 'https://cdnjs.cloudflare.com' );
 		}
 	}
@@ -122,14 +122,16 @@ class MantisGraphPlugin extends MantisPlugin  {
 	 * @return void
 	 */
 	function resources() {
-		if ( config_get_global( 'cdn_enabled' ) == ON ) {
-			html_javascript_cdn_link( 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/' . CHARTJS_VERSION . '/Chart.min.js', CHARTJS_HASH );
-			html_javascript_cdn_link( 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/' . CHARTJS_VERSION . '/Chart.bundle.min.js', CHARTJSBUNDLE_HASH );
-		} else {
-			echo '<script src="' . plugin_file( 'chart-' . CHARTJS_VERSION . '.min.js' ) . '"></script>';
-			echo '<script src="' . plugin_file( 'chart.bundle-' . CHARTJS_VERSION . '.min.js' ) . '"></script>';
+		if( current( explode( '/', gpc_get_string( 'page', '' ) ) ) === $this->basename ) {
+			if( config_get_global( 'cdn_enabled' ) == ON ) {
+				html_javascript_cdn_link('https://cdnjs.cloudflare.com/ajax/libs/Chart.js/' . CHARTJS_VERSION . '/Chart.min.js', CHARTJS_HASH);
+				html_javascript_cdn_link('https://cdnjs.cloudflare.com/ajax/libs/Chart.js/' . CHARTJS_VERSION . '/Chart.bundle.min.js', CHARTJSBUNDLE_HASH);
+			} else {
+				echo '<script src="' . plugin_file('chart-' . CHARTJS_VERSION . '.min.js') . '"></script>';
+				echo '<script src="' . plugin_file('chart.bundle-' . CHARTJS_VERSION . '.min.js') . '"></script>';
+			}
+			echo '<script src="' . plugin_file("MantisGraph.js") . '"></script>';
 		}
-		echo '<script src="' . plugin_file( "MantisGraph.js" ) . '"></script>';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #23446

We do request/deliver `chart.bundle-2.1.6.min.js`, `chart-2.1.6.min.js` and `MantisGraph.js` with *each* page request if Graphs plugin is enabled.

All in all about 322KB are transferred when accessing Mantis for the first time.
The files are cached, but they are still causing unneeded round trips to the server.

Most of the time the files are not needed as
- most of the users do not have access to the graphs ($g_view_summary_threshold = MANAGER)
- most of the pages don't need the scripts (might change in future, e.g. if we should have some graphs on `My View` page)
