### PR TITLE
Filter related fixes after PR1091

### DIFF
--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1603,7 +1603,7 @@ function print_page_links( $p_page, $p_start, $p_end, $p_current, $p_temp_filter
 		} else {
 			$t_delimiter = ( strpos( $p_page, '?' ) ? '&' : '?' ) ;
 			$t_filter_param = filter_get_temporary_key_param( $p_temp_filter_key );
-			$t_filter_param .= $t_filter_param === null ? : '&amp;';
+			$t_filter_param .= $t_filter_param === null ? '' : '&amp;';
 			array_push( $t_items, '<li class="pull-right"><a href="' . $p_page . $t_delimiter . $t_filter_param . 'page_number=' . $i . '">' . $i . '</a></li>' );
 		}
 	}

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1459,6 +1459,13 @@ function user_get_bug_filter( $p_user_id, $p_project_id = null ) {
 
 	# Currently we use the filters saved in db as "current" special filters,
 	# to track the active settings for filters in use.
+
+	# for anonymous user, we don't allow using persistent filter
+	# if this function is reached, we return a default filter for it.
+	if( user_is_anonymous( $p_user_id ) ) {
+		return filter_get_default();
+	}
+
 	$t_filter_id = filter_db_get_project_current( $t_project_id, $p_user_id );
 	if( $t_filter_id ) {
 		return filter_get( $t_filter_id );


### PR DESCRIPTION
Fixes two problems:
1) Pagination links in view_all_bug_page are sometimes corrupted
2) For anonymous login, view_all_bug_page still loads the stored filter for that user, which is not useful now that his filters can't be persisted. The listing should start with a clean filter.

I haven't opened bug ids, since this is not in a released version, not useful to appear as changelog, etc?