### PR TITLE
Truncate values before writing to database history table

### DIFF
--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -604,6 +604,7 @@ define( 'DB_FIELD_SIZE_USERNAME', 191 );
 define( 'DB_FIELD_SIZE_REALNAME', 255 );
 define( 'DB_FIELD_SIZE_PASSWORD', 64 );
 define( 'DB_FIELD_SIZE_API_TOKEN_NAME', 128 );
+define( 'DB_FIELD_SIZE_HISTORY_VALUE', 255 );
 
 # Maximum size for the user's password when storing it as a hash
 define( 'PASSWORD_MAX_SIZE_BEFORE_HASH', 1024 );

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -82,7 +82,11 @@ function history_log_event_direct( $p_bug_id, $p_field_name, $p_old_value, $p_ne
 
 		$c_field_name = $p_field_name;
 		$c_old_value = ( is_null( $p_old_value ) ? '' : (string)$p_old_value );
-		$c_new_value = ( is_null( $p_new_value ) ? '' : (string)$p_new_value );
+		if( is_null( $p_new_value ) ) {
+			$c_new_value = '';
+		} else {
+			$c_new_value = mb_strimwidth( $p_new_value, 0, DB_FIELD_SIZE_HISTORY_VALUE, '...' );
+		}
 
 		db_param_push();
 		$t_query = 'INSERT INTO {bug_history}
@@ -123,6 +127,8 @@ function history_log_event_special( $p_bug_id, $p_type, $p_old_value = '', $p_ne
 	}
 	if( is_null( $p_new_value ) ) {
 		$p_new_value = '';
+	} else {
+		$p_new_value = mb_strimwidth( $p_new_value, 0, DB_FIELD_SIZE_HISTORY_VALUE, '...' );
 	}
 
 	db_param_push();


### PR DESCRIPTION
TEXTAREA custom fields can contain more than 255 characters.
Changing such fields fails, as the new value can't be stored
in history table.

This change fixes the issue by truncating the string.
See #24056 for other options to fix it.

Fixes #24056