### PR TITLE
Support for updating issues via REST API

### DIFF
--- a/api/rest/restcore/issues_rest.php
+++ b/api/rest/restcore/issues_rest.php
@@ -141,6 +141,14 @@ function rest_issue_delete( \Slim\Http\Request $p_request, \Slim\Http\Response $
 	return $p_response->withStatus( HTTP_STATUS_NO_CONTENT );
 }
 
+/**
+ * Add issue note.
+ *
+ * @param \Slim\Http\Request $p_request   The request.
+ * @param \Slim\Http\Response $p_response The response.
+ * @param array $p_args Arguments
+ * @return \Slim\Http\Response The augmented response.
+ */
 function rest_issue_note_add( \Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
 	$t_note_info = $p_request->getParsedBody();
 
@@ -180,6 +188,14 @@ function rest_issue_note_add( \Slim\Http\Request $p_request, \Slim\Http\Response
 		withJson( array( 'note' => $t_note, 'issue' => $t_issue ) );
 }
 
+/**
+ * Delete issue note.
+ *
+ * @param \Slim\Http\Request $p_request   The request.
+ * @param \Slim\Http\Response $p_response The response.
+ * @param array $p_args Arguments
+ * @return \Slim\Http\Response The augmented response.
+ */
 function rest_issue_note_delete( \Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
 	$t_issue_id = isset( $p_args['id'] ) ? $p_args['id'] : $p_request->getParam( 'id' );
 	$t_issue_note_id = isset( $p_args['note_id'] ) ? $p_args['note_id'] : $p_request->getParam( 'note_id' );

--- a/api/rest/restcore/issues_rest.php
+++ b/api/rest/restcore/issues_rest.php
@@ -214,6 +214,10 @@ function rest_issue_update( \Slim\Http\Request $p_request, \Slim\Http\Response $
 
 	# Construct full issue from issue from db + patched info
 	$t_issue_patch = $p_request->getParsedBody();
+	if( isset( $t_issue_patch['id'] ) && $t_issue_patch['id'] != $t_issue_id ) {
+		return $p_response->withStatus( HTTP_STATUS_BAD_REQUEST, 'Issue id mismatch' );
+	}
+
 	$t_issue = (object)array_merge( $t_original_issue, $t_issue_patch );
 
 	# Trigger the issue update

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -1133,7 +1133,7 @@ function mc_issue_update( $p_username, $p_password, $p_issue_id, stdClass $p_iss
 
 	# submit the issue
 	log_event( LOG_WEBSERVICE, 'updating issue \'' . $p_issue_id . '\'' );
-	return $t_bug_data->update( true, true );
+	return $t_bug_data->update( /* update extended */ true, /* bypass email */ false );
 
 }
 


### PR DESCRIPTION
This PR builds on #1189

- Supports for updating issues via REST API via PATCH.
- Supports providing only fields that are updated in the PATCH payload.
- Enables email notifications for issue updates via SOAP / REST API.

Fixes #23396, 23477