### PR TITLE
Error page improvements

### DIFF
--- a/core/error_api.php
+++ b/core/error_api.php
@@ -105,11 +105,10 @@ function error_stack_trace( $p_exception = null ) {
 	}
 
 	if ( $p_exception === null ) {
-		$t_stack = debug_backtrace();
-
-		# remove this function and its caller from the stack trace.
-		array_shift( $t_stack );
-		array_shift( $t_stack );
+		# The reported stack trace should begin with the function call where the
+		# error was triggered, so we remove the internal error handler calls
+		# (this function, its parent and the error handler itself).
+		$t_stack = array_slice( debug_backtrace(), 3 );
 	} else {
 		$t_stack = $p_exception->getTrace();
 	}

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -323,14 +323,14 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 							}
 						}
 					} else {
-                        layout_page_header( $t_error_type );
-                    }
+						layout_page_header( $t_error_type );
+					}
 				} else {
 					# Output the previously sent headers, if defined
 					if( isset( $t_old_headers ) ) {
 						echo $t_old_headers, "\n";
-                        layout_page_header_end();
-                        layout_page_begin();
+						layout_page_header_end();
+						layout_page_begin();
 					}
 				}
 

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -433,20 +433,24 @@ function error_print_delayed() {
  * @return void
  */
 function error_print_details( $p_file, $p_line, array $p_context ) {
-	?>
-		<table class="width-100">
-			<tr>
-				<td>Full path: <?php echo htmlentities( $p_file, ENT_COMPAT, 'UTF-8' );?></td>
-			</tr>
-			<tr>
-				<td>Line: <?php echo $p_line?></td>
-			</tr>
-			<tr>
-				<td>
-					<?php error_print_context( $p_context )?>
-				</td>
-			</tr>
-		</table>
+?>
+	<div class="error-details">
+		<hr>
+		<h2>Detailed error information</h2>
+		<ul>
+			<li>Full path:
+				<span class="code">
+					<?php echo htmlentities( $p_file, ENT_COMPAT, 'UTF-8' );?>
+				</span>
+			</li>
+			<li>Line number:
+				<span class="code"><?php echo $p_line ?></span>
+			</li>
+		</ul>
+
+		<h3>Context</h3>
+		<?php error_print_context( $p_context )?>
+	</div>
 <?php
 }
 

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -538,26 +538,43 @@ function error_print_stack_trace( $p_exception = null ) {
 		echo error_stack_trace_as_string( $p_exception );
 		return;
 	}
-
-	echo '<div class="table-responsive">';
-	echo '<table class="table table-bordered table-striped table-condensed">';
-	echo '<tr><th>Filename</th><th>Line</th><th></th><th></th><th>Function</th><th>Args</th></tr>', "\n";
-
+?>
+	<h3>Stack trace</h3>
+		<div class="table-responsive">
+			<table class="table table-bordered table-striped table-condensed">
+				<tr>
+					<th>#</th>
+					<th>Filename</th>
+					<th>Line</th>
+					<th>Class</th>
+					<th>Type</th>
+					<th>Function</th>
+					<th>Args</th>
+				</tr>
+<?php
 	$t_stack = error_stack_trace( $p_exception );
 
-	foreach( $t_stack as $t_frame ) {
-		echo '<tr>';
-		echo '<td>', ( isset( $t_frame['file'] ) ? htmlentities( $t_frame['file'], ENT_COMPAT, 'UTF-8' ) : '-' ), '</td><td>', ( isset( $t_frame['line'] ) ? $t_frame['line'] : '-' ), '</td><td>', ( isset( $t_frame['class'] ) ? $t_frame['class'] : '-' ), '</td><td>', ( isset( $t_frame['type'] ) ? $t_frame['type'] : '-' ), '</td><td>', ( isset( $t_frame['function'] ) ? $t_frame['function'] : '-' ), '</td>';
-
-		$t_args = array();
+	foreach( $t_stack as $t_id => $t_frame ) {
 		if( isset( $t_frame['args'] ) && !empty( $t_frame['args'] ) ) {
+			$t_args = array();
 			foreach( $t_frame['args'] as $t_value ) {
 				$t_args[] = error_build_parameter_string( $t_value );
 			}
-			echo '<td>( ', htmlentities( implode( $t_args, ', ' ), ENT_COMPAT, 'UTF-8' ), ' )</td></tr>', "\n";
 		} else {
-			echo '<td>-</td></tr>', "\n";
+			$t_args = array('-');
 		}
+
+		printf(
+			"<tr>\n" . str_repeat( "<td>%s</td>\n", 7 ) . "</tr>\n",
+			$t_id,
+			isset( $t_frame['file'] ) ? htmlentities( $t_frame['file'], ENT_COMPAT, 'UTF-8' ) : '-',
+			isset( $t_frame['line'] ) ? $t_frame['line'] : '-',
+			isset( $t_frame['class'] ) ? $t_frame['class'] : '-',
+			isset( $t_frame['type'] ) ? $t_frame['type'] : '-',
+			isset( $t_frame['function'] ) ? $t_frame['function'] : '-',
+			htmlentities( implode( $t_args, ', ' ), ENT_COMPAT, 'UTF-8' )
+		);
+
 	}
 	echo '</table>', '</div>';
 }

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -130,7 +130,6 @@ function error_stack_trace( $p_exception = null ) {
  * @param string  $p_error   Contains the error message, as a string.
  * @param string  $p_file    Contains the filename that the error was raised in, as a string.
  * @param integer $p_line    Contains the line number the error was raised at, as an integer.
- * @param array   $p_context To the active symbol table at the point the error occurred (optional).
  * @return void
  * @uses lang_api.php
  * @uses config_api.php
@@ -138,7 +137,7 @@ function error_stack_trace( $p_exception = null ) {
  * @uses database_api.php (optional)
  * @uses html_api.php (optional)
  */
-function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) {
+function error_handler( $p_type, $p_error, $p_file, $p_line ) {
 	global $g_error_parameters, $g_error_handled, $g_error_proceed_url;
 	global $g_error_send_page_header;
 
@@ -352,7 +351,7 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 				echo '</div>', "\n";
 
 				if( $t_show_detailed_errors ) {
-					error_print_details( $p_file, $p_line, $p_context );
+					error_print_details( $p_file, $p_line );
 					error_print_stack_trace();
 				}
 				echo '</div></div>';
@@ -426,13 +425,12 @@ function error_print_delayed() {
 }
 
 /**
- * Print out the error details including context
+ * Print out the error details
  * @param string  $p_file    File error occurred in.
  * @param integer $p_line    Line number error occurred on.
- * @param array   $p_context Error context.
  * @return void
  */
-function error_print_details( $p_file, $p_line, array $p_context ) {
+function error_print_details( $p_file, $p_line ) {
 ?>
 	<div class="error-details">
 		<hr>
@@ -447,54 +445,10 @@ function error_print_details( $p_file, $p_line, array $p_context ) {
 				<span class="code"><?php echo $p_line ?></span>
 			</li>
 		</ul>
-
-		<h3>Context</h3>
-		<?php error_print_context( $p_context )?>
 	</div>
 <?php
 }
 
-/**
- * Print out the variable context given
- * @param array $p_context Error context.
- * @return void
- */
-function error_print_context( array $p_context ) {
-	if( !is_array( $p_context ) ) {
-		return;
-	}
-
-	echo '<table class="width100" style="table-layout:fixed;"><tr><th>Variable</th><th>Value</th><th>Type</th></tr>';
-
-	# print normal variables
-	foreach( $p_context as $t_var => $t_val ) {
-		if( !is_array( $t_val ) && !is_object( $t_val ) ) {
-			$t_type = gettype( $t_val );
-			$t_val = htmlentities( (string)$t_val, ENT_COMPAT, 'UTF-8' );
-
-			# Mask Passwords
-			if( strpos( $t_var, 'password' ) !== false ) {
-				$t_val = '**********';
-			}
-
-			echo '<tr><td style="width=20%; word-wrap:break-word; overflow:auto;">', $t_var,
-				'</td><td style="width=70%; word-wrap:break-word; overflow:auto;">', $t_val,
-				'</td><td style="width=10%;">', $t_type, '</td></tr>', "\n";
-		}
-	}
-
-	# print arrays
-	foreach( $p_context as $t_var => $t_val ) {
-		if( is_array( $t_val ) && ( $t_var != 'GLOBALS' ) ) {
-			echo '<tr><td colspan="3" style="word-wrap:break-word"><br /><strong>', $t_var, '</strong></td></tr>';
-			echo '<tr><td colspan="3">';
-			error_print_context( $t_val );
-			echo '</td></tr>';
-		}
-	}
-
-	echo '</table>';
-}
 
 /**
  * Get the stack trace as a string that can be logged or echoed to CLI output.

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -335,11 +335,11 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 				}
 
 				echo '<div class="col-md-12 col-xs-12">';
-				echo '<div class="space-20"></div>';
-				echo '<div class="alert alert-danger">';
+				echo '<div class="space-20"></div>', "\n";
+				echo '<div class="alert alert-danger">', "\n";
 
-				echo '<p class="bold">' . $t_error_type . '</p>';
-				echo '<p>', $t_error_description, '</p>';
+				echo '<p class="bold">' . $t_error_type . '</p>', "\n";
+				echo '<p>', $t_error_description, '</p>', "\n";
 
 				echo '<div class="error-info">';
 				if( null === $g_error_proceed_url ) {
@@ -347,15 +347,11 @@ function error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) 
 				} else {
 					echo '<a href="', $g_error_proceed_url, '">', lang_get( 'proceed' ), '</a>';
 				}
-				echo '</div>';
+				echo '</div>', "\n";
 
 				if( $t_show_detailed_errors ) {
-					echo '<p>';
 					error_print_details( $p_file, $p_line, $p_context );
-					echo '</p>';
-					echo '<p>';
 					error_print_stack_trace();
-					echo '</p>';
 				}
 				echo '</div></div>';
 
@@ -539,7 +535,7 @@ function error_print_stack_trace( $p_exception = null ) {
 
 	echo '<div class="table-responsive">';
 	echo '<table class="table table-bordered table-striped table-condensed">';
-	echo '<tr><th>Filename</th><th>Line</th><th></th><th></th><th>Function</th><th>Args</th></tr>';
+	echo '<tr><th>Filename</th><th>Line</th><th></th><th></th><th>Function</th><th>Args</th></tr>', "\n";
 
 	$t_stack = error_stack_trace( $p_exception );
 
@@ -552,13 +548,12 @@ function error_print_stack_trace( $p_exception = null ) {
 			foreach( $t_frame['args'] as $t_value ) {
 				$t_args[] = error_build_parameter_string( $t_value );
 			}
-			echo '<td>( ', htmlentities( implode( $t_args, ', ' ), ENT_COMPAT, 'UTF-8' ), ' )</td></tr>';
+			echo '<td>( ', htmlentities( implode( $t_args, ', ' ), ENT_COMPAT, 'UTF-8' ), ' )</td></tr>', "\n";
 		} else {
-			echo '<td>-</td></tr>';
+			echo '<td>-</td></tr>', "\n";
 		}
 	}
-
-	echo '</table>';
+	echo '</table>', '</div>';
 }
 
 /**

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -54,12 +54,15 @@ if( !$g_bypass_error_handler ) {
 	set_exception_handler( 'error_exception_handler' );
 }
 
+/**
+ * @global Exception $g_exception
+ */
 $g_exception = null;
 
 /**
  * Unhandled exception handler
  *
- * @param Exception|Error $p_exception The exception to handle
+ * @param \Mantis\Exceptions\MantisException|Exception|Error $p_exception The exception to handle
  * @return void
  */
 function error_exception_handler( $p_exception ) {

--- a/core/lang_api.php
+++ b/core/lang_api.php
@@ -263,9 +263,10 @@ function lang_get_current() {
  * This function will return one of (in order of preference):
  *  1. The string in the current user's preferred language (if defined)
  *  2. The string in English
+ * Note: when $p_string is 'MANTIS_ERROR', the return value is an array of error messages.
  * @param string $p_string The language string to retrieve.
  * @param string $p_lang   The language name.
- * @return string
+ * @return string|array
  */
 function lang_get( $p_string, $p_lang = null ) {
 	global $g_lang_strings;

--- a/css/default.css
+++ b/css/default.css
@@ -101,3 +101,7 @@ td.print-overdue    { font-weight: bold; }
 .resolved  {     
     text-decoration: line-through;
 }
+
+.error-details .code {
+	font-family: monospace;
+}


### PR DESCRIPTION
This PR includes several improvements to the "Detailed error page" (i.e. when $g_show_detailed_errors = ON)

- Fix HTML error causing page footer to be displayed behind the sidebar [#23926](https://mantisbt.org/bugs/view.php?id=23926)
- Stack trace should begin where error was triggered [#23944](https://mantisbt.org/bugs/view.php?id=23944)
- Improve page layout [#23943](https://mantisbt.org/bugs/view.php?id=23944)
- Remove error handler's "errcontext" parameter (deprecated in PHP 7.2) [#23942](https://mantisbt.org/bugs/view.php?id=23942)
- Minor tweaks (PHPDoc, generated HTML)
