### PR TITLE
Remove useless tab on manage_proj_page

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -606,7 +606,9 @@ function print_summary_submenu() {
 function print_manage_menu( $p_page = '' ) {
 	$t_pages = array();
 
-	$t_pages['manage_overview_page.php'] = array( 'url'   => 'manage_overview_page.php', 'label' => '' );
+	if( access_has_global_level( config_get( 'manage_site_threshold' ) ) ) {
+		$t_pages['manage_overview_page.php'] = array( 'url'   => 'manage_overview_page.php', 'label' => '' );
+	}
 	if( access_has_global_level( config_get( 'manage_user_threshold' ) ) ) {
 		$t_pages['manage_user_page.php'] = array( 'url'   => 'manage_user_page.php', 'label' => 'manage_users_link' );
 	}


### PR DESCRIPTION
Clicking on (i) tab (link to manage_overview_page.php) on manage_proj_page gives `Access Denied` if user does not have global manage_site_threshold access.

The tab should not be offered if user has no access rights for it.

Fixes #23460