### PR TITLE
WIP: Fix Markdown rendering issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "vboctor/disposable_email_checker": "^3.0",
         "adodb/adodb-php": "^5.20",
         "phpmailer/phpmailer": "~6.0",
-        "erusev/parsedown": "^1.7.0",
+        "erusev/parsedown": "^1.8.0@beta",
         "dapphp/securimage": "dev-mantis"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab2f6276fa9fa1610339ae5bf7a24f22",
+    "content-hash": "c5fca8741c36776451f9f1a242c082be",
     "packages": [
         {
             "name": "adodb/adodb-php",
@@ -142,16 +142,16 @@
         },
         {
             "name": "erusev/parsedown",
-            "version": "1.7.3",
+            "version": "1.8.0-beta-7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/erusev/parsedown.git",
-                "reference": "6d893938171a817f4e9bc9e86f2da1e370b7bcd7"
+                "reference": "fe7a50eceb4a3c867cc9fa9c0aa906b1067d1955"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown/zipball/6d893938171a817f4e9bc9e86f2da1e370b7bcd7",
-                "reference": "6d893938171a817f4e9bc9e86f2da1e370b7bcd7",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/fe7a50eceb4a3c867cc9fa9c0aa906b1067d1955",
+                "reference": "fe7a50eceb4a3c867cc9fa9c0aa906b1067d1955",
                 "shasum": ""
             },
             "require": {
@@ -184,7 +184,7 @@
                 "markdown",
                 "parser"
             ],
-            "time": "2019-03-17T18:48:37+00:00"
+            "time": "2019-03-17T18:47:21+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1962,6 +1962,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "erusev/parsedown": 10,
         "dapphp/securimage": 20
     },
     "prefer-stable": false,

--- a/core/classes/Avatar.class.php
+++ b/core/classes/Avatar.class.php
@@ -97,8 +97,7 @@ class Avatar
 
         if( $this->link === null ) {
             if ( $p_user_exists ) {
-                $this->link = config_get_global( 'path' ) .
-                    'view_user_page.php?id=' . $p_user_id;
+                $this->link = user_get_page_url( $p_user_id );
             } else {
                 $this->link = '';
             }

--- a/core/mention_api.php
+++ b/core/mention_api.php
@@ -151,18 +151,11 @@ function mention_format_text( $p_text, $p_html = true ) {
 
 	foreach( $t_mentioned_users as $t_username => $t_user_id  ) {
 		$t_mention = $t_mentions_tag . $t_username;
-		$t_mention_formatted = $t_mention;
 
 		if( $p_html ) {
-			$t_mention_formatted = string_display_line( $t_mention_formatted );
-
-			$t_mention_formatted = '<a href="' . user_get_page_url( $t_user_id ) . '">' . $t_mention_formatted . '</a>';
-
-			if( !user_is_enabled( $t_user_id ) ) {
-				$t_mention_formatted = '<s>' . $t_mention_formatted . '</s>';
-			}
-
-			$t_mention_formatted = '<span class="mention">' . $t_mention_formatted . '</span>';
+			$t_mention_formatted = '<span class="mention">' . prepare_user_name( $t_user_id, $t_mentions_tag ) . '</span>';
+		} else {
+			$t_mention_formatted = $t_mention;
 		}
 
 		$t_formatted_mentions[$t_mention] = $t_mention_formatted;

--- a/core/mention_api.php
+++ b/core/mention_api.php
@@ -156,7 +156,7 @@ function mention_format_text( $p_text, $p_html = true ) {
 		if( $p_html ) {
 			$t_mention_formatted = string_display_line( $t_mention_formatted );
 
-			$t_mention_formatted = '<a href="' . string_sanitize_url( 'view_user_page.php?id=' . $t_user_id, true ) . '">' . $t_mention_formatted . '</a>';
+			$t_mention_formatted = '<a href="' . user_get_page_url( $t_user_id ) . '">' . $t_mention_formatted . '</a>';
 
 			if( !user_is_enabled( $t_user_id ) ) {
 				$t_mention_formatted = '<s>' . $t_mention_formatted . '</s>';

--- a/core/mention_api.php
+++ b/core/mention_api.php
@@ -73,7 +73,10 @@ function mention_get_candidates( $p_text ) {
 			# Negative lookbehind  to ensure we don't match multiple tags
 			. '(?<!' . $t_quoted_tag . ')' . $t_quoted_tag
 			. ')'
+			# This is the main username matching pattern:
 			# any word char, dash or period, must end with word char
+			# It must be consistent and kept in sync with the one defined in
+			# MantisMarkdown class
 			. '([\w\-.]*[\w])'
 			# Lookforward to ensure next char is not a valid mention char or
 			# the end of the string, or the mention tag

--- a/core/prepare_api.php
+++ b/core/prepare_api.php
@@ -85,7 +85,7 @@ function prepare_user_name( $p_user_id, $p_link = true ) {
 
 	if( user_exists( $p_user_id ) && user_get_field( $p_user_id, 'enabled' ) ) {
 		if( $p_link ) {
-			return '<a ' . $t_tooltip . ' href="' . string_sanitize_url( 'view_user_page.php?id=' . $p_user_id, true ) . '">' . $t_name . '</a>';
+			return '<a ' . $t_tooltip . ' href="' . user_get_page_url( $p_user_id ) . '">' . $t_name . '</a>';
 		} else {
 			return '<span ' . $t_tooltip . '>' . $t_name . '</span>';
 		}

--- a/core/prepare_api.php
+++ b/core/prepare_api.php
@@ -87,13 +87,17 @@ function prepare_user_name( $p_user_id, $p_link = true, $p_prefix = '' ) {
 	$t_display = $p_prefix . $t_name;
 	if( user_exists( $p_user_id ) && user_get_field( $p_user_id, 'enabled' ) ) {
 		if( $p_link ) {
-			return '<a ' . $t_tooltip . ' href="' . user_get_page_url( $p_user_id ) . '">' . $t_display . '</a>';
+			$t_display = '<a ' . $t_tooltip . ' href="' . user_get_page_url( $p_user_id ) . '">' . $t_display . '</a>';
 		} else {
-			return '<span ' . $t_tooltip . '>' . $t_display . '</span>';
+			$t_display = '<span ' . $t_tooltip . '>' . $t_display . '</span>';
 		}
+		if( !user_is_enabled( $p_user_id ) ) {
+			$t_display = '<del>' . $t_display . '</del>';
+		}
+		
 	}
 
-	return '<del ' . $t_tooltip . '>' . $t_display . '</del>';
+	return $t_display;
 }
 
 /**

--- a/core/prepare_api.php
+++ b/core/prepare_api.php
@@ -65,9 +65,10 @@ function prepare_email_link( $p_email, $p_text ) {
  * Also can make it a link to user info page.
  * @param integer $p_user_id  A valid user identifier.
  * @param boolean $p_link     Whether to include an html link
+ * @param string $p_prefix Optional string prepended to the username before display
  * @return string
  */
-function prepare_user_name( $p_user_id, $p_link = true ) {
+function prepare_user_name( $p_user_id, $p_link = true, $p_prefix = '' ) {
 	# Catch a user_id of NO_USER (like when a handler hasn't been assigned)
 	if( NO_USER == $p_user_id ) {
 		return '';
@@ -83,15 +84,16 @@ function prepare_user_name( $p_user_id, $p_link = true ) {
 
 	$t_name = string_display_line( $t_name );
 
+	$t_display = $p_prefix . $t_name;
 	if( user_exists( $p_user_id ) && user_get_field( $p_user_id, 'enabled' ) ) {
 		if( $p_link ) {
-			return '<a ' . $t_tooltip . ' href="' . user_get_page_url( $p_user_id ) . '">' . $t_name . '</a>';
+			return '<a ' . $t_tooltip . ' href="' . user_get_page_url( $p_user_id ) . '">' . $t_display . '</a>';
 		} else {
-			return '<span ' . $t_tooltip . '>' . $t_name . '</span>';
+			return '<span ' . $t_tooltip . '>' . $t_display . '</span>';
 		}
 	}
 
-	return '<del ' . $t_tooltip . '>' . $t_name . '</del>';
+	return '<del ' . $t_tooltip . '>' . $t_display . '</del>';
 }
 
 /**

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -512,23 +512,21 @@ function string_insert_hrefs( $p_string, $p_markdown = false  ) {
 	}
 
 	# Find any URL in a string and replace it with a clickable link
-	$p_string = preg_replace_callback(
-		$s_url_regex,
-		function ( $p_match ) use ( $p_markdown ) {
-			$t_url_href = 'href="' . rtrim( $p_match[1], '.' ) . '"';
-			if( config_get( 'html_make_links' ) == LINKS_NEW_WINDOW ) {
-				$t_url_target = ' target="_blank"';
-			} else {
-				$t_url_target = '';
-			}
-			if( $p_markdown ) {
-				return "<${t_url_href}>";
-			} else {
+	# Not necessary for Markdown, as the parser automatically creates URL links
+	if( !$p_markdown ) {
+		$p_string = preg_replace_callback(
+			$s_url_regex,
+			function ( $p_match ) use ( $p_markdown ) {
+				$t_url_href = 'href="' . rtrim( $p_match[1], '.' ) . '"';
+				if( config_get( 'html_make_links' ) == LINKS_NEW_WINDOW ) {
+					$t_url_target = ' target="_blank"';
+				} else {
+					$t_url_target = '';
+				}
 				return "<a ${t_url_href}${t_url_target}>${p_match[1]}</a>";
-			}
-		},
-		$p_string
-	);
+			},
+			$p_string
+		);
 
 	# Find any email addresses in the string and replace them with a clickable
 	# mailto: link, making sure that we skip processing of any existing anchor

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -514,19 +514,20 @@ function string_insert_hrefs( $p_string, $p_markdown = false  ) {
 	# Find any URL in a string and replace it with a clickable link
 	# Not necessary for Markdown, as the parser automatically creates URL links
 	if( !$p_markdown ) {
+		if( config_get( 'html_make_links' ) == LINKS_NEW_WINDOW ) {
+			$t_url_target = ' target="_blank"';
+		} else {
+			$t_url_target = '';
+		}
 		$p_string = preg_replace_callback(
 			$s_url_regex,
-			function ( $p_match ) use ( $p_markdown ) {
+			function( $p_match ) use ( $t_url_target ) {
 				$t_url_href = 'href="' . rtrim( $p_match[1], '.' ) . '"';
-				if( config_get( 'html_make_links' ) == LINKS_NEW_WINDOW ) {
-					$t_url_target = ' target="_blank"';
-				} else {
-					$t_url_target = '';
-				}
 				return "<a ${t_url_href}${t_url_target}>${p_match[1]}</a>";
 			},
 			$p_string
 		);
+	}
 
 	# Find any email addresses in the string and replace them with a clickable
 	# mailto: link, making sure that we skip processing of any existing anchor

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -595,7 +595,23 @@ function string_strip_hrefs( $p_string, $p_markdown = false ) {
 	$p_string = preg_replace( '/<a\s[^\>]*href="mailto:([^\"]+)"[^\>]*>[^\<]*<\/a>/si', $t_replacement, $p_string );
 
 	# Then grab any other href
-	$p_string = preg_replace( '/<a\s[^\>]*href="([^\"]+)"[^\>]*>[^\<]*<\/a>/si', $t_replacement, $p_string );
+	$t_regex = '/<a\s[^\>]*href="([^\"]+)"[^\>]*>([^\<]*)<\/a>/si';
+	if( $p_markdown ) {
+		$p_string = preg_replace_callback(
+			$t_regex,
+			function( $p_match ) {
+				# Generate a Markdown link if the href is different from the text
+				if( $p_match[2] && $p_match[1] != $p_match[2] ) {
+					return "[{$p_match[2]}]({$p_match[1]})";
+				}
+				return "<{$p_match[1]}>";
+			},
+			$p_string
+		);
+	} else {
+		$p_string = preg_replace( $t_regex, $t_replacement, $p_string );
+	}
+
 	return $p_string;
 }
 

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1791,3 +1791,14 @@ function user_has_more_than_one_project( $p_user_id ) {
 	}
 	return true;
 }
+
+/**
+ * Return the URL for the user's page.
+ *
+ * @param integer $p_user_id A valid user identifier.
+ *
+ * @return string Sanitized user page URL
+ */
+function user_get_page_url( $p_user_id ) {
+	return string_sanitize_url( 'view_user_page.php?id=' . $p_user_id, true );
+}

--- a/plugin.php
+++ b/plugin.php
@@ -47,9 +47,25 @@ $t_plugin_path = config_get_global( 'plugin_path' );
 
 $f_page = gpc_get_string( 'page' );
 
+/**
+ * Return the error code to use depending on user's access level.
+ * If user does not have sufficient privileges to view the detailed error
+ * message, returns ERROR_GENERIC.
+ * @param integer $p_code Specific error code
+ * @return integer Error code
+ */
+function error_code($p_code) {
+	$t_can_view_detailed_error = access_compare_level(
+		current_user_get_access_level(),
+		config_get( 'manage_plugin_threshold' )
+	);
+
+	return $t_can_view_detailed_error ? $p_code : ERROR_GENERIC;
+}
+
 if( !preg_match( '/^([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+[\/a-zA-Z0-9_-]*)/', $f_page, $t_matches ) ) {
 	error_parameters( $f_page );
-	trigger_error( ERROR_PLUGIN_INVALID_PAGE, ERROR );
+	trigger_error( error_code( ERROR_PLUGIN_INVALID_PAGE ), ERROR );
 }
 
 $t_basename = $t_matches[1];

--- a/plugins/MantisCoreFormatting/MantisCoreFormatting.php
+++ b/plugins/MantisCoreFormatting/MantisCoreFormatting.php
@@ -177,8 +177,11 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 			} else {
 				$t_string = MantisMarkdown::convert_line( $t_string );
 			}
+		} else {
+			$t_string = mention_format_text( $t_string, /* html */ true );
 		}
 
+/*
 		if( ON == $s_urls && OFF == $s_markdown ) {
 			$t_string = string_insert_hrefs( $t_string );
 		}
@@ -186,8 +189,7 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 		if ( ON == $s_buglinks ) {
 			$t_string = $this->processBugAndNoteLinks( $t_string );
 		}
-
-		$t_string = mention_format_text( $t_string, /* html */ true );
+*/
 
 		return $t_string;
 	}

--- a/plugins/MantisCoreFormatting/MantisCoreFormatting.php
+++ b/plugins/MantisCoreFormatting/MantisCoreFormatting.php
@@ -161,31 +161,40 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 			$s_markdown = plugin_config_get( 'process_markdown' );
 		}
 
-		if( ON == $s_text ) {
-			$t_string = $this->processText( $t_string );
-
-			if( $p_multiline && OFF == $s_markdown ) {
-				$t_string = string_preserve_spaces_at_bol( $t_string );
-				$t_string = string_nl2br( $t_string );
-			}
-		}
-
 		# Process Markdown
 		if( ON == $s_markdown ) {
+			$t_string = string_strip_hrefs( $t_string, true );
+
+			# URLs preprocessing; the Markdown parser will generate the actual links
+			if( ON == $s_urls ) {
+				$t_string = string_insert_hrefs( $t_string, true );
+			}
+
 			if( $p_multiline ) {
 				$t_string = MantisMarkdown::convert_text( $t_string );
 			} else {
 				$t_string = MantisMarkdown::convert_line( $t_string );
 			}
+
+			# Mentions processing is handled by the Markdown parser
 		} else {
+			if( ON == $s_text ) {
+				$t_string = $this->processText( $t_string );
+
+				if( $p_multiline ) {
+					$t_string = string_preserve_spaces_at_bol( $t_string );
+					$t_string = string_nl2br( $t_string );
+				}
+			}
+
+			if( ON == $s_urls ) {
+				$t_string = string_insert_hrefs( $t_string );
+			}
+
 			$t_string = mention_format_text( $t_string, /* html */ true );
 		}
 
 /*
-		if( ON == $s_urls && OFF == $s_markdown ) {
-			$t_string = string_insert_hrefs( $t_string );
-		}
-
 		if ( ON == $s_buglinks ) {
 			$t_string = $this->processBugAndNoteLinks( $t_string );
 		}


### PR DESCRIPTION
I started working on a branch targeted at fixing the various rendering issues following the enabling of Parsedown safe mode ([#24186](https://www.mantisbt.org/bugs/view.php?id=24186)).

The work item covers refactoring of the following MantisCoreFormatting plugin features:
- [x] user mentions
- [x] URL and e-mail addresses
- [ ] Bug and Bugnote linking

This is still a work-in-progress at this time, but in the interest of getting some early testing and feedback, hopefully also by the people currently affected by the issue who are facing the difficult choice between disabling Markdown or leaving their MantisBT instance vulnerable to XSS, I thought I'd open a PR now.

Warning: this feature branch is subject to change (including rebasing) without notice.

Note: The PR currently includes a Composer update to a beta version of Parsedown, but it should also be possible to fix the issue (in a less elegant / complete way) with current 1.7.1 version. I'll decide which version to use later on (depending on when Parsedown 1.8.0 is released).

Fixes [#24628](https://www.mantisbt.org/bugs/view.php?id=24628), [#24241](https://www.mantisbt.org/bugs/view.php?id=24241)
