### PR TITLE
Fix filter APIs

### DIFF
--- a/core/classes/FilterConverter.class.php
+++ b/core/classes/FilterConverter.class.php
@@ -614,6 +614,7 @@ class FilterConverter {
 		unset( $p_criteria['_version'] );
 		unset( $p_criteria['_source_query_id'] );
 		unset( $p_criteria['_view_type'] );
+		unset( $p_criteria['_filter_id'] );
 	}
 
 	/**

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -3096,6 +3096,8 @@ function filter_db_get_available_queries( $p_project_id = null, $p_user_id = nul
 		if( !$t_filter_obj ) {
 			continue;
 		}
+
+		$t_row = filter_get_row( $t_filter_id );
 		$t_row['criteria'] = $t_filter_obj;
 		$t_row['url'] = filter_get_url( $t_filter_obj );
 		$t_filter_data[$t_filter_name] = $t_row;


### PR DESCRIPTION
The filter API was broken by recent refactoring causing it to return invalid id, name, public, and extra _filter_id.  This impacted both SOAP and REST APIs.

Fixes #24335, #24349