### PR TITLE
Remove usage of deprecated each() function

### DIFF
--- a/admin/check/check_php_inc.php
+++ b/admin/check/check_php_inc.php
@@ -190,7 +190,7 @@ $t_vars = array(
 	'date.timezone'
 );
 
-while( list( $t_foo, $t_var ) = each( $t_vars ) ) {
+foreach( $t_vars as $t_var ) {
 	$t_value = ini_get( $t_var );
 	if( $t_value != '' ) {
 		check_print_info_row( 'php.ini directive: ' . $t_var, htmlentities( $t_value ) );

--- a/core/config_api.php
+++ b/core/config_api.php
@@ -138,15 +138,13 @@ function config_get( $p_option, $p_default = null, $p_user = null, $p_project = 
 
 			if( isset( $g_cache_config[$p_option] ) ) {
 				$t_found = false;
-				reset( $t_users );
-				while( ( list(, $t_user ) = each( $t_users ) ) && !$t_found ) {
-					reset( $t_projects );
-					while( ( list(, $t_project ) = each( $t_projects ) ) && !$t_found ) {
+				foreach( $t_users as $t_user ) {
+					foreach( $t_projects as $t_project ) {
 						if( isset( $g_cache_config[$p_option][$t_user][$t_project] ) ) {
 							$t_value = $g_cache_config[$p_option][$t_user][$t_project];
 							$t_found = true;
-
 							# @@ debug @@ echo "clu found u=$t_user, p=$t_project, v=$t_value ";
+							break 2;
 						}
 					}
 				}
@@ -242,13 +240,12 @@ function config_get_access( $p_option, $p_user = null, $p_project = null ) {
 
 	$t_found = false;
 	if( isset( $g_cache_config[$p_option] ) ) {
-		reset( $t_users );
-		while( ( list(, $t_user ) = each( $t_users ) ) && !$t_found ) {
-			reset( $t_projects );
-			while( ( list(, $t_project ) = each( $t_projects ) ) && !$t_found ) {
+		foreach( $t_users as $t_user ) {
+			foreach( $t_projects as $t_project ) {
 				if( isset( $g_cache_config[$p_option][$t_user][$t_project] ) ) {
 					$t_access = $g_cache_config_access[$p_option][$t_user][$t_project];
 					$t_found = true;
+					break 2;
 				}
 			}
 		}
@@ -294,12 +291,11 @@ function config_is_set( $p_option, $p_user = null, $p_project = null ) {
 	}
 
 	$t_found = false;
-	reset( $t_users );
-	while( ( list(, $t_user ) = each( $t_users ) ) && !$t_found ) {
-		reset( $t_projects );
-		while( ( list(, $t_project ) = each( $t_projects ) ) && !$t_found ) {
+	foreach( $t_users as $t_user ) {
+		foreach( $t_projects as $t_project ) {
 			if( isset( $g_cache_config[$p_option][$t_user][$t_project] ) ) {
 				$t_found = true;
+				break 2;
 			}
 		}
 	}

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1017,10 +1017,8 @@ function html_button_bug_change_status( BugData $p_bug ) {
 
 	if( count( $t_enum_list ) > 0 ) {
 		# resort the list into ascending order after noting the key from the first element (the default)
-		$t_default_arr = each( $t_enum_list );
-		$t_default = $t_default_arr['key'];
+		$t_default = key( $t_enum_list );
 		ksort( $t_enum_list );
-		reset( $t_enum_list );
 
 		echo '<form method="post" action="bug_change_status_page.php" class="form-inline">';
 		# CSRF protection not required here - form does not result in modifications

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1115,7 +1115,7 @@ function print_language_option_list( $p_language ) {
  */
 function print_all_bug_action_option_list( array $p_project_ids = null ) {
 	$t_commands = bug_group_action_get_commands( $p_project_ids );
-	while( list( $t_action_id, $t_action_label ) = each( $t_commands ) ) {
+	foreach ( $t_commands as $t_action_id => $t_action_label) {
 		echo '<option value="' . $t_action_id . '">' . $t_action_label . '</option>';
 	}
 }
@@ -1838,7 +1838,7 @@ function get_dropdown( array $p_control_array, $p_control_name, $p_match = '', $
 	if( $p_add_any ) {
 		array_unshift_assoc( $p_control_array, META_FILTER_ANY, lang_trans( '[any]' ) );
 	}
-	while( list( $t_name, $t_desc ) = each( $p_control_array ) ) {
+	foreach ( $p_control_array as $t_name => $t_desc ) {
 		$t_sel = '';
 		if( is_array( $p_match ) ) {
 			if( in_array( $t_name, array_values( $p_match ) ) || in_array( $t_desc, array_values( $p_match ) ) ) {

--- a/my_view_page.php
+++ b/my_view_page.php
@@ -103,7 +103,8 @@ $t_two_columns_applied = false;
 
 define( 'MY_VIEW_INC_ALLOW', true );
 
-while (list ($t_box_title, $t_box_display) = each ($t_boxes)) {
+foreach( $t_boxes as $t_box_title => $t_box_display ) {
+# while (list ($t_box_title, $t_box_display) = each ($t_boxes)) {
 		# don't display bugs that are set as 0
 	if ($t_box_display == 0) {
 		$t_number_of_boxes = $t_number_of_boxes - 1;


### PR DESCRIPTION
each() has been deprecated as of PHP 7.2.0 [1]

[1] http://php.net/manual/en/function.each.php

Fixes #23640