### PR TITLE
Display username as tooltip if realname is displayed

### DIFF
--- a/core/prepare_api.php
+++ b/core/prepare_api.php
@@ -74,18 +74,18 @@ function prepare_user_name( $p_user_id ) {
 	$t_username = user_get_username( $p_user_id );
 	$t_name = user_get_name( $p_user_id );
 	if( $t_username != $t_name ) {
-		$t_tooltip = ' title="' . string_attribute( $t_name ) . '"';
+		$t_tooltip = ' title="' . string_attribute( $t_username ) . '"';
 	} else {
 		$t_tooltip = '';
 	}
 
-	$t_username = string_display_line( $t_username );
+	$t_name = string_display_line( $t_name );
 
 	if( user_exists( $p_user_id ) && user_get_field( $p_user_id, 'enabled' ) ) {
-		return '<a ' . $t_tooltip . ' href="' . string_sanitize_url( 'view_user_page.php?id=' . $p_user_id, true ) . '">' . $t_username . '</a>';
+		return '<a ' . $t_tooltip . ' href="' . string_sanitize_url( 'view_user_page.php?id=' . $p_user_id, true ) . '">' . $t_name . '</a>';
 	}
 
-	return '<del ' . $t_tooltip . '>' . $t_username . '</del>';
+	return '<del ' . $t_tooltip . '>' . $t_name . '</del>';
 }
 
 /**

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -220,7 +220,7 @@ function print_user_with_subject( $p_user_id, $p_bug_id ) {
 
 	if( user_exists( $p_user_id ) && user_get_field( $p_user_id, 'enabled' ) ) {
 		$t_email = user_get_email( $p_user_id );
-		print_email_link_with_subject( $t_email, $t_username, $t_name, $p_bug_id );
+		print_email_link_with_subject( $t_email, $t_name, $t_username, $p_bug_id );
 	} else {
 		$t_name = string_attribute( $t_name );
 		echo '<span style="text-decoration: line-through">';


### PR DESCRIPTION
Fixes #24436

Display realname if show_realname is set to ON and user is allowed to see realnames, display the username as tooltip.

This is more logical than what we have after https://mantisbt.org/bugs/view.php?id=23375 but is also better concerning @ mentions than what we had before implementation of # 23375
