### PR TITLE
Fix filter view_type after column sorting

### DIFF
--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -3159,7 +3159,11 @@ function filter_create_monitored_by( $p_project_id, $p_user_id ) {
  * @return array The resulting filter array
  */
 function filter_gpc_get( array $p_filter = null ) {
+	# Get or copy the view_type first as it's needed to get proper defaults
 	$f_view_type = gpc_get_string( 'view_type', null );
+	if( null === $f_view_type && is_array( $p_filter ) && isset( $p_filter['_view_type'] ) ) {
+		$f_view_type = $p_filter['_view_type'];
+	}
 
 	if( null === $p_filter ) {
 		$t_filter = filter_get_default_array( $f_view_type );


### PR DESCRIPTION
Keep the current view_type filter property after modifying the sorting
by clicking in column headers.

Fixes: #23528