### PR TITLE
Support standard filters in REST API

### DIFF
--- a/api/rest/restcore/issues_rest.php
+++ b/api/rest/restcore/issues_rest.php
@@ -79,12 +79,9 @@ function rest_issue_get( \Slim\Http\Request $p_request, \Slim\Http\Response $p_r
 			$t_message = "Project '$t_project_id' doesn't exist";
 			$p_response = $p_response->withStatus( HTTP_STATUS_NOT_FOUND, $t_message );
 		} else {
-			$t_filter_id = (int)$p_request->getParam( 'filter_id', 0 );
-			if( $t_filter_id !== 0 ) {
-				# TODO: we should have a better way to do this.
-				global $g_project_override;
-				$g_project_override = $t_project_id;
+			$t_filter_id = trim( $p_request->getParam( 'filter_id', '' ) );
 
+			if( !empty( $t_filter_id ) ) {
 				$t_issues = mc_filter_get_issues(
 					'', '', $t_project_id, $t_filter_id, $t_page_number, $t_page_size );
 			} else {

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -478,6 +478,12 @@ define( 'FILTER_TYPE_MULTI_INT', 4 );
 define( 'FILTER_MATCH_ALL', 0 );
 define( 'FILTER_MATCH_ANY', 1 );
 
+# Standard Filters
+define( 'FILTER_STANDARD_ASSIGNED', 'assigned' );
+define( 'FILTER_STANDARD_UNASSIGNED', 'unassigned' );
+define( 'FILTER_STANDARD_REPORTED', 'reported' );
+define( 'FILTER_STANDARD_MONITORED', 'monitored' );
+
 # Versions
 define( 'VERSION_ALL', null );
 define( 'VERSION_FUTURE', false );


### PR DESCRIPTION
The standard filters supported are:

- `assigned` - issues assigned to me.
- `unassigned` - unassigned issues.
- `reported` - issues reported by me.
- `monitored` - issues monitored by me.

Fixes #[22790](https://www.mantisbt.org/bugs/view.php?id=22790)