### PR TITLE
Fix Class 'ClientException' not found in tag api

### DIFF
--- a/api/soap/mc_tag_api.php
+++ b/api/soap/mc_tag_api.php
@@ -23,6 +23,8 @@
  * @link http://www.mantisbt.org
  */
 
+use Mantis\Exceptions\ClientException;
+
 /**
  * Retrieves all tags, unless the users
  *


### PR DESCRIPTION
Fixes #24398