### PR TITLE
Set default encoding to UTF-8

### DIFF
--- a/core.php
+++ b/core.php
@@ -82,6 +82,9 @@ if( !extension_loaded( 'mbstring' ) ) {
 	die();
 }
 
+# Ensure that encoding is always UTF-8 independant from any PHP default or ini setting
+mb_internal_encoding('UTF-8');
+
 ob_start();
 
 # Load Composer autoloader


### PR DESCRIPTION
Edit: Reword comment in source and commit message

Ensure that encoding is always set to UTF-8 independant from
any PHP default or ini setting

http://php.net/manual/en/ini.core.php#ini.default-charset

Fixes #24353