### PR TITLE
Fixed case-sensitive LDAP attributes names

### DIFF
--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -218,7 +218,6 @@ function ldap_escape_string( $p_string ) {
  * @return string The field value or null if not found.
  */
 function ldap_get_field_from_username( $p_username, $p_field ) {
-	$p_field = strtolower( $p_field );
 	$t_ldap_organization    = config_get( 'ldap_organization' );
 	$t_ldap_root_dn         = config_get( 'ldap_root_dn' );
 	$t_ldap_uid_field		= config_get( 'ldap_uid_field' );
@@ -268,8 +267,9 @@ function ldap_get_field_from_username( $p_username, $p_field ) {
 	}
 
 	# Make sure the requested field exists
-	if( is_array( $t_info[0] ) && array_key_exists( $p_field, $t_info[0] ) ) {
-		$t_value = $t_info[0][$p_field][0];
+	$t_field_lowercase = strtolower( $p_field );
+	if( is_array( $t_info[0] ) && array_key_exists( $t_field_lowercase, $t_info[0] ) ) {
+		$t_value = $t_info[0][$t_field_lowercase][0];
 		log_event( LOG_LDAP, 'Found value \'' . $t_value . '\' for field \'' . $p_field . '\'.' );
 	} else {
 		log_event( LOG_LDAP, 'WARNING: field \'' . $p_field . '\' does not exist' );

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -218,6 +218,7 @@ function ldap_escape_string( $p_string ) {
  * @return string The field value or null if not found.
  */
 function ldap_get_field_from_username( $p_username, $p_field ) {
+	$p_field = strtolower( $p_field );
 	$t_ldap_organization    = config_get( 'ldap_organization' );
 	$t_ldap_root_dn         = config_get( 'ldap_root_dn' );
 	$t_ldap_uid_field		= config_get( 'ldap_uid_field' );


### PR DESCRIPTION
A **ldap_get_entries()** function returns attribute names as lowercase keys so next call of **array_key_exists()** fails because of it performs a case-sensitive comparison. For example if a **$g_ldap_realname_field** option is set to '_givenName_' (a well-known LDAP attribute display name) then it finds nothing.