### PR TITLE
Improvements and code cleanup for Summary page

### DIFF
--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -210,57 +210,73 @@ function summary_print_by_enum( $p_enum ) {
 		
 		summary_helper_build_bugcount( $t_cache, $t_enum, $t_status, $t_bugcount );
 	}
+
+	switch( $p_enum ) {
+		case 'status':
+			$t_filter_property = FILTER_PROPERTY_STATUS;
+			break;
+		case 'severity':
+			$t_filter_property = FILTER_PROPERTY_SEVERITY;
+			break;
+		case 'resolution':
+			$t_filter_property = FILTER_PROPERTY_RESOLUTION;
+			break;
+		case 'priority':
+			$t_filter_property = FILTER_PROPERTY_PRIORITY;
+			break;
+		default:
+			# Unknown Enum type
+			trigger_error( ERROR_GENERIC, ERROR );
+	}
+
 	foreach( $t_cache as $t_enum => $t_item) {
 		# Build up the hyperlinks to bug views
-		$t_bug_link = '';
 		$t_bugs_open = isset( $t_item['open'] ) ? $t_item['open'] : 0;
 		$t_bugs_resolved = isset( $t_item['resolved'] ) ? $t_item['resolved'] : 0;
 		$t_bugs_closed = isset( $t_item['closed'] ) ? $t_item['closed'] : 0;
 		$t_bugs_total = $t_bugs_open + $t_bugs_resolved + $t_bugs_closed;
 		$t_bugs_ratio = summary_helper_get_bugratio( $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total_count);
 
-		switch( $p_enum ) {
-			case 'status':
-				$t_bug_link = '<a class="subtle" href="' . $t_filter_prefix . '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_enum;
-				break;
-			case 'severity':
-				$t_bug_link = '<a class="subtle" href="' . $t_filter_prefix . '&amp;' . FILTER_PROPERTY_SEVERITY . '=' . $t_enum;
-				break;
-			case 'resolution':
-				$t_bug_link = '<a class="subtle" href="' . $t_filter_prefix . '&amp;' . FILTER_PROPERTY_RESOLUTION . '=' . $t_enum;
-				break;
-			case 'priority':
-				$t_bug_link = '<a class="subtle" href="' . $t_filter_prefix . '&amp;' . FILTER_PROPERTY_PRIORITY . '=' . $t_enum;
-				break;
-		}
+		$t_bug_link = '<a class="subtle" href="' . $t_filter_prefix . '&amp;'
+			. $t_filter_property . '=' . $t_enum;
 
 		if( !is_blank( $t_bug_link ) ) {
 			$t_resolved_val = config_get( 'bug_resolved_status_threshold' );
 			$t_closed_val = config_get( 'bug_closed_status_threshold' );
 			
 			if( 0 < $t_bugs_open ) {
-				$t_bugs_open = $t_bug_link . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_resolved_val . '">' . $t_bugs_open . '</a>';
+				$t_bugs_open = $t_bug_link
+					. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_resolved_val . '">'
+					. $t_bugs_open . '</a>';
 			} else {
 				if( ( 'status' == $p_enum ) && ( $t_enum >= $t_resolved_val ) ) {
 					$t_bugs_open = '-';
 				}
 			}
 			if( 0 < $t_bugs_resolved ) {
-				$t_bugs_resolved = $t_bug_link . '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_resolved_val . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_closed_val . '">' . $t_bugs_resolved . '</a>';
+				$t_bugs_resolved = $t_bug_link
+					. '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_resolved_val
+					. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_closed_val . '">'
+					. $t_bugs_resolved . '</a>';
 			} else {
 				if( ( 'status' == $p_enum ) && (( $t_enum < $t_resolved_val ) || ( $t_enum >= $t_closed_val ) ) ) {
 					$t_bugs_resolved = '-';
 				}
 			}
 			if( 0 < $t_bugs_closed ) {
-				$t_bugs_closed = $t_bug_link . '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_closed_val . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">' . $t_bugs_closed . '</a>';
+				$t_bugs_closed = $t_bug_link
+					. '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_closed_val
+					. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">'
+					. $t_bugs_closed . '</a>';
 			} else {
 				if( ( 'status' == $p_enum ) && ( $t_enum < $t_closed_val ) ) {
 					$t_bugs_closed = '-';
 				}
 			}
 			if( 0 < $t_bugs_total ) {
-				$t_bugs_total = $t_bug_link . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">' . $t_bugs_total . '</a>';
+				$t_bugs_total = $t_bug_link
+					. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '='
+					. META_FILTER_NONE . '">' . $t_bugs_total . '</a>';
 			}	
 			if( 'status' == $p_enum )  $t_bugs_ratio[0] = '-';		
 		}

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -797,6 +797,13 @@ function summary_print_developer_resolution( $p_resolution_enum_string ) {
 		$t_arr = db_fetch_array( $t_result );
 	}
 
+	# Sort array so devs with highest number of bugs are listed first
+	uasort( $t_handler_res_arr,
+		function( $a, $b ) {
+			return $b['total'] - $a['total'];
+		}
+	);
+
 	$t_filter_prefix = config_get( 'bug_count_hyperlink_prefix' );
 	$t_row_count = 0;
 

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -255,7 +255,8 @@ function summary_print_by_enum( $p_enum ) {
 			}
 			if( 0 < $t_bugs_resolved ) {
 				$t_bugs_resolved = $t_bug_link
-					. '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_resolved_val
+					# Only add status filter if not already part of the link
+					. ( 'status' != $p_enum ? '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_resolved_val : '' )
 					. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_closed_val . '">'
 					. $t_bugs_resolved . '</a>';
 			} else {
@@ -265,7 +266,8 @@ function summary_print_by_enum( $p_enum ) {
 			}
 			if( 0 < $t_bugs_closed ) {
 				$t_bugs_closed = $t_bug_link
-					. '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_closed_val
+					# Only add status filter if not already part of the link
+					. ( 'status' != $p_enum ? '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_closed_val : '' )
 					. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">'
 					. $t_bugs_closed . '</a>';
 			} else {

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -804,6 +804,8 @@ function summary_print_developer_resolution( $p_resolution_enum_string ) {
 		}
 	);
 
+	$t_threshold_fixed = config_get( 'bug_resolution_fixed_threshold' );
+	$t_threshold_notfixed = config_get( 'bug_resolution_not_fixed_threshold' );
 	$t_filter_prefix = config_get( 'bug_count_hyperlink_prefix' );
 	$t_row_count = 0;
 
@@ -845,8 +847,8 @@ function summary_print_developer_resolution( $p_resolution_enum_string ) {
 				}
 				echo "</td>\n";
 
-				if( $c_res_s[$j] >= config_get( 'bug_resolution_fixed_threshold' ) ) {
-					if( $c_res_s[$j] < config_get( 'bug_resolution_not_fixed_threshold' ) ) {
+				if( $c_res_s[$j] >= $t_threshold_fixed ) {
+					if( $c_res_s[$j] < $t_threshold_notfixed ) {
 						# Count bugs with a resolution between fixed and not fixed thresholds
 						$t_bugs_fixed += $t_res_bug_count;
 					} else {
@@ -927,6 +929,8 @@ function summary_print_reporter_resolution( $p_resolution_enum_string ) {
 	arsort( $t_reporter_bugcount_arr );
 
 	$t_threshold_fixed = config_get( 'bug_resolution_fixed_threshold' );
+	$t_threshold_notfixed = config_get( 'bug_resolution_not_fixed_threshold' );
+	$t_filter_prefix = config_get( 'bug_count_hyperlink_prefix' );
 	$t_row_count = 0;
 
 	# We now have a multi dimensional array of users and resolutions, with the value of each resolution for each user
@@ -972,8 +976,8 @@ function summary_print_reporter_resolution( $p_resolution_enum_string ) {
 				}
 				echo "</td>\n";
 
-				if( $c_res_s[$j] >= config_get( 'bug_resolution_fixed_threshold' ) ) {
-					if( $c_res_s[$j] < config_get( 'bug_resolution_not_fixed_threshold' ) ) {
+				if( $c_res_s[$j] >= $t_threshold_fixed ) {
+					if( $c_res_s[$j] < $t_threshold_notfixed ) {
 						# Count bugs with a resolution between fixed and not fixed thresholds
 						$t_bugs_fixed += $t_res_bug_count;
 					} else {

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -809,12 +809,13 @@ function summary_print_developer_resolution( $p_resolution_enum_string ) {
 
 	# We now have a multi dimensional array of users and resolutions, with the value of each resolution for each user
 	foreach( $t_handler_res_arr as $t_handler_id => $t_arr2 ) {
+		$t_total = $t_arr2['total'];
 
 		# Only print developers who have had at least one bug assigned to them. This helps
 		# prevent divide by zeroes, showing developers not on this project, and showing
 		# users that aren't actually developers...
 
-		if( $t_arr2['total'] > 0 ) {
+		if( $t_total > 0 ) {
 			echo '<tr>';
 			$t_row_count++;
 			echo '<td>';
@@ -856,8 +857,17 @@ function summary_print_developer_resolution( $p_resolution_enum_string ) {
 
 			}
 
+			# Display Total
+			echo '<td class="align-right">';
+			$t_bug_link =  $t_filter_prefix .
+				'&amp;' . FILTER_PROPERTY_HANDLER_ID . '=' . $t_handler_id .
+				'&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE;
+			echo '<a class="subtle" href="' . $t_bug_link . '">' . $t_total . '</a>';
+			echo "</td>\n";
+
+			# Percentage
 			$t_percent_fixed = 0;
-			if( ( $t_arr2['total'] - $t_bugs_notbugs ) > 0 ) {
+			if( ( $t_total - $t_bugs_notbugs ) > 0 ) {
 				$t_percent_fixed = ( $t_bugs_fixed / ( $t_arr2['total'] - $t_bugs_notbugs ) );
 			}
 			echo '<td class="align-right">';
@@ -916,6 +926,7 @@ function summary_print_reporter_resolution( $p_resolution_enum_string ) {
 	# Sort our total bug count array so that the reporters with the highest number of bugs are listed first,
 	arsort( $t_reporter_bugcount_arr );
 
+	$t_threshold_fixed = config_get( 'bug_resolution_fixed_threshold' );
 	$t_row_count = 0;
 
 	# We now have a multi dimensional array of users and resolutions, with the value of each resolution for each user
@@ -951,11 +962,11 @@ function summary_print_reporter_resolution( $p_resolution_enum_string ) {
 
 				echo '<td class="align-right">';
 				if( 0 < $t_res_bug_count ) {
-					$t_bug_link = '<a class="subtle" href="' . config_get( 'bug_count_hyperlink_prefix' ) .
+					$t_bug_link = $t_filter_prefix .
 						'&amp;' . FILTER_PROPERTY_REPORTER_ID . '=' . $t_reporter_id .
 						'&amp;' . FILTER_PROPERTY_RESOLUTION . '=' . $c_res_s[$j] .
-						'&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">';
-					echo $t_bug_link . $t_res_bug_count . '</a>';
+						'&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE;
+					echo '<a class="subtle" href="' . $t_bug_link . '">' . $t_res_bug_count . '</a>';
 				} else {
 					echo $t_res_bug_count;
 				}
@@ -973,6 +984,15 @@ function summary_print_reporter_resolution( $p_resolution_enum_string ) {
 
 			}
 
+			# Display Total
+			echo '<td class="align-right">';
+			$t_bug_link =  $t_filter_prefix .
+				'&amp;' . FILTER_PROPERTY_REPORTER_ID . '=' . $t_reporter_id .
+				'&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE;
+			echo '<a class="subtle" href="' . $t_bug_link . '">' . $t_total_user_bugs . '</a>';
+			echo "</td>\n";
+
+			# Percentage
 			$t_percent_errors = 0;
 			if( $t_total_user_bugs > 0 ) {
 				$t_percent_errors = ( $t_bugs_notbugs / $t_total_user_bugs );

--- a/summary_page.php
+++ b/summary_page.php
@@ -322,6 +322,7 @@ print_summary_submenu();
 						echo '<th class="align-right">', get_enum_element( 'resolution', $t_resolution ), "</th>\n";
 					}
 
+					echo '<th class="align-right">', lang_get( 'total' ), "</th>\n";
 					echo '<th class="align-right">', lang_get( 'percentage_errors' ), "</th>\n";
 				?>
 			</tr>
@@ -344,6 +345,7 @@ print_summary_submenu();
 						echo '<th class="align-right">', get_enum_element( 'resolution', $t_resolution ), "</th>\n";
 					}
 
+					echo '<th class="align-right">', lang_get( 'total' ), "</th>\n";
 					echo '<th class="align-right">', lang_get( 'percentage_fixed' ), "</th>\n";
 				?>
 			</tr>


### PR DESCRIPTION
While working on summary page and API as part of #1231 and #1266, I took the opportunity to fix a few other issues in this area of the code.

Note: this branch includes the PR #1266's commits.

- [#12978](https://mantisbt.org/bugs/view.php?id=12978): move time stats calculation to API (code cleanup)
- [#11327](https://mantisbt.org/bugs/view.php?id=11327): sort "Dev by Resolution" by total bug count 
- [#23863](https://mantisbt.org/bugs/view.php?id=23863): add Total column to Reporter/Dev by Resolution 
- Move config_get() calls outside of loop (optimization)
