### PR TITLE
Enabled an independent using of LDAP user name and email

### DIFF
--- a/account_page.php
+++ b/account_page.php
@@ -95,11 +95,10 @@ $t_row = user_get_row( auth_get_current_user_id() );
 
 extract( $t_row, EXTR_PREFIX_ALL, 'u' );
 
-$t_ldap = ( LDAP == config_get_global( 'login_method' ) );
-
 # In case we're using LDAP to get the email address... this will pull out
 #  that version instead of the one in the DB
 $u_email = user_get_email( $u_id );
+$u_realname = user_get_realname( $u_id );
 
 # If the password is the default password, then prompt user to change it.
 $t_reset_password = $u_username == 'administrator' && auth_does_password_match( $u_id, 'root' );
@@ -219,7 +218,7 @@ print_account_menu( 'account_page.php' );
 				</td>
 				<td>
 				<?php
-				if( $t_ldap && ON == config_get( 'use_ldap_email' ) ) {
+				if( ON == config_get( 'use_ldap_email' ) ) {
 					# With LDAP
 					echo string_display_line( $u_email );
 				} else {
@@ -230,11 +229,11 @@ print_account_menu( 'account_page.php' );
 				</td>
 			</tr>
 			<tr><?php
-				if( $t_ldap && ON == config_get( 'use_ldap_realname' ) ) {
+				if( ON == config_get( 'use_ldap_realname' ) ) {
 					# With LDAP
 					echo '<td class="category">' . lang_get( 'realname' ) . '</td>';
 					echo '<td>';
-					echo string_display_line( ldap_realname_from_username( $u_username ) );
+					echo string_display_line( $u_realname );
 					echo '</td>';
 				} else {
 					# Without LDAP

--- a/account_update.php
+++ b/account_update.php
@@ -96,11 +96,9 @@ if( $t_account_verification && is_blank( $f_password ) ) {
 	trigger_error( ERROR_EMPTY_FIELD, ERROR );
 }
 
-$t_ldap = ( LDAP == config_get_global( 'login_method' ) );
-
 # Update email (but only if LDAP isn't being used)
 # Do not update email for a user verification
-if( !( $t_ldap && config_get( 'use_ldap_email' ) )
+if( !( ON == config_get( 'use_ldap_email' ) )
 	&& !$t_account_verification ) {
 	if( !is_blank( $f_email ) && $f_email != user_get_email( $t_user_id ) ) {
 		$t_update_email = true;
@@ -108,7 +106,7 @@ if( !( $t_ldap && config_get( 'use_ldap_email' ) )
 }
 
 # Update real name (but only if LDAP isn't being used)
-if( !( $t_ldap && config_get( 'use_ldap_realname' ) ) ) {
+if( !( ON == config_get( 'use_ldap_realname' ) ) ) {
 	# strip extra spaces from real name
 	$t_realname = string_normalize( $f_realname );
 	if( $t_realname != user_get_field( $t_user_id, 'realname' ) ) {

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1005,7 +1005,7 @@ function user_get_field( $p_user_id, $p_field_name ) {
  */
 function user_get_email( $p_user_id ) {
 	$t_email = '';
-	if( LDAP == config_get_global( 'login_method' ) && ON == config_get( 'use_ldap_email' ) ) {
+	if( ON == config_get( 'use_ldap_email' ) ) {
 		$t_email = ldap_email( $p_user_id );
 	}
 	if( is_blank( $t_email ) ) {
@@ -1033,7 +1033,7 @@ function user_get_username( $p_user_id ) {
 function user_get_realname( $p_user_id ) {
 	$t_realname = '';
 
-	if( LDAP == config_get_global( 'login_method' ) && ON == config_get( 'use_ldap_realname' ) ) {
+	if( ON == config_get( 'use_ldap_realname' ) ) {
 		$t_realname = ldap_realname( $p_user_id );
 	}
 

--- a/manage_user_create_page.php
+++ b/manage_user_create_page.php
@@ -49,8 +49,6 @@ auth_reauthenticate();
 
 access_ensure_global_level( config_get( 'manage_user_threshold' ) );
 
-$t_ldap = ( LDAP == config_get_global( 'login_method' ) );
-
 layout_page_header();
 
 layout_page_begin( 'manage_overview_page.php' );
@@ -83,7 +81,7 @@ print_manage_menu( 'manage_user_create_page.php' );
 					<input type="text" id="user-username" name="username" class="input-sm" size="32" maxlength="<?php echo DB_FIELD_SIZE_USERNAME;?>" />
 				</td>
 			</tr><?php
-			if( !$t_ldap || config_get( 'use_ldap_realname' ) == OFF ) { ?>
+			if( !( ON == config_get( 'use_ldap_realname' ) ) ) { ?>
 			<tr>
 				<td class="category">
 					<?php echo lang_get( 'realname' ) ?>
@@ -93,7 +91,7 @@ print_manage_menu( 'manage_user_create_page.php' );
 				</td>
 			</tr><?php
 			}
-			if( !$t_ldap || config_get( 'use_ldap_email' ) == OFF ) { ?>
+			if( !( ON == config_get( 'use_ldap_email' ) ) ) { ?>
 			<tr>
 				<td class="category">
 					<?php echo lang_get( 'email' ) ?>

--- a/manage_user_edit_page.php
+++ b/manage_user_edit_page.php
@@ -85,8 +85,6 @@ $t_user = user_get_row( $t_user_id );
 # current user.
 access_ensure_global_level( $t_user['access_level'] );
 
-$t_ldap = ( LDAP == config_get_global( 'login_method' ) );
-
 layout_page_header();
 
 layout_page_begin( 'manage_overview_page.php' );
@@ -129,7 +127,7 @@ print_manage_menu( 'manage_user_page.php' );
 
 			<!-- Realname -->
 			<tr><?php
-			if( $t_ldap && ON == config_get( 'use_ldap_realname' ) ) {
+			if( ON == config_get( 'use_ldap_realname' ) ) {
 				# With LDAP
 				echo '<td class="category">' . lang_get( 'realname_label' ) . '</td>';
 				echo '<td>';
@@ -144,7 +142,7 @@ print_manage_menu( 'manage_user_page.php' );
 			</tr>
 			<!-- Email -->
 			<tr><?php
-			if( $t_ldap && ON == config_get( 'use_ldap_email' ) ) {
+			if( ON == config_get( 'use_ldap_email' ) ) {
 				# With LDAP
 				echo '<td class="category">' . lang_get( 'email_label' ) . '</td>';
 				echo '<td>' . string_display_line( user_get_email( $t_user_id ) ) . '</td>';

--- a/manage_user_update.php
+++ b/manage_user_update.php
@@ -104,9 +104,7 @@ if( 0 != strcasecmp( $t_old_username, $f_username )
 
 user_ensure_name_valid( $f_username );
 
-$t_ldap = ( LDAP == config_get_global( 'login_method' ) );
-
-if( $t_ldap && config_get( 'use_ldap_realname' ) ) {
+if( ON == config_get( 'use_ldap_realname' ) ) {
 	$t_realname = ldap_realname_from_username( $f_username );
 } else {
 	# strip extra space from real name
@@ -114,7 +112,7 @@ if( $t_ldap && config_get( 'use_ldap_realname' ) ) {
 	user_ensure_realname_unique( $t_old_username, $t_realname );
 }
 
-if( $t_ldap && config_get( 'use_ldap_email' ) ) {
+if( ON == config_get( 'use_ldap_email' ) ) {
 	$t_email = ldap_email( $f_user_id );
 } else {
 	$t_email = trim( $f_email );


### PR DESCRIPTION
Real name and email are now independent from LDAP authentication i.e. when **$g_login_method != LDAP**. It's very useful when no LDAP authentication used but used a web-server authentication (IIS for example) instead with Active Directory.