### PR TITLE
Issue 0003790 dynamic enum users

### DIFF
--- a/config/custom_functions_inc.php.dynamic.enum.sample
+++ b/config/custom_functions_inc.php.dynamic.enum.sample
@@ -1,0 +1,122 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+
+/**
+ * Construct an enumeration for all users, having user_id and realname.
+ * To use this in a custom field type "=users" in the possible values field.
+ *
+ * @param hash $p_attr
+ *             keys => caller: used to change return content
+ *
+ * @param integer $p_issue_level Issue level.
+ * @return array
+ */
+function custom_function_override_enum_users($p_attr=null) {
+    return override_enum_users($p_attr);
+}
+
+/**
+ * Construct an enumeration for all users, having user_id and realname.
+ * To use this in a custom field type "=developers" in the possible values field.
+ *
+ * @param hash $p_attr
+ *             keys => caller: used to change return content
+ *
+ * @param integer $p_issue_level Issue level.
+ * @return array
+ */
+function custom_function_override_enum_developers($p_attr=null) {
+    $t_my = array('attr' => array('filter' => DEVELOPER));
+    array_merge($t_my['attr'],(array)$p_attr);
+    return override_enum_users($t_my['attr']);
+}
+
+
+/**
+ * Given a user id returns the realname
+ *
+ * @param int $p_value: user id
+ * @return string user realname, or '' if user id is not valid -> intval(user id) <=0
+ */
+function custom_function_override_enum_print_value_users($p_value) {
+    echo(intval($p_value) > 0 ? get_user_realname($p_value) : '' );
+}
+
+/**
+ * Given a user id returns the realname
+ *
+ * @param int $p_value: user id
+ * @return string user realname, or '' if user id is not valid -> intval(user id) <=0
+ */
+function custom_function_override_enum_get_verbose_value_users($p_value) {
+    return (intval($p_value) > 0 ? get_user_realname($p_value) : '' );
+}
+
+
+
+
+
+/**
+ * Construct an enumeration for all users.
+ *
+ * @param hash $p_attr
+ *             keys => caller: null => element will be composed user_id:realname
+ *                     caller: 'custom_field_validate' => element will be user_id
+ *
+ *                     filter: null => all users
+ *                             constant identifing an ACCESS LEVEL, only users with this access level.
+ *                             
+ * @return array
+ */
+function override_enum_users($p_attr=null) {
+
+    $t_my = array('attr' => array('caller' => null, 'filter' => ANYBODY));
+    $t_my['attr'] = array_merge($t_my['attr'],(array)$p_attr);
+
+    $t_filter = $t_my['attr']['filter'];
+    $t_caller = $t_my['attr']['caller'];
+
+    $t_users = project_get_all_user_rows( helper_get_current_project(), $t_filter );
+
+    $t_enum = array();
+
+    switch ($t_caller) {
+        case 'custom_field_validate':
+            foreach ( $t_users as $t_user ) {
+                $t_enum[] = $t_user['id'] ;
+            }
+        break;
+
+        default:
+            foreach ( $t_users as $t_user ) {
+                $t_enum[] = $t_user['id'] . ':' . $t_user['realname'];
+            }
+            sort( $t_enum );
+        break;        
+    }
+    $t_possible_values = implode( '|', $t_enum );
+
+    return $t_possible_values;
+}
+
+/**
+ *
+ */
+function get_user_realname($p_user_id) {
+    $t_field = user_get_field($p_user_id,'realname');
+    return $t_field;
+}

--- a/core/cfdefs/cfdef_standard.php
+++ b/core/cfdefs/cfdef_standard.php
@@ -520,7 +520,8 @@ function cfdef_prepare_list_distinct_values( array $p_field_def ) {
 }
 
 /**
- * print_custom_field_input
+ * Prints input for a custom field of type enum
+ *
  * @param array $p_field_def          Custom field definition.
  * @param mixed $p_custom_field_value Custom field value.
  * @param string $p_required          The "required" attribute to add to the field

--- a/core/cfdefs/cfdef_standard.php
+++ b/core/cfdefs/cfdef_standard.php
@@ -91,7 +91,7 @@ $g_custom_field_type_definition[CUSTOM_FIELD_TYPE_ENUM] = array (
 	'#function_return_distinct_values' => 'cfdef_prepare_list_distinct_values',
 	'#function_value_to_database' => null,
 	'#function_database_to_value' => null,
-	'#function_print_input' => 'cfdef_input_list',
+	'#function_print_input' => 'cfdef_input_enum',
 	'#function_print_value' => null,
 	'#function_string_value' => 'cfdef_prepare_list_value',
 	'#function_string_value_for_email' => 'cfdef_prepare_list_value_for_email',
@@ -517,4 +517,44 @@ function cfdef_prepare_list_distinct_values( array $p_field_def ) {
 		array_push( $t_return_arr, $t_option );
 	}
 	return $t_return_arr;
+}
+
+/**
+ * print_custom_field_input
+ * @param array $p_field_def          Custom field definition.
+ * @param mixed $p_custom_field_value Custom field value.
+ * @param string $p_required          The "required" attribute to add to the field
+ * @return void
+ */
+function cfdef_input_enum( array $p_field_def, $p_custom_field_value, $p_required = '' ) {
+
+	$t_values = explode( '|', custom_field_prepare_possible_values( $p_field_def['possible_values'] ) );
+
+	$t_possible_values_count = count( $t_values );
+	$t_list_size = 0;	# for enums the size is 0
+
+	echo '<select ' . helper_get_tab_index() . ' id="custom_field_' . $p_field_def['id'] . '" name="custom_field_' . $p_field_def['id'] . '" size="' . $t_list_size . '"' . $p_required .'>';
+
+
+	$t_selected_values = explode( '|', $p_custom_field_value );
+
+	$t_simple = ( strpos($t_values[0],':') === FALSE);
+	foreach( $t_values as $t_opcode ) {
+
+        if( $t_simple ) {
+	        $t_option = $t_human = $t_opcode;
+        }
+        else {
+			$t_opx = explode(':',$t_opcode);
+	        $t_option = $t_opx[0];
+	        $t_human = $t_opx[1];
+        }
+
+		if( in_array( $t_option, $t_selected_values, true ) ) {
+			echo '<option value="' . string_attribute( $t_option ) . '" selected="selected"> ' . string_display_line( $t_human ) . '</option>';
+		} else {
+			echo '<option value="' . string_attribute( $t_option ) . '">' .string_display_line( $t_human ) . '</option>';
+		}
+	}
+	echo '</select>';
 }

--- a/core/classes/MantisEnum.class.php
+++ b/core/classes/MantisEnum.class.php
@@ -163,8 +163,8 @@ class MantisEnum {
 	 * @param string $p_enum_string The enumerated string.
 	 * @return array array of unique values.
 	 */
-	public static function getValues( $p_enum_string ) {
-		return array_unique( array_keys( MantisEnum::getAssocArrayIndexedByValues( $p_enum_string ) ) );
+	public static function getValues( $p_enum_string, $attr=null  ) {
+		return array_unique( array_keys( MantisEnum::getAssocArrayIndexedByValues( $p_enum_string, $attr ) ) );
 	}
 
 	/**

--- a/core/filter_form_api.php
+++ b/core/filter_form_api.php
@@ -1801,10 +1801,28 @@ function print_filter_plugin_field( $p_field_name, $p_filter_object, array $p_fi
  * @return void
  */
 function print_filter_values_custom_field( array $p_filter, $p_field_id ) {
-	if( CUSTOM_FIELD_TYPE_DATE == custom_field_type( $p_field_id ) ) {
+	$t_cftype = custom_field_type( $p_field_id );
+    $t_dyn = false;
+  
+	switch( $t_cftype ){
+		case CUSTOM_FIELD_TYPE_DATE:
 		print_filter_values_custom_field_date( $p_filter, $p_field_id );
 		return;
+		break;
+
+		case CUSTOM_FIELD_TYPE_ENUM:
+			$t_cfdef = custom_field_get_definition( $p_field_id );
+
+			// Dynamic Domain ?
+			$t_dyn = ($t_cfdef['possible_values'][0] == '=');
+			if( $t_dyn ) {
+				$t_fn = 'custom_function_override_enum_get_verbose_value_' . 
+				         utf8_substr( $t_cfdef['possible_values'], 1 );
+	        }
+		break;
+
 	}
+
 
 	if( isset( $p_filter['custom_fields'][$p_field_id] ) ) {
 		$t_values = $p_filter['custom_fields'][$p_field_id];
@@ -1822,7 +1840,12 @@ function print_filter_values_custom_field( array $p_filter, $p_field_id ) {
 			if( filter_field_is_none( $t_val ) ) {
 				$t_strings[] = lang_get( 'none' );
 			} else {
+				if( $t_dyn ) {
+					$t_strings[] = call_user_func($t_fn,$t_val);
+				}	
+				else {
 				$t_strings[] = $t_val;
+			    }
 			}
 			$t_inputs[] = '<input type="hidden" name="custom_field_' . $p_field_id . '[]" value="' . string_attribute( $t_val ) . '" />';
 		}
@@ -1932,13 +1955,21 @@ function print_filter_custom_field( $p_field_id, array $p_filter = null ) {
 			$t_values = custom_field_distinct_values( $t_cfdef, $t_included_projects );
 			if( is_array( $t_values ) ){
 				$t_max_length = config_get( 'max_dropdown_length' );
-				foreach( $t_values as $t_val ) {
-					if( filter_field_is_any($t_val) || filter_field_is_none( $t_val ) ) {
+                # Dynamic Domain ENUM CUSTOM FIELD
+				$t_extract = (strpos($t_values[0],':') !== FALSE);
+				foreach( $t_values as $t_item ) {
+					$t_opt = $t_val = $t_item;
+					if( $t_extract ) {
+						$t_opt_val = explode(':',$t_item);
+						$t_opt = $t_opt_val[0];
+						$t_val = $t_opt_val[1];
+					}
+					if( filter_field_is_any($t_opt) || filter_field_is_none( $t_opt ) ) {
 						continue;
 					}
-					echo '<option value="' . string_attribute( $t_val ) . '"';
+					echo '<option value="' . string_attribute( $t_opt ) . '"';
 					if( isset( $p_filter['custom_fields'][$p_field_id] ) ) {
-						check_selected( $p_filter['custom_fields'][$p_field_id], $t_val, false );
+						check_selected( $p_filter['custom_fields'][$p_field_id], $t_opt, false );
 					}
 					echo '>' . string_attribute( string_shorten( $t_val, $t_max_length ) ) . '</option>';
 				}


### PR DESCRIPTION
Implementation is done to save for Custom Fields of Type Enum with a dynamic domain, the id instead of the string on mantis_custom_field_string_table.
This implementation has been tested to save user id, instead of realname.

hope code can be useful as a starting point, for a stable feature.