### PR TITLE
Use config get global where possible

### DIFF
--- a/account_delete.php
+++ b/account_delete.php
@@ -103,7 +103,7 @@ layout_page_begin();
 	<div class="space-10"></div>
 <?php
 echo lang_get( 'account_removed_msg' ) . '<br />';
-print_link_button( config_get( 'logout_redirect_page' ), lang_get( 'proceed' ));
+print_link_button( config_get_global( 'logout_redirect_page' ), lang_get( 'proceed' ));
 ?>
 </div>
 

--- a/account_page.php
+++ b/account_page.php
@@ -95,7 +95,7 @@ $t_row = user_get_row( auth_get_current_user_id() );
 
 extract( $t_row, EXTR_PREFIX_ALL, 'u' );
 
-$t_ldap = ( LDAP == config_get( 'login_method' ) );
+$t_ldap = ( LDAP == config_get_global( 'login_method' ) );
 
 # In case we're using LDAP to get the email address... this will pull out
 #  that version instead of the one in the DB

--- a/account_update.php
+++ b/account_update.php
@@ -96,7 +96,7 @@ if( $t_account_verification && is_blank( $f_password ) ) {
 	trigger_error( ERROR_EMPTY_FIELD, ERROR );
 }
 
-$t_ldap = ( LDAP == config_get( 'login_method' ) );
+$t_ldap = ( LDAP == config_get_global( 'login_method' ) );
 
 # Update email (but only if LDAP isn't being used)
 # Do not update email for a user verification

--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -183,7 +183,7 @@ if( $t_filter_default ) {
 }
 
 # Manage filter's persistency through cookie
-$t_cookie_name = config_get( 'manage_config_cookie' );
+$t_cookie_name = config_get_global( 'manage_config_cookie' );
 if( $t_filter_save ) {
 	# Save user's filter to the cookie
 	$t_cookie_string = implode(

--- a/admin/index.php
+++ b/admin/index.php
@@ -90,7 +90,7 @@ function print_info_row( $p_description, $p_value ) {
 <?php
 	print_info_row( lang_get( 'site_path' ), config_get_global( 'absolute_path' ) );
 	print_info_row( lang_get( 'core_path' ), config_get_global( 'core_path' ) );
-	print_info_row( lang_get( 'plugin_path' ), config_get( 'plugin_path' ) );
+	print_info_row( lang_get( 'plugin_path' ), config_get_global( 'plugin_path' ) );
 ?>
 	</table>
 </div>

--- a/admin/index.php
+++ b/admin/index.php
@@ -88,7 +88,7 @@ function print_info_row( $p_description, $p_value ) {
 			</td>
 		</tr>
 <?php
-	print_info_row( lang_get( 'site_path' ), config_get( 'absolute_path' ) );
+	print_info_row( lang_get( 'site_path' ), config_get_global( 'absolute_path' ) );
 	print_info_row( lang_get( 'core_path' ), config_get( 'core_path' ) );
 	print_info_row( lang_get( 'plugin_path' ), config_get( 'plugin_path' ) );
 ?>

--- a/admin/index.php
+++ b/admin/index.php
@@ -89,7 +89,7 @@ function print_info_row( $p_description, $p_value ) {
 		</tr>
 <?php
 	print_info_row( lang_get( 'site_path' ), config_get_global( 'absolute_path' ) );
-	print_info_row( lang_get( 'core_path' ), config_get( 'core_path' ) );
+	print_info_row( lang_get( 'core_path' ), config_get_global( 'core_path' ) );
 	print_info_row( lang_get( 'plugin_path' ), config_get( 'plugin_path' ) );
 ?>
 	</table>

--- a/admin/install.php
+++ b/admin/install.php
@@ -183,7 +183,7 @@ if( $t_config_exists && $t_install_state <= 1 ) {
 	# config already exists - probably an upgrade
 	$f_dsn                    = config_get( 'dsn', '' );
 	$f_hostname               = config_get( 'hostname', '' );
-	$f_db_type                = config_get( 'db_type', '' );
+	$f_db_type                = config_get_global( 'db_type', '' );
 	$f_database_name          = config_get_global( 'database_name', '' );
 	$f_db_username            = config_get_global( 'db_username', '' );
 	$f_db_password            = config_get_global( 'db_password', '' );
@@ -198,7 +198,7 @@ if( $t_config_exists && $t_install_state <= 1 ) {
 	# read control variables with defaults
 	$f_dsn                = gpc_get( 'dsn', config_get( 'dsn', '' ) );
 	$f_hostname           = gpc_get( 'hostname', config_get( 'hostname', 'localhost' ) );
-	$f_db_type            = gpc_get( 'db_type', config_get( 'db_type', '' ) );
+	$f_db_type            = gpc_get( 'db_type', config_get_global( 'db_type', '' ) );
 	$f_database_name      = gpc_get( 'database_name', config_get_global( 'database_name', 'bugtracker' ) );
 	$f_db_username        = gpc_get( 'db_username', config_get_global( 'db_username', '' ) );
 	$f_db_password        = gpc_get( 'db_password', config_get_global( 'db_password', '' ) );
@@ -1150,7 +1150,7 @@ if( 5 == $t_install_state ) {
 	} else {
 		# already exists, see if the information is the same
 		if( ( $f_hostname != config_get( 'hostname', '' ) ) ||
-			( $f_db_type != config_get( 'db_type', '' ) ) ||
+			( $f_db_type != config_get_global( 'db_type', '' ) ) ||
 			( $f_database_name != config_get_global( 'database_name', '' ) ) ||
 			( $f_db_username != config_get_global( 'db_username', '' ) ) ||
 			( $f_db_password != config_get_global( 'db_password', '' ) ) ) {

--- a/admin/install.php
+++ b/admin/install.php
@@ -186,7 +186,7 @@ if( $t_config_exists && $t_install_state <= 1 ) {
 	$f_db_type                = config_get( 'db_type', '' );
 	$f_database_name          = config_get_global( 'database_name', '' );
 	$f_db_username            = config_get_global( 'db_username', '' );
-	$f_db_password            = config_get( 'db_password', '' );
+	$f_db_password            = config_get_global( 'db_password', '' );
 	$f_timezone               = config_get( 'default_timezone', '' );
 
 	# Set default prefix/suffix form variables ($f_db_table_XXX)
@@ -201,9 +201,9 @@ if( $t_config_exists && $t_install_state <= 1 ) {
 	$f_db_type            = gpc_get( 'db_type', config_get( 'db_type', '' ) );
 	$f_database_name      = gpc_get( 'database_name', config_get_global( 'database_name', 'bugtracker' ) );
 	$f_db_username        = gpc_get( 'db_username', config_get_global( 'db_username', '' ) );
-	$f_db_password        = gpc_get( 'db_password', config_get( 'db_password', '' ) );
+	$f_db_password        = gpc_get( 'db_password', config_get_global( 'db_password', '' ) );
 	if( CONFIGURED_PASSWORD == $f_db_password ) {
-		$f_db_password = config_get( 'db_password' );
+		$f_db_password = config_get_global( 'db_password' );
 	}
 	$f_timezone           = gpc_get( 'timezone', config_get( 'default_timezone' ) );
 
@@ -1153,7 +1153,7 @@ if( 5 == $t_install_state ) {
 			( $f_db_type != config_get( 'db_type', '' ) ) ||
 			( $f_database_name != config_get_global( 'database_name', '' ) ) ||
 			( $f_db_username != config_get_global( 'db_username', '' ) ) ||
-			( $f_db_password != config_get( 'db_password', '' ) ) ) {
+			( $f_db_password != config_get_global( 'db_password', '' ) ) ) {
 			print_test_result( BAD, false, 'file ' . $t_config_filename . ' already exists and has different settings' );
 		} else {
 			print_test_result( GOOD, false );

--- a/admin/install.php
+++ b/admin/install.php
@@ -185,7 +185,7 @@ if( $t_config_exists && $t_install_state <= 1 ) {
 	$f_hostname               = config_get( 'hostname', '' );
 	$f_db_type                = config_get( 'db_type', '' );
 	$f_database_name          = config_get_global( 'database_name', '' );
-	$f_db_username            = config_get( 'db_username', '' );
+	$f_db_username            = config_get_global( 'db_username', '' );
 	$f_db_password            = config_get( 'db_password', '' );
 	$f_timezone               = config_get( 'default_timezone', '' );
 
@@ -200,7 +200,7 @@ if( $t_config_exists && $t_install_state <= 1 ) {
 	$f_hostname           = gpc_get( 'hostname', config_get( 'hostname', 'localhost' ) );
 	$f_db_type            = gpc_get( 'db_type', config_get( 'db_type', '' ) );
 	$f_database_name      = gpc_get( 'database_name', config_get_global( 'database_name', 'bugtracker' ) );
-	$f_db_username        = gpc_get( 'db_username', config_get( 'db_username', '' ) );
+	$f_db_username        = gpc_get( 'db_username', config_get_global( 'db_username', '' ) );
 	$f_db_password        = gpc_get( 'db_password', config_get( 'db_password', '' ) );
 	if( CONFIGURED_PASSWORD == $f_db_password ) {
 		$f_db_password = config_get( 'db_password' );
@@ -1152,7 +1152,7 @@ if( 5 == $t_install_state ) {
 		if( ( $f_hostname != config_get( 'hostname', '' ) ) ||
 			( $f_db_type != config_get( 'db_type', '' ) ) ||
 			( $f_database_name != config_get_global( 'database_name', '' ) ) ||
-			( $f_db_username != config_get( 'db_username', '' ) ) ||
+			( $f_db_username != config_get_global( 'db_username', '' ) ) ||
 			( $f_db_password != config_get( 'db_password', '' ) ) ) {
 			print_test_result( BAD, false, 'file ' . $t_config_filename . ' already exists and has different settings' );
 		} else {

--- a/admin/install.php
+++ b/admin/install.php
@@ -184,7 +184,7 @@ if( $t_config_exists && $t_install_state <= 1 ) {
 	$f_dsn                    = config_get( 'dsn', '' );
 	$f_hostname               = config_get( 'hostname', '' );
 	$f_db_type                = config_get( 'db_type', '' );
-	$f_database_name          = config_get( 'database_name', '' );
+	$f_database_name          = config_get_global( 'database_name', '' );
 	$f_db_username            = config_get( 'db_username', '' );
 	$f_db_password            = config_get( 'db_password', '' );
 	$f_timezone               = config_get( 'default_timezone', '' );
@@ -199,7 +199,7 @@ if( $t_config_exists && $t_install_state <= 1 ) {
 	$f_dsn                = gpc_get( 'dsn', config_get( 'dsn', '' ) );
 	$f_hostname           = gpc_get( 'hostname', config_get( 'hostname', 'localhost' ) );
 	$f_db_type            = gpc_get( 'db_type', config_get( 'db_type', '' ) );
-	$f_database_name      = gpc_get( 'database_name', config_get( 'database_name', 'bugtracker' ) );
+	$f_database_name      = gpc_get( 'database_name', config_get_global( 'database_name', 'bugtracker' ) );
 	$f_db_username        = gpc_get( 'db_username', config_get( 'db_username', '' ) );
 	$f_db_password        = gpc_get( 'db_password', config_get( 'db_password', '' ) );
 	if( CONFIGURED_PASSWORD == $f_db_password ) {
@@ -1151,7 +1151,7 @@ if( 5 == $t_install_state ) {
 		# already exists, see if the information is the same
 		if( ( $f_hostname != config_get( 'hostname', '' ) ) ||
 			( $f_db_type != config_get( 'db_type', '' ) ) ||
-			( $f_database_name != config_get( 'database_name', '' ) ) ||
+			( $f_database_name != config_get_global( 'database_name', '' ) ) ||
 			( $f_db_username != config_get( 'db_username', '' ) ) ||
 			( $f_db_password != config_get( 'db_password', '' ) ) ) {
 			print_test_result( BAD, false, 'file ' . $t_config_filename . ' already exists and has different settings' );

--- a/admin/install.php
+++ b/admin/install.php
@@ -182,7 +182,7 @@ foreach( $t_prefix_defaults['oci8'] as $t_key => $t_value ) {
 if( $t_config_exists && $t_install_state <= 1 ) {
 	# config already exists - probably an upgrade
 	$f_dsn                    = config_get( 'dsn', '' );
-	$f_hostname               = config_get( 'hostname', '' );
+	$f_hostname               = config_get_global( 'hostname', '' );
 	$f_db_type                = config_get_global( 'db_type', '' );
 	$f_database_name          = config_get_global( 'database_name', '' );
 	$f_db_username            = config_get_global( 'db_username', '' );
@@ -197,7 +197,7 @@ if( $t_config_exists && $t_install_state <= 1 ) {
 } else {
 	# read control variables with defaults
 	$f_dsn                = gpc_get( 'dsn', config_get( 'dsn', '' ) );
-	$f_hostname           = gpc_get( 'hostname', config_get( 'hostname', 'localhost' ) );
+	$f_hostname           = gpc_get( 'hostname', config_get_global( 'hostname', 'localhost' ) );
 	$f_db_type            = gpc_get( 'db_type', config_get_global( 'db_type', '' ) );
 	$f_database_name      = gpc_get( 'database_name', config_get_global( 'database_name', 'bugtracker' ) );
 	$f_db_username        = gpc_get( 'db_username', config_get_global( 'db_username', '' ) );
@@ -1149,7 +1149,7 @@ if( 5 == $t_install_state ) {
 		}
 	} else {
 		# already exists, see if the information is the same
-		if( ( $f_hostname != config_get( 'hostname', '' ) ) ||
+		if( ( $f_hostname != config_get_global( 'hostname', '' ) ) ||
 			( $f_db_type != config_get_global( 'db_type', '' ) ) ||
 			( $f_database_name != config_get_global( 'database_name', '' ) ) ||
 			( $f_db_username != config_get_global( 'db_username', '' ) ) ||

--- a/admin/move_attachments.php
+++ b/admin/move_attachments.php
@@ -70,7 +70,7 @@ function move_attachments_to_db( $p_type, $p_projects ) {
 		# Project upload path
 		$t_upload_path = project_get_field( $t_project, 'file_path' );
 		if( is_blank( $t_upload_path ) ) {
-			$t_upload_path = config_get( 'absolute_path_default_upload_folder', '', ALL_USERS, $t_project );
+			$t_upload_path = config_get_global( 'absolute_path_default_upload_folder', '', ALL_USERS, $t_project );
 		}
 
 		if( is_blank( $t_upload_path )

--- a/admin/move_attachments_page.php
+++ b/admin/move_attachments_page.php
@@ -154,7 +154,7 @@ if( isset( $t_projects[ALL_PROJECTS] ) ) {
 
 		$t_file_path = $t_project['file_path'];
 		if( is_blank( $t_file_path ) ) {
-			$t_file_path = config_get( 'absolute_path_default_upload_folder' );
+			$t_file_path = config_get_global( 'absolute_path_default_upload_folder' );
 		}
 
 		echo '<tr>';

--- a/admin/test_langs.php
+++ b/admin/test_langs.php
@@ -96,7 +96,7 @@ if( function_exists( 'scandir' ) ) {
 # attempt to find plugin language files
 echo 'Trying to find+check plugin language files...<br />';
 if( function_exists( 'scandir' ) ) {
-	checkplugins( config_get( 'plugin_path' ) );
+	checkplugins( config_get_global( 'plugin_path' ) );
 } else {
 	echo 'php scandir is disabled - skipping<br />';
 }

--- a/api/soap/mantisconnect.php
+++ b/api/soap/mantisconnect.php
@@ -69,7 +69,7 @@ if( !mci_is_webservice_call() ) {
 
 	header( 'Content-Type: text/xml' );
 	$t_wsdl = file_get_contents( 'mantisconnect.wsdl' );
-	$t_wsdl = str_replace( 'http://www.mantisbt.org/bugs/api/soap/mantisconnect.php', config_get( 'path' ).'api/soap/mantisconnect.php', $t_wsdl );
+	$t_wsdl = str_replace( 'http://www.mantisbt.org/bugs/api/soap/mantisconnect.php', config_get_global( 'path' ).'api/soap/mantisconnect.php', $t_wsdl );
 	echo $t_wsdl;
 	exit();
 }

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -662,7 +662,7 @@ function mci_sanitize_xml_string ( $p_input ) {
  * @return string MantisBT URL terminated by a /.
  */
 function mci_get_mantis_path() {
-	return config_get( 'path' );
+	return config_get_global( 'path' );
 }
 
 /**

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -551,7 +551,7 @@ function mci_related_issue_as_array_by_id( $p_issue_id ) {
 function mci_get_user_lang( $p_user_id ) {
 	$t_lang = user_pref_get_pref( $p_user_id, 'language' );
 	if( $t_lang == 'auto' ) {
-		$t_lang = config_get( 'fallback_language' );
+		$t_lang = config_get_global( 'fallback_language' );
 	}
 	return $t_lang;
 }

--- a/api/soap/mc_file_api.php
+++ b/api/soap/mc_file_api.php
@@ -105,11 +105,11 @@ function mci_file_add( $p_id, $p_name, $p_content, $p_file_type, $p_table, $p_ti
 	}
 
 	if( $t_project_id == ALL_PROJECTS ) {
-		$t_file_path = config_get( 'absolute_path_default_upload_folder' );
+		$t_file_path = config_get_global( 'absolute_path_default_upload_folder' );
 	} else {
 		$t_file_path = project_get_field( $t_project_id, 'file_path' );
 		if( is_blank( $t_file_path ) ) {
-			$t_file_path = config_get( 'absolute_path_default_upload_folder' );
+			$t_file_path = config_get_global( 'absolute_path_default_upload_folder' );
 		}
 	}
 

--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -107,7 +107,7 @@ if( $t_show_page_header ) {
 
 $t_action_button_position = config_get( 'action_button_position' );
 
-$t_bugslist = gpc_get_cookie( config_get( 'bug_list_cookie' ), false );
+$t_bugslist = gpc_get_cookie( config_get_global( 'bug_list_cookie' ), false );
 
 $t_show_versions = version_should_show_product_version( $t_bug->project_id );
 $t_show_product_version = $t_show_versions && in_array( 'product_version', $t_fields );

--- a/core/access_api.php
+++ b/core/access_api.php
@@ -92,7 +92,7 @@ function access_denied() {
 				print_link_button( auth_login_page( 'return=' . $t_return_page ), lang_get( 'click_to_login' ) );
 				echo '</p><p class="center">';
 				print_link_button(
-					helper_mantis_url( config_get( 'default_home_page' ) ),
+					helper_mantis_url( config_get_global( 'default_home_page' ) ),
 					lang_get( 'proceed' )
 				);
 				echo '</p>';
@@ -102,7 +102,7 @@ function access_denied() {
 			layout_admin_page_begin();
 			echo '<div class="space-10"></div>';
 			html_operation_failure(
-				helper_mantis_url( config_get( 'default_home_page' ) ),
+				helper_mantis_url( config_get_global( 'default_home_page' ) ),
 				error_string( ERROR_ACCESS_DENIED )
 			);
 			layout_admin_page_end();

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -831,7 +831,7 @@ function auth_generate_confirm_hash( $p_user_id ) {
  */
 function auth_set_cookies( $p_user_id, $p_perm_login = false ) {
 	$t_cookie_string = user_get_field( $p_user_id, 'cookie_string' );
-	$t_cookie_name = config_get( 'string_cookie' );
+	$t_cookie_name = config_get_global( 'string_cookie' );
 	gpc_set_cookie( $t_cookie_name, $t_cookie_string, auth_session_expiry( $p_perm_login ) );
 }
 
@@ -848,7 +848,7 @@ function auth_clear_cookies() {
 
 	# clear cookie, if not logged in from script
 	if( $g_script_login_cookie == null ) {
-		$t_cookie_name = config_get( 'string_cookie' );
+		$t_cookie_name = config_get_global( 'string_cookie' );
 		$t_cookie_path = config_get_global( 'cookie_path' );
 
 		gpc_clear_cookie( $t_cookie_name, $t_cookie_path );
@@ -916,7 +916,7 @@ function auth_get_current_user_cookie( $p_login_anonymous = true ) {
 	}
 
 	# fetch user cookie
-	$t_cookie_name = config_get( 'string_cookie' );
+	$t_cookie_name = config_get_global( 'string_cookie' );
 	$t_cookie = gpc_get_cookie( $t_cookie_name, '' );
 
 	# if cookie not found, and anonymous login enabled, use cookie of anonymous account.

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -332,7 +332,7 @@ function auth_is_user_authenticated() {
 function auth_prepare_username( $p_username ) {
 	$t_username = null;
 
-	switch( config_get( 'login_method' ) ) {
+	switch( config_get_global( 'login_method' ) ) {
 		case BASIC_AUTH:
 			if( isset( $_SERVER['REMOTE_USER'] ) ) {
 				$t_username = $_SERVER['REMOTE_USER'];
@@ -368,7 +368,7 @@ function auth_prepare_username( $p_username ) {
  * @access public
  */
 function auth_prepare_password( $p_password ) {
-	switch( config_get( 'login_method' ) ) {
+	switch( config_get_global( 'login_method' ) ) {
 		case BASIC_AUTH:
 			$f_password = $_SERVER['PHP_AUTH_PW'];
 			break;
@@ -405,7 +405,7 @@ function auth_prepare_password( $p_password ) {
  * @access private
  */
 function auth_auto_create_user( $p_username, $p_password ) {
-	$t_login_method = config_get( 'login_method' );
+	$t_login_method = config_get_global( 'login_method' );
 
 	if( $t_login_method == BASIC_AUTH ) {
 		$t_auto_create = true;
@@ -663,7 +663,7 @@ function auth_logout() {
 		helper_clear_pref_cookies();
 	}
 
-	if( HTTP_AUTH == config_get( 'login_method' ) ) {
+	if( HTTP_AUTH == config_get_global( 'login_method' ) ) {
 		auth_http_set_logout_pending( true );
 	}
 
@@ -676,7 +676,7 @@ function auth_logout() {
  * @access public
  */
 function auth_automatic_logon_bypass_form() {
-	return config_get( 'login_method' ) == HTTP_AUTH;
+	return config_get_global( 'login_method' ) == HTTP_AUTH;
 }
 
 /**
@@ -686,7 +686,7 @@ function auth_automatic_logon_bypass_form() {
  * @access public
  */
 function auth_get_password_max_size() {
-	switch( config_get( 'login_method' ) ) {
+	switch( config_get_global( 'login_method' ) ) {
 		# Max password size cannot be bigger than the database field
 		case PLAIN:
 		case BASIC_AUTH:
@@ -708,7 +708,7 @@ function auth_get_password_max_size() {
  * @access public
  */
 function auth_does_password_match( $p_user_id, $p_test_password ) {
-	$t_configured_login_method = config_get( 'login_method' );
+	$t_configured_login_method = config_get_global( 'login_method' );
 
 	if( LDAP == $t_configured_login_method ) {
 		return ldap_authenticate( $p_user_id, $p_test_password );
@@ -766,7 +766,7 @@ function auth_does_password_match( $p_user_id, $p_test_password ) {
  * @access public
  */
 function auth_process_plain_password( $p_password, $p_salt = null, $p_method = null ) {
-	$t_login_method = config_get( 'login_method' );
+	$t_login_method = config_get_global( 'login_method' );
 	if( $p_method !== null ) {
 		$t_login_method = $p_method;
 	}
@@ -987,7 +987,7 @@ function auth_reauthentication_expiry() {
  * @access public
  */
 function auth_reauthenticate() {
-	if( !auth_reauthentication_enabled() || BASIC_AUTH == config_get( 'login_method' ) || HTTP_AUTH == config_get( 'login_method' ) ) {
+	if( !auth_reauthentication_enabled() || BASIC_AUTH == config_get_global( 'login_method' ) || HTTP_AUTH == config_get_global( 'login_method' ) ) {
 		return true;
 	}
 

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -1157,7 +1157,7 @@ function auth_http_prompt() {
  * @return void
  */
 function auth_http_set_logout_pending( $p_pending ) {
-	$t_cookie_name = config_get( 'logout_cookie' );
+	$t_cookie_name = config_get_global( 'logout_cookie' );
 
 	if( $p_pending ) {
 		gpc_set_cookie( $t_cookie_name, '1', false );
@@ -1174,7 +1174,7 @@ function auth_http_set_logout_pending( $p_pending ) {
  * @access public
  */
 function auth_http_is_logout_pending() {
-	$t_cookie_name = config_get( 'logout_cookie' );
+	$t_cookie_name = config_get_global( 'logout_cookie' );
 	$t_cookie = gpc_get_cookie( $t_cookie_name, '' );
 
 	return( $t_cookie > '' );

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -849,7 +849,7 @@ function auth_clear_cookies() {
 	# clear cookie, if not logged in from script
 	if( $g_script_login_cookie == null ) {
 		$t_cookie_name = config_get( 'string_cookie' );
-		$t_cookie_path = config_get( 'cookie_path' );
+		$t_cookie_path = config_get_global( 'cookie_path' );
 
 		gpc_clear_cookie( $t_cookie_name, $t_cookie_path );
 		$t_cookies_cleared = true;
@@ -1162,7 +1162,7 @@ function auth_http_set_logout_pending( $p_pending ) {
 	if( $p_pending ) {
 		gpc_set_cookie( $t_cookie_name, '1', false );
 	} else {
-		$t_cookie_path = config_get( 'cookie_path' );
+		$t_cookie_path = config_get_global( 'cookie_path' );
 		gpc_clear_cookie( $t_cookie_name, $t_cookie_path );
 	}
 }

--- a/core/classes/AuthFlags.class.php
+++ b/core/classes/AuthFlags.class.php
@@ -267,7 +267,7 @@ class AuthFlags {
 	 */
 	function getLogoutRedirectPage() {
 		if( is_null( $this->logout_redirect_page ) ) {
-			return config_get( 'logout_redirect_page' );
+			return config_get_global( 'logout_redirect_page' );
 		}
 
 		return $this->logout_redirect_page;

--- a/core/custom_function_api.php
+++ b/core/custom_function_api.php
@@ -282,7 +282,7 @@ function custom_function_default_auth_can_change_password() {
 		MD5,
 	);
 
-	return in_array( config_get( 'login_method' ), $t_can_change );
+	return in_array( config_get_global( 'login_method' ), $t_can_change );
 }
 
 /**

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -1259,7 +1259,7 @@ function email_send( EmailData $p_email_data ) {
 	}
 
 	# @@@ should this be the current language (for the recipient) or the default one (for the user running the command) (thraxisp)
-	$t_lang = config_get( 'default_language' );
+	$t_lang = config_get_global( 'default_language' );
 	if( 'auto' == $t_lang ) {
 		$t_lang = config_get( 'fallback_language' );
 	}

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -1261,7 +1261,7 @@ function email_send( EmailData $p_email_data ) {
 	# @@@ should this be the current language (for the recipient) or the default one (for the user running the command) (thraxisp)
 	$t_lang = config_get_global( 'default_language' );
 	if( 'auto' == $t_lang ) {
-		$t_lang = config_get( 'fallback_language' );
+		$t_lang = config_get_global( 'fallback_language' );
 	}
 	$t_mail->SetLanguage( lang_get( 'phpmailer_language', $t_lang ) );
 

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -304,7 +304,7 @@ function file_normalize_attachment_path( $p_diskfile, $p_project_id ) {
 		}
 	}
 
-	$t_path = config_get( 'absolute_path_default_upload_folder' );
+	$t_path = config_get_global( 'absolute_path_default_upload_folder' );
 	if( !is_blank( $t_path ) ) {
 		$t_diskfile = file_path_combine( $t_path, $t_basename );
 
@@ -741,11 +741,11 @@ function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p
 	}
 
 	if( $t_project_id == ALL_PROJECTS ) {
-		$t_file_path = config_get( 'absolute_path_default_upload_folder' );
+		$t_file_path = config_get_global( 'absolute_path_default_upload_folder' );
 	} else {
 		$t_file_path = project_get_field( $t_project_id, 'file_path' );
 		if( is_blank( $t_file_path ) ) {
-			$t_file_path = config_get( 'absolute_path_default_upload_folder' );
+			$t_file_path = config_get_global( 'absolute_path_default_upload_folder' );
 		}
 	}
 
@@ -1045,12 +1045,12 @@ function file_move_bug_attachments( $p_bug_id, $p_project_id_to ) {
 
 	$t_path_from = project_get_field( $t_project_id_from, 'file_path' );
 	if( is_blank( $t_path_from ) ) {
-		$t_path_from = config_get( 'absolute_path_default_upload_folder', null, null, $t_project_id_from );
+		$t_path_from = config_get_global( 'absolute_path_default_upload_folder' );
 	}
 	file_ensure_valid_upload_path( $t_path_from );
 	$t_path_to = project_get_field( $p_project_id_to, 'file_path' );
 	if( is_blank( $t_path_to ) ) {
-		$t_path_to = config_get( 'absolute_path_default_upload_folder', null, null, $p_project_id_to );
+		$t_path_to = config_get_global( 'absolute_path_default_upload_folder' );
 	}
 	file_ensure_valid_upload_path( $t_path_to );
 	if( $t_path_from == $t_path_to ) {

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -243,7 +243,7 @@ function file_can_delete_bug_attachments( $p_bug_id, $p_uploader_user_id = null 
  * @return array
  */
 function file_get_icon_url( $p_display_filename ) {
-	$t_file_type_icons = config_get( 'file_type_icons' );
+	$t_file_type_icons = config_get_global( 'file_type_icons' );
 
 	$t_ext = utf8_strtolower( pathinfo( $p_display_filename, PATHINFO_EXTENSION ) );
 	if( is_blank( $t_ext ) || !isset( $t_file_type_icons[$t_ext] ) ) {

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -973,7 +973,7 @@ function file_get_content( $p_file_id, $p_type = 'bug' ) {
 	# If finfo is available (always true for PHP >= 5.3.0) we can use it to determine the MIME type of files
 	$t_finfo_available = false;
 	if( class_exists( 'finfo' ) ) {
-		$t_info_file = config_get( 'fileinfo_magic_db_file' );
+		$t_info_file = config_get_global( 'fileinfo_magic_db_file' );
 
 		if( is_blank( $t_info_file ) ) {
 			$t_finfo = new finfo( FILEINFO_MIME );

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -351,7 +351,7 @@ function filter_get_url( array $p_custom_filter ) {
 
 	if( count( $t_query ) > 0 ) {
 		$t_query_str = implode( $t_query, '&' );
-		$t_url = config_get( 'path' ) . 'search.php?' . $t_query_str;
+		$t_url = config_get_global( 'path' ) . 'search.php?' . $t_query_str;
 	} else {
 		$t_url = '';
 	}

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -985,7 +985,7 @@ function filter_serialize( $p_filter_array ) {
  * @return boolean
  */
 function filter_is_cookie_valid() {
-	$t_view_all_cookie_id = gpc_get_cookie( config_get( 'view_all_cookie' ), '' );
+	$t_view_all_cookie_id = gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' );
 	$t_view_all_cookie = filter_db_get_filter( $t_view_all_cookie_id );
 
 	# check to see if the cookie does not exist

--- a/core/gpc_api.php
+++ b/core/gpc_api.php
@@ -372,7 +372,7 @@ function gpc_set_cookie( $p_name, $p_value, $p_expire = false, $p_path = null, $
 	if( false === $p_expire ) {
 		$p_expire = 0;
 	} else if( true === $p_expire ) {
-		$t_cookie_length = config_get( 'cookie_time_length' );
+		$t_cookie_length = config_get_global( 'cookie_time_length' );
 		$p_expire = time() + $t_cookie_length;
 	}
 

--- a/core/gpc_api.php
+++ b/core/gpc_api.php
@@ -381,7 +381,7 @@ function gpc_set_cookie( $p_name, $p_value, $p_expire = false, $p_path = null, $
 	}
 
 	if( null === $p_domain ) {
-		$p_domain = config_get( 'cookie_domain' );
+		$p_domain = config_get_global( 'cookie_domain' );
 	}
 
 	return setcookie( $p_name, $p_value, $p_expire, $p_path, $p_domain, $g_cookie_secure_flag_enabled, true );
@@ -399,7 +399,7 @@ function gpc_clear_cookie( $p_name, $p_path = null, $p_domain = null ) {
 		$p_path = config_get_global( 'cookie_path' );
 	}
 	if( null === $p_domain ) {
-		$p_domain = config_get( 'cookie_domain' );
+		$p_domain = config_get_global( 'cookie_domain' );
 	}
 
 	if( isset( $_COOKIE[$p_name] ) ) {

--- a/core/gpc_api.php
+++ b/core/gpc_api.php
@@ -377,7 +377,7 @@ function gpc_set_cookie( $p_name, $p_value, $p_expire = false, $p_path = null, $
 	}
 
 	if( null === $p_path ) {
-		$p_path = config_get( 'cookie_path' );
+		$p_path = config_get_global( 'cookie_path' );
 	}
 
 	if( null === $p_domain ) {
@@ -396,7 +396,7 @@ function gpc_set_cookie( $p_name, $p_value, $p_expire = false, $p_path = null, $
  */
 function gpc_clear_cookie( $p_name, $p_path = null, $p_domain = null ) {
 	if( null === $p_path ) {
-		$p_path = config_get( 'cookie_path' );
+		$p_path = config_get_global( 'cookie_path' );
 	}
 	if( null === $p_domain ) {
 		$p_domain = config_get( 'cookie_domain' );

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -319,7 +319,7 @@ function helper_get_current_project() {
 	}
 
 	if( $g_cache_current_project === null ) {
-		$t_cookie_name = config_get( 'project_cookie' );
+		$t_cookie_name = config_get_global( 'project_cookie' );
 
 		$t_project_id = gpc_get_cookie( $t_cookie_name, null );
 
@@ -347,7 +347,7 @@ function helper_get_current_project() {
  * @return array
  */
 function helper_get_current_project_trace() {
-	$t_cookie_name = config_get( 'project_cookie' );
+	$t_cookie_name = config_get_global( 'project_cookie' );
 
 	$t_project_id = gpc_get_cookie( $t_cookie_name, null );
 
@@ -388,7 +388,7 @@ function helper_get_current_project_trace() {
 function helper_set_current_project( $p_project_id ) {
 	global $g_cache_current_project;
 
-	$t_project_cookie_name = config_get( 'project_cookie' );
+	$t_project_cookie_name = config_get_global( 'project_cookie' );
 
 	$g_cache_current_project = $p_project_id;
 	gpc_set_cookie( $t_project_cookie_name, $p_project_id, true );
@@ -401,7 +401,7 @@ function helper_set_current_project( $p_project_id ) {
  * @return void
  */
 function helper_clear_pref_cookies() {
-	gpc_clear_cookie( config_get( 'project_cookie' ) );
+	gpc_clear_cookie( config_get_global( 'project_cookie' ) );
 	gpc_clear_cookie( config_get( 'manage_users_cookie' ) );
 	gpc_clear_cookie( config_get( 'manage_config_cookie' ) );
 }

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -604,7 +604,7 @@ function helper_log_to_page() {
  * @return boolean
  */
 function helper_show_query_count() {
-	return ON == config_get( 'show_queries_count' );
+	return ON == config_get_global( 'show_queries_count' );
 }
 
 /**

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -403,7 +403,7 @@ function helper_set_current_project( $p_project_id ) {
 function helper_clear_pref_cookies() {
 	gpc_clear_cookie( config_get_global( 'project_cookie' ) );
 	gpc_clear_cookie( config_get( 'manage_users_cookie' ) );
-	gpc_clear_cookie( config_get( 'manage_config_cookie' ) );
+	gpc_clear_cookie( config_get_global( 'manage_config_cookie' ) );
 }
 
 /**

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -361,11 +361,11 @@ function html_print_logo( $p_logo = null ) {
 	}
 
 	if( !is_blank( $p_logo ) ) {
-		$t_logo_url = config_get( 'logo_url' );
+		$t_logo_url = config_get_global( 'logo_url' );
 		$t_show_url = !is_blank( $t_logo_url );
 
 		if( $t_show_url ) {
-			echo '<a id="logo-link" href="', config_get( 'logo_url' ), '">';
+			echo '<a id="logo-link" href="', config_get_global( 'logo_url' ), '">';
 		}
 		$t_alternate_text = string_html_specialchars( config_get( 'window_title' ) );
 		echo '<img id="logo-image" alt="', $t_alternate_text, '" style="max-height: 80px;" src="' . helper_mantis_url( $p_logo ) . '" />';

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -208,7 +208,7 @@ function require_css( $p_stylesheet_path ) {
  */
 function html_css() {
 	global $g_stylesheets_included;
-	html_css_link( config_get( 'css_include_file' ) );
+	html_css_link( config_get_global( 'css_include_file' ) );
 	# Add right-to-left css if needed
 	if( lang_get( 'directionality' ) == 'rtl' ) {
 		html_css_link( config_get( 'css_rtl_include_file' ) );

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -277,7 +277,7 @@ function html_meta_redirect( $p_url, $p_time = null, $p_sanitize = true ) {
 		$p_time = current_user_get_pref( 'redirect_delay' );
 	}
 
-	$t_url = config_get( 'path' );
+	$t_url = config_get_global( 'path' );
 	if( $p_sanitize ) {
 		$t_url .= string_sanitize_url( $p_url );
 	} else {

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -382,7 +382,7 @@ function html_print_logo( $p_logo = null ) {
  * @return void
  */
 function html_top_banner() {
-	$t_page = config_get( 'top_include_page' );
+	$t_page = config_get_global( 'top_include_page' );
 	$t_logo_image = config_get( 'logo_image' );
 
 	if( !is_blank( $t_page ) && file_exists( $t_page ) && !is_dir( $t_page ) ) {

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -809,7 +809,7 @@ function print_account_menu( $p_page = '' ) {
  */
 function print_doc_menu( $p_page = '' ) {
 	# User Documentation
-	$t_doc_url = config_get( 'manual_url' );
+	$t_doc_url = config_get_global( 'manual_url' );
 	if( is_null( parse_url( $t_doc_url, PHP_URL_SCHEME ) ) ) {
 		# URL has no scheme, so it is relative to MantisBT root
 		if( is_blank( $t_doc_url ) ||

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -211,7 +211,7 @@ function html_css() {
 	html_css_link( config_get_global( 'css_include_file' ) );
 	# Add right-to-left css if needed
 	if( lang_get( 'directionality' ) == 'rtl' ) {
-		html_css_link( config_get( 'css_rtl_include_file' ) );
+		html_css_link( config_get_global( 'css_rtl_include_file' ) );
 	}
 	foreach( $g_stylesheets_included as $t_stylesheet_path ) {
 		# status_config.php is a special css file, dynamically generated.

--- a/core/lang_api.php
+++ b/core/lang_api.php
@@ -139,7 +139,7 @@ function lang_map_auto() {
 
 	if( isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) {
 		$t_accept_langs = explode( ',', $_SERVER['HTTP_ACCEPT_LANGUAGE'] );
-		$t_auto_map = config_get( 'language_auto_map' );
+		$t_auto_map = config_get_global( 'language_auto_map' );
 
 		# Expand language map
 		$t_auto_map_exp = array();
@@ -364,7 +364,7 @@ function lang_get_current_datetime_locale() {
 	$t_lang = lang_get_current();
 
 	# Lookup $g_language_auto_map by value and then return the first key
-	$t_auto_map = config_get( 'language_auto_map' );
+	$t_auto_map = config_get_global( 'language_auto_map' );
 	$t_entry = array_search( $t_lang, $t_auto_map );
 	$t_key_arr = explode( ',', $t_entry );
 

--- a/core/lang_api.php
+++ b/core/lang_api.php
@@ -67,7 +67,7 @@ function lang_load( $p_lang, $p_dir = null ) {
 	}
 
 	if( $p_dir === null ) {
-		include_once( config_get( 'language_path' ) . 'strings_' . $p_lang . '.txt' );
+		include_once( config_get_global( 'language_path' ) . 'strings_' . $p_lang . '.txt' );
 	} else {
 		if( is_file( $p_dir . 'strings_' . $p_lang . '.txt' ) ) {
 			include_once( $p_dir . 'strings_' . $p_lang . '.txt' );

--- a/core/lang_api.php
+++ b/core/lang_api.php
@@ -294,7 +294,7 @@ function lang_get( $p_string, $p_lang = null ) {
 	} else {
 		$t_plugin_current = plugin_get_current();
 		if( !is_null( $t_plugin_current ) ) {
-			lang_load( $t_lang, config_get( 'plugin_path' ) . $t_plugin_current . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR );
+			lang_load( $t_lang, config_get_global( 'plugin_path' ) . $t_plugin_current . DIRECTORY_SEPARATOR . 'lang' . DIRECTORY_SEPARATOR );
 			if( lang_exists( $p_string, $t_lang ) ) {
 				return $g_lang_strings[$t_lang][$p_string];
 			}

--- a/core/lang_api.php
+++ b/core/lang_api.php
@@ -211,7 +211,7 @@ function lang_push( $p_lang = null ) {
 	$t_lang = $p_lang;
 
 	if( null === $t_lang ) {
-		$t_lang = config_get( 'default_language' );
+		$t_lang = config_get_global( 'default_language' );
 	}
 
 	# don't allow 'auto' as a language to be pushed onto the stack

--- a/core/lang_api.php
+++ b/core/lang_api.php
@@ -135,7 +135,7 @@ function lang_get_default() {
  * @return string
  */
 function lang_map_auto() {
-	$t_lang = config_get( 'fallback_language' );
+	$t_lang = config_get_global( 'fallback_language' );
 
 	if( isset( $_SERVER['HTTP_ACCEPT_LANGUAGE'] ) ) {
 		$t_accept_langs = explode( ',', $_SERVER['HTTP_ACCEPT_LANGUAGE'] );
@@ -218,7 +218,7 @@ function lang_push( $p_lang = null ) {
 	#  The results from auto are always the local user, not what the
 	#  override wants, unless this is the first language setting
 	if( ( 'auto' == $t_lang ) && ( 0 < count( $g_lang_overrides ) ) ) {
-		$t_lang = config_get( 'fallback_language' );
+		$t_lang = config_get_global( 'fallback_language' );
 	}
 
 	$g_lang_overrides[] = $t_lang;

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -537,7 +537,7 @@ function layout_navbar_projects_menu() {
 
 			# Force reload of current page, except if we got here after
 			# creating the first project
-			$t_redirect_url = str_replace( config_get( 'short_path' ), '', $_SERVER['REQUEST_URI'] );
+			$t_redirect_url = str_replace( config_get_global( 'short_path' ), '', $_SERVER['REQUEST_URI'] );
 			if( 'manage_proj_create.php' != $t_redirect_url ) {
 				html_meta_redirect( $t_redirect_url, 0, false );
 			}

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -1148,7 +1148,7 @@ function layout_footer() {
 
 	event_signal( 'EVENT_LAYOUT_PAGE_FOOTER' );
 
-	if( config_get( 'show_timer' ) || config_get( 'show_memory_usage' ) || config_get( 'show_queries_count' ) ) {
+	if( config_get( 'show_timer' ) || config_get( 'show_memory_usage' ) || config_get_global( 'show_queries_count' ) ) {
 		echo '<div class="col-xs-12 no-padding grey">' . "\n";
 		echo '<address class="no-margin pull-right">' . "\n";
 	}
@@ -1167,7 +1167,7 @@ function layout_footer() {
 	}
 
 	# Determine number of unique queries executed
-	if( config_get( 'show_queries_count' ) ) {
+	if( config_get_global( 'show_queries_count' ) ) {
 		$t_total_queries_count = count( $g_queries_array );
 		$t_unique_queries_count = 0;
 		$t_total_query_execution_time = 0;
@@ -1193,7 +1193,7 @@ function layout_footer() {
 		echo '<small><i class="fa fa-clock-o"></i> ' . $t_total_query_time . '</small>&#160;&#160;&#160;&#160;' . "\n";
 	}
 
-	if( config_get( 'show_timer' ) || config_get( 'show_memory_usage' ) || config_get( 'show_queries_count' ) ) {
+	if( config_get( 'show_timer' ) || config_get( 'show_memory_usage' ) || config_get_global( 'show_queries_count' ) ) {
 		echo '</address>' . "\n";
 		echo '</div>' . "\n";
 	}

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -382,7 +382,7 @@ function layout_login_page_end() {
  * @return void
  */
 function layout_navbar() {
-	$t_logo_url = config_get('logo_url');
+	$t_logo_url = config_get_global('logo_url');
 
 	echo '<div id="navbar" class="navbar navbar-default navbar-collapse navbar-fixed-top noprint">';
 	echo '<div id="navbar-container" class="navbar-container">';

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -405,7 +405,7 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
  * @return boolean true if enabled, false otherwise.
  */
 function ldap_simulation_is_enabled() {
-	$t_filename = config_get( 'ldap_simulation_file_path' );
+	$t_filename = config_get_global( 'ldap_simulation_file_path' );
 	return !is_blank( $t_filename );
 }
 
@@ -416,7 +416,7 @@ function ldap_simulation_is_enabled() {
  * @return array|null An associate array with user information or null if not found.
  */
 function ldap_simulation_get_user( $p_username ) {
-	$t_filename = config_get( 'ldap_simulation_file_path' );
+	$t_filename = config_get_global( 'ldap_simulation_file_path' );
 	$t_lines = file( $t_filename );
 	if( $t_lines === false ) {
 		log_event( LOG_LDAP, 'ldap_simulation_get_user: could not read simulation data from ' . $t_filename );

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -165,7 +165,7 @@ function plugin_route_group( $p_base_name = null ) {
  * @return mixed File path or false if FNF
  */
 function plugin_file_path( $p_filename, $p_base_name ) {
-	$t_file_path = config_get( 'plugin_path' );
+	$t_file_path = config_get_global( 'plugin_path' );
 	$t_file_path .= $p_base_name . DIRECTORY_SEPARATOR;
 	$t_file_path .= 'files' . DIRECTORY_SEPARATOR . $p_filename;
 

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -111,7 +111,7 @@ function print_header_redirect( $p_url, $p_die = true, $p_sanitize = false, $p_a
 		if( $p_sanitize ) {
 			$t_url = string_sanitize_url( $p_url, true );
 		} else {
-			$t_url = config_get( 'path' ) . $p_url;
+			$t_url = config_get_global( 'path' ) . $p_url;
 		}
 	}
 
@@ -1787,7 +1787,7 @@ function print_file_icon( $p_filename ) {
  * @return void
  */
 function print_rss( $p_feed_url, $p_title = '' ) {
-	$t_path = config_get( 'path' );
+	$t_path = config_get_global( 'path' );
 	echo '<a class="rss" rel="alternate" href="', htmlspecialchars( $p_feed_url ), '" title="', $p_title, '"><i class="fa fa-rss fa-lg orange" alt="', $p_title, '"></i></a>';
 }
 

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -310,7 +310,7 @@ function validate_project_file_path( $p_file_path ) {
 		# If the provided path is the same as the default, make the path blank.
 		# This means that if the default upload path is changed, you don't have
 		# to update the upload path for every single project.
-		if( !strcmp( $p_file_path, config_get( 'absolute_path_default_upload_folder' ) ) ) {
+		if( !strcmp( $p_file_path, config_get_global( 'absolute_path_default_upload_folder' ) ) ) {
 			$p_file_path = '';
 		} else {
 			file_ensure_valid_upload_path( $p_file_path );
@@ -729,11 +729,11 @@ function project_get_upload_path( $p_project_id ) {
 	}
 
 	if( $p_project_id == ALL_PROJECTS ) {
-		$t_path = config_get( 'absolute_path_default_upload_folder', '', ALL_USERS, ALL_PROJECTS );
+		$t_path = config_get_global( 'absolute_path_default_upload_folder', '' );
 	} else {
 		$t_path = project_get_field( $p_project_id, 'file_path' );
 		if( is_blank( $t_path ) ) {
-			$t_path = config_get( 'absolute_path_default_upload_folder', '', ALL_USERS, $p_project_id );
+			$t_path = config_get_global( 'absolute_path_default_upload_folder', '' );
 		}
 	}
 

--- a/core/rss_api.php
+++ b/core/rss_api.php
@@ -122,7 +122,7 @@ function rss_get_issues_feed_url( $p_project_id = null, $p_username = null, $p_f
 	$t_user_id = user_get_id_by_name( $t_username );
 
 	if( $p_relative ) {
-		$t_url = config_get( 'path' );
+		$t_url = config_get_global( 'path' );
 	} else {
 		$t_url = '';
 	}
@@ -171,7 +171,7 @@ function rss_get_news_feed_url( $p_project_id = null, $p_username = null, $p_rel
 	if( $p_relative ) {
 		$t_rss_link = '';
 	} else {
-		$t_rss_link = config_get( 'path' );
+		$t_rss_link = config_get_global( 'path' );
 	}
 
 	$t_user_id = user_get_id_by_name( $t_username );

--- a/core/session_api.php
+++ b/core/session_api.php
@@ -110,7 +110,7 @@ class MantisPHPSession extends MantisSession {
 
 		# Handle session cookie and caching
 		session_cache_limiter( 'private_no_expire' );
-		session_set_cookie_params( 0, config_get_global( 'cookie_path' ), config_get( 'cookie_domain' ), $g_cookie_secure_flag_enabled, true );
+		session_set_cookie_params( 0, config_get_global( 'cookie_path' ), config_get_global( 'cookie_domain' ), $g_cookie_secure_flag_enabled, true );
 
 		# Handle existent session ID
 		if( !is_null( $p_session_id ) ) {

--- a/core/session_api.php
+++ b/core/session_api.php
@@ -110,7 +110,7 @@ class MantisPHPSession extends MantisSession {
 
 		# Handle session cookie and caching
 		session_cache_limiter( 'private_no_expire' );
-		session_set_cookie_params( 0, config_get( 'cookie_path' ), config_get( 'cookie_domain' ), $g_cookie_secure_flag_enabled, true );
+		session_set_cookie_params( 0, config_get_global( 'cookie_path' ), config_get( 'cookie_domain' ), $g_cookie_secure_flag_enabled, true );
 
 		# Handle existent session ID
 		if( !is_null( $p_session_id ) ) {

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -250,7 +250,7 @@ function string_url( $p_string ) {
 function string_sanitize_url( $p_url, $p_return_absolute = false ) {
 	$t_url = strip_tags( urldecode( $p_url ) );
 
-	$t_path = rtrim( config_get( 'path' ), '/' );
+	$t_path = rtrim( config_get_global( 'path' ), '/' );
 	$t_short_path = rtrim( config_get( 'short_path' ), '/' );
 
 	$t_pattern = '(?:/*(?P<script>[^\?#]*))(?:\?(?P<query>[^#]*))?(?:#(?P<anchor>[^#]*))?';
@@ -737,7 +737,7 @@ function string_get_bugnote_view_url( $p_bug_id, $p_bugnote_id ) {
  * @return string
  */
 function string_get_bugnote_view_url_with_fqdn( $p_bug_id, $p_bugnote_id ) {
-	return config_get( 'path' ) . string_get_bug_view_url( $p_bug_id ) . '#c' . $p_bugnote_id;
+	return config_get_global( 'path' ) . string_get_bug_view_url( $p_bug_id ) . '#c' . $p_bugnote_id;
 }
 
 /**
@@ -748,7 +748,7 @@ function string_get_bugnote_view_url_with_fqdn( $p_bug_id, $p_bugnote_id ) {
  * @return string
  */
 function string_get_bug_view_url_with_fqdn( $p_bug_id ) {
-	return config_get( 'path' ) . string_get_bug_view_url( $p_bug_id );
+	return config_get_global( 'path' ) . string_get_bug_view_url( $p_bug_id );
 }
 
 /**
@@ -801,7 +801,7 @@ function string_get_bug_report_url() {
  * @return string
  */
 function string_get_confirm_hash_url( $p_user_id, $p_confirm_hash ) {
-	$t_path = config_get( 'path' );
+	$t_path = config_get_global( 'path' );
 	return $t_path . 'verify.php?id=' . string_url( $p_user_id ) . '&confirm_hash=' . string_url( $p_confirm_hash );
 }
 

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -591,7 +591,7 @@ function string_restore_valid_html_tags( $p_string, $p_multiline = true ) {
 	global $g_cache_html_valid_tags_single_line, $g_cache_html_valid_tags;
 
 	if( is_blank( ( $p_multiline ? $g_cache_html_valid_tags : $g_cache_html_valid_tags_single_line ) ) ) {
-		$t_html_valid_tags = config_get( $p_multiline ? 'html_valid_tags' : 'html_valid_tags_single_line' );
+		$t_html_valid_tags = config_get_global( $p_multiline ? 'html_valid_tags' : 'html_valid_tags_single_line' );
 
 		if( OFF === $t_html_valid_tags || is_blank( $t_html_valid_tags ) ) {
 			return $p_string;

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -251,7 +251,7 @@ function string_sanitize_url( $p_url, $p_return_absolute = false ) {
 	$t_url = strip_tags( urldecode( $p_url ) );
 
 	$t_path = rtrim( config_get_global( 'path' ), '/' );
-	$t_short_path = rtrim( config_get( 'short_path' ), '/' );
+	$t_short_path = rtrim( config_get_global( 'short_path' ), '/' );
 
 	$t_pattern = '(?:/*(?P<script>[^\?#]*))(?:\?(?P<query>[^#]*))?(?:#(?P<anchor>[^#]*))?';
 

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -921,7 +921,7 @@ function user_get_field( $p_user_id, $p_field_name ) {
  */
 function user_get_email( $p_user_id ) {
 	$t_email = '';
-	if( LDAP == config_get( 'login_method' ) && ON == config_get( 'use_ldap_email' ) ) {
+	if( LDAP == config_get_global( 'login_method' ) && ON == config_get( 'use_ldap_email' ) ) {
 		$t_email = ldap_email( $p_user_id );
 	}
 	if( is_blank( $t_email ) ) {
@@ -949,7 +949,7 @@ function user_get_username( $p_user_id ) {
 function user_get_realname( $p_user_id ) {
 	$t_realname = '';
 
-	if( LDAP == config_get( 'login_method' ) && ON == config_get( 'use_ldap_realname' ) ) {
+	if( LDAP == config_get_global( 'login_method' ) && ON == config_get( 'use_ldap_realname' ) ) {
 		$t_realname = ldap_realname( $p_user_id );
 	}
 

--- a/core/utility_api.php
+++ b/core/utility_api.php
@@ -302,7 +302,7 @@ function get_font_path() {
  */
 function finfo_get_if_available() {
 	if( class_exists( 'finfo' ) ) {
-		$t_info_file = config_get( 'fileinfo_magic_db_file' );
+		$t_info_file = config_get_global( 'fileinfo_magic_db_file' );
 
 		if( is_blank( $t_info_file ) ) {
 			$t_finfo = new finfo( FILEINFO_MIME );

--- a/index.php
+++ b/index.php
@@ -34,7 +34,7 @@ require_api( 'config_api.php' );
 require_api( 'print_api.php' );
 
 if( auth_is_user_authenticated() ) {
-	print_header_redirect( config_get( 'default_home_page' ) );
+	print_header_redirect( config_get_global( 'default_home_page' ) );
 } else {
 	print_header_redirect( auth_login_page() );
 }

--- a/issues_rss.php
+++ b/issues_rss.php
@@ -95,7 +95,7 @@ if( $f_sort === 'update' ) {
 	$c_sort_field = 'date_submitted';
 }
 
-$t_path = config_get( 'path' );
+$t_path = config_get_global( 'path' );
 
 # construct rss file
 

--- a/login.php
+++ b/login.php
@@ -94,7 +94,7 @@ if( auth_attempt_login( $f_username, $f_password, $f_perm_login ) ) {
 
 	$t_redirect_url = auth_login_page( $t_query_text );
 
-	if( HTTP_AUTH == config_get( 'login_method' ) ) {
+	if( HTTP_AUTH == config_get_global( 'login_method' ) ) {
 		auth_http_prompt();
 		exit;
 	}

--- a/login.php
+++ b/login.php
@@ -43,7 +43,7 @@ require_api( 'string_api.php' );
 
 $f_username		= gpc_get_string( 'username', '' );
 $f_password		= gpc_get_string( 'password', '' );
-$t_return		= string_url( string_sanitize_url( gpc_get_string( 'return', config_get( 'default_home_page' ) ) ) );
+$t_return		= string_url( string_sanitize_url( gpc_get_string( 'return', config_get_global( 'default_home_page' ) ) ) );
 $f_from			= gpc_get_string( 'from', '' );
 $f_secure_session = gpc_get_bool( 'secure_session', false );
 $f_reauthenticate = gpc_get_bool( 'reauthenticate', false );

--- a/login_page.php
+++ b/login_page.php
@@ -86,7 +86,7 @@ if( auth_is_user_authenticated() && !current_user_is_anonymous() ) {
 	if( !is_blank( $f_return ) ) {
 		print_header_redirect( $f_return, false, false, true );
 	} else {
-		print_header_redirect( config_get( 'default_home_page' ) );
+		print_header_redirect( config_get_global( 'default_home_page' ) );
 	}
 }
 

--- a/login_page.php
+++ b/login_page.php
@@ -166,7 +166,7 @@ if( config_get_global( 'admin_checks' ) == ON ) {
 	}
 
 	$t_config = 'show_detailed_errors';
-	if( config_get( $t_config ) != OFF ) {
+	if( config_get_global( $t_config ) != OFF ) {
 		$t_warnings[] = debug_setting_message( 'security', $t_config, 'OFF' );
 	}
 	$t_config = 'display_errors';

--- a/login_password_page.php
+++ b/login_password_page.php
@@ -121,7 +121,7 @@ if( auth_is_user_authenticated() && !current_user_is_anonymous() && !$f_reauthen
 	if( !is_blank( $f_return ) ) {
 		print_header_redirect( $f_return, false, false, true );
 	} else {
-		print_header_redirect( config_get( 'default_home_page' ) );
+		print_header_redirect( config_get_global( 'default_home_page' ) );
 	}
 }
 

--- a/manage_overview_page.php
+++ b/manage_overview_page.php
@@ -112,7 +112,7 @@ print_manage_menu( 'manage_overview_page.php' );
 		</tr>
 		<tr>
 			<th class="category"><?php echo lang_get( 'plugin_path' ) ?></th>
-			<td><?php echo config_get( 'plugin_path' ) ?></td>
+			<td><?php echo config_get_global( 'plugin_path' ) ?></td>
 		</tr>
 		<tr class="spacer">
 			<td colspan="2"></td>

--- a/manage_overview_page.php
+++ b/manage_overview_page.php
@@ -108,7 +108,7 @@ print_manage_menu( 'manage_overview_page.php' );
 		</tr>
 		<tr>
 			<th class="category"><?php echo lang_get( 'core_path' ) ?></th>
-			<td><?php echo config_get( 'core_path' ) ?></td>
+			<td><?php echo config_get_global( 'core_path' ) ?></td>
 		</tr>
 		<tr>
 			<th class="category"><?php echo lang_get( 'plugin_path' ) ?></th>

--- a/manage_overview_page.php
+++ b/manage_overview_page.php
@@ -89,7 +89,7 @@ print_manage_menu( 'manage_overview_page.php' );
 		</tr>
 		<tr>
 			<th class="category"><?php echo lang_get( 'database_driver' ) ?></th>
-			<td><?php echo config_get( 'db_type' ) ?></td>
+			<td><?php echo config_get_global( 'db_type' ) ?></td>
 		</tr>
 		<tr>
 			<th class="category"><?php echo lang_get( 'database_version_description' ) ?></th>

--- a/manage_overview_page.php
+++ b/manage_overview_page.php
@@ -104,7 +104,7 @@ print_manage_menu( 'manage_overview_page.php' );
 		</tr>
 		<tr>
 			<th class="category"><?php echo lang_get( 'site_path' ) ?></th>
-			<td><?php echo config_get( 'absolute_path' ) ?></td>
+			<td><?php echo config_get_global( 'absolute_path' ) ?></td>
 		</tr>
 		<tr>
 			<th class="category"><?php echo lang_get( 'core_path' ) ?></th>

--- a/manage_proj_create_page.php
+++ b/manage_proj_create_page.php
@@ -158,7 +158,7 @@ $f_parent_id = gpc_get( 'parent_id', null );
 				$t_file_path = '';
 				# Don't reveal the absolute path to non-administrators for security reasons
 				if( current_user_is_administrator() ) {
-					$t_file_path = config_get( 'absolute_path_default_upload_folder' );
+					$t_file_path = config_get_global( 'absolute_path_default_upload_folder' );
 				}
 				?>
 				<tr>

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -168,7 +168,7 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 				$t_file_path = $t_row['file_path'];
 				# Don't reveal the absolute path to non-administrators for security reasons
 				if( is_blank( $t_file_path ) && current_user_is_administrator() ) {
-					$t_file_path = config_get( 'absolute_path_default_upload_folder' );
+					$t_file_path = config_get_global( 'absolute_path_default_upload_folder' );
 				}
 				?>
 				<tr>

--- a/manage_user_create.php
+++ b/manage_user_create.php
@@ -109,7 +109,7 @@ access_ensure_global_level( $f_access_level );
 
 # Need to send the user creation mail in the tracker language, not in the creating admin's language
 # Park the current language name until the user has been created
-lang_push( config_get( 'default_language' ) );
+lang_push( config_get_global( 'default_language' ) );
 
 # create the user
 $t_admin_name = user_get_name( auth_get_current_user_id() );

--- a/manage_user_create_page.php
+++ b/manage_user_create_page.php
@@ -49,7 +49,7 @@ auth_reauthenticate();
 
 access_ensure_global_level( config_get( 'manage_user_threshold' ) );
 
-$t_ldap = ( LDAP == config_get( 'login_method' ) );
+$t_ldap = ( LDAP == config_get_global( 'login_method' ) );
 
 layout_page_header();
 

--- a/manage_user_edit_page.php
+++ b/manage_user_edit_page.php
@@ -85,7 +85,7 @@ $t_user = user_get_row( $t_user_id );
 # current user.
 access_ensure_global_level( $t_user['access_level'] );
 
-$t_ldap = ( LDAP == config_get( 'login_method' ) );
+$t_ldap = ( LDAP == config_get_global( 'login_method' ) );
 
 layout_page_header();
 

--- a/manage_user_impersonate.php
+++ b/manage_user_impersonate.php
@@ -49,7 +49,7 @@ auth_impersonate( $f_user_id );
 
 form_security_purge( 'manage_user_impersonate' );
 
-$t_redirect_to = config_get( 'default_home_page' );
+$t_redirect_to = config_get_global( 'default_home_page' );
 
 layout_page_header();
 

--- a/manage_user_update.php
+++ b/manage_user_update.php
@@ -104,7 +104,7 @@ if( 0 != strcasecmp( $t_old_username, $f_username )
 
 user_ensure_name_valid( $f_username );
 
-$t_ldap = ( LDAP == config_get( 'login_method' ) );
+$t_ldap = ( LDAP == config_get_global( 'login_method' ) );
 
 if( $t_ldap && config_get( 'use_ldap_realname' ) ) {
 	$t_realname = ldap_realname_from_username( $f_username );

--- a/manage_user_update.php
+++ b/manage_user_update.php
@@ -203,7 +203,7 @@ if( $f_send_email_notification ) {
 	if( !empty( $t_changes ) ) {
 		$t_subject = '[' . config_get( 'window_title' ) . '] ' . lang_get( 'email_user_updated_subject' );
 		$t_updated_msg = lang_get( 'email_user_updated_msg' );
-		$t_message = $t_updated_msg . "\n\n" . config_get( 'path' ) . 'account_page.php' . "\n\n" . $t_changes;
+		$t_message = $t_updated_msg . "\n\n" . config_get_global( 'path' ) . 'account_page.php' . "\n\n" . $t_changes;
 
 		if( null === email_store( $t_email, $t_subject, $t_message ) ) {
 			log_event( LOG_EMAIL, 'Notification was NOT sent to ' . $f_username );

--- a/news_rss.php
+++ b/news_rss.php
@@ -81,7 +81,7 @@ if( $f_project_id != ALL_PROJECTS ) {
 # construct rss file
 
 $t_encoding = 'utf-8';
-$t_about = config_get( 'path' );
+$t_about = config_get_global( 'path' );
 $t_title = string_rss_links( config_get( 'window_title' ) . ' - ' . lang_get( 'news' ) );
 
 if( $f_username !== null ) {
@@ -89,7 +89,7 @@ if( $f_username !== null ) {
 }
 
 $t_description = $t_title;
-$t_image_link = config_get( 'path' ) . 'images/mantis_logo_button.gif';
+$t_image_link = config_get_global( 'path' ) . 'images/mantis_logo_button.gif';
 
 # only rss 2.0
 $t_category = string_rss_links( project_get_name( $f_project_id ) );
@@ -150,7 +150,7 @@ for( $i = 0; $i < $t_news_count; $i++ ) {
 	$v_headline 	= string_rss_links( $v_headline );
 	$v_body 	= string_rss_links( $v_body );
 
-	$t_about = $t_link = config_get( 'path' ) . 'news_view_page.php?news_id=' . $v_id;
+	$t_about = $t_link = config_get_global( 'path' ) . 'news_view_page.php?news_id=' . $v_id;
 	$t_title = $v_headline;
 	$t_description = $v_body;
 

--- a/plugin.php
+++ b/plugin.php
@@ -43,7 +43,7 @@ if( $t_allow_caching ) {
 	http_security_headers();
 }
 
-$t_plugin_path = config_get( 'plugin_path' );
+$t_plugin_path = config_get_global( 'plugin_path' );
 
 $f_page = gpc_get_string( 'page' );
 

--- a/plugin_file.php
+++ b/plugin_file.php
@@ -36,7 +36,7 @@ require_api( 'constant_inc.php' );
 require_api( 'gpc_api.php' );
 require_api( 'plugin_api.php' );
 
-$t_plugin_path = config_get( 'plugin_path' );
+$t_plugin_path = config_get_global( 'plugin_path' );
 
 $f_file = gpc_get_string( 'file' );
 

--- a/plugins/MantisGraph/pages/issues_trend_page.php
+++ b/plugins/MantisGraph/pages/issues_trend_page.php
@@ -45,7 +45,7 @@ $f_type = gpc_get_int( 'graph_type', 0 );
 $f_show_as_table = gpc_get_bool( 'show_table', false );
 
 layout_page_header_begin( plugin_lang_get( 'graph_page' ) );
-$t_path = config_get( 'path' );
+$t_path = config_get_global( 'path' );
 layout_page_header_end();
 
 layout_page_begin();

--- a/plugins/XmlImportExport/pages/export.php
+++ b/plugins/XmlImportExport/pages/export.php
@@ -55,7 +55,7 @@ header( 'Content-Transfer-Encoding: BASE64;' );
 header( 'Content-Disposition: attachment; filename="' . $t_filename . '"' );
 
 $t_version = MANTIS_VERSION;
-$t_url = config_get( 'path' );
+$t_url = config_get_global( 'path' );
 $t_bug_link = config_get( 'bug_link_tag' );
 $t_bugnote_link = config_get( 'bugnote_link_tag' );
 

--- a/plugins/XmlImportExport/pages/import_action.php
+++ b/plugins/XmlImportExport/pages/import_action.php
@@ -22,7 +22,7 @@
  * Process XML Import
  */
 
-$t_plugin_path = config_get( 'plugin_path' );
+$t_plugin_path = config_get_global( 'plugin_path' );
 require_once( $t_plugin_path . 'XmlImportExport/ImportXml.php' );
 
 form_security_validate( 'plugin_xml_import_action' );

--- a/print_all_bug_page.php
+++ b/print_all_bug_page.php
@@ -71,7 +71,7 @@ $t_columns = helper_get_columns_to_view( COLUMNS_TARGET_PRINT_PAGE );
 $t_num_of_columns = count( $t_columns );
 
 # Initialize the filter from the cookie, use default if not set
-$t_cookie_value_id = gpc_get_cookie( config_get( 'view_all_cookie' ), '' );
+$t_cookie_value_id = gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' );
 $t_cookie_value = filter_db_get_filter( $t_cookie_value_id );
 if( is_blank( $t_cookie_value ) ) {
 	$t_filter_cookie_arr = filter_get_default();

--- a/query_store.php
+++ b/query_store.php
@@ -89,7 +89,7 @@ if( $f_all_projects ) {
 	$t_project_id = 0;
 }
 
-$t_filter_string = filter_db_get_filter( gpc_get_cookie( config_get( 'view_all_cookie' ), '' ) );
+$t_filter_string = filter_db_get_filter( gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' ) );
 # named filters must not reference source query id
 $t_filter = filter_deserialize( $t_filter_string );
 if( isset( $t_filter['_source_query_id'] ) ) {

--- a/query_store_page.php
+++ b/query_store_page.php
@@ -66,7 +66,7 @@ layout_page_begin();
 	</h4>
 </div>
 <?php
-$t_query_to_store = filter_db_get_filter( gpc_get_cookie( config_get( 'view_all_cookie' ), '' ) );
+$t_query_to_store = filter_db_get_filter( gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' ) );
 $t_query_arr = filter_db_get_available_queries();
 
 # Let's just see if any of the current filters are the

--- a/search.php
+++ b/search.php
@@ -157,7 +157,7 @@ $t_project_id = ( $t_project_id * -1 );
 $t_row_id = filter_db_set_for_current_user( $t_project_id, false, '', $t_settings_string );
 
 # set cookie values
-gpc_set_cookie( config_get( 'view_all_cookie' ), $t_row_id, time()+config_get_global( 'cookie_time_length' ), config_get_global( 'cookie_path' ) );
+gpc_set_cookie( config_get_global( 'view_all_cookie' ), $t_row_id, time()+config_get_global( 'cookie_time_length' ), config_get_global( 'cookie_path' ) );
 
 # redirect to print_all or view_all page
 if( $f_print ) {

--- a/search.php
+++ b/search.php
@@ -157,7 +157,7 @@ $t_project_id = ( $t_project_id * -1 );
 $t_row_id = filter_db_set_for_current_user( $t_project_id, false, '', $t_settings_string );
 
 # set cookie values
-gpc_set_cookie( config_get( 'view_all_cookie' ), $t_row_id, time()+config_get_global( 'cookie_time_length' ), config_get( 'cookie_path' ) );
+gpc_set_cookie( config_get( 'view_all_cookie' ), $t_row_id, time()+config_get_global( 'cookie_time_length' ), config_get_global( 'cookie_path' ) );
 
 # redirect to print_all or view_all page
 if( $f_print ) {

--- a/search.php
+++ b/search.php
@@ -157,7 +157,7 @@ $t_project_id = ( $t_project_id * -1 );
 $t_row_id = filter_db_set_for_current_user( $t_project_id, false, '', $t_settings_string );
 
 # set cookie values
-gpc_set_cookie( config_get( 'view_all_cookie' ), $t_row_id, time()+config_get( 'cookie_time_length' ), config_get( 'cookie_path' ) );
+gpc_set_cookie( config_get( 'view_all_cookie' ), $t_row_id, time()+config_get_global( 'cookie_time_length' ), config_get( 'cookie_path' ) );
 
 # redirect to print_all or view_all page
 if( $f_print ) {

--- a/set_project.php
+++ b/set_project.php
@@ -78,9 +78,9 @@ helper_set_current_project( $f_project_id );
 if( !is_blank( $c_ref ) ) {
 	$t_redirect_url = $c_ref;
 } else if( !isset( $_SERVER['HTTP_REFERER'] ) || is_blank( $_SERVER['HTTP_REFERER'] ) ) {
-	$t_redirect_url = config_get( 'default_home_page' );
+	$t_redirect_url = config_get_global( 'default_home_page' );
 } else {
-	$t_home_page = config_get( 'default_home_page' );
+	$t_home_page = config_get_global( 'default_home_page' );
 
 	# Check that referrer matches our address after squashing case (case insensitive compare)
 	$t_path = rtrim( config_get_global( 'path' ), '/' );

--- a/set_project.php
+++ b/set_project.php
@@ -83,7 +83,7 @@ if( !is_blank( $c_ref ) ) {
 	$t_home_page = config_get( 'default_home_page' );
 
 	# Check that referrer matches our address after squashing case (case insensitive compare)
-	$t_path = rtrim( config_get( 'path' ), '/' );
+	$t_path = rtrim( config_get_global( 'path' ), '/' );
 	if( preg_match( '@^(' . $t_path . ')/(?:/*([^\?#]*))(.*)?$@', $_SERVER['HTTP_REFERER'], $t_matches ) ) {
 		$t_referrer_page = $t_matches[2];
 		$t_param = $t_matches[3];

--- a/tests/test_config_get_set.php
+++ b/tests/test_config_get_set.php
@@ -39,12 +39,12 @@ $t_test = config_get( $t_config );
 print_r( $t_test );
 
 $t_config = 'default_home_page';
-$t_test = config_get( $t_config );
+$t_test = config_get_global( $t_config );
 print_r( $t_config );
 print_r( $t_test );
 $t_test .= '?test';
-config_set( $t_config, $t_test );
-$t_test = config_get( $t_config );
+config_set_global( $t_config, $t_test );
+$t_test = config_get_global( $t_config );
 print_r( $t_test );
 
 $g_test_config = array();

--- a/view_all_bug_page.php
+++ b/view_all_bug_page.php
@@ -82,7 +82,7 @@ for( $i=0; $i < $t_row_count; $i++ ) {
 	$t_project_id = $t_rows[$i]->project_id;
 	$t_unique_project_ids[$t_project_id] = $t_project_id;
 }
-gpc_set_cookie( config_get( 'bug_list_cookie' ), implode( ',', $t_bugslist ) );
+gpc_set_cookie( config_get_global( 'bug_list_cookie' ), implode( ',', $t_bugslist ) );
 
 compress_enable();
 

--- a/view_all_set.php
+++ b/view_all_set.php
@@ -106,7 +106,7 @@ if( ( $f_type == 3 ) && ( $f_source_query_id == -1 ) ) {
 # 	26: $f_show_profile
 
 # Set new filter values.  These are stored in a cookie
-$t_view_all_cookie_id = gpc_get_cookie( config_get( 'view_all_cookie' ), '' );
+$t_view_all_cookie_id = gpc_get_cookie( config_get_global( 'view_all_cookie' ), '' );
 $t_view_all_cookie = filter_db_get_filter( $t_view_all_cookie_id );
 
 # process the cookie if it exists, it may be blank in a new install
@@ -225,7 +225,7 @@ if( !$f_temp_filter ) {
 	$t_row_id = filter_db_set_for_current_user( $t_project_id, false, '', $t_settings_string );
 
 	# set cookie values
-	gpc_set_cookie( config_get( 'view_all_cookie' ), $t_row_id, time()+config_get_global( 'cookie_time_length' ), config_get_global( 'cookie_path' ) );
+	gpc_set_cookie( config_get_global( 'view_all_cookie' ), $t_row_id, time()+config_get_global( 'cookie_time_length' ), config_get_global( 'cookie_path' ) );
 }
 
 # redirect to print_all or view_all page

--- a/view_all_set.php
+++ b/view_all_set.php
@@ -225,7 +225,7 @@ if( !$f_temp_filter ) {
 	$t_row_id = filter_db_set_for_current_user( $t_project_id, false, '', $t_settings_string );
 
 	# set cookie values
-	gpc_set_cookie( config_get( 'view_all_cookie' ), $t_row_id, time()+config_get( 'cookie_time_length' ), config_get( 'cookie_path' ) );
+	gpc_set_cookie( config_get( 'view_all_cookie' ), $t_row_id, time()+config_get_global( 'cookie_time_length' ), config_get( 'cookie_path' ) );
 }
 
 # redirect to print_all or view_all page

--- a/view_all_set.php
+++ b/view_all_set.php
@@ -225,7 +225,7 @@ if( !$f_temp_filter ) {
 	$t_row_id = filter_db_set_for_current_user( $t_project_id, false, '', $t_settings_string );
 
 	# set cookie values
-	gpc_set_cookie( config_get( 'view_all_cookie' ), $t_row_id, time()+config_get_global( 'cookie_time_length' ), config_get( 'cookie_path' ) );
+	gpc_set_cookie( config_get( 'view_all_cookie' ), $t_row_id, time()+config_get_global( 'cookie_time_length' ), config_get_global( 'cookie_path' ) );
 }
 
 # redirect to print_all or view_all page


### PR DESCRIPTION
There is no need to call config_get for all options that are contained in $g_global_settings
Using config_get_global instead of config_get avoids unneeded calls of config_can_set_in_database.