### PR TITLE
Support issue history in REST API

### DIFF
--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -90,7 +90,243 @@ function mc_issue_get( $p_username, $p_password, $p_issue_id ) {
 }
 
 /**
-* Get history details about an issue.
+ * Get history details for an issue that is visible to specified user.
+ * This is used by REST APIs and assumes that user access to issue is
+ * already done.
+ *
+ * @param integer $p_issue_id The issue id.
+ * @param integer $p_user_id The user id.
+ * @param string $p_lang The user language.
+ * @return array history entries or empty if user has no access to history.
+ */
+function mci_issue_get_history( $p_issue_id, $p_user_id, $p_lang ) {
+	$t_project_id = bug_get_field( $p_issue_id, 'project_id' );
+
+	$t_view_history_threshold = config_get( 'view_history_threshold', null, null, $t_project_id );
+	if( !access_has_bug_level( $t_view_history_threshold, $p_issue_id, $p_user_id ) ) {
+		return array();
+	}
+
+	$t_history_rows = history_get_raw_events_array( $p_issue_id, $p_user_id );
+
+	$t_history = array();
+
+	foreach( $t_history_rows as $t_history_row ) {
+		$t_type = (int)$t_history_row['type'];
+
+		$t_skip = false;
+
+		switch( $t_type ) {
+			case BUG_ADD_SPONSORSHIP:         # Deprecated, not exposed in REST API
+			case BUG_UPDATE_SPONSORSHIP:      # Deprecated, not exposed in REST API
+			case BUG_DELETE_SPONSORSHIP:      # Deprecated, not exposed in REST API
+			case BUG_REVISION_DROPPED:        # Not Supported
+			case BUGNOTE_REVISION_DROPPED:    # Not Supported
+				$t_skip = true;
+				break;
+		}
+
+		$t_event = array();
+
+		$t_event['created_at'] = ApiObjectFactory::datetime( $t_history_row['date'] );
+		$t_event['user'] = mci_account_get_array_by_id( $t_history_row['userid'] );
+
+		$t_field = $t_history_row['field'];
+		if( !is_blank( $t_field ) ) {
+			# map field names to external names
+			switch( $t_field )  {
+				case 'reporter_id':
+					$t_field = 'reporter';
+					break;
+				case 'handler_id':
+					$t_field = 'handler';
+					break;
+				case 'sponsorship_total':
+					# Skip sponsorship fields
+					$t_skip = true;
+					break;
+			}
+
+			$t_event['field'] = array(
+				'name' => $t_field,
+				'label' => history_localize_field_name( $t_history_row['field'] ) );
+		}
+
+		if( $t_skip ) {
+			continue;
+		}
+
+		$t_event['type'] = array(
+			'id' => $t_type,
+			'name' => history_get_type_name( $t_history_row['type'] ) );
+
+		$t_old_value_name = 'old_value';
+		$t_new_value_name = 'new_value';
+
+		$t_show_old_value = true;
+		$t_show_new_value = true;
+
+		switch( $t_type ) {
+			case NEW_BUG:
+			case DESCRIPTION_UPDATED:
+			case ADDITIONAL_INFO_UPDATED:
+			case STEP_TO_REPRODUCE_UPDATED:
+				$t_show_old_value = false;
+				$t_show_new_value = false;
+				break;
+			case TAG_ATTACHED:
+			case TAG_DETACHED:
+				$t_show_new_value = false;
+				$t_old_value_name = 'tag';
+				break;
+			case FILE_ADDED:
+			case FILE_DELETED:
+				$t_show_new_value = false;
+				$t_old_value_name = 'file';
+				break;
+			case BUGNOTE_ADDED:
+			case BUGNOTE_UPDATED:
+			case BUGNOTE_DELETED:
+				$t_show_new_value = false;
+				$t_old_value_name = 'note';
+				break;
+			case BUGNOTE_STATE_CHANGED:
+				$t_old_value_name = 'view_state';
+				$t_new_value_name = 'note';
+				break;
+			case BUG_ADD_RELATIONSHIP:
+			case BUG_REPLACE_RELATIONSHIP:
+			case BUG_DEL_RELATIONSHIP:
+				$t_old_value_name = 'relationship';
+				$t_new_value_name = 'issue';
+				break;
+			case BUG_CLONED_TO:
+				$t_show_old_value = false;
+				$t_new_value_name = 'issue';
+				break;
+		}
+
+		$t_files = file_get_visible_attachments( $p_issue_id );
+
+		$fn_process_value = function( $p_issue_id, $p_type, $p_field, $p_value, $p_lang, $p_new_value ) use ( $t_files ) {
+			if( is_blank( $p_value ) ) {
+				return '';
+			}
+
+			switch( $p_type ) {
+				case TAG_ATTACHED:
+				case TAG_DETACHED:
+					$t_tag = tag_get_by_name( $p_value );
+					if( $t_tag === false ) {
+						return array( 'name' => $p_value );
+					}
+
+					return array( 'id' => $t_tag['id'], 'name' => $t_tag['name'] );
+				case BUGNOTE_ADDED:
+				case BUGNOTE_DELETED:
+					return array( 'id' => (int)$p_value );
+				case BUGNOTE_UPDATED:
+					if( !$p_new_value ) {
+						return array( 'id' => (int) $p_value );
+					}
+
+					return '';
+				case FILE_ADDED:
+				case FILE_DELETED:
+					$t_value = array();
+
+					$t_id = null;
+					foreach( $t_files as $t_file ) {
+						if( $t_file['display_name'] == $p_value ) {
+							$t_value['id'] = (int)$t_file['id'];
+							break;
+						}
+					}
+
+					$t_value['filename'] = $p_value;
+
+					return $t_value;
+				case BUGNOTE_STATE_CHANGED:
+					if( $p_new_value ) {
+						return array( 'id' => (int)$p_value );
+					}
+
+					return mci_enum_get_array_by_id( (int)$p_value, 'view_state', $p_lang );
+				case BUG_ADD_RELATIONSHIP:
+				case BUG_REPLACE_RELATIONSHIP:
+				case BUG_DEL_RELATIONSHIP:
+					if( $p_new_value ) {
+						return array( 'id' => (int)$p_value );
+					}
+
+					return array(
+						'id' => (int)$p_value,
+						'name' => relationship_get_name_for_api( (int)$p_value ),
+						'label' => relationship_get_description_for_history( (int)$p_value ) );
+				case BUG_CLONED_TO:
+					return array( 'id' => (int)$p_value );
+			}
+
+			switch( $p_field ) {
+				case 'status':
+					$t_value = mci_enum_get_array_by_id( (int)$p_value, 'status', $p_lang );
+					break;
+				case 'priority':
+					$t_value = mci_enum_get_array_by_id( (int)$p_value, 'priority', $p_lang );
+					break;
+				case 'severity':
+					$t_value = mci_enum_get_array_by_id( (int)$p_value, 'severity', $p_lang );
+					break;
+				case 'view_state':
+					$t_value = mci_enum_get_array_by_id( (int)$p_value, 'view_state', $p_lang );
+					break;
+				case 'resolution':
+					$t_value = mci_enum_get_array_by_id( (int)$p_value, 'resolution', $p_lang );
+					break;
+				case 'reproducibility':
+					$t_value = mci_enum_get_array_by_id( (int)$p_value, 'reproducibility', $p_lang );
+					break;
+				case 'reporter':
+				case 'handler':
+					$t_value = mci_account_get_array_by_id( (int)$p_value );
+					break;
+				default:
+					$t_value = $p_value;
+					break;
+			}
+
+			return $t_value;
+		};
+
+		if( $t_show_old_value ) {
+			$t_event[$t_old_value_name] = $fn_process_value( $p_issue_id, $t_type, $t_field, $t_history_row['old_value'], $p_lang, false );
+		}
+
+		if( $t_show_new_value ) {
+			$t_event[$t_new_value_name] = $fn_process_value( $p_issue_id, $t_type, $t_field, $t_history_row['new_value'], $p_lang, true );
+		}
+
+		$t_localized_row = history_localize_item(
+			$t_history_row['field'],
+			$t_history_row['type'],
+			$t_history_row['old_value'],
+			$t_history_row['new_value'],
+			false );
+
+		$t_event['message'] = $t_localized_row['note'];
+
+		if( !is_blank( $t_localized_row['change'] ) ) {
+			$t_event['change'] = $t_localized_row['change'];
+		}
+
+		$t_history[] = $t_event;
+	}
+
+	return $t_history;
+}
+
+/**
+* Get history details about an issue, used by SOAP APIs.
 *
 * @param string  $p_username The name of the user trying to access the issue.
 * @param string  $p_password The password of the user.
@@ -1647,6 +1883,11 @@ function mci_issue_data_as_array( BugData $p_issue_data, $p_user_id, $p_lang ) {
 	$t_issue['monitors'] = mci_account_get_array_by_ids( bug_get_monitors( $p_issue_data->id ) );
 
 	if( !ApiObjectFactory::$soap ) {
+		$t_history = mci_issue_get_history( $p_issue_data->id, $p_user_id, $p_lang );
+		if( !empty( $t_history ) ) {
+			$t_issue['history'] = $t_history;
+		}
+
 		mci_remove_null_keys( $t_issue );
 		mci_remove_empty_arrays( $t_issue );
 	}

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -510,110 +510,51 @@ function history_get_raw_events_array( $p_bug_id, $p_user_id = null, $p_start_ti
 }
 
 /**
- * Localizes one raw history item specified by set the next parameters: $p_field_name, $p_type, $p_old_value, $p_new_value
- * Returns array with two elements indexed as 'note' and 'change'
- * @param string  $p_field_name The field name of the field being localized.
- * @param integer $p_type       The type of the history entry.
- * @param string  $p_old_value  The old value of the field.
- * @param string  $p_new_value  The new value of the field.
- * @param boolean $p_linkify    Whether to return a string containing hyperlinks.
- * @return array
+ * Localize the specified field name for native or custom fields.
+ *
+ * @param string $p_field_name The field name.
+ * @return string The localized field name.
  */
-function history_localize_item( $p_field_name, $p_type, $p_old_value, $p_new_value, $p_linkify = true ) {
-	$t_note = '';
-	$t_change = '';
-	$t_field_localized = $p_field_name;
-	$t_raw = true;
-
-	if( PLUGIN_HISTORY == $p_type ) {
-		$t_note = lang_get_defaulted( 'plugin_' . $p_field_name, $p_field_name );
-		$t_change = ( isset( $p_new_value ) ? $p_old_value . ' => ' . $p_new_value : $p_old_value );
-
-		return array( 'note' => $t_note, 'change' => $t_change, 'raw' => true );
-	}
-
+function history_localize_field_name( $p_field_name ) {
 	switch( $p_field_name ) {
 		case 'category':
 			$t_field_localized = lang_get( 'category' );
 			break;
 		case 'status':
-			$p_old_value = get_enum_element( 'status', $p_old_value );
-			$p_new_value = get_enum_element( 'status', $p_new_value );
 			$t_field_localized = lang_get( 'status' );
 			break;
 		case 'severity':
-			$p_old_value = get_enum_element( 'severity', $p_old_value );
-			$p_new_value = get_enum_element( 'severity', $p_new_value );
 			$t_field_localized = lang_get( 'severity' );
 			break;
 		case 'reproducibility':
-			$p_old_value = get_enum_element( 'reproducibility', $p_old_value );
-			$p_new_value = get_enum_element( 'reproducibility', $p_new_value );
 			$t_field_localized = lang_get( 'reproducibility' );
 			break;
 		case 'resolution':
-			$p_old_value = get_enum_element( 'resolution', $p_old_value );
-			$p_new_value = get_enum_element( 'resolution', $p_new_value );
 			$t_field_localized = lang_get( 'resolution' );
 			break;
 		case 'priority':
-			$p_old_value = get_enum_element( 'priority', $p_old_value );
-			$p_new_value = get_enum_element( 'priority', $p_new_value );
 			$t_field_localized = lang_get( 'priority' );
 			break;
 		case 'eta':
-			$p_old_value = get_enum_element( 'eta', $p_old_value );
-			$p_new_value = get_enum_element( 'eta', $p_new_value );
 			$t_field_localized = lang_get( 'eta' );
 			break;
 		case 'view_state':
-			$p_old_value = get_enum_element( 'view_state', $p_old_value );
-			$p_new_value = get_enum_element( 'view_state', $p_new_value );
 			$t_field_localized = lang_get( 'view_status' );
 			break;
 		case 'projection':
-			$p_old_value = get_enum_element( 'projection', $p_old_value );
-			$p_new_value = get_enum_element( 'projection', $p_new_value );
 			$t_field_localized = lang_get( 'projection' );
 			break;
 		case 'sticky':
-			$p_old_value = gpc_string_to_bool( $p_old_value ) ? lang_get( 'yes' ) : lang_get( 'no' );
-			$p_new_value = gpc_string_to_bool( $p_new_value ) ? lang_get( 'yes' ) : lang_get( 'no' );
 			$t_field_localized = lang_get( 'sticky_issue' );
 			break;
 		case 'project_id':
-			if( project_exists( $p_old_value ) ) {
-				$p_old_value = project_get_field( $p_old_value, 'name' );
-			} else {
-				$p_old_value = '@' . $p_old_value . '@';
-			}
-
-			# Note that the new value maybe an intermediately project and not the
-			# current one.
-			if( project_exists( $p_new_value ) ) {
-				$p_new_value = project_get_field( $p_new_value, 'name' );
-			} else {
-				$p_new_value = '@' . $p_new_value . '@';
-			}
 			$t_field_localized = lang_get( 'email_project' );
 			break;
 		case 'handler_id':
 			$t_field_localized = lang_get( 'assigned_to' );
+			break;
 		case 'reporter_id':
-			if( 'reporter_id' == $p_field_name ) {
-				$t_field_localized = lang_get( 'reporter' );
-			}
-			if( 0 == $p_old_value ) {
-				$p_old_value = '';
-			} else {
-				$p_old_value = user_get_name( $p_old_value );
-			}
-
-			if( 0 == $p_new_value ) {
-				$p_new_value = '';
-			} else {
-				$p_new_value = user_get_name( $p_new_value );
-			}
+			$t_field_localized = lang_get( 'reporter' );
 			break;
 		case 'version':
 			$t_field_localized = lang_get( 'product_version' );
@@ -625,13 +566,9 @@ function history_localize_item( $p_field_name, $p_type, $p_old_value, $p_new_val
 			$t_field_localized = lang_get( 'target_version' );
 			break;
 		case 'date_submitted':
-			$p_old_value = date( config_get( 'normal_date_format' ), $p_old_value );
-			$p_new_value = date( config_get( 'normal_date_format' ), $p_new_value );
 			$t_field_localized = lang_get( 'date_submitted' );
 			break;
 		case 'last_updated':
-			$p_old_value = date( config_get( 'normal_date_format' ), $p_old_value );
-			$p_new_value = date( config_get( 'normal_date_format' ), $p_new_value );
 			$t_field_localized = lang_get( 'last_update' );
 			break;
 		case 'os':
@@ -656,16 +593,226 @@ function history_localize_item( $p_field_name, $p_type, $p_old_value, $p_new_val
 			$t_field_localized = lang_get( 'sponsorship_total' );
 			break;
 		case 'due_date':
+			$t_field_localized = lang_get( 'due_date' );
+			break;
+		default:
+			# assume it's a custom field name
+			$t_field_localized = lang_get_defaulted( $p_field_name );
+			break;
+	}
+
+	return $t_field_localized;
+}
+
+/**
+ * Get name of the change type.
+ *
+ * @param integer $p_type The type code.
+ * @return string The type name.
+ */
+function history_get_type_name( $p_type ) {
+	$t_type = (int)$p_type;
+
+	switch( $t_type ) {
+		case NORMAL_TYPE:
+			$t_type_name = 'field-updated';
+			break;
+		case NEW_BUG:
+			$t_type_name = 'issue-new';
+			break;
+		case BUGNOTE_ADDED:
+			$t_type_name = 'note-added';
+			break;
+		case BUGNOTE_UPDATED:
+			$t_type_name = 'note-updated';
+			break;
+		case BUGNOTE_DELETED:
+			$t_type_name = 'note-deleted';
+			break;
+		case DESCRIPTION_UPDATED:
+			$t_type_name = 'issue-description-updated';
+			break;
+		case ADDITIONAL_INFO_UPDATED:
+			$t_type_name = 'issue-additional-info-updated';
+			break;
+		case STEP_TO_REPRODUCE_UPDATED:
+			$t_type_name = 'issue-steps-to-reproduce-updated';
+			break;
+		case FILE_ADDED:
+			$t_type_name = 'file-added';
+			break;
+		case FILE_DELETED:
+			$t_type_name = 'file-deleted';
+			break;
+		case BUGNOTE_STATE_CHANGED:
+			$t_type_name = 'note-view-state-updated';
+			break;
+		case BUG_MONITOR:
+			$t_type_name = 'monitor-added';
+			break;
+		case BUG_UNMONITOR:
+			$t_type_name = 'monitor-deleted';
+			break;
+		case BUG_DELETED:
+			$t_type_name = 'issue-deleted';
+			break;
+		case BUG_ADD_SPONSORSHIP:
+			$t_type_name = 'sponsorship-added';
+			break;
+		case BUG_UPDATE_SPONSORSHIP:
+			$t_type_name = 'sponsorship-updated';
+			break;
+		case BUG_DELETE_SPONSORSHIP:
+			$t_type_name = 'sponsorship-deleted';
+			break;
+		case BUG_PAID_SPONSORSHIP:
+			$t_type_name = 'sponsorship-paid';
+			break;
+		case BUG_ADD_RELATIONSHIP:
+			$t_type_name = 'relationship-added';
+			break;
+		case BUG_REPLACE_RELATIONSHIP:
+			$t_type_name = 'relationship-updated';
+			break;
+		case BUG_DEL_RELATIONSHIP:
+			$t_type_name = 'relationship-deleted';
+			break;
+		case BUG_CLONED_TO:
+			$t_type_name = 'issue-cloned-to';
+			break;
+		case BUG_CREATED_FROM:
+			$t_type_name = 'issue-cloned-from';
+			break;
+		case TAG_ATTACHED:
+			$t_type_name = 'tag-added';
+			break;
+		case TAG_DETACHED:
+			$t_type_name = 'tag-deleted';
+			break;
+		case TAG_RENAMED:
+			$t_type_name = 'tag-updated';
+			break;
+		case BUG_REVISION_DROPPED:
+			$t_type_name = 'revision-deleted';
+			break;
+		case BUGNOTE_REVISION_DROPPED:
+			$t_type_name = 'note-revision-deleted';
+			break;
+		default:
+			$t_type_name = '';
+			break;
+	}
+
+	return $t_type_name;
+}
+
+/**
+ * Localizes one raw history item specified by set the next parameters: $p_field_name, $p_type, $p_old_value, $p_new_value
+ * Returns array with two elements indexed as 'note' and 'change'
+ * @param string  $p_field_name The field name of the field being localized.
+ * @param integer $p_type       The type of the history entry.
+ * @param string  $p_old_value  The old value of the field.
+ * @param string  $p_new_value  The new value of the field.
+ * @param boolean $p_linkify    Whether to return a string containing hyperlinks.
+ * @return array
+ */
+function history_localize_item( $p_field_name, $p_type, $p_old_value, $p_new_value, $p_linkify = true ) {
+	$t_note = '';
+	$t_change = '';
+	$t_field_localized = $p_field_name;
+	$t_raw = true;
+
+	if( PLUGIN_HISTORY == $p_type ) {
+		$t_note = lang_get_defaulted( 'plugin_' . $p_field_name, $p_field_name );
+		$t_change = ( isset( $p_new_value ) ? $p_old_value . ' => ' . $p_new_value : $p_old_value );
+
+		return array( 'note' => $t_note, 'change' => $t_change, 'raw' => true );
+	}
+
+	$t_field_localized = history_localize_field_name( $p_field_name );
+	switch( $p_field_name ) {
+		case 'status':
+			$p_old_value = get_enum_element( 'status', $p_old_value );
+			$p_new_value = get_enum_element( 'status', $p_new_value );
+			break;
+		case 'severity':
+			$p_old_value = get_enum_element( 'severity', $p_old_value );
+			$p_new_value = get_enum_element( 'severity', $p_new_value );
+			break;
+		case 'reproducibility':
+			$p_old_value = get_enum_element( 'reproducibility', $p_old_value );
+			$p_new_value = get_enum_element( 'reproducibility', $p_new_value );
+			break;
+		case 'resolution':
+			$p_old_value = get_enum_element( 'resolution', $p_old_value );
+			$p_new_value = get_enum_element( 'resolution', $p_new_value );
+			break;
+		case 'priority':
+			$p_old_value = get_enum_element( 'priority', $p_old_value );
+			$p_new_value = get_enum_element( 'priority', $p_new_value );
+			break;
+		case 'eta':
+			$p_old_value = get_enum_element( 'eta', $p_old_value );
+			$p_new_value = get_enum_element( 'eta', $p_new_value );
+			break;
+		case 'view_state':
+			$p_old_value = get_enum_element( 'view_state', $p_old_value );
+			$p_new_value = get_enum_element( 'view_state', $p_new_value );
+			break;
+		case 'projection':
+			$p_old_value = get_enum_element( 'projection', $p_old_value );
+			$p_new_value = get_enum_element( 'projection', $p_new_value );
+			break;
+		case 'sticky':
+			$p_old_value = gpc_string_to_bool( $p_old_value ) ? lang_get( 'yes' ) : lang_get( 'no' );
+			$p_new_value = gpc_string_to_bool( $p_new_value ) ? lang_get( 'yes' ) : lang_get( 'no' );
+			break;
+		case 'project_id':
+			if( project_exists( $p_old_value ) ) {
+				$p_old_value = project_get_field( $p_old_value, 'name' );
+			} else {
+				$p_old_value = '@' . $p_old_value . '@';
+			}
+
+			# Note that the new value maybe an intermediately project and not the
+			# current one.
+			if( project_exists( $p_new_value ) ) {
+				$p_new_value = project_get_field( $p_new_value, 'name' );
+			} else {
+				$p_new_value = '@' . $p_new_value . '@';
+			}
+			break;
+		case 'handler_id':
+		case 'reporter_id':
+			if( 0 == $p_old_value ) {
+				$p_old_value = '';
+			} else {
+				$p_old_value = user_get_name( $p_old_value );
+			}
+
+			if( 0 == $p_new_value ) {
+				$p_new_value = '';
+			} else {
+				$p_new_value = user_get_name( $p_new_value );
+			}
+			break;
+		case 'date_submitted':
+			$p_old_value = date( config_get( 'normal_date_format' ), $p_old_value );
+			$p_new_value = date( config_get( 'normal_date_format' ), $p_new_value );
+			break;
+		case 'last_updated':
+			$p_old_value = date( config_get( 'normal_date_format' ), $p_old_value );
+			$p_new_value = date( config_get( 'normal_date_format' ), $p_new_value );
+			break;
+		case 'due_date':
 			if( $p_old_value !== '' ) {
 				$p_old_value = date( config_get( 'normal_date_format' ), (int)$p_old_value );
 			}
 			if( $p_new_value !== '' ) {
 				$p_new_value = date( config_get( 'normal_date_format' ), (int)$p_new_value );
 			}
-			$t_field_localized = lang_get( 'due_date' );
 			break;
 		default:
-
 			# assume it's a custom field name
 			$t_field_id = custom_field_get_id_from_name( $p_field_name );
 			if( false !== $t_field_id ) {
@@ -673,8 +820,8 @@ function history_localize_item( $p_field_name, $p_type, $p_old_value, $p_new_val
 				if( '' != $p_old_value ) {
 					$p_old_value = string_custom_field_value_for_email( $p_old_value, $t_cf_type );
 				}
+
 				$p_new_value = string_custom_field_value_for_email( $p_new_value, $t_cf_type );
-				$t_field_localized = lang_get_defaulted( $p_field_name );
 			}
 		}
 

--- a/core/relationship_api.php
+++ b/core/relationship_api.php
@@ -138,6 +138,7 @@ $g_relationships = array();
 $g_relationships[BUG_DEPENDANT] = array(
 	'#forward' => true,
 	'#complementary' => BUG_BLOCKS,
+	'#name' => 'parent-of',
 	'#description' => 'dependant_on',
 	'#notify_added' => 'email_notification_title_for_action_dependant_on_relationship_added',
 	'#notify_deleted' => 'email_notification_title_for_action_dependant_on_relationship_deleted',
@@ -149,6 +150,7 @@ $g_relationships[BUG_DEPENDANT] = array(
 $g_relationships[BUG_BLOCKS] = array(
 	'#forward' => false,
 	'#complementary' => BUG_DEPENDANT,
+	'#name' => 'child-of',
 	'#description' => 'blocks',
 	'#notify_added' => 'email_notification_title_for_action_blocks_relationship_added',
 	'#notify_deleted' => 'email_notification_title_for_action_blocks_relationship_deleted',
@@ -160,6 +162,7 @@ $g_relationships[BUG_BLOCKS] = array(
 $g_relationships[BUG_DUPLICATE] = array(
 	'#forward' => true,
 	'#complementary' => BUG_HAS_DUPLICATE,
+	'#name' => 'duplicate-of',
 	'#description' => 'duplicate_of',
 	'#notify_added' => 'email_notification_title_for_action_duplicate_of_relationship_added',
 	'#notify_deleted' => 'email_notification_title_for_action_duplicate_of_relationship_deleted',
@@ -171,12 +174,14 @@ $g_relationships[BUG_DUPLICATE] = array(
 $g_relationships[BUG_HAS_DUPLICATE] = array(
 	'#forward' => false,
 	'#complementary' => BUG_DUPLICATE,
+	'#name' => 'has-duplicate',
 	'#description' => 'has_duplicate',
 	'#notify_added' => 'email_notification_title_for_action_has_duplicate_relationship_added',
 	'#notify_deleted' => 'email_notification_title_for_action_has_duplicate_relationship_deleted',
 );
 $g_relationships[BUG_RELATED] = array(
 	'#forward' => true,
+	'#name' => 'related-to',
 	'#complementary' => BUG_RELATED,
 	'#description' => 'related_to',
 	'#notify_added' => 'email_notification_title_for_action_related_to_relationship_added',
@@ -617,6 +622,21 @@ function relationship_get_description_dest_side( $p_relationship_type ) {
  */
 function relationship_get_description_for_history( $p_relationship_code ) {
 	return relationship_get_description_src_side( $p_relationship_code );
+}
+
+/**
+ * Get class API name of a relationship as it's stored in the history.
+ * @param integer $p_relationship_type Relationship Type.
+ * @return string Relationship API name
+ */
+function relationship_get_name_for_api( $p_relationship_type ) {
+	global $g_relationships;
+
+	if( !isset( $g_relationships[$p_relationship_type] ) ) {
+		trigger_error( ERROR_RELATIONSHIP_NOT_FOUND, ERROR );
+	}
+
+	return $g_relationships[$p_relationship_type]['#name'];
 }
 
 /**


### PR DESCRIPTION
Getting an issue via REST API should return issue history information.

See [Sample](https://gist.github.com/vboctor/1f5f39c28539f752ad811d53a4131ff4) responses.

The issue history is pretty comprehensive, however, the revisions for text area fields like description, additional information, steps to reproduce and notes are not included.  However, the act of changing such fields is included in the returned history.

Fixes #23616