### PR TITLE
Fix Manage Plugins UI for protected plugins

### DIFF
--- a/manage_plugin_page.php
+++ b/manage_plugin_page.php
@@ -185,13 +185,13 @@ foreach ( $t_plugins_installed as $t_basename => $t_plugin ) {
 	} else {
 		echo '<td class="center">',
 			'<select name="priority_' . $t_basename . '"',
-				check_disabled( $t_protected ), ' class="input-sm">',
+				' class="input-sm">',
 				print_plugin_priority_list( $t_priority ),
 			'</select>','</td>';
 		echo '<td class="center">',
 		'<label>',
 			'<input type="checkbox" class="ace" name="protected_' . $t_basename . '"',
-				check_disabled( $t_protected ), check_checked( $t_protected ), ' />',
+				check_checked( $t_protected ), ' />',
 		'<span class="lbl"></span>',
 		'</label>',
 			'</select>','</td>';


### PR DESCRIPTION
After setting a plugin to `protected` there are some UI issues

- the `protected` checkbox is not editable, thus you can't unprotect
- clicking the `Update` button resets all `protected` plugins to unprotected
- clicking the `Update` button resets `priority`of all protected plugins to 3 

The PR fixes these issues and reverts to the behavior in earlier versions, thus setting to `protected` means nothing more than `Hide the Uninstall button`.

Fixes #23658