### PR TITLE
Files (attachments) REST APIs

### DIFF
--- a/api/rest/restcore/issues_rest.php
+++ b/api/rest/restcore/issues_rest.php
@@ -514,16 +514,10 @@ function rest_issue_files_get( \Slim\Http\Request $p_request, \Slim\Http\Respons
 	foreach( $t_internal_files as $t_internal_file ) {
 		$t_file = array(
 			'id' => (int)$t_internal_file['id'],
-			'filename' => $t_internal_file['display_name'],
 			'reporter' => mci_account_get_array_by_id( $t_internal_file['user_id'] ),
-			'size' => (int)$t_internal_file['size'],
 			'created_at' => ApiObjectFactory::datetimeString( $t_internal_file['date_added'] ),
-			'icon' => $t_internal_file['icon']['url'],
-			'alt' => $t_internal_file['alt'],
-			'access' => array(
-				'download' => $t_internal_file['can_download'],
-				'delete' => $t_internal_file['can_delete']
-			)
+			'filename' => $t_internal_file['display_name'],
+			'size' => (int)$t_internal_file['size'],
 		);
 
 		if( $t_internal_file['exists'] ) {

--- a/api/rest/restcore/issues_rest.php
+++ b/api/rest/restcore/issues_rest.php
@@ -526,14 +526,6 @@ function rest_issue_files_get( \Slim\Http\Request $p_request, \Slim\Http\Respons
 			)
 		);
 
-		if( $t_internal_file['can_download'] ) {
-			$t_file['download_url'] = $t_internal_file['download_url'];
-		}
-
-		if( $t_internal_file['can_delete'] ) {
-			$t_file['delete_url'] = $t_internal_file['delete_url'];
-		}
-
 		if( $t_internal_file['exists'] ) {
 			$t_file['content_type'] = $t_internal_file['content_type'];
 			$t_file['content'] = base64_encode( $t_internal_file['content'] );

--- a/api/rest/restcore/issues_rest.php
+++ b/api/rest/restcore/issues_rest.php
@@ -514,17 +514,25 @@ function rest_issue_files_get( \Slim\Http\Request $p_request, \Slim\Http\Respons
 	foreach( $t_internal_files as $t_internal_file ) {
 		$t_file = array(
 			'id' => (int)$t_internal_file['id'],
-			'name' => $t_internal_file['display_name'],
+			'filename' => $t_internal_file['display_name'],
 			'reporter' => mci_account_get_array_by_id( $t_internal_file['user_id'] ),
 			'size' => (int)$t_internal_file['size'],
 			'created_at' => ApiObjectFactory::datetimeString( $t_internal_file['date_added'] ),
-			'icon' => $t_internal_file['icon']['url'], # ??
-			'alt' => $t_internal_file['alt'], # ??
+			'icon' => $t_internal_file['icon']['url'],
+			'alt' => $t_internal_file['alt'],
 			'access' => array(
 				'download' => $t_internal_file['can_download'],
 				'delete' => $t_internal_file['can_delete']
 			)
 		);
+
+		if( $t_internal_file['can_download'] ) {
+			$t_file['download_url'] = $t_internal_file['download_url'];
+		}
+
+		if( $t_internal_file['can_delete'] ) {
+			$t_file['delete_url'] = $t_internal_file['delete_url'];
+		}
 
 		if( $t_internal_file['exists'] ) {
 			$t_file['content_type'] = $t_internal_file['content_type'];

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -486,21 +486,17 @@ function mci_issue_get_custom_fields( $p_issue_id ) {
  * @return array that represents an AttachmentData structure
  */
 function mci_issue_get_attachments( $p_issue_id ) {
-	$t_attachment_rows = bug_get_attachments( $p_issue_id );
-
+	$t_attachment_rows = file_get_visible_attachments( $p_issue_id );
 	if( $t_attachment_rows == null ) {
 		return array();
 	}
 
 	$t_result = array();
 	foreach( $t_attachment_rows as $t_attachment_row ) {
-		if( !file_can_view_bug_attachments( $p_issue_id, (int)$t_attachment_row['user_id'] ) ) {
-			continue;
-		}
 		$t_attachment = array();
 		$t_attachment['id'] = (int)$t_attachment_row['id'];
-		$t_attachment['filename'] = $t_attachment_row['filename'];
-		$t_attachment['size'] = (int)$t_attachment_row['filesize'];
+		$t_attachment['filename'] = $t_attachment_row['display_name'];
+		$t_attachment['size'] = (int)$t_attachment_row['size'];
 		$t_attachment['content_type'] = $t_attachment_row['file_type'];
 
 		$t_created_at = ApiObjectFactory::datetime( $t_attachment_row['date_added'] );
@@ -509,7 +505,21 @@ function mci_issue_get_attachments( $p_issue_id ) {
 			$t_attachment['download_url'] = mci_get_mantis_path() . 'file_download.php?file_id=' . $t_attachment_row['id'] . '&amp;type=bug';
 			$t_attachment['date_submitted'] = $t_created_at;
 		} else {
-			$t_attachment['download_url'] = mci_get_mantis_path() . 'file_download.php?file_id=' . $t_attachment_row['id'] . '&type=bug';
+			$t_attachment['icon'] = $t_attachment_row['icon']['url'];
+			$t_attachment['alt'] = $t_attachment_row['alt'];
+			$t_attachment['access'] = array(
+				'download' => $t_attachment_row['can_download'],
+				'delete' => $t_attachment_row['can_delete']
+			);
+
+			if( $t_attachment_row['can_download'] ) {
+				$t_attachment['download_url'] = mci_get_mantis_path() . 'file_download.php?file_id=' . $t_attachment_row['id'] . '&type=bug';
+			}
+
+			if( $t_attachment_row['can_delete'] ) {
+				$t_attachment['delete_url'] = mci_get_mantis_path() . 'bug_file_delete.php?file_id=' . $t_attachment_row['id'];
+			}
+
 			$t_attachment['created_at'] = $t_created_at;
 		}
 

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -512,14 +512,6 @@ function mci_issue_get_attachments( $p_issue_id ) {
 				'delete' => $t_attachment_row['can_delete']
 			);
 
-			if( $t_attachment_row['can_download'] ) {
-				$t_attachment['download_url'] = mci_get_mantis_path() . 'file_download.php?file_id=' . $t_attachment_row['id'] . '&type=bug';
-			}
-
-			if( $t_attachment_row['can_delete'] ) {
-				$t_attachment['delete_url'] = mci_get_mantis_path() . 'bug_file_delete.php?file_id=' . $t_attachment_row['id'];
-			}
-
 			$t_attachment['created_at'] = $t_created_at;
 		}
 

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -495,30 +495,23 @@ function mci_issue_get_attachments( $p_issue_id ) {
 	foreach( $t_attachment_rows as $t_attachment_row ) {
 		$t_attachment = array();
 		$t_attachment['id'] = (int)$t_attachment_row['id'];
-		$t_attachment['filename'] = $t_attachment_row['display_name'];
-		$t_attachment['size'] = (int)$t_attachment_row['size'];
-		$t_attachment['content_type'] = $t_attachment_row['file_type'];
 
 		$t_created_at = ApiObjectFactory::datetime( $t_attachment_row['date_added'] );
 
 		if( ApiObjectFactory::$soap ) {
-			$t_attachment['download_url'] = mci_get_mantis_path() . 'file_download.php?file_id=' . $t_attachment_row['id'] . '&amp;type=bug';
+			$t_attachment['user_id'] = (int)$t_attachment_row['user_id'];
 			$t_attachment['date_submitted'] = $t_created_at;
 		} else {
-			$t_attachment['icon'] = $t_attachment_row['icon']['url'];
-			$t_attachment['alt'] = $t_attachment_row['alt'];
-			$t_attachment['access'] = array(
-				'download' => $t_attachment_row['can_download'],
-				'delete' => $t_attachment_row['can_delete']
-			);
-
+			$t_attachment['reporter'] = mci_account_get_array_by_id( $t_attachment_row['user_id'] );
 			$t_attachment['created_at'] = $t_created_at;
 		}
 
+		$t_attachment['filename'] = $t_attachment_row['display_name'];
+		$t_attachment['size'] = (int)$t_attachment_row['size'];
+		$t_attachment['content_type'] = $t_attachment_row['file_type'];
+
 		if( ApiObjectFactory::$soap ) {
-			$t_attachment['user_id'] = (int)$t_attachment_row['user_id'];
-		} else {
-			$t_attachment['reporter'] = mci_account_get_array_by_id( $t_attachment_row['user_id'] );
+			$t_attachment['download_url'] = mci_get_mantis_path() . 'file_download.php?file_id=' . $t_attachment_row['id'] . '&amp;type=bug';
 		}
 
 		$t_result[] = $t_attachment;

--- a/core/commands/IssueFileGetCommand.php
+++ b/core/commands/IssueFileGetCommand.php
@@ -77,9 +77,6 @@ class IssueFileGetCommand extends Command {
 			$t_result = file_get_content( $t_attachment['id'] );
 			$t_attachment['content_type'] = $t_result['type'];
 			$t_attachment['content'] = $t_result['content'];
-			$t_attachment['download_url'] = $t_mantis_path .
-				'file_download.php?file_id=' . $t_attachment['id'] . '&type=bug';
-			$t_attachment['delete_url'] = $t_mantis_path . 'bug_file_delete.php?file_id=' . $t_attachment_row['id'];
 	
 			$t_matching_attachments[] = $t_attachment;
 		}

--- a/core/commands/IssueFileGetCommand.php
+++ b/core/commands/IssueFileGetCommand.php
@@ -68,6 +68,7 @@ class IssueFileGetCommand extends Command {
 		$t_file_id = $this->query( 'file_id' );
 		$t_attachments = file_get_visible_attachments( $this->issue_id );
 		$t_matching_attachments = array();
+		$t_mantis_path = config_get_global( 'path' );
 		foreach( $t_attachments as $t_attachment ) {
 			if( $t_file_id != null && $t_file_id != $t_attachment['id'] ) {
 				continue;
@@ -76,7 +77,10 @@ class IssueFileGetCommand extends Command {
 			$t_result = file_get_content( $t_attachment['id'] );
 			$t_attachment['content_type'] = $t_result['type'];
 			$t_attachment['content'] = $t_result['content'];
-
+			$t_attachment['download_url'] = $t_mantis_path .
+				'file_download.php?file_id=' . $t_attachment['id'] . '&type=bug';
+			$t_attachment['delete_url'] = $t_mantis_path . 'bug_file_delete.php?file_id=' . $t_attachment_row['id'];
+	
 			$t_matching_attachments[] = $t_attachment;
 		}
 

--- a/core/commands/IssueFileGetCommand.php
+++ b/core/commands/IssueFileGetCommand.php
@@ -1,0 +1,86 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+require_api( 'authentication_api.php' );
+require_api( 'bug_api.php' );
+require_api( 'constant_inc.php' );
+require_api( 'config_api.php' );
+require_api( 'helper_api.php' );
+require_api( 'user_api.php' );
+
+use Mantis\Exceptions\ClientException;
+
+/**
+ * A command that gets issue attachments.
+ */
+class IssueFileGetCommand extends Command {
+	/**
+	 * The issue id.
+	 */
+	private $issue_id;
+
+	/**
+	 * Constructor
+	 *
+	 * @param array $p_data The command data.
+	 */
+	function __construct( array $p_data ) {
+		parent::__construct( $p_data );
+	}
+
+	/**
+	 * Validate the data.
+	 */
+	function validate() {
+		$this->issue_id = helper_parse_issue_id( $this->query( 'issue_id' ) );
+	}
+
+	/**
+	 * Process the command.
+	 *
+	 * @returns array Command response
+	 */
+	protected function process() {
+		$t_issue = bug_get( $this->issue_id, true );
+		$this->user_id = auth_get_current_user_id();
+
+		if( $t_issue->project_id != helper_get_current_project() ) {
+			# in case the current project is not the same project of the bug we are
+			# viewing, override the current project. This to avoid problems with
+			# categories and handlers lists etc.
+			global $g_project_override;
+			$g_project_override = $t_issue->project_id;
+		}
+
+		$t_file_id = $this->query( 'file_id' );
+		$t_attachments = file_get_visible_attachments( $this->issue_id );
+		$t_matching_attachments = array();
+		foreach( $t_attachments as $t_attachment ) {
+			if( $t_file_id != null && $t_file_id != $t_attachment['id'] ) {
+				continue;
+			}
+
+			$t_result = file_get_content( $t_attachment['id'] );
+			$t_attachment['content_type'] = $t_result['type'];
+			$t_attachment['content'] = $t_result['content'];
+
+			$t_matching_attachments[] = $t_attachment;
+		}
+
+		return $t_matching_attachments;
+	}
+}
+

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -384,6 +384,7 @@ function file_get_visible_attachments( $p_bug_id ) {
 		$t_attachment['size'] = $t_filesize;
 		$t_attachment['date_added'] = $t_date_added;
 		$t_attachment['diskfile'] = $t_diskfile;
+		$t_attachment['file_type'] = $t_row['file_type'];
 
 		$t_attachment['can_download'] = file_can_download_bug_attachments( $p_bug_id, (int)$t_row['user_id'] );
 		$t_attachment['can_delete'] = file_can_delete_bug_attachments( $p_bug_id, (int)$t_row['user_id'] );


### PR DESCRIPTION
- Add `access` to attachment information to indicate user's access to download and delete attachment.
- Add `delete_url` for the attachment's delete url, similar to `download_url`.
- Add `icon` for fontowesome icon and `alt` for alternate text.
- Ability to download all attachments associated with an issue via one request.
- Ability to download one attachment associated with an issue.