### PR TITLE
Support default description

### DIFF
--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -174,7 +174,7 @@ if( $f_master_bug_id > 0 ) {
 	$f_severity				= gpc_get_int( 'severity', (int)config_get( 'default_bug_severity' ) );
 	$f_priority				= gpc_get_int( 'priority', (int)config_get( 'default_bug_priority' ) );
 	$f_summary				= gpc_get_string( 'summary', '' );
-	$f_description			= gpc_get_string( 'description', '' );
+	$f_description			= gpc_get_string( 'description', config_get( 'default_bug_description' ) );
 	$f_steps_to_reproduce	= gpc_get_string( 'steps_to_reproduce', config_get( 'default_bug_steps_to_reproduce' ) );
 	$f_additional_info		= gpc_get_string( 'additional_info', config_get( 'default_bug_additional_info' ) );
 	$f_view_state			= gpc_get_int( 'view_state', (int)config_get( 'default_bug_view_status' ) );

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -1407,6 +1407,13 @@ $g_default_project_view_status = VS_PUBLIC;
 $g_default_bug_view_status = VS_PUBLIC;
 
 /**
+ * Default value for bug description field used on bug report page.
+ *
+ * @global string $g_default_bug_description
+ */
+ $g_default_bug_description = '';
+ 
+/**
  * Default value for steps to reproduce field.
  * @global string $g_default_bug_steps_to_reproduce
  */
@@ -4437,6 +4444,7 @@ $g_public_config_names = array(
 	'date_partitions',
 	'datetime_picker_format',
 	'default_bug_additional_info',
+	'default_bug_description',
 	'default_bug_eta',
 	'default_bug_priority',
 	'default_bug_projection',

--- a/docbook/Admin_Guide/en-US/config/defaults.xml
+++ b/docbook/Admin_Guide/en-US/config/defaults.xml
@@ -33,6 +33,15 @@
 			</listitem>
 		</varlistentry>
 		<varlistentry>
+			<term>$g_default_bug_steps_to_reproduce</term>
+			<listitem>
+				<para>
+				Default value for bug steps to reproduce field used on bug report page.
+				Default is empty.
+				</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
 			<term>$g_default_bug_view_status</term>
 			<listitem>
 				<para>The default viewing status for the new bug (VS_PUBLIC or

--- a/docbook/Admin_Guide/en-US/config/defaults.xml
+++ b/docbook/Admin_Guide/en-US/config/defaults.xml
@@ -33,6 +33,15 @@
 			</listitem>
 		</varlistentry>
 		<varlistentry>
+			<term>$g_default_bug_additional_info</term>
+			<listitem>
+				<para>
+				Default value for bug additional info field used on bug report page.
+				Default is empty.
+				</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
 			<term>$g_default_bug_steps_to_reproduce</term>
 			<listitem>
 				<para>

--- a/docbook/Admin_Guide/en-US/config/defaults.xml
+++ b/docbook/Admin_Guide/en-US/config/defaults.xml
@@ -24,6 +24,15 @@
 			</listitem>
 		</varlistentry>
 		<varlistentry>
+			<term>$g_default_bug_description</term>
+			<listitem>
+				<para>
+				Default value for bug description field used on bug report page.
+				Default is empty description.
+				</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
 			<term>$g_default_bug_view_status</term>
 			<listitem>
 				<para>The default viewing status for the new bug (VS_PUBLIC or


### PR DESCRIPTION
Fixes the following 3 issues:

- [24158](https://mantisbt.org/bugs/view.php?id=24158): Support providing a default value for issue description
- [24159](https://mantisbt.org/bugs/view.php?id=24159): $g_default_bug_steps_to_reproduce not documented
- [24160](https://mantisbt.org/bugs/view.php?id=24160): $g_default_bug_additional_info not documented

See also [related discussion](https://github.com/mantisbt-plugins/Announce/issues/32).