### PR TITLE
Fix application of "view_handler_threshold", "show_assigned_names"

### DIFF
--- a/core/access_api.php
+++ b/core/access_api.php
@@ -836,3 +836,26 @@ function access_threshold_min_level( $p_threshold ) {
 	}
 
 }
+
+/**
+ * Checks if the user can view the handler for the bug.
+ * @param BugData      $p_bug     Bug to check access against.
+ * @param integer|null $p_user_id Integer representing user id, defaults to null to use current user.
+ * @return boolean whether user can view the handler user.
+ */
+function access_can_see_handler_for_bug( BugData $p_bug, $p_user_id = null ) {
+	if( null === $p_user_id ) {
+		$t_user_id = auth_get_current_user_id();
+	} else {
+		$t_user_id = $p_user_id;
+	}
+
+	# handler can be viewed if allowed by access level, OR the user himself is the handler
+	$t_can_view_handler =
+		( $p_bug->handler_id == $t_user_id )
+		|| access_has_bug_level(
+			config_get( 'view_handler_threshold', null, $t_user_id, $p_bug->project_id ),
+			$p_bug->id );
+
+	return $t_can_view_handler;
+}

--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -1399,7 +1399,9 @@ function print_column_status( BugData $p_bug, $p_columns_target = COLUMNS_TARGET
 	);
 
 	# print handler user next to status
-	if( $p_bug->handler_id > 0 && ON == config_get( 'show_assigned_names' ) && access_can_see_handler_for_bug( $p_bug ) ) {
+	if( $p_bug->handler_id > 0
+			&& ON == config_get( 'show_assigned_names', null, $t_current_user, $p_bug->project_id )
+			&& access_can_see_handler_for_bug( $p_bug ) ) {
 		printf( ' (%s)', prepare_user_name( $p_bug->handler_id ) );
 	}
 	echo '</div></td>';

--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -1387,18 +1387,19 @@ function print_column_resolution( BugData $p_bug, $p_columns_target = COLUMNS_TA
  * @access public
  */
 function print_column_status( BugData $p_bug, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
+	$t_current_user = auth_get_current_user_id();
 	# choose color based on status
-	$status_label = html_get_status_css_class( $p_bug->status, auth_get_current_user_id(), $p_bug->project_id );
+	$status_label = html_get_status_css_class( $p_bug->status, $t_current_user, $p_bug->project_id );
 	echo '<td class="column-status">';
 	echo '<div class="align-left">';
 	echo '<i class="fa fa-square fa-status-box ' . $status_label . '"></i> ';
 	printf( '<span title="%s">%s</span>',
-		get_enum_element( 'resolution', $p_bug->resolution, auth_get_current_user_id(), $p_bug->project_id ),
-		get_enum_element( 'status', $p_bug->status, auth_get_current_user_id(), $p_bug->project_id )
+		get_enum_element( 'resolution', $p_bug->resolution, $t_current_user, $p_bug->project_id ),
+		get_enum_element( 'status', $p_bug->status, $t_current_user, $p_bug->project_id )
 	);
 
-	# print username instead of status
-	if( ( ON == config_get( 'show_assigned_names' ) ) && ( $p_bug->handler_id > 0 ) && ( access_has_project_level( config_get( 'view_handler_threshold' ), $p_bug->project_id ) ) ) {
+	# print handler user next to status
+	if( $p_bug->handler_id > 0 && ON == config_get( 'show_assigned_names' ) && access_can_see_handler_for_bug( $p_bug ) ) {
 		printf( ' (%s)', prepare_user_name( $p_bug->handler_id ) );
 	}
 	echo '</div></td>';

--- a/core/custom_function_api.php
+++ b/core/custom_function_api.php
@@ -108,7 +108,7 @@ function custom_function_default_changelog_print_issue( $p_issue_id, $p_issue_le
 	echo '<i class="fa fa-square fa-status-box ' . $status_label . '" title="' . $t_status_title . '"></i> ';
 	echo string_get_bug_view_link( $p_issue_id );
 	echo ': <span class="label label-light">', $t_category, '</span> ' , string_display_line_links( $t_bug->summary );
-	if( $t_bug->handler_id != 0 ) {
+	if( $t_bug->handler_id > 0 && ON == config_get( 'show_assigned_names' ) && access_can_see_handler_for_bug( $t_bug ) ) {
 		echo ' (', prepare_user_name( $t_bug->handler_id ), ')';
 	}
 	echo '<div class="space-2"></div>';
@@ -164,7 +164,7 @@ function custom_function_default_roadmap_print_issue( $p_issue_id, $p_issue_leve
 	echo '<i class="fa fa-square fa-status-box ' . $status_label . '" title="' . $t_status_title . '"></i> ';
 	echo string_get_bug_view_link( $p_issue_id );
 	echo ': <span class="label label-light">', $t_category, '</span> ', $t_strike_start, string_display_line_links( $t_bug->summary ), $t_strike_end;
-	if( $t_bug->handler_id != 0 ) {
+	if( $t_bug->handler_id > 0 && ON == config_get( 'show_assigned_names' ) && access_can_see_handler_for_bug( $t_bug ) ) {
 		echo ' (', prepare_user_name( $t_bug->handler_id ), ')';
 	}
 	echo '<div class="space-2"></div>';

--- a/core/custom_function_api.php
+++ b/core/custom_function_api.php
@@ -87,6 +87,7 @@ function custom_function_default_changelog_print_issue( $p_issue_id, $p_issue_le
 	static $s_status;
 
 	$t_bug = bug_get( $p_issue_id );
+	$t_current_user = auth_get_current_user_id();
 
 	if( $t_bug->category_id ) {
 		$t_category_name = category_get_name( $t_bug->category_id );
@@ -97,18 +98,20 @@ function custom_function_default_changelog_print_issue( $p_issue_id, $p_issue_le
 	$t_category = is_blank( $t_category_name ) ? '' : '<strong>[' . string_display_line( $t_category_name ) . ']</strong> ';
 
 	if( !isset( $s_status[$t_bug->status] ) ) {
-		$s_status[$t_bug->status] = get_enum_element( 'status', $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
+		$s_status[$t_bug->status] = get_enum_element( 'status', $t_bug->status, $t_current_user, $t_bug->project_id );
 	}
 
 	# choose color based on status
-	$status_label = html_get_status_css_class( $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
+	$status_label = html_get_status_css_class( $t_bug->status, $t_current_user, $t_bug->project_id );
 	$t_status_title = string_attribute( get_enum_element( 'status', bug_get_field( $t_bug->id, 'status' ), $t_bug->project_id ) );;
 
 	echo utf8_str_pad( '', $p_issue_level * 36, '&#160;' );
 	echo '<i class="fa fa-square fa-status-box ' . $status_label . '" title="' . $t_status_title . '"></i> ';
 	echo string_get_bug_view_link( $p_issue_id );
 	echo ': <span class="label label-light">', $t_category, '</span> ' , string_display_line_links( $t_bug->summary );
-	if( $t_bug->handler_id > 0 && ON == config_get( 'show_assigned_names' ) && access_can_see_handler_for_bug( $t_bug ) ) {
+	if( $t_bug->handler_id > 0
+			&& ON == config_get( 'show_assigned_names', null, $t_current_user, $t_bug->project_id )
+			&& access_can_see_handler_for_bug( $t_bug ) ) {
 		echo ' (', prepare_user_name( $t_bug->handler_id ), ')';
 	}
 	echo '<div class="space-2"></div>';
@@ -136,6 +139,7 @@ function custom_function_default_roadmap_print_issue( $p_issue_id, $p_issue_leve
 	static $s_status;
 
 	$t_bug = bug_get( $p_issue_id );
+	$t_current_user = auth_get_current_user_id();
 
 	if( bug_is_resolved( $p_issue_id ) ) {
 		$t_strike_start = '<s>';
@@ -153,18 +157,20 @@ function custom_function_default_roadmap_print_issue( $p_issue_id, $p_issue_leve
 	$t_category = is_blank( $t_category_name ) ? '' : '<strong>[' . string_display_line( $t_category_name ) . ']</strong> ';
 
 	if( !isset( $s_status[$t_bug->status] ) ) {
-		$s_status[$t_bug->status] = get_enum_element( 'status', $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
+		$s_status[$t_bug->status] = get_enum_element( 'status', $t_bug->status, $t_current_user, $t_bug->project_id );
 	}
 
 	# choose color based on status
-	$status_label = html_get_status_css_class( $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
+	$status_label = html_get_status_css_class( $t_bug->status, $t_current_user, $t_bug->project_id );
 	$t_status_title = string_attribute( get_enum_element( 'status', bug_get_field( $t_bug->id, 'status' ), $t_bug->project_id ) );;
 
 	echo utf8_str_pad( '', $p_issue_level * 36, '&#160;' );
 	echo '<i class="fa fa-square fa-status-box ' . $status_label . '" title="' . $t_status_title . '"></i> ';
 	echo string_get_bug_view_link( $p_issue_id );
 	echo ': <span class="label label-light">', $t_category, '</span> ', $t_strike_start, string_display_line_links( $t_bug->summary ), $t_strike_end;
-	if( $t_bug->handler_id > 0 && ON == config_get( 'show_assigned_names' ) && access_can_see_handler_for_bug( $t_bug ) ) {
+	if( $t_bug->handler_id > 0
+			&& ON == config_get( 'show_assigned_names', null, $t_current_user, $t_bug->project_id )
+			&& access_can_see_handler_for_bug( $t_bug ) ) {
 		echo ' (', prepare_user_name( $t_bug->handler_id ), ')';
 	}
 	echo '<div class="space-2"></div>';


### PR DESCRIPTION
Fix the validation of view_handler_threshold for specific overrides,
instead of checking on only at global level.

Introduce the validation in changelog and roadmap.

Fixes: [#23503](https://mantisbt.org/bugs/view.php?id=23503)