### PR TITLE
Fix preview of non UTF-8 text attachments

### DIFF
--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1986,7 +1986,7 @@ function print_bug_attachment_preview_text( array $p_attachment ) {
 		default:
 			trigger_error( ERROR_GENERIC, ERROR );
 	}
-	echo htmlspecialchars( $t_content );
+	echo htmlspecialchars( $t_content, ENT_SUBSTITUTE, 'UTF-8' );
 	echo '</pre>';
 }
 


### PR DESCRIPTION
Functionality of function htmlspecialchars depends on PHP version [1].

The change ensures that
  - UTF-8 is used in any case
  - Single non UTF-8 characters are replaced in the string
    instead of replacing the whole string by an empty string

[1] www.php.net/manual/en/function.htmlspecialchars.php

Fixes #23645