### PR TITLE
Bugnote text area not styled correctly when private by default

### DIFF
--- a/bug_actiongroup_page.php
+++ b/bug_actiongroup_page.php
@@ -381,13 +381,17 @@ if( $t_multiple_projects ) {
 	event_signal( 'EVENT_BUG_ACTIONGROUP_FORM', array( $t_event_params ) );
 
 	if( $t_bugnote ) {
+		$t_default_bugnote_view_status = config_get( 'default_bugnote_view_status' );
+		$t_bugnote_private = $t_default_bugnote_view_status == VS_PRIVATE;
+		$t_bugnote_class = $t_bugnote_private ? 'form-control bugnote-private' : 'form-control';
+
 ?>
 				<tr>
 					<th class="category">
 						<?php echo lang_get( 'add_bugnote_title' ); ?>
 					</th>
 					<td>
-						<textarea class="form-control" name="bugnote_text" id="bugnote_text" cols="80" rows="10"></textarea>
+						<textarea name="bugnote_text" id="bugnote_text" class="<?php echo $t_bugnote_class ?>" cols="80" rows="7"></textarea>
 					</td>
 				</tr>
 <?php
@@ -399,7 +403,6 @@ if( $t_multiple_projects ) {
 					</th>
 					<td>
 <?php
-			$t_default_bugnote_view_status = config_get( 'default_bugnote_view_status' );
 			if( access_has_project_level( config_get( 'set_view_status_threshold' ), $t_project_id ) ) {
 ?>
 						<input type="checkbox" class="ace" name="private" <?php check_checked( $t_default_bugnote_view_status, VS_PRIVATE ); ?> />

--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -341,6 +341,9 @@ layout_page_begin();
 				<td>
 <?php
 		$t_default_bugnote_view_status = config_get( 'default_bugnote_view_status' );
+		$t_bugnote_private = $t_default_bugnote_view_status == VS_PRIVATE;
+		$t_bugnote_class = $t_bugnote_private ? 'form-control bugnote-private' : 'form-control';
+
 		if( access_has_bug_level( config_get( 'set_view_status_threshold' ), $f_bug_id ) ) {
 ?>
 			<input type="checkbox" id="bugnote_add_view_status" class="ace" name="private"
@@ -360,7 +363,7 @@ layout_page_begin();
 					<?php echo lang_get( 'add_bugnote_title' ) ?>
 				</th>
 				<td>
-					<textarea class="form-control" name="bugnote_text" id="bugnote_text" cols="80" rows="10"></textarea>
+					<textarea name="bugnote_text" id="bugnote_text" class="<?php echo $t_bugnote_class ?>" cols="80" rows="7"></textarea>
 				</td>
 			</tr>
 <?php

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -701,9 +701,13 @@ if( $t_custom_fields_found ) {
 }
 
 # Bugnote Text Box
+$t_default_bugnote_view_status = config_get( 'default_bugnote_view_status' );
+$t_bugnote_private = $t_default_bugnote_view_status == VS_PRIVATE;
+$t_bugnote_class = $t_bugnote_private ? 'form-control bugnote-private' : 'form-control';
+
 echo '<tr>';
 echo '<th class="category"><label for="bugnote_text">' . lang_get( 'add_bugnote_title' ) . '</label></th>';
-echo '<td colspan="5"><textarea class="form-control" ', helper_get_tab_index(), ' id="bugnote_text" name="bugnote_text" cols="80" rows="10"></textarea></td></tr>';
+echo '<td colspan="5"><textarea ', helper_get_tab_index(), ' id="bugnote_text" name="bugnote_text" class="', $t_bugnote_class, '" cols="80" rows="7"></textarea></td></tr>';
 
 # Bugnote Private Checkbox (if permitted)
 if( access_has_bug_level( config_get( 'private_bugnote_threshold' ), $t_bug_id ) ) {
@@ -711,7 +715,6 @@ if( access_has_bug_level( config_get( 'private_bugnote_threshold' ), $t_bug_id )
 	echo '<th class="category">' . lang_get( 'private' ) . '</th>';
 	echo '<td colspan="5">';
 
-	$t_default_bugnote_view_status = config_get( 'default_bugnote_view_status' );
 	if( access_has_bug_level( config_get( 'set_view_status_threshold' ), $t_bug_id ) ) {
 		echo '<label>';
 		echo '<input ', helper_get_tab_index(), ' type="checkbox" class="ace" id="private" name="private" ', check_checked( config_get( 'default_bugnote_view_status' ), VS_PRIVATE ), ' />';

--- a/bugnote_add_inc.php
+++ b/bugnote_add_inc.php
@@ -93,6 +93,9 @@ require_api( 'lang_api.php' );
 
 <?php
 	$t_default_bugnote_view_status = config_get( 'default_bugnote_view_status' );
+	$t_bugnote_private = $t_default_bugnote_view_status == VS_PRIVATE;
+	$t_bugnote_class = $t_bugnote_private ? 'form-control bugnote-private' : 'form-control';
+
 	if( access_has_bug_level( config_get( 'set_view_status_threshold' ), $f_bug_id ) ) {
 ?>
 			<tr>
@@ -113,10 +116,9 @@ require_api( 'lang_api.php' );
 					<?php echo lang_get( 'bugnote' ) ?>
 				</th>
 				<td width="85%">
-					<textarea name="bugnote_text" id="bugnote_text" class="form-control" rows="7"></textarea>
+					<textarea name="bugnote_text" id="bugnote_text" class="<?php echo $t_bugnote_class ?>" rows="7"></textarea>
 				</td>
 			</tr>
-
 
 <?php
 	if( config_get( 'time_tracking_enabled' ) ) {


### PR DESCRIPTION
When bugnotes are private by default, they are not styled with bugnote-private class, hence, not yellow.

Fixes #23555

There may be an opportunity for refactoring here.