### PR TITLE
Use rgb color values for Markdown quote styling

### DIFF
--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -169,7 +169,7 @@ class MantisMarkdown extends Parsedown
 
 		if( $block = call_user_func( 'parent::' . $fn, $line, $block ) ) {
 			# TODO: To open another issue to track css style sheet issue vs. inline style.
-			$block['element']['attributes']['style'] = 'padding:0.13em 1em;color:#777;border-left:0.25em solid #C0C0C0;font-size:13px;';
+			$block['element']['attributes']['style'] = 'padding:0.13em 1em;color:rgb(119,119,119);border-left:0.25em solid #C0C0C0;font-size:13px;';
 		}
 
 		return $block;


### PR DESCRIPTION
Workaround as using hex values for colors starting with # introduces
unwanted side effects.

Fixes #24233

Let's fix this one now independant from the other conceptual Markdown issues, as we don't know at the moment how (maybe have to wait for new Parsedown version) and when the other issues can be fixed. 