### PR TITLE
Apply 'fa-tag' icon to Tag timeline events

### DIFF
--- a/core/classes/IssueTagTimelineEvent.class.php
+++ b/core/classes/IssueTagTimelineEvent.class.php
@@ -55,7 +55,7 @@ class IssueTagTimelineEvent extends TimelineEvent {
 		$t_string = $this->tag ? lang_get( 'timeline_issue_tagged' ) : lang_get( 'timeline_issue_untagged' );
 		$t_tag_row = tag_get_by_name( $this->tag_name );
 
-		$t_html = $this->html_start();
+		$t_html = $this->html_start( 'fa-tag' );
 		$t_html .= '<div class="action">'
 			. sprintf(
 				$t_string,


### PR DESCRIPTION
Fixes [#23961](https://mantisbt.org/bugs/view.php?id=23961)

## Before
![timeline-tag-before](https://user-images.githubusercontent.com/449891/36067737-b5643df6-0ec3-11e8-9929-dd595bef2cc6.png)

## After
![timeline-tag-after](https://user-images.githubusercontent.com/449891/36067738-ba58af86-0ec3-11e8-8733-1b871fd3ad60.png)
