### PR TITLE
summary page enhancement with bugs ratio added.

### DIFF
--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -132,11 +132,11 @@ function summary_helper_build_bugcount( &$p_cache, $p_key, $p_status, $p_bugcoun
 /** 
  * Build bug links for 'open', 'resolved' and 'closed' issue counts
  * 
- * @param string $p_bug_link 		The base bug link.
- * @param string &$p_bugs_open 		The open bugs count, return open bugs link.
- * @param string &$p_bugs_resolved 	The resovled bugs count, return resolved bugs link.
- * @param string &$p_bugs_closed   	The closed bugs count, return closed bugs link.
- * @param string &$p_bugs_total   	The total bugs count, return total bugs link.
+ * @param string $p_bug_link            The base bug link.
+ * @param string &$p_bugs_open          The open bugs count, return open bugs link.
+ * @param string &$p_bugs_resolved      The resovled bugs count, return resolved bugs link.
+ * @param string &$p_bugs_closed        The closed bugs count, return closed bugs link.
+ * @param string &$p_bugs_total         The total bugs count, return total bugs link.
  * @return void 
  */
 function summary_helper_build_buglinks( $p_bug_link, &$p_bugs_open, &$p_bugs_resolved, &$p_bugs_closed, &$p_bugs_total) {
@@ -159,11 +159,11 @@ function summary_helper_build_buglinks( $p_bug_link, &$p_bugs_open, &$p_bugs_res
 
 /**
  * Calculate bug ratio 
- * @param integer $p_bugs_open 		The open bugs count.
- * @param integer $p_bugs_resolved 	The resovled bugs count.
- * @param integer $p_bugs_closed   	The closed bugs count.
- * @param integer $p_bugs_total_count   	The total bugs count.
- * @return array	array of ($t_bugs_resolved_ratio, $t_bugs_ratio)
+ * @param integer $p_bugs_open            The open bugs count.
+ * @param integer $p_bugs_resolved        The resovled bugs count.
+ * @param integer $p_bugs_closed          The closed bugs count.
+ * @param integer $p_bugs_total_count     The total bugs count.
+ * @return array  array of ($t_bugs_resolved_ratio, $t_bugs_ratio)
  */
 function summary_helper_get_bugratio( $p_bugs_open, $p_bugs_resolved, $p_bugs_closed, $p_bugs_total_count) {
 	$t_bugs_total = $p_bugs_open + $p_bugs_resolved + $p_bugs_closed;

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -96,13 +96,13 @@ function summary_helper_get_developer_label( $p_user_id ) {
 }
 
 /**
- * Calculate bug status count according to  'open', 'resolved' and 'closed', 
+ * Calculate bug status count according to 'open', 'resolved' and 'closed',
  * then put the numbers into $p_cache array
  *
  * @param array &$p_cache    The cache array.
  * @param string $p_key      The key of the array.
  * @param string $p_status   The status of issues.
- * @param string $p_bugcount The bug count of $p_status issues.
+ * @param integer $p_bugcount The bug count of $p_status issues.
  * @return void
  */
 function summary_helper_build_bugcount( &$p_cache, $p_key, $p_status, $p_bugcount ) {

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -124,7 +124,7 @@ function summary_print_by_enum( $p_enum ) {
 	$t_resolved_val = config_get( 'bug_resolved_status_threshold' );
 	$t_closed_val = config_get( 'bug_closed_status_threshold' );
 
-	$p_cache = array();
+	$t_cache = array();
 	$t_bugs_total_count = 0;
 	$t_bugs_open = 0;
 	$t_bugs_resolved = 0;
@@ -139,36 +139,36 @@ function summary_print_by_enum( $p_enum ) {
 		
 
 		if( $t_closed_val <= $t_status ) {
-			if( isset( $p_cache[$t_enum]['closed'] ) ) {
-				$p_cache[$t_enum]['closed'] += $t_bugcount;
+			if( isset( $t_cache[$t_enum]['closed'] ) ) {
+				$t_cache[$t_enum]['closed'] += $t_bugcount;
 			} else {
-				$p_cache[$t_enum]['closed'] = $t_bugcount;
+				$t_cache[$t_enum]['closed'] = $t_bugcount;
 			}
 		} else if( $t_resolved_val <= $t_status ) {
-			if( isset( $p_cache[$t_enum]['resolved'] ) ) {
-				$p_cache[$t_enum]['resolved'] += $t_bugcount;
+			if( isset( $t_cache[$t_enum]['resolved'] ) ) {
+				$t_cache[$t_enum]['resolved'] += $t_bugcount;
 			} else {
-				$p_cache[$t_enum]['resolved'] = $t_bugcount;
+				$t_cache[$t_enum]['resolved'] = $t_bugcount;
 			}
 		} else {
-			if( isset( $p_cache[$t_enum]['open'] ) ) {
-				$p_cache[$t_enum]['open'] += $t_bugcount;
+			if( isset( $t_cache[$t_enum]['open'] ) ) {
+				$t_cache[$t_enum]['open'] += $t_bugcount;
 			} else {
-				$p_cache[$t_enum]['open'] = $t_bugcount;
+				$t_cache[$t_enum]['open'] = $t_bugcount;
 			}
 		}
 	}
-	foreach( $p_cache as $t_enum=>$t_item) {
+	foreach( $t_cache as $t_enum => $t_item) {
 		# Build up the hyperlinks to bug views
 		$t_bug_link = '';
-		$t_bugs_open = isset($t_item['open']) ? $t_item['open'] : 0;
-		$t_bugs_resolved = isset($t_item['resolved']) ? $t_item['resolved'] : 0;
-		$t_bugs_closed = isset($t_item['closed']) ? $t_item['closed'] : 0;
+		$t_bugs_open = isset( $t_item['open'] ) ? $t_item['open'] : 0;
+		$t_bugs_resolved = isset( $t_item['resolved'] ) ? $t_item['resolved'] : 0;
+		$t_bugs_closed = isset( $t_item['closed'] ) ? $t_item['closed'] : 0;
 		$t_bugs_total = $t_bugs_open + $t_bugs_resolved + $t_bugs_closed;
-		$t_bugs_resolved_ratio = ($t_bugs_resolved + $t_bugs_closed)/($t_bugs_total==0 ? 1 : $t_bugs_total);
-		$t_bugs_ratio = $t_bugs_total /( $t_bugs_total_count == 0 ? 1 : $t_bugs_total_count);
-		$p_bugs_resolved_ratio = sprintf("%.1f%%", $t_bugs_resolved_ratio*100);
-		$p_bugs_ratio = sprintf("%.1f%%", $t_bugs_ratio*100);
+		$t_bugs_resolved_ratio = ( $t_bugs_resolved + $t_bugs_closed ) / ( $t_bugs_total == 0 ? 1 : $t_bugs_total );
+		$t_bugs_ratio = $t_bugs_total / ( $t_bugs_total_count == 0 ? 1 : $t_bugs_total_count );
+		$p_bugs_resolved_ratio = sprintf( "%.1f%%", $t_bugs_resolved_ratio * 100 );
+		$p_bugs_ratio = sprintf( "%.1f%%", $t_bugs_ratio * 100 );
 
 		switch( $p_enum ) {
 			case 'status':
@@ -447,7 +447,7 @@ function summary_print_by_developer() {
 	$t_closed_val = config_get( 'bug_closed_status_threshold' );
 
 	$t_summaryusers = array();
-	$p_cache = array();
+	$t_cache = array();
 	$t_bugs_total_count = 0;
 	$t_bugs_open = 0;
 	$t_bugs_resolved = 0;
@@ -461,42 +461,42 @@ function summary_print_by_developer() {
 		$t_label = $t_row['handler_id'];
 
 		if( $t_closed_val <= $t_status ) {
-			if( isset( $p_cache[$t_label]['closed'] ) ) {
-				$p_cache[$t_label]['closed'] += $t_bugcount;
+			if( isset( $t_cache[$t_label]['closed'] ) ) {
+				$t_cache[$t_label]['closed'] += $t_bugcount;
 			} else {
-				$p_cache[$t_label]['closed'] = $t_bugcount;
+				$t_cache[$t_label]['closed'] = $t_bugcount;
 			}
 		} else if( $t_resolved_val <= $t_status ) {
-			if( isset( $p_cache[$t_label]['resolved'] ) ) {
-				$p_cache[$t_label]['resolved'] += $t_bugcount;
+			if( isset( $t_cache[$t_label]['resolved'] ) ) {
+				$t_cache[$t_label]['resolved'] += $t_bugcount;
 			} else {
-				$p_cache[$t_label]['resolved'] = $t_bugcount;
+				$t_cache[$t_label]['resolved'] = $t_bugcount;
 			}
 		} else {
-			if( isset( $p_cache[$t_label]['open'] ) ) {
-				$p_cache[$t_label]['open'] += $t_bugcount;
+			if( isset( $t_cache[$t_label]['open'] ) ) {
+				$t_cache[$t_label]['open'] += $t_bugcount;
 			} else {
-				$p_cache[$t_label]['open'] = $t_bugcount;
+				$t_cache[$t_label]['open'] = $t_bugcount;
 			}
 		}
 	}
 	
 	user_cache_array_rows( array_unique( $t_summaryusers ) );
 
-	foreach( $p_cache as $t_label=>$t_item) {
+	foreach( $t_cache as $t_label => $t_item) {
 		# Build up the hyperlinks to bug views
 		$t_bug_link = '';
-		$t_bugs_open = isset($t_item['open']) ? $t_item['open'] : 0;
-		$t_bugs_resolved = isset($t_item['resolved']) ? $t_item['resolved'] : 0;
-		$t_bugs_closed = isset($t_item['closed']) ? $t_item['closed'] : 0;
+		$t_bugs_open = isset( $t_item['open'] ) ? $t_item['open'] : 0;
+		$t_bugs_resolved = isset( $t_item['resolved'] ) ? $t_item['resolved'] : 0;
+		$t_bugs_closed = isset( $t_item['closed'] ) ? $t_item['closed'] : 0;
 		$t_bugs_total = $t_bugs_open + $t_bugs_resolved + $t_bugs_closed;
-		$t_bugs_resolved_ratio = ($t_bugs_resolved + $t_bugs_closed)/($t_bugs_total==0 ? 1 : $t_bugs_total);
-		$t_bugs_ratio = $t_bugs_total /( $t_bugs_total_count == 0 ? 1 : $t_bugs_total_count);
-		$p_bugs_resolved_ratio = sprintf("%.1f%%", $t_bugs_resolved_ratio*100);
-		$p_bugs_ratio = sprintf("%.1f%%", $t_bugs_ratio*100);
+		$t_bugs_resolved_ratio = ( $t_bugs_resolved + $t_bugs_closed ) / ( $t_bugs_total==0 ? 1 : $t_bugs_total );
+		$t_bugs_ratio = $t_bugs_total /( $t_bugs_total_count == 0 ? 1 : $t_bugs_total_count );
+		$p_bugs_resolved_ratio = sprintf( "%.1f%%", $t_bugs_resolved_ratio * 100 );
+		$p_bugs_ratio = sprintf( "%.1f%%", $t_bugs_ratio * 100 );
 
 		$t_bug_link = '<a class="subtle" href="' . config_get( 'bug_count_hyperlink_prefix' ) . '&amp;' . FILTER_PROPERTY_HANDLER_ID . '=' . $t_label;
-		$t_label = summary_helper_get_developer_label($t_label);
+		$t_label = summary_helper_get_developer_label( $t_label );
 
 		if( 0 < $t_bugs_open ) {
 			$t_bugs_open = $t_bug_link . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_resolved_val . '">' . $t_bugs_open . '</a>';
@@ -575,10 +575,10 @@ function summary_print_by_reporter() {
 		}
 
 		$t_bugs_total = $t_bugs_open + $t_bugs_resolved + $t_bugs_closed;
-		$t_bugs_resolved_ratio = ($t_bugs_resolved + $t_bugs_closed)/($t_bugs_total==0 ? 1 : $t_bugs_total);
-		$t_bugs_ratio = $t_bugs_total /( $t_bugs_total_count == 0 ? 1 : $t_bugs_total_count);
-		$p_bugs_resolved_ratio = sprintf("%.1f%%", $t_bugs_resolved_ratio*100);
-		$p_bugs_ratio = sprintf("%.1f%%", $t_bugs_ratio*100);
+		$t_bugs_resolved_ratio = ( $t_bugs_resolved + $t_bugs_closed ) / ( $t_bugs_total==0 ? 1 : $t_bugs_total );
+		$t_bugs_ratio = $t_bugs_total /( $t_bugs_total_count == 0 ? 1 : $t_bugs_total_count );
+		$p_bugs_resolved_ratio = sprintf( "%.1f%%", $t_bugs_resolved_ratio * 100 );
+		$p_bugs_ratio = sprintf( "%.1f%%", $t_bugs_ratio * 100 );
 
 		if( 0 < $t_bugs_total ) {
 			$t_user = string_display_line( user_get_name( $v_reporter_id ) );
@@ -630,7 +630,7 @@ function summary_print_by_category() {
 	$t_resolved_val = config_get( 'bug_resolved_status_threshold' );
 	$t_closed_val = config_get( 'bug_closed_status_threshold' );
 
-	$p_cache = array();
+	$t_cache = array();
 	$t_category_name = "";
 	$t_project = "";
 	$t_bugs_total_count = 0;
@@ -648,37 +648,37 @@ function summary_print_by_category() {
 		} 
 
 		if( $t_closed_val <= $t_status ) {
-			if( isset( $p_cache[$t_label]['closed'] ) ) {
-				$p_cache[$t_label]['closed'] += $t_bugcount;
+			if( isset( $t_cache[$t_label]['closed'] ) ) {
+				$t_cache[$t_label]['closed'] += $t_bugcount;
 			} else {
-				$p_cache[$t_label]['closed'] = $t_bugcount;
+				$t_cache[$t_label]['closed'] = $t_bugcount;
 			}
 		} else if( $t_resolved_val <= $t_status ) {
-			if( isset( $p_cache[$t_label]['resolved'] ) ) {
-				$p_cache[$t_label]['resolved'] += $t_bugcount;
+			if( isset( $t_cache[$t_label]['resolved'] ) ) {
+				$t_cache[$t_label]['resolved'] += $t_bugcount;
 			} else {
-				$p_cache[$t_label]['resolved'] = $t_bugcount;
+				$t_cache[$t_label]['resolved'] = $t_bugcount;
 			}
 		} else {
-			if( isset( $p_cache[$t_label]['open'] ) ) {
-				$p_cache[$t_label]['open'] += $t_bugcount;
+			if( isset( $t_cache[$t_label]['open'] ) ) {
+				$t_cache[$t_label]['open'] += $t_bugcount;
 			} else {
-				$p_cache[$t_label]['open'] = $t_bugcount;
+				$t_cache[$t_label]['open'] = $t_bugcount;
 			}
 		}
 	}
 	
-	foreach( $p_cache as $t_label=>$t_item) {
+	foreach( $t_cache as $t_label => $t_item) {
 		# Build up the hyperlinks to bug views
 		$t_bug_link = '';
-		$t_bugs_open = isset($t_item['open']) ? $t_item['open'] : 0;
-		$t_bugs_resolved = isset($t_item['resolved']) ? $t_item['resolved'] :0;
-		$t_bugs_closed = isset($t_item['closed']) ? $t_item['closed'] : 0;
+		$t_bugs_open = isset( $t_item['open'] ) ? $t_item['open'] : 0;
+		$t_bugs_resolved = isset( $t_item['resolved'] ) ? $t_item['resolved'] :0;
+		$t_bugs_closed = isset( $t_item['closed'] ) ? $t_item['closed'] : 0;
 		$t_bugs_total = $t_bugs_open + $t_bugs_resolved + $t_bugs_closed;
-		$t_bugs_resolved_ratio = ($t_bugs_resolved + $t_bugs_closed)/($t_bugs_total==0 ? 1 : $t_bugs_total);
-		$t_bugs_ratio = $t_bugs_total /( $t_bugs_total_count == 0 ? 1 : $t_bugs_total_count);
-		$p_bugs_resolved_ratio = sprintf("%.1f%%", $t_bugs_resolved_ratio*100);
-		$p_bugs_ratio = sprintf("%.1f%%", $t_bugs_ratio*100);
+		$t_bugs_resolved_ratio = ( $t_bugs_resolved + $t_bugs_closed ) / ( $t_bugs_total==0 ? 1 : $t_bugs_total );
+		$t_bugs_ratio = $t_bugs_total /( $t_bugs_total_count == 0 ? 1 : $t_bugs_total_count );
+		$p_bugs_resolved_ratio = sprintf( "%.1f%%", $t_bugs_resolved_ratio * 100 );
+		$p_bugs_ratio = sprintf( "%.1f%%", $t_bugs_ratio * 100 );
 
 		$t_bug_link = '<a class="subtle" href="' . config_get( 'bug_count_hyperlink_prefix' ) . '&amp;' . FILTER_PROPERTY_CATEGORY_ID . '=' . urlencode( $t_label );
 		if( 0 < $t_bugs_open ) {
@@ -770,10 +770,10 @@ function summary_print_by_project( array $p_projects = array(), $p_level = 0, ar
 		$t_bugs_closed = isset( $t_pdata['closed'] ) ? $t_pdata['closed'] : 0;
 		$t_bugs_total = $t_bugs_open + $t_bugs_resolved + $t_bugs_closed;
 		
-		$t_bugs_resolved_ratio = ($t_bugs_resolved + $t_bugs_closed)/($t_bugs_total==0 ? 1 : $t_bugs_total);
-		$t_bugs_ratio = $t_bugs_total /( $t_bugs_total_count == 0 ? 1 : $t_bugs_total_count);
-		$p_bugs_resolved_ratio = sprintf("%.1f%%", $t_bugs_resolved_ratio*100);
-		$p_bugs_ratio = sprintf("%.1f%%", $t_bugs_ratio*100);
+		$t_bugs_resolved_ratio = ( $t_bugs_resolved + $t_bugs_closed ) / ( $t_bugs_total == 0 ? 1 : $t_bugs_total );
+		$t_bugs_ratio = $t_bugs_total / ( $t_bugs_total_count == 0 ? 1 : $t_bugs_total_count );
+		$p_bugs_resolved_ratio = sprintf( "%.1f%%", $t_bugs_resolved_ratio * 100 );
+		$p_bugs_ratio = sprintf( "%.1f%%", $t_bugs_ratio * 100 );
 		
 		summary_helper_print_row( string_display_line( $t_name ), $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total, $p_bugs_resolved_ratio, $p_bugs_ratio);
 

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -201,10 +201,6 @@ function summary_print_by_enum( $p_enum ) {
 
 	$t_cache = array();
 	$t_bugs_total_count = 0;
-	$t_bugs_open = 0;
-	$t_bugs_resolved = 0;
-	$t_bugs_closed = 0;
-	$t_bugs_total = 0;
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_enum = $t_row[$p_enum];
@@ -502,10 +498,7 @@ function summary_print_by_developer() {
 	$t_summaryusers = array();
 	$t_cache = array();
 	$t_bugs_total_count = 0;
-	$t_bugs_open = 0;
-	$t_bugs_resolved = 0;
-	$t_bugs_closed = 0;
-	
+
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_summaryusers[] = $t_row['handler_id'];
 		$t_status = $t_row['status'];
@@ -520,7 +513,6 @@ function summary_print_by_developer() {
 
 	foreach( $t_cache as $t_label => $t_item) {
 		# Build up the hyperlinks to bug views
-		$t_bug_link = '';
 		$t_bugs_open = isset( $t_item['open'] ) ? $t_item['open'] : 0;
 		$t_bugs_resolved = isset( $t_item['resolved'] ) ? $t_item['resolved'] : 0;
 		$t_bugs_closed = isset( $t_item['closed'] ) ? $t_item['closed'] : 0;
@@ -644,12 +636,7 @@ function summary_print_by_category() {
 	$t_result = db_query( $t_query );
 
 	$t_cache = array();
-	$t_category_name = "";
-	$t_project = "";
 	$t_bugs_total_count = 0;
-	$t_bugs_open = 0;
-	$t_bugs_resolved = 0;
-	$t_bugs_closed = 0;
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_status = $t_row['status'];

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -60,8 +60,8 @@ require_api( 'utility_api.php' );
  * @param string $p_resolved Count of resolved issues - normally string with hyperlink to filter.
  * @param string $p_closed   Count of closed issues - normally string with hyperlink to filter.
  * @param string $p_total    Count of total issues - normally string with hyperlink to filter.
- * @param string $p_resolved_ratio  ratio of resolved
- * @param string $p_closed_ratio   ratio of closed
+ * @param string $p_resolved_ratio  Ratio of resolved
+ * @param string $p_ratio    Ratio of total bugs
  * @return void
  */
 function summary_helper_print_row( $p_label, $p_open, $p_resolved, $p_closed, $p_total, $p_resolved_ratio, $p_ratio) {
@@ -99,7 +99,7 @@ function summary_helper_get_developer_label( $p_user_id ) {
  * Calculate bug status count according to  'open', 'resolved' and 'closed', 
  * then put the numbers into $p_cache array
  *
- * @param string &$p_cache    The cache array.
+ * @param array &$p_cache    The cache array.
  * @param string $p_key      The key of the array.
  * @param string $p_status   The status of issues.
  * @param string $p_bugcount The bug count of $p_status issues.
@@ -158,12 +158,12 @@ function summary_helper_build_buglinks( $p_bug_link, &$p_bugs_open, &$p_bugs_res
 }
 
 /**
- * Calcute bug ratio 
- * @param string $p_bugs_open 		The open bugs count.
- * @param string $p_bugs_resolved 	The resovled bugs count.
- * @param string $p_bugs_closed   	The closed bugs count.
- * @param string $p_bugs_total_count   	The total bugs count.
- * @return array($t_bugs_resolved_ratio, $t_bugs_ratio)
+ * Calculate bug ratio 
+ * @param integer $p_bugs_open 		The open bugs count.
+ * @param integer $p_bugs_resolved 	The resovled bugs count.
+ * @param integer $p_bugs_closed   	The closed bugs count.
+ * @param integer $p_bugs_total_count   	The total bugs count.
+ * @return array	array of ($t_bugs_resolved_ratio, $t_bugs_ratio)
  */
 function summary_helper_get_bugratio( $p_bugs_open, $p_bugs_resolved, $p_bugs_closed, $p_bugs_total_count) {
 	$t_bugs_total = $p_bugs_open + $p_bugs_resolved + $p_bugs_closed;

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -65,15 +65,15 @@ require_api( 'utility_api.php' );
  * @return void
  */
 function summary_helper_print_row( $p_label, $p_open, $p_resolved, $p_closed, $p_total, $p_resolved_ratio, $p_ratio) {
-        echo '<tr>';
-        printf( '<td class="width50">%s</td>', $p_label );
-        printf( '<td class="width12 align-right">%s</td>', $p_open );
-        printf( '<td class="width12 align-right">%s</td>', $p_resolved );
-        printf( '<td class="width12 align-right">%s</td>', $p_closed );
-        printf( '<td class="width12 align-right">%s</td>', $p_total );
-        printf( '<td class="width12 align-right">%s</td>', $p_resolved_ratio );
-        printf( '<td class="width12 align-right">%s</td>', $p_ratio );
-        echo '</tr>';
+	echo '<tr>';
+	printf( '<td class="width50">%s</td>', $p_label );
+	printf( '<td class="width12 align-right">%s</td>', $p_open );
+	printf( '<td class="width12 align-right">%s</td>', $p_resolved );
+	printf( '<td class="width12 align-right">%s</td>', $p_closed );
+	printf( '<td class="width12 align-right">%s</td>', $p_total );
+	printf( '<td class="width12 align-right">%s</td>', $p_resolved_ratio );
+	printf( '<td class="width12 align-right">%s</td>', $p_ratio );
+	echo '</tr>';
 }
 
 /**

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1193,7 +1193,7 @@ $s_total_time = 'Total time';
 $s_developer_stats = 'Developer Stats';
 $s_reporter_stats = 'Reporter Stats';
 $s_orct = '(open/resolved/closed/total)';
-$s_summary_header = '(open/resolved/closed/total/resolved ratio/ratio)';
+$s_summary_header = 'open/resolved/closed/total/resolved ratio/ratio';
 
 # view_all_bug_page.php
 $s_any = 'any';

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1192,7 +1192,7 @@ $s_average_time = 'Average time';
 $s_total_time = 'Total time';
 $s_developer_stats = 'Developer Stats';
 $s_reporter_stats = 'Reporter Stats';
-$s_orct = '(open/resolved/closed/total)';
+$s_orct = '(open/resolved/closed/total/resolved ratio/ratio)';
 
 # view_all_bug_page.php
 $s_any = 'any';

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1192,7 +1192,8 @@ $s_average_time = 'Average time';
 $s_total_time = 'Total time';
 $s_developer_stats = 'Developer Stats';
 $s_reporter_stats = 'Reporter Stats';
-$s_orct = '(open/resolved/closed/total/resolved ratio/ratio)';
+$s_orct = '(open/resolved/closed/total)';
+$s_summary_header = '(open/resolved/closed/total/resolved ratio/ratio)';
 
 # view_all_bug_page.php
 $s_any = 'any';

--- a/summary_page.php
+++ b/summary_page.php
@@ -111,13 +111,13 @@ $t_largest_diff 	= number_format( $t_largest_diff / SECONDS_PER_DAY, 2 );
 $t_total_time		= number_format( $t_total_time / SECONDS_PER_DAY, 2 );
 $t_average_time 	= number_format( $t_average_time / SECONDS_PER_DAY, 2 );
 
-$t_orct_arr = preg_split( '/[\)\/\(]/', lang_get( 'orct' ), -1, PREG_SPLIT_NO_EMPTY );
+$t_summary_header_arr = preg_split( '/[\)\/\(]/', lang_get( 'summary_header' ), -1, PREG_SPLIT_NO_EMPTY );
 
-$t_orcttab = '';
-foreach ( $t_orct_arr as $t_orct_s ) {
-	$t_orcttab .= '<th class="align-right">';
-	$t_orcttab .= $t_orct_s;
-	$t_orcttab .= '</th>';
+$t_summary_header = '';
+foreach ( $t_summary_header_arr as $t_summary_header_name ) {
+	$t_summary_header .= '<th class="align-right">';
+	$t_summary_header .= $t_summary_header_name;
+	$t_summary_header .= '</th>';
 }
 
 layout_page_header( lang_get( 'summary_link' ) );
@@ -154,7 +154,7 @@ print_summary_submenu();
 		<thead>
 			<tr>
 				<th class="width-35"><?php echo lang_get( 'by_project' ) ?></th>
-				<?php echo $t_orcttab ?>
+				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
 		<?php summary_print_by_project(); ?>
@@ -169,7 +169,7 @@ print_summary_submenu();
 		<thead>
 			<tr>
 				<th class="width-35"><?php echo lang_get( 'by_status' ) ?></th>
-				<?php echo $t_orcttab ?>
+				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
 		<?php summary_print_by_enum( 'status' ) ?>
@@ -183,7 +183,7 @@ print_summary_submenu();
 		<thead>
 			<tr>
 				<th class="width-35"><?php echo lang_get( 'by_severity' ) ?></th>
-				<?php echo $t_orcttab ?>
+				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
 		<?php summary_print_by_enum( 'severity' ) ?>
@@ -197,7 +197,7 @@ print_summary_submenu();
 		<thead>
 			<tr>
 				<th class="width-35"><?php echo lang_get( 'by_category' ) ?></th>
-				<?php echo $t_orcttab ?>
+				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
 		<?php summary_print_by_category() ?>
@@ -243,7 +243,7 @@ print_summary_submenu();
 		<thead>
 			<tr>
 				<th><?php echo lang_get( 'developer_stats' ) ?></th>
-				<?php echo $t_orcttab ?>
+				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
 		<?php summary_print_by_developer() ?>
@@ -305,7 +305,7 @@ print_summary_submenu();
 		<thead>
 			<tr>
 				<th class="width-35"><?php echo lang_get( 'by_resolution' ) ?></th>
-				<?php echo $t_orcttab ?>
+				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
 		<?php summary_print_by_enum( 'resolution' ) ?>
@@ -319,7 +319,7 @@ print_summary_submenu();
 		<thead>
 			<tr>
 				<th class="width-35"><?php echo lang_get( 'by_priority' ) ?></th>
-				<?php echo $t_orcttab ?>
+				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
 		<?php summary_print_by_enum( 'priority' ) ?>
@@ -333,7 +333,7 @@ print_summary_submenu();
 		<thead>
 			<tr>
 				<th class="width-35"><?php echo lang_get( 'reporter_stats' ) ?></th>
-				<?php echo $t_orcttab ?>
+				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
 		<?php summary_print_by_reporter() ?>

--- a/summary_page.php
+++ b/summary_page.php
@@ -146,7 +146,6 @@ print_summary_submenu();
 <!-- LEFT COLUMN -->
 <div class="col-md-6 col-xs-12">
 
-	<?php if( 0 < count( $t_project_ids ) ) { ?>
 	<!-- BY PROJECT -->
 	<div class="space-10"></div>
 	<div class="widget-box table-responsive">
@@ -160,7 +159,6 @@ print_summary_submenu();
 		<?php summary_print_by_project(); ?>
 	</table>
 	</div>
-	<?php } ?>
 
 	<!-- BY STATUS -->
 	<div class="space-10"></div>

--- a/summary_page.php
+++ b/summary_page.php
@@ -146,7 +146,7 @@ print_summary_submenu();
 <!-- LEFT COLUMN -->
 <div class="col-md-6 col-xs-12">
 
-	<?php if( 1 < count( $t_project_ids ) ) { ?>
+	<?php if( 0 < count( $t_project_ids ) ) { ?>
 	<!-- BY PROJECT -->
 	<div class="space-10"></div>
 	<div class="widget-box table-responsive">

--- a/summary_page.php
+++ b/summary_page.php
@@ -153,7 +153,11 @@ print_summary_submenu();
 		<table class="table table-hover table-bordered table-condensed table-striped">
 		<thead>
 			<tr>
+			<?php if( 1 == count( $t_project_ids ) ) { ?>
+				<th class="width-35"><?php echo lang_get( 'email_project' ) ?></th>
+			<?php } else { ?>
 				<th class="width-35"><?php echo lang_get( 'by_project' ) ?></th>
+			<?php } ?>
 				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>

--- a/summary_page.php
+++ b/summary_page.php
@@ -111,7 +111,7 @@ $t_largest_diff 	= number_format( $t_largest_diff / SECONDS_PER_DAY, 2 );
 $t_total_time		= number_format( $t_total_time / SECONDS_PER_DAY, 2 );
 $t_average_time 	= number_format( $t_average_time / SECONDS_PER_DAY, 2 );
 
-$t_summary_header_arr = preg_split( '/[\)\/\(]/', lang_get( 'summary_header' ), -1, PREG_SPLIT_NO_EMPTY );
+$t_summary_header_arr = explode( '/', lang_get( 'summary_header' ) );
 
 $t_summary_header = '';
 foreach ( $t_summary_header_arr as $t_summary_header_name ) {

--- a/summary_page.php
+++ b/summary_page.php
@@ -153,11 +153,7 @@ print_summary_submenu();
 		<table class="table table-hover table-bordered table-condensed table-striped">
 		<thead>
 			<tr>
-			<?php if( 1 == count( $t_project_ids ) ) { ?>
-				<th class="width-35"><?php echo lang_get( 'email_project' ) ?></th>
-			<?php } else { ?>
 				<th class="width-35"><?php echo lang_get( 'by_project' ) ?></th>
-			<?php } ?>
 				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>


### PR DESCRIPTION
In summary page, added two columns in by_project, by_enum, by_developer and by_reporter summary tables: resolved bug ratio, i.e. (resolved + closed)/total *100%, and item ratio, i.e. (item total)/(sum of total bugs).

Fixed #0023627: Summary page enhancement with bugs ratio support