### PR TITLE
Login page fixes

### DIFF
--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -100,7 +100,7 @@ function auth_flags( $p_user_id = null, $p_username = '' ) {
 	}
 
 	if( $t_user_id ) {
-		$t_username = user_get_name( $t_user_id );
+		$t_username = user_get_username( $t_user_id );
 		$t_email = user_get_email( $t_user_id );
 	} else {
 		$t_username = $p_username;

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -997,7 +997,8 @@ function user_get_name( $p_user_id ) {
  * @return bool true to show, false otherwise.
  */
 function user_show_realname() {
-	return access_has_project_level( config_get( 'show_user_realname_threshold', null, null, ALL_PROJECTS ) );
+	return auth_is_user_authenticated() &&
+	       access_has_project_level( config_get( 'show_user_realname_threshold', null, null, ALL_PROJECTS ) );
 }
 
 /**


### PR DESCRIPTION
This login page was broken when:
- Show realname is ON.
- Show realname threshold not NOBODY.
- Anonymous access is disabled.

This was caused by a combination of an old and a new bug.

OLD Issue
- [23960](https://mantisbt.org/bugs/view.php?id=23960) EVENT_AUTH_USER_FLAGS should always be passed username rather than name

NEW Issue
- [23958](https://mantisbt.org/bugs/view.php?id=23958) Login page broken


