### PR TITLE
Fix rendering of @ mentions

### DIFF
--- a/plugins/MantisCoreFormatting/MantisCoreFormatting.php
+++ b/plugins/MantisCoreFormatting/MantisCoreFormatting.php
@@ -178,8 +178,6 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 			$t_string = $this->processBugAndNoteLinks( $t_string );
 		}
 
-		$t_string = mention_format_text( $t_string, /* html */ true );
-
 		# Process Markdown
 		if( ON == $s_markdown ) {
 			if( $p_multiline ) {
@@ -188,6 +186,8 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 				$t_string = MantisMarkdown::convert_line( $t_string );
 			}
 		}
+
+		$t_string = mention_format_text( $t_string, /* html */ true );
 
 		return $t_string;
 	}


### PR DESCRIPTION
Fixes #24201

I am not complete sure if this the right approach to fix it.
I just moved the @ mention processing  after the markdown procession as `setSafeMode` of  Parsedown destroyed our @ mention links.