### PR TITLE
Fix regression that discloses file path in some errors

### DIFF
--- a/api/rest/index.php
+++ b/api/rest/index.php
@@ -45,7 +45,9 @@ ApiObjectFactory::$soap = false;
 
 # Show SLIM detailed errors according to Mantis settings
 $t_config = array();
-if( ON == config_get_global( 'show_detailed_errors' ) ) {
+
+$t_show_detailed_errors = ON == config_get_global( 'show_detailed_errors' );
+if( $t_show_detailed_errors ) {
 	$t_config['settings'] = array( 'displayErrorDetails' => true );
 }
 
@@ -74,7 +76,11 @@ $t_container['errorHandler'] = function( $p_container ) {
 		$t_error_to_log =  $p_exception->getMessage() . "\n" . $t_stack_as_string;
 		error_log( $t_error_to_log );
 
-		return $p_response->withStatus( HTTP_STATUS_INTERNAL_SERVER_ERROR )->withJson( $t_data );
+		if( $t_show_detailed_errors ) {
+			$p_response = $p_response->withJson( $t_data );
+		}
+
+		return $p_response->withStatus( HTTP_STATUS_INTERNAL_SERVER_ERROR );
 	};
 };
 

--- a/api/rest/index.php
+++ b/api/rest/index.php
@@ -70,7 +70,11 @@ $t_container['errorHandler'] = function( $p_container ) {
 			return $p_response->withStatus( $p_exception->getCode(), $p_exception->getMessage() )->withJson( $t_data );
 		}
 
-		return $p_response->withStatus( HTTP_STATUS_INTERNAL_SERVER_ERROR, $p_exception->getMessage() )->withJson( $t_data );
+		$t_stack_as_string = error_stack_track_as_string( $p_exception );
+		$t_error_to_log =  $p_exception->getMessage() . "\n" . $t_stack_as_string;
+		error_log( $t_error_to_log );
+
+		return $p_response->withStatus( HTTP_STATUS_INTERNAL_SERVER_ERROR )->withJson( $t_data );
 	};
 };
 

--- a/api/rest/index.php
+++ b/api/rest/index.php
@@ -70,7 +70,7 @@ $t_container['errorHandler'] = function( $p_container ) {
 			return $p_response->withStatus( $p_exception->getCode(), $p_exception->getMessage() )->withJson( $t_data );
 		}
 
-		$t_stack_as_string = error_stack_track_as_string( $p_exception );
+		$t_stack_as_string = error_stack_trace_as_string( $p_exception );
 		$t_error_to_log =  $p_exception->getMessage() . "\n" . $t_stack_as_string;
 		error_log( $t_error_to_log );
 

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -1070,7 +1070,7 @@ function mc_error_exception_handler( $p_exception ) {
 	}
 
 	if( $t_log ) {
-		$t_stack_as_string = error_stack_track_as_string( $p_exception );
+		$t_stack_as_string = error_stack_trace_as_string( $p_exception );
 		$t_error_to_log =  $p_exception->getMessage() . "\n" . $t_stack_as_string;
 		error_log( $t_error_to_log );
 	}

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -162,10 +162,6 @@ class ApiObjectFactory {
 	 */
 	static function faultFromException( Exception $p_exception ) {
 		$t_code = $p_exception->getCode();
-		$t_message = $p_exception->getMessage();
-
-		# Make sure the file path is not disclosed via exception details
-		$t_message = str_replace( config_get_global( 'absolute_path' ), '.../', $t_message );
 
 		switch( $t_code ) {
 			case ERROR_NO_FILE_SPECIFIED:
@@ -231,7 +227,7 @@ class ApiObjectFactory {
 			case ERROR_COLUMNS_INVALID:
 			case ERROR_API_TOKEN_NAME_NOT_UNIQUE:
 			case ERROR_INVALID_FIELD_VALUE:
-				return ApiObjectFactory::faultBadRequest( $t_message );
+				return ApiObjectFactory::faultBadRequest( $p_exception->getMessage() );
 
 			case ERROR_BUG_NOT_FOUND:
 			case ERROR_FILE_NOT_FOUND:
@@ -253,7 +249,7 @@ class ApiObjectFactory {
 			case ERROR_FILTER_NOT_FOUND:
 			case ERROR_TAG_NOT_FOUND:
 			case ERROR_TOKEN_NOT_FOUND:
-				return ApiObjectFactory::faultNotFound( $t_message );
+				return ApiObjectFactory::faultNotFound( $p_exception->getMessage() );
 				
 			case ERROR_ACCESS_DENIED:
 			case ERROR_PROTECTED_ACCOUNT:
@@ -271,18 +267,18 @@ class ApiObjectFactory {
 			case ERROR_LOST_PASSWORD_NOT_ENABLED:
 			case ERROR_LOST_PASSWORD_MAX_IN_PROGRESS_ATTEMPTS_REACHED:
 			case ERROR_FORM_TOKEN_INVALID:
-				return ApiObjectFactory::faultForbidden( $t_message );
+				return ApiObjectFactory::faultForbidden( $p_exception->getMessage() );
 
 			case ERROR_SPAM_SUSPECTED:
-				return ApiObjectFactory::faultTooManyRequests( $t_message );
+				return ApiObjectFactory::faultTooManyRequests( $p_exception->getMessage() );
 
 			case ERROR_CONFIG_OPT_INVALID:
 			case ERROR_FILE_INVALID_UPLOAD_PATH:
 				# TODO: These are configuration or db state errors.
-				return ApiObjectFactory::faultServerError( $t_message );
+				return ApiObjectFactory::faultServerError( $p_exception->getMessage() );
 
 			default:
-				return ApiObjectFactory::faultServerError( $t_message );
+				return ApiObjectFactory::faultServerError( $p_exception->getMessage() );
 		}
 	}
 
@@ -1138,9 +1134,6 @@ function mc_error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context
 
 	$t_error_stack = error_get_stack_trace();
 
-	# Make sure the file path is not disclosed via exception details
-	$t_error_description = str_replace( config_get_global( 'absolute_path' ), '.../', $t_error_description );
-	
 	error_log( '[mantisconnect.php] Error Type: ' . $t_error_type . ',' . "\n" . 'Error Description: ' . $t_error_description . "\n" . 'Stack Trace:' . "\n" . $t_error_stack );
 
 	throw new SoapFault( 'Server', 'Error Type: ' . $t_error_type . ',' . "\n" . 'Error Description: ' . $t_error_description );

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -1057,11 +1057,25 @@ function mci_get_time_tracking_from_note( $p_issue_id, array $p_note ) {
 function mc_error_exception_handler( $p_exception ) {
 	if( is_a( $p_exception, 'Mantis\Exceptions\ClientException' ) ) {
 		$t_cause = 'Client';
+		$t_message = $p_exception->getMessage();
+		$t_log = false;
+	} else if( is_a( $p_exception, 'Mantis\Exceptions\MantisException' ) ) {
+		$t_cause = 'Server';
+		$t_message = $p_exception->getMessage();
+		$t_log = true;
 	} else {
 		$t_cause = 'Server';
+		$t_message = 'Internal Service Error';		
+		$t_log = true;
 	}
 
-	$t_fault = htmlentities( $p_exception->getMessage() );
+	if( $t_log ) {
+		$t_stack_as_string = error_stack_track_as_string( $p_exception );
+		$t_error_to_log =  $p_exception->getMessage() . "\n" . $t_stack_as_string;
+		error_log( $t_error_to_log );
+	}
+
+	$t_fault = htmlentities( $t_message );
 
 	echo <<<EOL
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -162,6 +162,10 @@ class ApiObjectFactory {
 	 */
 	static function faultFromException( Exception $p_exception ) {
 		$t_code = $p_exception->getCode();
+		$t_message = $p_exception->getMessage();
+
+		# Make sure the file path is not disclosed via exception details
+		$t_message = str_replace( config_get_global( 'absolute_path' ), '.../', $t_message );
 
 		switch( $t_code ) {
 			case ERROR_NO_FILE_SPECIFIED:
@@ -227,7 +231,7 @@ class ApiObjectFactory {
 			case ERROR_COLUMNS_INVALID:
 			case ERROR_API_TOKEN_NAME_NOT_UNIQUE:
 			case ERROR_INVALID_FIELD_VALUE:
-				return ApiObjectFactory::faultBadRequest( $p_exception->getMessage() );
+				return ApiObjectFactory::faultBadRequest( $t_message );
 
 			case ERROR_BUG_NOT_FOUND:
 			case ERROR_FILE_NOT_FOUND:
@@ -249,7 +253,7 @@ class ApiObjectFactory {
 			case ERROR_FILTER_NOT_FOUND:
 			case ERROR_TAG_NOT_FOUND:
 			case ERROR_TOKEN_NOT_FOUND:
-				return ApiObjectFactory::faultNotFound( $p_exception->getMessage() );
+				return ApiObjectFactory::faultNotFound( $t_message );
 				
 			case ERROR_ACCESS_DENIED:
 			case ERROR_PROTECTED_ACCOUNT:
@@ -267,18 +271,18 @@ class ApiObjectFactory {
 			case ERROR_LOST_PASSWORD_NOT_ENABLED:
 			case ERROR_LOST_PASSWORD_MAX_IN_PROGRESS_ATTEMPTS_REACHED:
 			case ERROR_FORM_TOKEN_INVALID:
-				return ApiObjectFactory::faultForbidden( $p_exception->getMessage() );
+				return ApiObjectFactory::faultForbidden( $t_message );
 
 			case ERROR_SPAM_SUSPECTED:
-				return ApiObjectFactory::faultTooManyRequests( $p_exception->getMessage() );
+				return ApiObjectFactory::faultTooManyRequests( $t_message );
 
 			case ERROR_CONFIG_OPT_INVALID:
 			case ERROR_FILE_INVALID_UPLOAD_PATH:
 				# TODO: These are configuration or db state errors.
-				return ApiObjectFactory::faultServerError( $p_exception->getMessage() );
+				return ApiObjectFactory::faultServerError( $t_message );
 
 			default:
-				return ApiObjectFactory::faultServerError( $p_exception->getMessage() );
+				return ApiObjectFactory::faultServerError( $t_message );
 		}
 	}
 
@@ -1134,6 +1138,9 @@ function mc_error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context
 
 	$t_error_stack = error_get_stack_trace();
 
+	# Make sure the file path is not disclosed via exception details
+	$t_error_description = str_replace( config_get_global( 'absolute_path' ), '.../', $t_error_description );
+	
 	error_log( '[mantisconnect.php] Error Type: ' . $t_error_type . ',' . "\n" . 'Error Description: ' . $t_error_description . "\n" . 'Stack Trace:' . "\n" . $t_error_stack );
 
 	throw new SoapFault( 'Server', 'Error Type: ' . $t_error_type . ',' . "\n" . 'Error Description: ' . $t_error_description );

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -532,8 +532,6 @@ function error_stack_trace_as_string( $p_exception = null ) {
  * @param Exception|null $p_exception The exception to print stack trace for.  Null will check last seen exception.
  */
 function error_print_stack_trace( $p_exception = null ) {
-	$t_stack = error_stack_trace( $p_exception );
-
 	if( php_sapi_name() == 'cli' ) {
 		echo error_stack_trace_as_string( $p_exception );
 		return;
@@ -543,7 +541,7 @@ function error_print_stack_trace( $p_exception = null ) {
 	echo '<table class="table table-bordered table-striped table-condensed">';
 	echo '<tr><th>Filename</th><th>Line</th><th></th><th></th><th>Function</th><th>Args</th></tr>';
 
-	# remove the call to the error handler from the stack trace
+	$t_stack = error_stack_trace( $p_exception );
 
 	foreach( $t_stack as $t_frame ) {
 		echo '<tr>';
@@ -559,6 +557,7 @@ function error_print_stack_trace( $p_exception = null ) {
 			echo '<td>-</td></tr>';
 		}
 	}
+
 	echo '</table>';
 }
 

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -247,11 +247,16 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 
 	$t_error_description = nl2br( $t_error_description );
 
+	# Make sure the file path is not disclosed via exception details
+	$t_error_description = str_replace( config_get_global( 'absolute_path' ), '.../', $t_error_description );
+
+	$t_show_detailed_errors = config_get_global( 'show_detailed_errors' ) == ON;
+
 	if( php_sapi_name() == 'cli' ) {
 		if( DISPLAY_ERROR_NONE != $t_method ) {
 			echo $t_error_type . ': ' . $t_error_description . "\n";
 
-			if( ON == config_get_global( 'show_detailed_errors' ) ) {
+			if( $t_show_detailed_errors ) {
 				echo "\n";
 				error_print_stack_trace();
 			}
@@ -334,7 +339,7 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 				}
 				echo '</div>';
 
-				if( ON == config_get_global( 'show_detailed_errors' ) ) {
+				if( $t_show_detailed_errors ) {
 					echo '<p>';
 					error_print_details( $p_file, $p_line, $p_context );
 					echo '</p>';

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -206,7 +206,7 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 				$t_error_description = '';
 
 				global $g_exception;
-				$t_stack_as_string = error_stack_track_as_string();
+				$t_stack_as_string = error_stack_trace_as_string();
 				$t_error_to_log =  $g_exception->getMessage() . "\n" . $t_stack_as_string;
 				error_log( $t_error_to_log );
 			} else {
@@ -493,7 +493,7 @@ function error_print_context( array $p_context ) {
  * @param Exception|null $p_exception The exception to print stack trace for.  Null will check last seen exception.
  * @return string multi-line printout of stack trace.
  */
-function error_stack_track_as_string( $p_exception = null ) {
+function error_stack_trace_as_string( $p_exception = null ) {
 	$t_stack = error_stack_trace( $p_exception );
 	$t_output = '';
 
@@ -528,7 +528,7 @@ function error_print_stack_trace( $p_exception = null ) {
 	$t_stack = error_stack_trace( $p_exception );
 
 	if( php_sapi_name() == 'cli' ) {
-		echo error_stack_track_as_string( $p_exception );
+		echo error_stack_trace_as_string( $p_exception );
 		return;
 	}
 

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -247,16 +247,11 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 
 	$t_error_description = nl2br( $t_error_description );
 
-	# Make sure the file path is not disclosed via exception details
-	$t_error_description = str_replace( config_get_global( 'absolute_path' ), '.../', $t_error_description );
-
-	$t_show_detailed_errors = config_get_global( 'show_detailed_errors' ) == ON;
-
 	if( php_sapi_name() == 'cli' ) {
 		if( DISPLAY_ERROR_NONE != $t_method ) {
 			echo $t_error_type . ': ' . $t_error_description . "\n";
 
-			if( $t_show_detailed_errors ) {
+			if( ON == config_get_global( 'show_detailed_errors' ) ) {
 				echo "\n";
 				error_print_stack_trace();
 			}
@@ -339,7 +334,7 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 				}
 				echo '</div>';
 
-				if( $t_show_detailed_errors ) {
+				if( ON == config_get_global( 'show_detailed_errors' ) ) {
 					echo '<p>';
 					error_print_details( $p_file, $p_line, $p_context );
 					echo '</p>';

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -175,6 +175,8 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 		}
 	}
 
+	$t_show_detailed_errors = config_get_global( 'show_detailed_errors' ) == ON;
+
 	# Force errors to use HALT method.
 	if( $p_type == E_USER_ERROR || $p_type == E_ERROR || $p_type == E_RECOVERABLE_ERROR ) {
 		$t_method = DISPLAY_ERROR_HALT;
@@ -203,12 +205,17 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 		case E_USER_ERROR:
 			if( $p_error == ERROR_PHP ) {
 				$t_error_type = 'INTERNAL APPLICATION ERROR';
-				$t_error_description = '';
 
 				global $g_exception;
-				$t_stack_as_string = error_stack_trace_as_string();
-				$t_error_to_log =  $g_exception->getMessage() . "\n" . $t_stack_as_string;
+				$t_error_description = $g_exception->getMessage();
+				$t_error_to_log = $t_error_description . "\n" . error_stack_trace_as_string();
 				error_log( $t_error_to_log );
+
+				# If show detailed errors is OFF hide PHP exceptions since they sometimes
+				# include file path.
+				if( !$t_show_detailed_errors ) {
+					$t_error_description = '';
+				}
 			} else {
 				$t_error_type = 'APPLICATION ERROR #' . $p_error;
 				$t_error_description = error_string( $p_error );
@@ -259,7 +266,7 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 		if( DISPLAY_ERROR_NONE != $t_method ) {
 			echo $t_error_type . ': ' . $t_error_description . "\n";
 
-			if( ON == config_get_global( 'show_detailed_errors' ) ) {
+			if( $t_show_detailed_errors ) {
 				echo "\n";
 				error_print_stack_trace();
 			}
@@ -342,7 +349,7 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 				}
 				echo '</div>';
 
-				if( ON == config_get_global( 'show_detailed_errors' ) ) {
+				if( $t_show_detailed_errors ) {
 					echo '<p>';
 					error_print_details( $p_file, $p_line, $p_context );
 					echo '</p>';


### PR DESCRIPTION
This was introduced as part of refactoring error handler and it happens with some errors even when show_detailed_errors is set to OFF.

Fixes #23925