### PR TITLE
Upgrade: improve handling of unserialize errors

### DIFF
--- a/core/error_api.php
+++ b/core/error_api.php
@@ -404,6 +404,22 @@ function error_handler( $p_type, $p_error, $p_file, $p_line ) {
 	$g_error_proceed_url = null;
 }
 
+
+/**
+ * Error handler to convert PHP errors to Exceptions.
+ * This is used to temporarily override the default error handler, when it is
+ * required to catch a PHP error (e.g. when unserializing data in install
+ * helper functions).
+ * @param integer $p_type    Level of the error raised.
+ * @param string  $p_error   Error message.
+ * @param string  $p_file    Filename that the error was raised in.
+ * @param integer $p_line    Line number the error was raised at.
+ * @throws ErrorException
+ */
+function error_convert_to_exception( $p_type, $p_error, $p_file, $p_line ) {
+	throw new ErrorException( $p_error, 0, $p_type, $p_file, $p_line );
+}
+
 /**
  * Prints messages from the delayed errors queue
  * The error handler enqueues deprecation warnings that would be printed inline,

--- a/core/install_helper_functions_api.php
+++ b/core/install_helper_functions_api.php
@@ -667,20 +667,20 @@ function install_check_config_serialization() {
 
 	$t_result = db_query( $query );
 	while( $t_row = db_fetch_array( $t_result ) ) {
-		$config_id = $t_row['config_id'];
-		$project_id = (int)$t_row['project_id'];
-		$user_id = (int)$t_row['user_id'];
-		$value = $t_row['value'];
+		$t_config_id = $t_row['config_id'];
+		$t_project_id = (int)$t_row['project_id'];
+		$t_user_id = (int)$t_row['user_id'];
+		$t_value = $t_row['value'];
 
 		try {
-			$t_config = safe_unserialize( $value );
+			$t_config = safe_unserialize( $t_value );
 		}
 		catch( ErrorException $e ) {
 			install_print_unserialize_error(
-				"Config '$config_id' for project id $project_id, user id $user_id",
+				"Config '$t_config_id' for project id $t_project_id, user id $t_user_id",
 				'config',
 				$e->getMessage(),
-				$value
+				$t_value
 			);
 
 			return 1; # Fatal: invalid data found in config table
@@ -690,7 +690,7 @@ function install_check_config_serialization() {
 
 		db_param_push();
 		$t_query = 'UPDATE {config} SET value=' .db_param() . ' WHERE config_id=' .db_param() . ' AND project_id=' .db_param() . ' AND user_id=' .db_param();
-		db_query( $t_query, array( $t_json_config, $config_id, $project_id, $user_id ) );
+		db_query( $t_query, array( $t_json_config, $t_config_id, $t_project_id, $t_user_id ) );
 	}
 
 	# flush config here as we've changed the format of the configuration table

--- a/core/install_helper_functions_api.php
+++ b/core/install_helper_functions_api.php
@@ -676,8 +676,24 @@ function install_check_config_serialization() {
 		$user_id = (int)$t_row['user_id'];
 		$value = $t_row['value'];
 
-		$t_config = unserialize( $value );
-		if( $t_config === false ) {
+		try {
+			$t_config = safe_unserialize( $value );
+		}
+		catch( ErrorException $e ) {
+			printf('<p><br>Config "%s" for project id %d, user id %d '
+				. 'could not be converted because its data is not valid. '
+				. 'Fix the problem by manually repairing or deleting the '
+				. 'offending %s row as appropriate, then try again.'
+				. '<br>Error: <em>%s</em> in the string below</p>'
+				. '<pre>%s</pre>',
+				$t_row['config_id'],
+				$t_row['project_id'],
+				$t_row['user_id'],
+				db_get_table( 'config' ),
+				$e->getMessage(),
+				$t_row['value']
+			);
+
 			return 1; # Fatal: invalid data found in config table
 		}
 

--- a/core/install_helper_functions_api.php
+++ b/core/install_helper_functions_api.php
@@ -498,15 +498,11 @@ function install_stored_filter_migrate() {
 		# details about the error and abort the upgrade.
 		# Let the user investigate and fix the problem before trying again.
 		if( $t_filter_arr === null ) {
-			printf('<p><br>Filter id %d %s'
-				. 'could not be converted because its data is not valid. '
-				. 'Fix the problem by manually repairing or deleting the '
-				. 'offending %s row as appropriate, then try again.'
-				. '<br>Error: <em>%s</em> in the string below</p>'
-				. '<pre>%s</pre>',
-				$t_row['id'],
-				$t_row['name'] ? "('${t_row['name']}') " : '',
-				db_get_table( 'filters' ),
+			$t_id = $t_row['id'];
+			$t_name = $t_row['name'];
+			install_print_unserialize_error(
+				sprintf( "Filter id $t_id %s", $t_name ? "('$t_name') " : '' ),
+				'filters',
 				$t_error,
 				$t_setting_arr[1]
 			);
@@ -680,18 +676,11 @@ function install_check_config_serialization() {
 			$t_config = safe_unserialize( $value );
 		}
 		catch( ErrorException $e ) {
-			printf('<p><br>Config "%s" for project id %d, user id %d '
-				. 'could not be converted because its data is not valid. '
-				. 'Fix the problem by manually repairing or deleting the '
-				. 'offending %s row as appropriate, then try again.'
-				. '<br>Error: <em>%s</em> in the string below</p>'
-				. '<pre>%s</pre>',
-				$t_row['config_id'],
-				$t_row['project_id'],
-				$t_row['user_id'],
-				db_get_table( 'config' ),
+			install_print_unserialize_error(
+				"Config '$config_id' for project id $project_id, user id $user_id",
+				'config',
 				$e->getMessage(),
-				$t_row['value']
+				$value
 			);
 
 			return 1; # Fatal: invalid data found in config table
@@ -737,14 +726,9 @@ function install_check_token_serialization() {
 					continue;
 				}
 
-				printf('<p><br>Token id %d '
-					. 'could not be converted because its data is not valid. '
-					. 'Fix the problem by manually repairing or deleting the '
-					. 'offending %s row as appropriate, then try again.'
-					. '<br>Error: <em>%s</em> in the string below</p>'
-					. '<pre>%s</pre>',
-					$t_id,
-					db_get_table( 'tokens' ),
+				install_print_unserialize_error(
+					"Token id $t_id",
+					'tokens',
 					$e->getMessage(),
 					$t_value
 				);
@@ -798,4 +782,26 @@ function install_gravatar_plugin() {
 function InsertData( $p_table, $p_data ) {
 	$t_query = 'INSERT INTO ' . $p_table . $p_data;
 	return array( $t_query );
+}
+
+/**
+ * Print a friendly error message following an unserialize() error.
+ *
+ * @param string $p_description Description to identify the offending row
+ * @param string $p_table Mantis table name
+ * @param string $p_error Error message
+ * @param string $p_value The data that could not be unserialized
+ * @return void
+ */
+function install_print_unserialize_error( $p_description, $p_table, $p_error, $p_value ) {
+	printf('<p><br>%s could not be converted because its data is not valid. '
+		. 'Fix the problem by manually repairing or deleting the '
+		. 'offending %s row as appropriate, then try again.'
+		. '<br>Error: <em>%s</em> occured because of the string below</p>'
+		. '<pre>%s</pre>',
+		$p_description,
+		db_get_table( $p_table ),
+		$p_error,
+		$p_value
+	);
 }

--- a/core/utility_api.php
+++ b/core/utility_api.php
@@ -295,3 +295,27 @@ function get_font_path() {
 		}
 		return $t_font_path;
 }
+
+/**
+ * unserialize() with Exception instead of PHP notice.
+ *
+ * When given invalid data, unserialize() throws a PHP notice; this function
+ * relies on a custom error handler to throw an Exception instead.
+ *
+ * @param string $p_string The serialized string.
+ * @return mixed The converted value
+ *
+ * @throws ErrorException
+ */
+function safe_unserialize( $p_string ) {
+	set_error_handler( 'error_convert_to_exception' );
+	try {
+		$t_data = unserialize( $p_string );
+	}
+	catch( ErrorException $e ) {
+		restore_error_handler();
+		throw $e;
+	}
+	restore_error_handler();
+	return $t_data;
+}


### PR DESCRIPTION
In MantisBT 1.3, the method used to store config, token and filter data 
changed from _serialize_ to JSON. Upgrade steps 193, 194 and 195 were
added to convert legacy data to the new format.

This frequently caused the upgrade process to fail when unserialize()
could not interpret the data, but the MantisBT installer just aborted
without providing any useful information to the admin.

This improves the error reporting, clearly identifying the offending
record so that the admin can take appropriate action to fix the problem.

Fixes #24416, #21376 (and maybe others too)
