### PR TITLE
Support languages Georgian, Luxembourgish, Persian and Zazaki

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -844,6 +844,7 @@ $g_language_choices_arr = array(
 	'finnish',
 	'french',
 	'galician',
+	'georgian',
 	'german',
 	'greek',
 	'hebrew',
@@ -855,10 +856,12 @@ $g_language_choices_arr = array(
 	'korean',
 	'latvian',
 	'lithuanian',
+	'luxembourgish',
 	'macedonian',
 	'norwegian_bokmal',
 	'norwegian_nynorsk',
 	'occitan',
+	'persian',
 	'polish',
 	'portuguese_brazil',
 	'portuguese_standard',
@@ -877,6 +880,7 @@ $g_language_choices_arr = array(
 	'urdu',
 	'vietnamese',
 	'volapuk',
+	'zazaki',
 );
 
 /**
@@ -900,6 +904,7 @@ $g_language_auto_map = array(
 	'nl-be, nl' => 'dutch',
 	'en-us, en-gb, en-au, en' => 'english',
 	'et' => 'estonian',
+	'fa' => 'persian',
 	'fi' => 'finnish',
 	'fr-ca, fr-be, fr-ch, fr' => 'french',
 	'gl' => 'galician',
@@ -912,8 +917,10 @@ $g_language_auto_map = array(
 	'ia' => 'interlingua',
 	'it-ch, it' => 'italian',
 	'ja' => 'japanese',
+	'ka' => 'georgian',
 	'ko' => 'korean',
 	'ksh' => 'ripoarisch',
+	'lb' => 'luxembourgish',
 	'lt' => 'lithuanian',
 	'lv' => 'latvian',
 	'mk' => 'macedonian',
@@ -935,6 +942,7 @@ $g_language_auto_map = array(
 	'uk' => 'ukrainian',
 	'vi' => 'vietnamese',
 	'vo' => 'volapuk',
+	'zza' => 'zazaki',
 );
 
 /**


### PR DESCRIPTION
Fixes #24020

I added just Georgian, Luxembourgish, Persian and Zazaki.

There are a lot more new language files provided by Translatewiki, but just a few plugin strings are translated, no translation of the Mantis Core. 
 
strings_bengali.txt
strings_bosnian.txt
strings_indonesian.txt
strings_laki.txt
strings_lezgi.txt
strings_lower_sorbian.txt
strings_malay.txt
strings_malayalam.txt
strings_mirandese.txt
strings_piedmontese.txt
strings_tachelhit.txt
strings_telugu.txt
strings_tunisian_arabic.txt
strings_upper_sorbian.txt