### PR TITLE
Fix change status php error

### DIFF
--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -333,17 +333,18 @@ layout_page_begin();
 		printf( '	<input type="hidden" name="resolution" value="%s" />' . "\n", config_get( 'bug_reopen_resolution' ) );
 	}
 ?>
-<?php if( access_has_bug_level( config_get( 'private_bugnote_threshold' ), $f_bug_id ) ) { ?>
+<?php
+	$t_default_bugnote_view_status = config_get( 'default_bugnote_view_status' );
+	$t_bugnote_private = $t_default_bugnote_view_status == VS_PRIVATE;
+	$t_bugnote_class = $t_bugnote_private ? 'form-control bugnote-private' : 'form-control';
+
+	if( access_has_bug_level( config_get( 'private_bugnote_threshold' ), $f_bug_id ) ) { ?>
 			<tr>
 				<th class="category">
 					<?php echo lang_get( 'view_status' ) ?>
 				</th>
 				<td>
 <?php
-		$t_default_bugnote_view_status = config_get( 'default_bugnote_view_status' );
-		$t_bugnote_private = $t_default_bugnote_view_status == VS_PRIVATE;
-		$t_bugnote_class = $t_bugnote_private ? 'form-control bugnote-private' : 'form-control';
-
 		if( access_has_bug_level( config_get( 'set_view_status_threshold' ), $f_bug_id ) ) {
 ?>
 			<input type="checkbox" id="bugnote_add_view_status" class="ace" name="private"


### PR DESCRIPTION
Fix change status php error when private notes are not accessible.

Fixes #[23721](https://www.mantisbt.org/bugs/view.php?id=23721)