### PR TITLE
Revise show realname code and uniqueness checks

### DIFF
--- a/account_update.php
+++ b/account_update.php
@@ -113,8 +113,7 @@ if( !( $t_ldap && config_get( 'use_ldap_realname' ) ) ) {
 	$t_realname = string_normalize( $f_realname );
 	if( $t_realname != user_get_field( $t_user_id, 'realname' ) ) {
 		# checks for problems with realnames
-		$t_username = user_get_username( $t_user_id );
-		user_ensure_realname_unique( $t_username, $t_realname );
+		user_ensure_realname_unique( $t_realname, $t_user_id );
 		$t_update_realname = true;
 	}
 }

--- a/account_update.php
+++ b/account_update.php
@@ -112,8 +112,6 @@ if( !( $t_ldap && config_get( 'use_ldap_realname' ) ) ) {
 	# strip extra spaces from real name
 	$t_realname = string_normalize( $f_realname );
 	if( $t_realname != user_get_field( $t_user_id, 'realname' ) ) {
-		# checks for problems with realnames
-		user_ensure_realname_unique( $t_realname, $t_user_id );
 		$t_update_realname = true;
 	}
 }

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -1308,10 +1308,9 @@ function mc_project_get_users( $p_username, $p_password, $p_project_id, $p_acces
 	$t_sort = array();
 
 	foreach( $t_users as $t_user ) {
-		$t_user_name = user_get_name_for_sorting_from_row( $t_user );
-		$t_user_name = string_attribute( $t_user_name );
-		$t_display[] = $t_user_name;
-		$t_sort[] = $t_sort_name;
+		$t_user_name = user_get_name_from_row( $t_user );
+		$t_display[] = string_attribute( $t_user_name );
+		$t_sort[] = user_get_name_for_sorting_from_row( $t_user );
 	}
 
 	array_multisort( $t_sort, SORT_ASC, SORT_STRING, $t_users, $t_display );

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -1306,23 +1306,14 @@ function mc_project_get_users( $p_username, $p_password, $p_project_id, $p_acces
 
 	$t_display = array();
 	$t_sort = array();
-	$t_show_realname = ( ON == config_get( 'show_realname' ) );
-	$t_sort_by_last_name = ( ON == config_get( 'sort_by_last_name' ) );
+
 	foreach( $t_users as $t_user ) {
-		$t_user_name = string_attribute( $t_user['username'] );
-		$t_sort_name = strtolower( $t_user_name );
-		if( $t_show_realname && ( $t_user['realname'] <> '' ) ) {
-			$t_user_name = string_attribute( $t_user['realname'] );
-			if( $t_sort_by_last_name ) {
-				$t_sort_name_bits = explode( ' ', strtolower( $t_user_name ), 2 );
-				$t_sort_name = ( isset( $t_sort_name_bits[1] ) ? $t_sort_name_bits[1] . ', ' : '' ) . $t_sort_name_bits[0];
-			} else {
-				$t_sort_name = strtolower( $t_user_name );
-			}
-		}
+		$t_user_name = user_get_name_for_sorting_from_row( $t_user );
+		$t_user_name = string_attribute( $t_user_name );
 		$t_display[] = $t_user_name;
 		$t_sort[] = $t_sort_name;
 	}
+
 	array_multisort( $t_sort, SORT_ASC, SORT_STRING, $t_users, $t_display );
 
 	$t_result = array();

--- a/billing_export_to_csv.php
+++ b/billing_export_to_csv.php
@@ -51,7 +51,6 @@ billing_ensure_reporting_access( $f_project_id );
 $t_show_cost = ON == config_get( 'time_tracking_with_billing' ) && $f_cost != 0;
 
 $t_billing_rows = billing_get_for_project( $f_project_id, $f_from, $f_to, $f_cost, $f_include_subprojects );
-$t_show_realname = config_get( 'show_realname' ) == ON;
 
 csv_start( csv_get_default_filename() );
 
@@ -59,13 +58,7 @@ echo csv_escape_string( lang_get( 'issue_id' ) ) . $t_separator;
 echo csv_escape_string( lang_get( 'project_name' ) ) . $t_separator;
 echo csv_escape_string( lang_get( 'category' ) ) . $t_separator;
 echo csv_escape_string( lang_get( 'summary' ) ) . $t_separator;
-
-if( $t_show_realname ) {
-	echo csv_escape_string( lang_get( 'realname' ) ) . $t_separator;
-} else {
-	echo csv_escape_string( lang_get( 'username' ) ) . $t_separator;
-}
-
+echo csv_escape_string( lang_get( 'username' ) ) . $t_separator;
 echo csv_escape_string( lang_get( 'timestamp' ) ) . $t_separator;
 echo csv_escape_string( lang_get( 'minutes' ) ) . $t_separator;
 echo csv_escape_string( lang_get( 'time_tracking_time_spent' ) ) . $t_separator;
@@ -82,13 +75,7 @@ foreach( $t_billing_rows as $t_billing ) {
 	echo csv_escape_string( $t_billing['project_name'] ) . $t_separator;
 	echo csv_escape_string( $t_billing['bug_category'] ) . $t_separator;
 	echo csv_escape_string( $t_billing['bug_summary'] ) . $t_separator;
-
-	if( $t_show_realname ) {
-		echo csv_escape_string( $t_billing['reporter_realname'] ) . $t_separator;
-	} else {
-		echo csv_escape_string( $t_billing['reporter_username'] ) . $t_separator;
-	}
-
+	echo csv_escape_string( $t_billing['reporter_name'] ) . $t_separator;
 	echo csv_escape_string( date( $t_date_format, $t_billing['date_submitted'] ) ) . $t_separator;
 	echo csv_escape_string( $t_billing['minutes'] ) . $t_separator;
 	echo csv_escape_string( $t_billing['duration'] ) . $t_separator;

--- a/billing_export_to_excel.php
+++ b/billing_export_to_excel.php
@@ -49,7 +49,6 @@ billing_ensure_reporting_access( $f_project_id );
 $t_show_cost = ON == config_get( 'time_tracking_with_billing' ) && $f_cost != 0;
 
 $t_billing_rows = billing_get_for_project( $f_project_id, $f_from, $f_to, $f_cost, $f_include_subprojects );
-$t_show_realname = config_get( 'show_realname' ) == ON;
 
 header( 'Content-Type: application/vnd.ms-excel; charset=UTF-8' );
 header( 'Pragma: public' );
@@ -61,13 +60,7 @@ echo excel_format_column_title( lang_get( 'issue_id' ) );
 echo excel_format_column_title( lang_get( 'project_name' ) );
 echo excel_format_column_title( lang_get( 'category' ) );
 echo excel_format_column_title( lang_get( 'summary' ) );
-
-if( $t_show_realname ) {
-	echo excel_format_column_title( lang_get( 'realname' ) );
-} else {
-	echo excel_format_column_title( lang_get( 'username' ) );
-}
-
+echo excel_format_column_title( lang_get( 'username' ) );
 echo excel_format_column_title( lang_get( 'timestamp' ) );
 echo excel_format_column_title( lang_get( 'minutes' ) );
 echo excel_format_column_title( lang_get( 'time_tracking_time_spent' ) );
@@ -85,13 +78,7 @@ foreach( $t_billing_rows as $t_billing ) {
 	echo excel_prepare_string( $t_billing['project_name'] );
 	echo excel_prepare_string( $t_billing['bug_category'] );
 	echo excel_prepare_string( $t_billing['bug_summary'] );
-
-	if( $t_show_realname ) {
-		echo excel_prepare_string( $t_billing['reporter_realname'] );
-	} else {
-		echo excel_prepare_string( $t_billing['reporter_username'] );
-	}
-
+	echo excel_prepare_string( $t_billing['reporter_name'] );
 	echo excel_prepare_string( date( $t_date_format, $t_billing['date_submitted'] ) );
 	echo excel_prepare_number( $t_billing['minutes'] );
 	echo excel_prepare_string( $t_billing['duration'] );

--- a/billing_inc.php
+++ b/billing_inc.php
@@ -224,11 +224,11 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 			$t_link = sprintf( lang_get( 'label' ), string_get_bug_view_link( $t_issue_id ) ) . lang_get( 'word_separator' ) . $t_project_info . string_display( $t_issue['summary'] );
 			echo '<tr class="row-category-history"><td colspan="4">' . $t_link . '</td></tr>';
 
-			foreach( $t_issue['users'] as $t_username => $t_user_info ) {
+			foreach( $t_issue['users'] as $t_user_id => $t_user_info ) {
 ?>
 	<tr>
 		<td class="small-caption">
-			<?php echo $t_username ?>
+			<?php print_user( $t_user_id ) ?>
 		</td>
 		<td class="small-caption">
 			<?php echo db_minutes_to_hhmm( $t_user_info['minutes'] ) ?>
@@ -278,11 +278,11 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 	</tr>
 
 <?php
-	foreach ( $t_bugnote_stats['users'] as $t_username => $t_user_info ) {
+	foreach ( $t_bugnote_stats['users'] as $t_user_id => $t_user_info ) {
 ?>
 	<tr>
 		<td class="small-caption">
-			<?php echo $t_username; ?>
+			<?php print_user( $t_user_id ) ?>
 		</td>
 		<td class="small-caption">
 			<?php echo db_minutes_to_hhmm( $t_user_info['minutes'] ); ?>

--- a/billing_inc.php
+++ b/billing_inc.php
@@ -178,13 +178,6 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 		$t_to = $t_bugnote_stats_to_y . '-' . $t_bugnote_stats_to_m . '-' . $t_bugnote_stats_to_d;
 		$t_bugnote_stats = billing_get_summaries( $f_project_id, $t_from, $t_to, $f_bugnote_cost, $f_include_subprojects );
 
-		# Sort the array by bug_id, user/real name
-		if( ON == config_get( 'show_realname' ) ) {
-			$t_name_field = 'realname';
-		} else {
-			$t_name_field = 'username';
-		}
-
 		if( is_blank( $f_bugnote_cost ) || ( (double)$f_bugnote_cost == 0 ) ) {
 			$t_cost_col = false;
 		}
@@ -213,7 +206,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 <table class="table table-bordered table-condensed table-striped">
 	<tr>
 		<td class="small-caption">
-			<?php echo lang_get( $t_name_field ) ?>
+			<?php echo lang_get( 'username' ) ?>
 		</td>
 		<td class="small-caption">
 			<?php echo lang_get( 'time_tracking' ) ?>
@@ -272,7 +265,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 <table class="table table-bordered table-condensed table-striped">
 	<tr>
 		<td class="small-caption">
-			<?php echo lang_get( $t_name_field ) ?>
+			<?php echo lang_get( 'username' ) ?>
 		</td>
 		<td class="small-caption">
 			<?php echo lang_get( 'time_tracking' ) ?>

--- a/bugnote_stats_inc.php
+++ b/bugnote_stats_inc.php
@@ -146,15 +146,10 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 		$t_to = $t_bugnote_stats_to_y . '-' . $t_bugnote_stats_to_m . '-' . $t_bugnote_stats_to_d;
 		$t_bugnote_stats = bugnote_stats_get_events_array( $f_bug_id, $t_from, $t_to );
 
-		# Sort the array by user/real name
-		if( ON == config_get( 'show_realname' ) ) {
-			$t_name_field = 'realname';
-		} else {
-			$t_name_field = 'username';
-		}
+		# Sort the array by user name
 		$t_sort_name = array();
 		foreach ( $t_bugnote_stats as $t_key => $t_item ) {
-			$t_sort_name[$t_key] = $t_item[$t_name_field];
+			$t_sort_name[$t_key] = $t_item['name'];
 		}
 		array_multisort( $t_sort_name, $t_bugnote_stats );
 		unset( $t_sort_name );
@@ -165,7 +160,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 						<table class="table table-bordered table-condensed table-striped">
 							<tr>
 								<td class="small-caption align-left">
-									<?php echo lang_get( $t_name_field ) ?>
+									<?php echo lang_get( 'username' ) ?>
 								</td>
 								<td class="small-caption align-left">
 									<?php echo lang_get( 'time_tracking' ) ?>
@@ -180,7 +175,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 						?>
 							<tr>
 								<td class="small-caption">
-									<?php echo string_display_line( $t_item[$t_name_field] ) ?>
+									<?php echo string_display_line( $t_item['name'] ) ?>
 								</td>
 								<td class="small-caption">
 									<?php echo $t_item['sum_time_tracking'] ?>

--- a/bugnote_stats_inc.php
+++ b/bugnote_stats_inc.php
@@ -149,8 +149,9 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 		# Sort the array by user name
 		$t_sort_name = array();
 		foreach ( $t_bugnote_stats as $t_key => $t_item ) {
-			$t_sort_name[$t_key] = $t_item['name'];
+			$t_sort_name[$t_key] = user_get_name_for_sorting_from_row( $t_item );
 		}
+
 		array_multisort( $t_sort_name, $t_bugnote_stats );
 		unset( $t_sort_name );
 ?>
@@ -175,7 +176,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 						?>
 							<tr>
 								<td class="small-caption">
-									<?php echo string_display_line( $t_item['name'] ) ?>
+									<?php print_user( $t_item['user_id'] ) ?>
 								</td>
 								<td class="small-caption">
 									<?php echo $t_item['sum_time_tracking'] ?>

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -1204,6 +1204,7 @@ $g_show_version_dates_threshold = NOBODY;
 
 /**
  * show users with their real name or not
+ * @see $g_sort_by_last_name
  * @global integer $g_show_realname
  */
 $g_show_realname = OFF;
@@ -1211,6 +1212,7 @@ $g_show_realname = OFF;
 /**
  * sorting for names in dropdown lists. If turned on, "Jane Doe" will be sorted
  * with the "D"s
+ * @see $g_show_realname
  * @global integer $g_sort_by_last_name
  */
 $g_sort_by_last_name = OFF;

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -1209,12 +1209,6 @@ $g_show_version_dates_threshold = NOBODY;
 $g_show_realname = OFF;
 
 /**
- * leave off for now
- * @global integer $g_differentiate_duplicates
- */
-$g_differentiate_duplicates = OFF;
-
-/**
  * sorting for names in dropdown lists. If turned on, "Jane Doe" will be sorted
  * with the "D"s
  * @global integer $g_sort_by_last_name
@@ -4479,7 +4473,6 @@ $g_public_config_names = array(
 	'delete_bugnote_threshold',
 	'delete_project_threshold',
 	'development_team_threshold',
-	'differentiate_duplicates',
 	'disallowed_files',
 	'display_bug_padding',
 	'display_bugnote_padding',

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -624,6 +624,7 @@ $g_show_user_email_threshold = NOBODY;
 /**
  * This specifies the access level that is needed to see realnames on user view
  * page
+ * @see $g_show_realname
  * @global integer $g_show_user_realname_threshold
  */
 $g_show_user_realname_threshold = NOBODY;
@@ -1205,6 +1206,7 @@ $g_show_version_dates_threshold = NOBODY;
 /**
  * show users with their real name or not
  * @see $g_sort_by_last_name
+ * @see $g_show_user_realname_threshold
  * @global integer $g_show_realname
  */
 $g_show_realname = OFF;

--- a/core/billing_api.php
+++ b/core/billing_api.php
@@ -242,14 +242,8 @@ function billing_rows_to_array( $p_bugnotes ) {
 		$t_row['duration'] = db_minutes_to_hhmm( $t_note['minutes'] );
 		$t_row['note'] = $t_note['note'];
 		$t_row['reporter_id'] = $t_note['reporter_id'];
-		$t_row['reporter_username'] = user_get_name( $t_note['reporter_id'] );
-		$t_row['reporter_realname'] = user_get_realname( $t_note['reporter_id'] );
+		$t_row['reporter_name'] = user_get_name( $t_note['reporter_id'] );
 		$t_row['date_submitted'] = $t_note['date_submitted'];
-
-		if ( is_blank( $t_row['reporter_realname'] ) ) {
-			$t_row['reporter_realname'] = $t_row['reporter_username'];
-		}
-
 		$t_row['bug_id'] = $t_note['bug_id'];
 		$t_row['project_id'] = $t_note['project_id'];
 		$t_row['project_name'] = project_get_name( $t_note['project_id'] );

--- a/core/billing_api.php
+++ b/core/billing_api.php
@@ -149,17 +149,17 @@ function billing_get_summaries( $p_project_id, $p_from, $p_to, $p_cost_per_hour,
 	foreach ( $t_billing_notes as $t_note ) {
 		extract( $t_note, EXTR_PREFIX_ALL, 'v' );
 
-		$t_username = user_get_name( $v_reporter_id );
+		$t_user_id = $v_reporter_id;
 
 		# Create users in collection of users if not already exists
-		if( !isset( $t_users[$t_username] ) ) {
-			$t_users[$t_username] = array();
-			$t_users[$t_username]['minutes'] = 0;
-			$t_users[$t_username]['cost'] = 0;
+		if( !isset( $t_users[$t_user_id] ) ) {
+			$t_users[$t_user_id] = array();
+			$t_users[$t_user_id]['minutes'] = 0;
+			$t_users[$t_user_id]['cost'] = 0;
 		}
 
 		# Update user total minutes
-		$t_users[$t_username]['minutes'] += $v_minutes;
+		$t_users[$t_user_id]['minutes'] += $v_minutes;
 
 		# Create issue if it doesn't exist yet.
 		if( !isset( $t_issues[$v_bug_id] ) ) {
@@ -173,14 +173,14 @@ function billing_get_summaries( $p_project_id, $p_from, $p_to, $p_cost_per_hour,
 		}
 
 		# Create user within issue if they don't exist yet
-		if( !isset( $t_issues[$v_bug_id]['users'][$t_username] ) ) {
-			$t_issues[$v_bug_id]['users'][$t_username] = array();
-			$t_issues[$v_bug_id]['users'][$t_username]['minutes'] = 0;
-			$t_issues[$v_bug_id]['users'][$t_username]['cost'] = 0;
+		if( !isset( $t_issues[$v_bug_id]['users'][$t_user_id] ) ) {
+			$t_issues[$v_bug_id]['users'][$t_user_id] = array();
+			$t_issues[$v_bug_id]['users'][$t_user_id]['minutes'] = 0;
+			$t_issues[$v_bug_id]['users'][$t_user_id]['cost'] = 0;
 		}
 
 		# Update total minutes for user within the issue
-		$t_issues[$v_bug_id]['users'][$t_username]['minutes'] += $v_minutes;
+		$t_issues[$v_bug_id]['users'][$t_user_id]['minutes'] += $v_minutes;
 
 		# Update total minutes for issue
 		$t_issues[$v_bug_id]['minutes'] += $v_minutes;
@@ -203,8 +203,8 @@ function billing_get_summaries( $p_project_id, $p_from, $p_to, $p_cost_per_hour,
 		$t_total['minutes'] += $t_issue_info['minutes'];
 
 		# Calculate cost per user per issue
-		foreach( $t_issue_info['users'] as $t_username => $t_user_info ) {
-			$t_issues[$t_issue_id]['users'][$t_username]['cost'] =
+		foreach( $t_issue_info['users'] as $t_user_id => $t_user_info ) {
+			$t_issues[$t_issue_id]['users'][$t_user_id]['cost'] =
 				$t_user_info['minutes'] * $p_cost_per_hour / 60;
 		}
 
@@ -212,8 +212,8 @@ function billing_get_summaries( $p_project_id, $p_from, $p_to, $p_cost_per_hour,
 	}
 
 	# Calculate total cost per user across all issues
-	foreach( $t_users as $t_username => $t_info ) {
-		$t_users[$t_username]['cost'] = $t_info['minutes'] * $p_cost_per_hour / 60;
+	foreach( $t_users as $t_user_id => $t_info ) {
+		$t_users[$t_user_id]['cost'] = $t_info['minutes'] * $p_cost_per_hour / 60;
 	}
 
 	ksort( $t_users );

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -782,7 +782,7 @@ function bugnote_stats_get_events_array( $p_bug_id, $p_from, $p_to ) {
 	$t_results = array();
 
 	db_param_push();
-	$t_query = 'SELECT username, realname, SUM(time_tracking) AS sum_time_tracking
+	$t_query = 'SELECT u.id AS user_id, username, realname, SUM(time_tracking) AS sum_time_tracking
 				FROM {user} u, {bugnote} bn
 				WHERE u.id = bn.reporter_id AND bn.time_tracking != 0 AND
 				bn.bug_id = ' . db_param() . $t_from_where . $t_to_where .
@@ -791,7 +791,7 @@ function bugnote_stats_get_events_array( $p_bug_id, $p_from, $p_to ) {
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_row['name'] = user_get_name_from_row( $t_row );
-		$t_results[] = $t_row;
+		$t_results[(int)$t_row['user_id']] = $t_row;
 	}
 
 	return $t_results;

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -782,7 +782,7 @@ function bugnote_stats_get_events_array( $p_bug_id, $p_from, $p_to ) {
 	$t_results = array();
 
 	db_param_push();
-	$t_query = 'SELECT username, realname, SUM(time_tracking) AS sum_time_tracking
+	$t_query = 'SELECT u.id AS user_id, username, realname, SUM(time_tracking) AS sum_time_tracking
 				FROM {user} u, {bugnote} bn
 				WHERE u.id = bn.reporter_id AND bn.time_tracking != 0 AND
 				bn.bug_id = ' . db_param() . $t_from_where . $t_to_where .
@@ -790,6 +790,7 @@ function bugnote_stats_get_events_array( $p_bug_id, $p_from, $p_to ) {
 	$t_result = db_query( $t_query, array( $p_bug_id ) );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
+		$t_row['name'] = user_get_name( $t_row['user_id'] );
 		$t_results[] = $t_row;
 	}
 

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -782,7 +782,7 @@ function bugnote_stats_get_events_array( $p_bug_id, $p_from, $p_to ) {
 	$t_results = array();
 
 	db_param_push();
-	$t_query = 'SELECT u.id AS user_id, username, realname, SUM(time_tracking) AS sum_time_tracking
+	$t_query = 'SELECT username, realname, SUM(time_tracking) AS sum_time_tracking
 				FROM {user} u, {bugnote} bn
 				WHERE u.id = bn.reporter_id AND bn.time_tracking != 0 AND
 				bn.bug_id = ' . db_param() . $t_from_where . $t_to_where .
@@ -790,7 +790,7 @@ function bugnote_stats_get_events_array( $p_bug_id, $p_from, $p_to ) {
 	$t_result = db_query( $t_query, array( $p_bug_id ) );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
-		$t_row['name'] = user_get_name( $t_row['user_id'] );
+		$t_row['name'] = user_get_name_from_row( $t_row );
 		$t_results[] = $t_row;
 	}
 

--- a/core/filter_form_api.php
+++ b/core/filter_form_api.php
@@ -196,12 +196,8 @@ function print_filter_reporter_id( array $p_filter = null ) {
 	#
 	if( ( ON === config_get( 'limit_reporters' ) ) && ( !access_has_project_level( access_threshold_min_level( config_get( 'report_bug_threshold' ) ) + 1 ) ) ) {
 		$t_id = auth_get_current_user_id();
-		$t_username = user_get_username( $t_id );
-		$t_realname = user_get_field( $t_id, 'realname' );
+		$t_username = user_get_name( $t_id );
 		$t_display_name = string_attribute( $t_username );
-		if( ( isset( $t_realname ) ) && ( $t_realname > '' ) && ( ON == config_get( 'show_realname' ) ) ) {
-			$t_display_name = string_attribute( $t_realname );
-		}
 		echo '<option value="' . $t_id . '" selected="selected">' . $t_display_name . '</option>';
 	} else {
 		?>

--- a/core/obsolete.php
+++ b/core/obsolete.php
@@ -214,3 +214,6 @@ config_obsolete( 'inline_file_exts' );
 
 # changes in 2.9.0
 config_obsolete( 'meta_include_file' );
+
+# changes in 2.11.0
+config_obsolete( 'differentiate_duplicates' );

--- a/core/prepare_api.php
+++ b/core/prepare_api.php
@@ -74,12 +74,12 @@ function prepare_user_name( $p_user_id ) {
 	$t_username = user_get_username( $p_user_id );
 	$t_name = user_get_name( $p_user_id );
 	if( $t_username != $t_name ) {
-		$t_tooltip = ' title="' . $t_name . '"';
+		$t_tooltip = ' title="' . string_attribute( $t_name ) . '"';
 	} else {
 		$t_tooltip = '';
 	}
 
-	$t_name = string_display_line( $t_username );
+	$t_username = string_display_line( $t_username );
 
 	if( user_exists( $p_user_id ) && user_get_field( $p_user_id, 'enabled' ) ) {
 		return '<a class="user"' . $t_tooltip . ' href="' . string_sanitize_url( 'view_user_page.php?id=' . $p_user_id, true ) . '">' . $t_username . '</a>';

--- a/core/prepare_api.php
+++ b/core/prepare_api.php
@@ -71,13 +71,21 @@ function prepare_user_name( $p_user_id ) {
 		return '';
 	}
 
-	$t_username = user_get_name( $p_user_id );
-	$t_username = string_display_line( $t_username );
-	if( user_exists( $p_user_id ) && user_get_field( $p_user_id, 'enabled' ) ) {
-		return '<a class="user" href="' . string_sanitize_url( 'view_user_page.php?id=' . $p_user_id, true ) . '">' . $t_username . '</a>';
+	$t_username = user_get_username( $p_user_id );
+	$t_name = user_get_name( $p_user_id );
+	if( $t_username != $t_name ) {
+		$t_tooltip = ' title="' . $t_name . '"';
 	} else {
-		return '<del class="user">' . $t_username . '</del>';
+		$t_tooltip = '';
 	}
+
+	$t_name = string_display_line( $t_username );
+
+	if( user_exists( $p_user_id ) && user_get_field( $p_user_id, 'enabled' ) ) {
+		return '<a class="user"' . $t_tooltip . ' href="' . string_sanitize_url( 'view_user_page.php?id=' . $p_user_id, true ) . '">' . $t_username . '</a>';
+	}
+
+	return '<del class="user"' . $t_tooltip . '>' . $t_username . '</del>';
 }
 
 /**

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -304,25 +304,16 @@ function print_user_option_list( $p_user_id, $p_project_id = null, $p_access = A
 
 	$t_display = array();
 	$t_sort = array();
-	$t_show_realname = ( ON == config_get( 'show_realname' ) );
-	$t_sort_by_last_name = ( ON == config_get( 'sort_by_last_name' ) );
+
 	foreach( $t_users as $t_key => $t_user ) {
-		$t_user_name = string_attribute( $t_user['username'] );
-		$t_sort_name = utf8_strtolower( $t_user_name );
-		if( $t_show_realname && ( $t_user['realname'] <> '' ) ) {
-			$t_user_name = string_attribute( $t_user['realname'] );
-			if( $t_sort_by_last_name ) {
-				$t_sort_name_bits = explode( ' ', utf8_strtolower( $t_user_name ), 2 );
-				$t_sort_name = ( isset( $t_sort_name_bits[1] ) ? $t_sort_name_bits[1] . ', ' : '' ) . $t_sort_name_bits[0];
-			} else {
-				$t_sort_name = utf8_strtolower( $t_user_name );
-			}
-		}
-		$t_display[] = $t_user_name;
-		$t_sort[] = $t_sort_name;
+		$t_user_name = user_get_name_from_row( $t_user );
+		$t_display[] = string_attribute( $t_user_name );
+		$t_sort[] = user_get_name_for_sorting_from_row( $t_user );;
 	}
+
 	array_multisort( $t_sort, SORT_ASC, SORT_STRING, $t_users, $t_display );
 	unset( $t_sort );
+
 	$t_count = count( $t_users );
 	for( $i = 0;$i < $t_count;$i++ ) {
 		$t_row = $t_users[$i];

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1148,7 +1148,7 @@ function print_all_bug_action_option_list( array $p_project_ids = null ) {
 function print_project_user_list_option_list( $p_project_id = null ) {
 	$t_users = user_get_unassigned_by_project_id( $p_project_id );
 	foreach( $t_users as $t_id=>$t_name ) {
-		echo '<option value="' . $t_id . '">' . $t_name . '</option>';
+		echo '<option value="' . $t_id . '">' . string_attribute( $t_name ) . '</option>';
 	}
 }
 

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -315,7 +315,7 @@ function print_user_option_list( $p_user_id, $p_project_id = null, $p_access = A
 		}
 
 		$t_display[] = string_attribute( $t_user_name );
-		$t_sort[] = user_get_name_for_sorting_from_row( $t_user );;
+		$t_sort[] = user_get_name_for_sorting_from_row( $t_user );
 	}
 
 	array_multisort( $t_sort, SORT_ASC, SORT_STRING, $t_users, $t_display );

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -309,12 +309,7 @@ function print_user_option_list( $p_user_id, $p_project_id = null, $p_access = A
 	$t_sort = array();
 
 	foreach( $t_users as $t_key => $t_user ) {
-		$t_user_name = user_get_name_from_row( $t_user );
-		if( $t_user_name != $t_user['username'] ) {
-			$t_user_name = $t_user['username'] . ' (' . $t_user_name . ')';
-		}
-
-		$t_display[] = string_attribute( $t_user_name );
+		$t_display[] = user_get_expanded_name_from_row( $t_user );
 		$t_sort[] = user_get_name_for_sorting_from_row( $t_user );
 	}
 
@@ -326,7 +321,7 @@ function print_user_option_list( $p_user_id, $p_project_id = null, $p_access = A
 		$t_row = $t_users[$i];
 		echo '<option value="' . $t_row['id'] . '" ';
 		check_selected( $p_user_id, (int)$t_row['id'] );
-		echo '>' . $t_display[$i] . '</option>';
+		echo '>' . string_attribute( $t_display[$i] ) . '</option>';
 	}
 }
 

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -215,13 +215,16 @@ function print_user_with_subject( $p_user_id, $p_bug_id ) {
 		return;
 	}
 
-	$t_username = user_get_name( $p_user_id );
+	$t_username = user_get_username( $p_user_id );
+	$t_name = user_get_name( $p_user_id );
+
 	if( user_exists( $p_user_id ) && user_get_field( $p_user_id, 'enabled' ) ) {
 		$t_email = user_get_email( $p_user_id );
-		print_email_link_with_subject( $t_email, $t_username, $p_bug_id );
+		print_email_link_with_subject( $t_email, $t_username, $t_name, $p_bug_id );
 	} else {
+		$t_name = string_attribute( $t_name );
 		echo '<span class="user" style="text-decoration: line-through">';
-		echo $t_username;
+		echo '<a title="' . $t_name . '">' . $t_username . '</a>';
 		echo '</span>';
 	}
 }
@@ -307,6 +310,10 @@ function print_user_option_list( $p_user_id, $p_project_id = null, $p_access = A
 
 	foreach( $t_users as $t_key => $t_user ) {
 		$t_user_name = user_get_name_from_row( $t_user );
+		if( $t_user_name != $t_user['username'] ) {
+			$t_user_name = $t_user['username'] . ' (' . $t_user_name . ')';
+		}
+
 		$t_display[] = string_attribute( $t_user_name );
 		$t_sort[] = user_get_name_for_sorting_from_row( $t_user );;
 	}
@@ -1636,39 +1643,35 @@ function get_email_link( $p_email, $p_text ) {
  *
  * @param string $p_email  Email Address.
  * @param string $p_text   Link text to display to user.
+ * @param string $p_tooltip The tooltip to show.
  * @param string $p_bug_id The bug identifier.
  * @return void
  */
-function print_email_link_with_subject( $p_email, $p_text, $p_bug_id ) {
+function print_email_link_with_subject( $p_email, $p_text, $p_tooltip, $p_bug_id ) {
+	if( !is_blank( $p_tooltip ) && $p_tooltip != $p_text ) {
+		$t_tooltip = ' title="' . $p_tooltip . '"';
+	} else {
+		$t_tooltip = '';
+	}
+
 	$t_bug = bug_get( $p_bug_id, true );
 	if( !access_has_project_level( config_get( 'show_user_email_threshold', null, null, $t_bug->project_id ), $t_bug->project_id ) ) {
-		echo $p_text;
+		echo $t_tooltip != '' ? '<a' . $t_tooltip . '>' . $p_text . '</a>' : $p_text;
 		return;
 	}
-	$t_subject = email_build_subject( $p_bug_id );
-	echo get_email_link_with_subject( $p_email, $p_text, $t_subject );
-}
 
-/**
- * return the mailto: href string link instead of printing it
- * add subject line
- *
- * @param string $p_email   Email Address.
- * @param string $p_text    Link text to display to user.
- * @param string $p_subject Email subject line.
- * @return string
- */
-function get_email_link_with_subject( $p_email, $p_text, $p_subject ) {
+	$t_subject = email_build_subject( $p_bug_id );
+
 	# If we apply string_url() to the whole mailto: link then the @
 	# gets turned into a %40 and you can't right click in browsers to
 	# do Copy Email Address.  If we don't apply string_url() to the
 	# subject text then an ampersand (for example) will truncate the text
-	$t_subject = string_url( $p_subject );
+	$t_subject = string_url( $t_subject );
 	$t_email = string_url( $p_email );
 	$t_mailto = string_attribute( 'mailto:' . $t_email . '?subject=' . $t_subject );
 	$t_text = string_display( $p_text );
 
-	return '<a class="user" href="' . $t_mailto . '">' . $t_text . '</a>';
+	echo '<a class="user" href="' . $t_mailto . '"' . $t_tooltip . '>' . $t_text . '</a>';
 }
 
 /**

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -937,7 +937,12 @@ function user_get_email( $p_user_id ) {
  * @return string
  */
 function user_get_username( $p_user_id ) {
-	return user_get_field( $p_user_id, 'username' );
+	$t_row = user_cache_row( $p_user_id, false );
+	if( false == $t_row ) {
+		return lang_get( 'prefix_for_deleted_users' ) . (int)$p_user_id;
+	}
+
+	return $t_row['username'];
 }
 
 /**

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1027,21 +1027,15 @@ function user_get_name( $p_user_id ) {
 
 	if( false == $t_row ) {
 		return lang_get( 'prefix_for_deleted_users' ) . (int)$p_user_id;
-	} else {
-		if( ON == config_get( 'show_realname' ) ) {
-			if( is_blank( $t_row['realname'] ) ) {
-				return $t_row['username'];
-			} else {
-				if( isset( $t_row['duplicate_realname'] ) && ( ON == $t_row['duplicate_realname'] ) ) {
-					return $t_row['realname'] . ' (' . $t_row['username'] . ')';
-				} else {
-					return $t_row['realname'];
-				}
-			}
-		} else {
-			return $t_row['username'];
+	}
+
+	if( ON == config_get( 'show_realname' ) ) {
+		if( !is_blank( $t_row['realname'] ) ) {
+			return $t_row['realname'];
 		}
 	}
+
+	return $t_row['username'];
 }
 
 /**

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -987,14 +987,22 @@ function user_get_name( $p_user_id ) {
 }
 
 /**
+ * Show realnames be shown to logged in user?
+ *
+ * @return bool true to show, false otherwise.
+ */
+function user_show_realname() {
+	return access_has_project_level( config_get( 'show_user_realname_threshold', null, null, ALL_PROJECTS ) );
+}
+
+/**
  * Return the user's name for display.
  *
  * @param array $p_user_row The user row with 'realname' and 'username' fields
  * @return string display name
  */
 function user_get_name_from_row( array $p_user_row ) {
-	if( ON == config_get( 'show_realname' ) &&
-	    access_has_project_level( config_get( 'show_user_realname_threshold', null, null, ALL_PROJECTS ) ) ) {
+	if( user_show_realname() ) {
 		if( !is_blank( $p_user_row['realname'] ) ) {
 			return $p_user_row['realname'];
 		}
@@ -1010,13 +1018,15 @@ function user_get_name_from_row( array $p_user_row ) {
  * @return string name for sorting
  */
 function user_get_name_for_sorting_from_row( array $p_user_row ) {
-	if( !is_blank( $p_user_row['realname'] ) && config_get( 'show_realname' ) == ON ) {
-		if( config_get( 'sort_by_last_name' ) == ON ) {
-			$t_sort_name_bits = explode( ' ', utf8_strtolower( $p_user_row['realname'] ), 2 );
-			return ( isset( $t_sort_name_bits[1] ) ? $t_sort_name_bits[1] . ', ' : '' ) . $t_sort_name_bits[0];
+	if( !is_blank( $p_user_row['realname'] ) ) {
+		if( user_show_realname() ) {
+			if( config_get( 'sort_by_last_name' ) == ON ) {
+				$t_sort_name_bits = explode( ' ', utf8_strtolower( $p_user_row['realname'] ), 2 );
+				return ( isset( $t_sort_name_bits[1] ) ? $t_sort_name_bits[1] . ', ' : '' ) . $t_sort_name_bits[0];
+			}
+
+			return utf8_strtolower( $p_user_row['realname'] );
 		}
-		
-		return $t_sort_name = utf8_strtolower( $p_user_row['realname'] );
 	}
 
 	return utf8_strtolower( $p_user_row['username'] );

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1017,6 +1017,21 @@ function user_get_name_from_row( array $p_user_row ) {
 }
 
 /**
+ * Get display name in format "username (realname)"
+ *
+ * @param array $p_user_row The user row with 'realname' and 'username' fields
+ * @return string display name
+ */
+function user_get_expanded_name_from_row( array $p_user_row ) {
+	$t_name = user_get_name_from_row( $p_user_row );
+	if( $t_name != $p_user_row['username'] ) {
+		return $t_name . ' (' . $p_user_row['username'] . ')';
+	}
+
+	return $p_user_row['username'];
+}
+
+/**
  * Get name used for sorting.
  * 
  * @param array $p_user_row The user row with 'realname' and 'username' fields
@@ -1026,11 +1041,11 @@ function user_get_name_for_sorting_from_row( array $p_user_row ) {
 	if( !is_blank( $p_user_row['realname'] ) ) {
 		if( user_show_realname() ) {
 			if( config_get( 'sort_by_last_name' ) == ON ) {
-				$t_sort_name_bits = explode( ' ', utf8_strtolower( $p_user_row['realname'] ), 2 );
+				$t_sort_name_bits = explode( ' ', utf8_strtolower( trim( $p_user_row['realname'] ) ), 2 );
 				return ( isset( $t_sort_name_bits[1] ) ? $t_sort_name_bits[1] . ', ' : '' ) . $t_sort_name_bits[0];
 			}
 
-			return utf8_strtolower( $p_user_row['realname'] );
+			return utf8_strtolower( trim( $p_user_row['realname'] ) );
 		}
 	}
 
@@ -1317,8 +1332,7 @@ function user_get_unassigned_by_project_id( $p_project_id = null ) {
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_users[] = $t_row['id'];
-		$t_user_name = user_get_name_from_row( $t_row );
-		$t_display[] = string_attribute( $t_user_name );
+		$t_display[] = user_get_expanded_name_from_row( $t_row );
 		$t_sort[] = user_get_name_for_sorting_from_row( $t_row );
 	}
 

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -242,23 +242,31 @@ function user_ensure_exists( $p_user_id ) {
 /**
  * return true if the username is unique, false if there is already a user with that username
  * @param string $p_username The username to check.
+ * @param integer|null The user id allowed to conflict, otherwise null.
  * @return boolean
  */
-function user_is_name_unique( $p_username ) {
-	db_param_push();
-	$t_query = 'SELECT username FROM {user} WHERE username=' . db_param();
-	$t_result = db_query( $t_query, array( $p_username ), 1 );
+function user_is_name_unique( $p_username, $p_user_id = null ) {
+	$t_existing_user_id = user_get_id_by_name( $p_username );
+	if( $t_existing_user_id !== false && ( $p_user_id === null || (int)$t_existing_user_id !== $p_user_id ) ) {
+		return false;
+	}
 
-	return !db_result( $t_result );
+	$t_existing_user_id = user_get_id_by_realname( $p_username );
+	if( $t_existing_user_id !== false && ( $p_user_id === null || (int)$t_existing_user_id !== $p_user_id ) ) {
+		return false;
+	}
+
+	return true;
 }
 
 /**
  * Check if the username is unique and trigger an ERROR if it isn't
  * @param string $p_username The username to check.
+ * @param integer|null $p_user_id The user id allowed to conflict, otherwise null.
  * @return void
  */
-function user_ensure_name_unique( $p_username ) {
-	if( !user_is_name_unique( $p_username ) ) {
+function user_ensure_name_unique( $p_username, $p_user_id = null ) {
+	if( !user_is_name_unique( $p_username, $p_user_id ) ) {
 		throw new ClientException(
 			sprintf( "Username '%s' already used.", $p_username ),
 			ERROR_USER_NAME_NOT_UNIQUE );
@@ -318,64 +326,42 @@ function user_ensure_email_unique( $p_email, $p_user_id = null ) {
 /**
  * Check if realname is specified, a unique real name, and doesn't match a username of another user.
  *
- * @param string $p_username The username to check.
  * @param string $p_realname The realname to check.
- * @return integer 0 realname matches another user's username, 1 no conflicts, >1 realname not unique.
+ * @param integer|null $p_user_id The user id that is allowed to conflict, otherwise, null.
+ * @return bool true: unique, false otherwise.
  */
-function user_is_realname_unique( $p_username, $p_realname ) {
+function user_is_realname_unique( $p_realname, $p_user_id = null ) {
 	if( is_blank( $p_realname ) ) {
 		# don't bother checking if realname is blank
-		return 1;
+		return true;
 	}
 
-	$p_username = trim( $p_username );
 	$p_realname = trim( $p_realname );
 
-	# allow realname to match username
-	$t_duplicate_count = 0;
-	if( $p_realname !== $p_username ) {
-		# check realname does not match an existing username
-		#  but allow it to match the current user
-		$t_target_user = user_get_id_by_name( $p_username );
-		$t_other_user = user_get_id_by_name( $p_realname );
-		if( ( false !== $t_other_user ) && ( $t_target_user !== $t_other_user ) ) {
-			return 0;
-		}
-
-		# check to see if the realname is unique
-		db_param_push();
-		$t_query = 'SELECT id FROM {user} WHERE realname=' . db_param();
-		$t_result = db_query( $t_query, array( $p_realname ) );
-
-		$t_users = array();
-		while( $t_row = db_fetch_array( $t_result ) ) {
-			$t_users[] = $t_row;
-		}
-		$t_duplicate_count = count( $t_users );
-
-		if( $t_duplicate_count > 0 ) {
-			# set flags for non-unique realnames
-			if( config_get( 'differentiate_duplicates' ) ) {
-				for( $i = 0;$i < $t_duplicate_count;$i++ ) {
-					$t_user_id = $t_users[$i]['id'];
-					user_set_field( $t_user_id, 'duplicate_realname', ON );
-				}
-			}
-		}
+	# check realname does not match an existing realname
+	$t_existing_user_id = user_get_id_by_name( $p_realname );
+	if( $t_existing_user_id !== false && ( $p_user_id === null || (int)$t_existing_user_id !== $p_user_id ) ) {
+		return false;
 	}
-	return $t_duplicate_count + 1;
+
+	$t_existing_user_id = user_get_id_by_realname( $p_realname );
+	if( $t_existing_user_id !== false && ( $p_user_id === null || (int)$t_existing_user_id !== $p_user_id ) ) {
+		return false;
+	}
+
+	return true;
 }
 
 /**
  * Check if the realname is a unique
  * Trigger an error if the username is not valid
  *
- * @param string $p_username The username to check.
  * @param string $p_realname The realname to check.
+ * @param integer|null $p_user_id  The user id that is allowed to conflict, otherwise null.
  * @return void
  */
-function user_ensure_realname_unique( $p_username, $p_realname ) {
-	if( 1 > user_is_realname_unique( $p_username, $p_realname ) ) {
+function user_ensure_realname_unique( $p_realname, $p_user_id = null ) {
+	if( !user_is_realname_unique( $p_realname, $p_user_id ) ) {
 		throw new ClientException(
 			sprintf( "Realname '%s' is not unique", $p_realname ),
 			ERROR_USER_REAL_MATCH_USER );
@@ -595,7 +581,7 @@ function user_create( $p_username, $p_password, $p_email = '',
 	user_ensure_name_valid( $p_username );
 	user_ensure_name_unique( $p_username );
 	user_ensure_email_unique( $p_email );
-	user_ensure_realname_unique( $p_username, $p_realname );
+	user_ensure_realname_unique( $p_realname );
 	email_ensure_valid( $p_email );
 	email_ensure_not_disposable( $p_email );
 
@@ -736,30 +722,6 @@ function user_delete( $p_user_id ) {
 
 	# Remove project specific access levels
 	user_delete_project_specific_access_levels( $p_user_id );
-
-	# unset non-unique realname flags if necessary
-	if( config_get( 'differentiate_duplicates' ) ) {
-		$c_realname = user_get_field( $p_user_id, 'realname' );
-		db_param_push();
-		$t_query = 'SELECT id FROM {user} WHERE realname=' . db_param();
-		$t_result = db_query( $t_query, array( $c_realname ) );
-
-		$t_users = array();
-		while( $t_row = db_fetch_array( $t_result ) ) {
-			$t_users[] = $t_row;
-		}
-
-		$t_user_count = count( $t_users );
-
-		if( $t_user_count == 2 ) {
-			# unset flags if there are now only 2 unique names
-			for( $i = 0;$i < $t_user_count;$i++ ) {
-				$t_user_id = $t_users[$i]['id'];
-				user_set_field( $t_user_id, 'duplicate_realname', OFF );
-			}
-		}
-	}
-
 	user_clear_cache( $p_user_id );
 
 	# Remove account
@@ -1758,7 +1720,7 @@ function user_set_realname( $p_user_id, $p_realname ) {
  */
 function user_set_name( $p_user_id, $p_username ) {
 	user_ensure_name_valid( $p_username );
-	user_ensure_name_unique( $p_username );
+	user_ensure_name_unique( $p_username, $p_user_id );
 
 	return user_set_field( $p_user_id, 'username', $p_username );
 }

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -993,7 +993,8 @@ function user_get_name( $p_user_id ) {
  * @return string display name
  */
 function user_get_name_from_row( array $p_user_row ) {
-	if( ON == config_get( 'show_realname' ) ) {
+	if( ON == config_get( 'show_realname' ) &&
+	    access_has_project_level( config_get( 'show_user_realname_threshold', null, null, ALL_PROJECTS ) ) ) {
 		if( !is_blank( $p_user_row['realname'] ) ) {
 			return $p_user_row['realname'];
 		}

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1347,10 +1347,9 @@ function user_get_unassigned_by_project_id( $p_project_id = null ) {
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$t_users[] = $t_row['id'];
-		$t_user_name = user_get_name_for_sorting_from_row( $t_row );
-		$t_user_name = string_attribute( $t_user_name );
-		$t_display[] = $t_user_name;
-		$t_sort[] = $t_sort_name;
+		$t_user_name = user_get_name_from_row( $t_row );
+		$t_display[] = string_attribute( $t_user_name );
+		$t_sort[] = user_get_name_for_sorting_from_row( $t_row );
 	}
 
 	array_multisort( $t_sort, SORT_ASC, SORT_STRING, $t_users, $t_display );

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -324,51 +324,6 @@ function user_ensure_email_unique( $p_email, $p_user_id = null ) {
 }
 
 /**
- * Check if realname is specified, a unique real name, and doesn't match a username of another user.
- *
- * @param string $p_realname The realname to check.
- * @param integer|null $p_user_id The user id that is allowed to conflict, otherwise, null.
- * @return bool true: unique, false otherwise.
- */
-function user_is_realname_unique( $p_realname, $p_user_id = null ) {
-	if( is_blank( $p_realname ) ) {
-		# don't bother checking if realname is blank
-		return true;
-	}
-
-	$p_realname = trim( $p_realname );
-
-	# check realname does not match an existing realname
-	$t_existing_user_id = user_get_id_by_name( $p_realname );
-	if( $t_existing_user_id !== false && ( $p_user_id === null || (int)$t_existing_user_id !== $p_user_id ) ) {
-		return false;
-	}
-
-	$t_existing_user_id = user_get_id_by_realname( $p_realname );
-	if( $t_existing_user_id !== false && ( $p_user_id === null || (int)$t_existing_user_id !== $p_user_id ) ) {
-		return false;
-	}
-
-	return true;
-}
-
-/**
- * Check if the realname is a unique
- * Trigger an error if the username is not valid
- *
- * @param string $p_realname The realname to check.
- * @param integer|null $p_user_id  The user id that is allowed to conflict, otherwise null.
- * @return void
- */
-function user_ensure_realname_unique( $p_realname, $p_user_id = null ) {
-	if( !user_is_realname_unique( $p_realname, $p_user_id ) ) {
-		throw new ClientException(
-			sprintf( "Realname '%s' is not unique", $p_realname ),
-			ERROR_USER_REAL_MATCH_USER );
-	}
-}
-
-/**
  * Check if the username is a valid username (does not account for uniqueness) realname can match
  * @param string $p_username The username to check.
  * @return boolean return true if user name is valid, false otherwise
@@ -581,7 +536,6 @@ function user_create( $p_username, $p_password, $p_email = '',
 	user_ensure_name_valid( $p_username );
 	user_ensure_name_unique( $p_username );
 	user_ensure_email_unique( $p_email );
-	user_ensure_realname_unique( $p_realname );
 	email_ensure_valid( $p_email );
 	email_ensure_not_disposable( $p_email );
 

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1057,14 +1057,14 @@ function user_get_name_from_row( array $p_user_row ) {
 function user_get_name_for_sorting_from_row( array $p_user_row ) {
 	if( !is_blank( $p_user_row['realname'] ) && config_get( 'show_realname' ) == ON ) {
 		if( config_get( 'sort_by_last_name' ) == ON ) {
-			$t_sort_name_bits = explode( ' ', strtolower( $p_user_row['realname'] ), 2 );
+			$t_sort_name_bits = explode( ' ', utf8_strtolower( $p_user_row['realname'] ), 2 );
 			return ( isset( $t_sort_name_bits[1] ) ? $t_sort_name_bits[1] . ', ' : '' ) . $t_sort_name_bits[0];
 		}
 		
-		return $t_sort_name = strtolower( $p_user_row['realname'] );
+		return $t_sort_name = utf8_strtolower( $p_user_row['realname'] );
 	}
 
-	return strtolower( $p_user_row['username'] );
+	return utf8_strtolower( $p_user_row['username'] );
 }
 
 /**

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -726,16 +726,16 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 		<tbody>
 <?php
 	$t_users = project_get_all_user_rows( $f_project_id, ANYBODY, $f_show_global_users );
-	$t_display = array();
+	$t_user_ids = array();
 	$t_sort = array();
 
 	foreach ( $t_users as $t_user ) {
 		$t_user_name = user_get_name_from_row( $t_user );
-		$t_display[] = string_attribute( $t_user_name );
+		$t_user_ids[] = $t_user['id'];
 		$t_sort[] = user_get_name_for_sorting_from_row( $t_user );
 	}
 
-	array_multisort( $t_sort, SORT_ASC, SORT_STRING, $t_users, $t_display );
+	array_multisort( $t_sort, SORT_ASC, SORT_STRING, $t_users, $t_user_ids );
 
 	$t_users_count = count( $t_sort );
 	$t_removable_users_exist = false;
@@ -754,7 +754,7 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 			<tr>
 				<td>
 					<a href="manage_user_edit_page.php?user_id=<?php echo $t_user['id'] ?>">
-						<?php echo $t_display[$i] ?>
+						<?php print_user( $t_user_ids[$i] ) ?>
 					</a>
 				</td>
 				<td>
@@ -842,7 +842,7 @@ if( count( $t_users ) > 0 ) { ?>
 				<td>
 					<select id="project-add-users-username" name="user_id[]" class="input-sm" multiple="multiple" size="10" required><?php
 						foreach( $t_users AS $t_user_id=>$t_display_name ) {
-							echo '<option value="', $t_user_id, '">', $t_display_name, '</option>';
+							echo '<option value="', $t_user_id, '">', string_attribute( $t_display_name ), '</option>';
 						} ?>
 					</select>
 				</td>

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -728,20 +728,11 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 	$t_users = project_get_all_user_rows( $f_project_id, ANYBODY, $f_show_global_users );
 	$t_display = array();
 	$t_sort = array();
+
 	foreach ( $t_users as $t_user ) {
-		$t_user_name = string_attribute( $t_user['username'] );
-		$t_sort_name = utf8_strtolower( $t_user_name );
-		if( ( isset( $t_user['realname'] ) ) && ( $t_user['realname'] > "" ) && ( ON == config_get( 'show_realname' ) ) ){
-			$t_user_name = string_attribute( $t_user['realname'] ) . " (" . $t_user_name . ")";
-			if( ON == config_get( 'sort_by_last_name') ) {
-				$t_sort_name_bits = explode( ' ', utf8_strtolower( $t_user_name ), 2 );
-				$t_sort_name = $t_sort_name_bits[1] . ', ' . $t_sort_name_bits[1];
-			} else {
-				$t_sort_name = utf8_strtolower( $t_user_name );
-			}
-		}
-		$t_display[] = $t_user_name;
-		$t_sort[] = $t_sort_name;
+		$t_user_name = user_get_name_from_row( $t_user );
+		$t_display[] = string_attribute( $t_user_name );
+		$t_sort[] = user_get_name_for_sorting_from_row( $t_user );
 	}
 
 	array_multisort( $t_sort, SORT_ASC, SORT_STRING, $t_users, $t_display );

--- a/manage_user_update.php
+++ b/manage_user_update.php
@@ -111,7 +111,6 @@ if( $t_ldap && config_get( 'use_ldap_realname' ) ) {
 } else {
 	# strip extra space from real name
 	$t_realname = string_normalize( $f_realname );
-	user_ensure_realname_unique( $t_realname, $f_user_id );
 }
 
 if( $t_ldap && config_get( 'use_ldap_email' ) ) {

--- a/manage_user_update.php
+++ b/manage_user_update.php
@@ -111,7 +111,7 @@ if( $t_ldap && config_get( 'use_ldap_realname' ) ) {
 } else {
 	# strip extra space from real name
 	$t_realname = string_normalize( $f_realname );
-	user_ensure_realname_unique( $t_old_username, $t_realname );
+	user_ensure_realname_unique( $t_realname, $f_user_id );
 }
 
 if( $t_ldap && config_get( 'use_ldap_email' ) ) {

--- a/project_page.php
+++ b/project_page.php
@@ -119,9 +119,8 @@ if( count( $t_users ) > 0 ) {
 
 	# @todo sort users in DESC order by access level, then ASC by username/realname.
 	foreach ( $t_users as $t_user_data ) {
-		$t_user_id = $t_user_data['id'];
-		$t_user_name = user_get_name( $t_user_id );
-		echo $t_user_name, ' (', get_enum_element( 'access_levels', $t_user_data['access_level'] ), ')<br />';
+		print_user( $t_user_data['id'] );
+		echo ' (', get_enum_element( 'access_levels', $t_user_data['access_level'] ), ')<br />';
 	}
 }
 

--- a/project_page.php
+++ b/project_page.php
@@ -113,7 +113,6 @@ if( !is_blank( $t_description ) ) {
 $t_access_level_for_dev_team = config_get( 'development_team_threshold' );
 
 $t_users = project_get_all_user_rows( $f_project_id, $t_access_level_for_dev_team );
-$t_show_real_names = config_get( 'show_realname' ) == ON;
 
 if( count( $t_users ) > 0 ) {
 	echo '<h2>', lang_get( 'development_team' ), '</h2>';
@@ -121,13 +120,7 @@ if( count( $t_users ) > 0 ) {
 	# @todo sort users in DESC order by access level, then ASC by username/realname.
 	foreach ( $t_users as $t_user_data ) {
 		$t_user_id = $t_user_data['id'];
-
-		if( $t_show_real_names && !is_blank( $t_user_data['realname'] ) ) {
-			$t_user_name = $t_user_data['realname'];
-		} else {
-			$t_user_name = $t_user_data['username'];
-		}
-
+		$t_user_name = user_get_name( $t_user_id );
 		echo $t_user_name, ' (', get_enum_element( 'access_levels', $t_user_data['access_level'] ), ')<br />';
 	}
 }


### PR DESCRIPTION
- Remove user realname uniqueness check against usernames or real names.  Username is required to be unique.
- Remove `$g_differentiate_duplicates` config option and reference to `duplicate_realname` user field that doesn't exist.
- When displaying usernames always display username, then annotate with realname in tooltip or realname between brackets.  This guarantees uniquness.
- Always showing username makes @ mentioning users easier. #23375
- Refactor code to centralize crafting of display name.
- Refactor code to centralize crafting of name used for sorting.
- Make sure that show realname threshold is always checked.

Fixes #23909, #23900, #23375