### PR TITLE
Show default category handler only for managers + only show user account reference

### DIFF
--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -900,7 +900,7 @@ function mci_project_categories( $p_project_id ) {
 
 		$t_default_handler_id = (int)$t_category['user_id'];
 		if( $t_default_handler_id != 0 ) {
-			$t_result['default_handler'] = mci_user_get( $t_default_handler_id );
+			$t_result['default_handler'] = mci_account_get_array_by_id( $t_default_handler_id );
 		}
 
 		$t_results[] = $t_result;

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -892,14 +892,18 @@ function mci_project_categories( $p_project_id ) {
 	$t_results = array();
 
 	foreach( $t_categories as $t_category ) {
+		$t_project_id = (int)$t_category['project_id'];
 		$t_result = array(
 			'id' => (int)$t_category['id'],
 			'name' => $t_category['name'],
-			'project' => array( 'id' => (int)$t_category['project_id'], 'name' => $t_category['project_name'] ),
+			'project' => array( 'id' => $t_project_id, 'name' => $t_category['project_name'] ),
 		);
 
+		# Do access check here to take into consider the project id that the category is associated with
+		# in case of inherited categories.
 		$t_default_handler_id = (int)$t_category['user_id'];
-		if( $t_default_handler_id != 0 ) {
+		if( $t_default_handler_id != 0 &&
+		    access_has_project_level( config_get( 'manage_project_threshold', null, null, $t_project_id ), $t_project_id ) ) {
 			$t_result['default_handler'] = mci_account_get_array_by_id( $t_default_handler_id );
 		}
 


### PR DESCRIPTION
Fixes #24343 - don't show full user info for default category handler, just user reference.
Fixes #24346 - don't show default category handler except for users that can manage the project.