### PR TITLE
Remove special handling for Microsoft browsers

### DIFF
--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -242,9 +242,6 @@ function layout_is_rtl() {
  * @return void
  */
 function layout_head_meta() {
-	# use the following meta to force IE use its most up to date rendering engine
-	echo '<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />' . "\n";
-
 	echo '<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />' . "\n";
 }
 


### PR DESCRIPTION
The following line in head section
```
<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
```
is no longer needed when using IE11 or Edge and using `<!DOCTYPE html>`, see [1]

Fixes #24476

[1] https://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-ua-compatible-content-ie-edge-do