### PR TITLE
Notifications and EmailNotifications skeleton

### DIFF
--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -720,3 +720,6 @@ define( 'DB_TYPE_MYSQL', 1 );
 define( 'DB_TYPE_PGSQL', 2 );
 define( 'DB_TYPE_MSSQL', 3 );
 define( 'DB_TYPE_ORACLE', 4 );
+
+# Notification Types
+define( 'NOTIFICATION_TYPE_ISSUE_NOTE_ADDED', 'issue_note_added' );

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -970,18 +970,18 @@ function email_bugnote_add( $p_bugnote_id, $p_files = array(), $p_exclude_user_i
 
 	ignore_user_abort( true );
 
+	$t_notification_data = array(
+		'issue_note_id' => $p_bugnote_id,
+		'files' => $p_files
+	);
+
+	$t_notification = new IssueNoteAddedNotification( $t_data );
+
 	$t_bugnote = bugnote_get( $p_bugnote_id );
 
 	log_event( LOG_EMAIL, sprintf( 'Note ~%d added to issue #%d', $p_bugnote_id, $t_bugnote->bug_id ) );
 
 	$t_project_id = bug_get_field( $t_bugnote->bug_id, 'project_id' );
-	$t_separator = config_get( 'email_separator2' );
-	$t_time_tracking_access_threshold = config_get( 'time_tracking_view_threshold' );
-	$t_view_attachments_threshold = config_get( 'view_attachments_threshold' );
-	$t_message_id = 'email_notification_title_for_action_bugnote_submitted';
-
-	$t_subject = email_build_subject( $t_bugnote->bug_id );
-
 	$t_recipients = email_collect_recipients( $t_bugnote->bug_id, 'bugnote', /* extra_user_ids */ array(), $p_bugnote_id );
 	$t_recipients_verbose = array();
 
@@ -999,40 +999,9 @@ function email_bugnote_add( $p_bugnote_id, $p_files = array(), $p_exclude_user_i
 			continue;
 		}
 
-		log_event( LOG_EMAIL_VERBOSE, 'Issue = #%d, Note = ~%d, Type = %s, Msg = \'%s\', User = @U%d, Email = \'%s\'.',
-			$t_bugnote->bug_id, $p_bugnote_id, 'bugnote', $t_message_id, $t_user_id, $t_user_email );
-
-		# load (push) user language
-		lang_push( user_pref_get_language( $t_user_id, $t_project_id ) );
-
-		$t_message = lang_get( 'email_notification_title_for_action_bugnote_submitted' ) . "\n\n";
-
-		$t_show_time_tracking = access_has_bug_level( $t_time_tracking_access_threshold, $t_bugnote->bug_id, $t_user_id );
-		$t_formatted_note = email_format_bugnote( $t_bugnote, $t_project_id, $t_show_time_tracking, $t_separator );
-		$t_message .= trim( $t_formatted_note ) . "\n";
-		$t_message .= $t_separator . "\n";
-
-		# Files attached
-		if( count( $p_files ) > 0 &&
-			access_has_bug_level( $t_view_attachments_threshold, $t_bugnote->bug_id, $t_user_id ) ) {
-			$t_message .= lang_get( 'bugnote_attached_files' ) . "\n";
-
-			foreach( $p_files as $t_file ) {
-				$t_message .= '- ' . $t_file['name'] . ' (' . number_format( $t_file['size'] ) .
-					' ' . lang_get( 'bytes' ) . ")\n";
-			}
-
-			$t_message .= $t_separator . "\n";
-		}
-
-		$t_contents = $t_message . "\n";
-
-		email_store( $t_user_email, $t_subject, $t_contents );
-
-		log_event( LOG_EMAIL_VERBOSE, 'queued bugnote email for note ~' . $p_bugnote_id .
-			' issue #' . $t_bugnote->bug_id . ' by U' . $t_user_id );
-
-		lang_pop();
+		$t_email = new IssueNoteAddedEmail( $t_notification, $t_user_id );
+		$t_email_data = $t_email->getEmailData();
+		email_store_email_data( $t_email_data );
 	}
 
 	# Send emails out for users that select verbose notifications
@@ -1131,6 +1100,46 @@ function email_bug_deleted( $p_bug_id ) {
 }
 
 /**
+ * Get hostname sending out the emails.
+ * @return string host name.
+ */
+function email_get_hostname() {
+	$t_hostname = '';
+	if( isset( $_SERVER['SERVER_NAME'] ) ) {
+		$t_hostname = $_SERVER['SERVER_NAME'];
+	} else {
+		$t_address = explode( '@', config_get( 'from_email' ) );
+		if( isset( $t_address[1] ) ) {
+			$t_hostname = $t_address[1];
+		}
+	}
+
+	return $t_hostname;
+}
+
+/**
+ * Store email in queue for sending
+ *
+ * @param array $p_email_data The email data
+ * @return integer|null Email id or null if no email to be sent.
+ */
+function email_store_email_data( $p_email_data ) {
+	if( $p_email_data === null ) {
+		return null;
+	}
+
+	$t_email_id = email_queue_add( $p_email_data );
+
+	# Set the email processing flag for the shutdown function
+	$g_email_shutdown_processing |= EMAIL_SHUTDOWN_GENERATED;
+	if( $p_force ) {
+		$g_email_shutdown_processing |= EMAIL_SHUTDOWN_FORCE;
+	}
+
+	return $t_email_id;
+}
+
+/**
  * Store email in queue for sending
  *
  * @param string  $p_recipient Email recipient address.
@@ -1139,7 +1148,7 @@ function email_bug_deleted( $p_bug_id ) {
  * @param array   $p_headers   Array of additional headers to send with the email.
  * @param boolean $p_force     True to force sending of emails in shutdown function,
  *                             even when using cronjob
- * @return integer|null
+ * @return integer|null Email id or null if no email to be sent.
  */
 function email_store( $p_recipient, $p_subject, $p_message, array $p_headers = null, $p_force = false ) {
 	global $g_email_shutdown_processing;
@@ -1159,32 +1168,13 @@ function email_store( $p_recipient, $p_subject, $p_message, array $p_headers = n
 	$t_email_data->email = $t_recipient;
 	$t_email_data->subject = $t_subject;
 	$t_email_data->body = $t_message;
-	$t_email_data->metadata = array();
-	$t_email_data->metadata['headers'] = $p_headers === null ? array() : $p_headers;
 
-	# Urgent = 1, Not Urgent = 5, Disable = 0
-	$t_email_data->metadata['charset'] = 'utf-8';
+	$t_email_data->metadata = array(
+		'headers' => $p_headers === null ? array() : $p_headers,
+		'charset' => 'utf-8'
+	);
 
-	$t_hostname = '';
-	if( isset( $_SERVER['SERVER_NAME'] ) ) {
-		$t_hostname = $_SERVER['SERVER_NAME'];
-	} else {
-		$t_address = explode( '@', config_get( 'from_email' ) );
-		if( isset( $t_address[1] ) ) {
-			$t_hostname = $t_address[1];
-		}
-	}
-	$t_email_data->metadata['hostname'] = $t_hostname;
-
-	$t_email_id = email_queue_add( $t_email_data );
-
-	# Set the email processing flag for the shutdown function
-	$g_email_shutdown_processing |= EMAIL_SHUTDOWN_GENERATED;
-	if( $p_force ) {
-		$g_email_shutdown_processing |= EMAIL_SHUTDOWN_FORCE;
-	}
-
-	return $t_email_id;
+	return email_store_email_data( $t_email_data );
 }
 
 /**
@@ -1261,9 +1251,7 @@ function email_send( EmailData $p_email_data ) {
 		$t_mail = $g_phpMailer;
 	}
 
-	if( isset( $t_email_data->metadata['hostname'] ) ) {
-		$t_mail->Hostname = $t_email_data->metadata['hostname'];
-	}
+	$t_mail->Hostname = email_get_hostname();
 
 	# @@@ should this be the current language (for the recipient) or the default one (for the user running the command) (thraxisp)
 	$t_lang = config_get_global( 'default_language' );
@@ -1317,6 +1305,7 @@ function email_send( EmailData $p_email_data ) {
 		$t_mail->DKIM_identity = config_get( 'email_dkim_identity' );
 	}
 
+	# TODO: handle notifications can generate HTML emails
 	$t_mail->IsHTML( false );              # set email format to plain text
 	$t_mail->WordWrap = 80;              # set word wrap to 80 characters
 	$t_mail->CharSet = $t_email_data->metadata['charset'];

--- a/core/emails/Email.php
+++ b/core/emails/Email.php
@@ -1,0 +1,93 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Mantis\Emails;
+
+/**
+ * A base class for for email notifications.  An Email instance corresponds to a
+ * single email.  Hence, a single notification may trigger creation of N Email instances
+ * and hence N emails.
+ */
+abstract class Email {
+	protected $notification;
+	protected $target_user_id;
+
+	/**
+	 * Command constructor taking in all required data to execute the command.
+	 *
+	 * @param array $p_notification The notification that triggered the email.
+	 * @param int $p_target_user_id The target user id for the notification.
+	 */
+	function __construct( $p_notification, $p_target_user_id ) {
+		$this->notification = $p_notification;
+		$this->target_user_id = $p_target_user_id;
+	}
+
+	/**
+	 * @return array Array with key as header names and values as header values
+	 */
+	protected function generatedHeaders() {
+		return array();
+	}
+
+	/**
+	 * @returns string subject for email.
+	 */
+	abstract protected function generateSubject();
+
+	/**
+	 * @returns string The text version of the email or null.
+	 */
+	abstract protected function generateTextBody();
+
+	/**
+	 * @returns string The html version of the email or null.
+	 */
+	abstract protected function generateHtmlBody();
+
+	public function getEmailData() {
+		if( OFF == config_get( 'enable_email_notification' ) ) {
+			return null;
+		}
+
+		$t_email = user_get_email( $this->target_user_id );
+		if( is_blank( $t_email ) ) {
+			return null;
+		}
+
+		$t_headers = $this->generateHeaders();
+		if( !is_array( $t_headers ) ) {
+			$t_headers = array();
+		}
+
+		$t_metadata = array(
+			'headers' => $t_headers,
+			'charset' => 'utf-8',
+		);
+
+		lang_push( user_pref_get_language( $this->target_user_id ) );
+
+		$t_email_data = new EmailData;
+		$t_email_data->email = $t_email;
+		$t_email_data->subject = trim( $this->generateSubject() );
+		$t_email_data->body = trim( $this->generateTextBody() );
+		$t_email_data->metadata = $t_metadata;
+
+		lang_pop();
+
+		return $t_email_data;
+	}
+}

--- a/core/emails/IssueNoteAddedEmail.php
+++ b/core/emails/IssueNoteAddedEmail.php
@@ -1,0 +1,95 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Mantis\Notifications;
+
+/**
+ * Email for issue note added notification.
+ */
+class IssueNoteAddedEmail extends Email {
+	private $note;
+
+	/**
+	 * Command constructor taking in all required data to execute the command.
+	 *
+	 * @param string $p_notification_type The notification type
+	 * @param array $p_data The command data.
+	 */
+	function __construct( $p_notification, $p_target_user_id ) {
+		parent::__construct( $p_notification, $p_target_user_id );
+
+		$t_issue_note_id = $this->payload( 'issue_note_id' );
+		$this->note = bugnote_get( $p_bugnote_id );
+
+	}
+
+	function generateSubject() {
+		return email_build_subject( $this->note->bug_id );
+	}
+
+	function generateTextBody() {
+		$t_user_id = $this->target_user_id;
+		$t_bugnote = $this->note;
+
+		$t_user_email = user_get_email( $t_user_id );
+		if( is_blank( $t_user_email ) ) {
+			# TODO: log that user skipped because email is empty
+			return null;
+		}
+
+		$t_project_id = bug_get_field( $t_bugnote->bug_id, 'project_id' );
+		$t_separator = config_get( 'email_separator2' );
+		$t_time_tracking_access_threshold = config_get( 'time_tracking_view_threshold' );
+		$t_view_attachments_threshold = config_get( 'view_attachments_threshold' );
+		$t_message_id = 'email_notification_title_for_action_bugnote_submitted';
+		$t_verbose = config_get( 'email_notifications_verbose', /* default */ null, $t_user_id, $t_project_id ) == ON;
+
+		log_event( LOG_EMAIL_VERBOSE, 'Issue = #%d, Note = ~%d, Type = %s, Msg = \'%s\', User = @U%d, Email = \'%s\'.',
+			$t_bugnote->bug_id, $t_bugnote->id, 'bugnote', $t_message_id, $t_user_id, $t_user_email );
+
+		$t_message = lang_get( 'email_notification_title_for_action_bugnote_submitted' ) . "\n\n";
+
+		$t_show_time_tracking = access_has_bug_level( $t_time_tracking_access_threshold, $t_bugnote->bug_id, $t_user_id );
+		$t_formatted_note = email_format_bugnote( $t_bugnote, $t_project_id, $t_show_time_tracking, $t_separator );
+		$t_message .= trim( $t_formatted_note ) . "\n";
+		$t_message .= $t_separator . "\n";
+
+		# Files attached
+		$t_files = $this->notification->payload( 'files', array() );
+		if( count( $t_files ) > 0 &&
+			access_has_bug_level( $t_view_attachments_threshold, $t_bugnote->bug_id, $t_user_id ) ) {
+			$t_message .= lang_get( 'bugnote_attached_files' ) . "\n";
+
+			foreach( $t_files as $t_file ) {
+				$t_message .= '- ' . $t_file['name'] . ' (' . number_format( $t_file['size'] ) .
+					' ' . lang_get( 'bytes' ) . ")\n";
+			}
+
+			$t_message .= $t_separator . "\n";
+		}
+
+		$t_contents = $t_message . "\n";
+
+		log_event( LOG_EMAIL_VERBOSE, 'queued bugnote email for note ~' . $p_bugnote_id .
+			' issue #' . $t_bugnote->bug_id . ' by U' . $t_user_id );
+
+		return $t_contents;
+	}
+
+	protected function generateHtmlEmail() {
+		return null;
+	}
+}

--- a/core/notifications/IssueNoteAddedNotification.php
+++ b/core/notifications/IssueNoteAddedNotification.php
@@ -1,0 +1,32 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Mantis\Notifications;
+
+/**
+ * A base class for notifications.
+ */
+class IssueNoteAddedNotification extends Notification {
+	/**
+	 * Command constructor taking in all required data to execute the command.
+	 *
+	 * @param string $p_notification_type The notification type
+	 * @param array $p_data The command data.
+	 */
+	function __construct( array $p_data ) {
+		parent::__construct( $p_data, NOTIFICATION_TYPE_ISSUE_NOTE_ADDED );
+	}
+}

--- a/core/notifications/Notification.php
+++ b/core/notifications/Notification.php
@@ -1,0 +1,66 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Mantis\Notifications;
+
+/**
+ * A base class for notifications.
+ */
+abstract class Notification
+{
+	protected $type;
+
+	/**
+	 * This is the data for the notification.
+	 * @var array The input data for the command.
+	 */
+	protected $data;
+
+	/**
+	 * Command constructor taking in all required data to execute the command.
+	 *
+	 * @param array $p_data The command data.
+	 * @param string $p_type The notification type
+	 */
+	function __construct( array $p_data, $p_type ) {
+		$this->data = $p_data;
+		$this->type = $p_type;
+	}
+
+	public function getType() {
+		return $this->type;
+	}
+
+	public function getData() {
+		return $this->data;
+	}
+
+	/**
+	 * Gets the value of a payload field or its default.
+	 *
+	 * @param string $p_name The field name.
+	 * @param mixed  $p_default The default value.
+	 *
+	 * @return mixed The payload field value or its default.
+	 */
+	public function payload( $p_name, $p_default = null ) {
+		if( isset( $this->data[$p_name] ) ) {
+			return $this->data[$p_name];
+		}
+
+		return $p_default;
+	}
+}


### PR DESCRIPTION
This is not a functioning code but a proposal for starting to clean up notifications.

- Notifications - These are classes that capture information about a change that should trigger notifications like email notifications and possibly others in the future (e.g. plugin notifications).  A notification is a single logical change that can trigger N emails, a slack notification, etc.

- Dispatching - Once a notification is triggered, the first step is to determine who should receive the notification.  In the current change it is the N users that should be notified via email.  This is currently done implicitly in an email_(change_type)().  In the future, we may refactor to have some dispatcher.

- Email Generation - The class that should handle a specific notification type for a single target user.  The notification derived class would generate the subject, meta-data, text body, html body and produce an EmailData class.

- Email APIs - The email API would handle queuing of email and sending of emails based on EmailData.

Let me know your feedback.