### PR TITLE
Uniformize display of failed group updates

### DIFF
--- a/bug_actiongroup.php
+++ b/bug_actiongroup.php
@@ -341,27 +341,10 @@ foreach( $f_bug_arr as $t_bug_id ) {
 
 form_security_purge( $t_form_name );
 
-$t_redirect_url = 'view_all_bug_page.php';
-
 if( count( $t_failed_ids ) > 0 ) {
-	layout_page_header();
-	layout_page_begin();
-
-	echo '<div><br />';
-	echo '<div class="table-responsive">';
-	echo '<table class="table table-bordered table-condensed table-striped">';
-	$separator = lang_get( 'word_separator' );
-	foreach( $t_failed_ids as $t_id => $t_reason ) {
-		$label = sprintf( lang_get( 'label' ), string_get_bug_view_link( $t_id ) ) . $separator;
-		$t_summary = string_display_line( bug_get_field( $t_id, 'summary' ) );
-		printf( "<tr><td width=\"50%%\">%s%s</td><td>%s</td></tr>\n", $label, $t_summary, $t_reason );
-	}
-	echo '</div>';
-	echo '</table><br />';
-	print_link_button( $t_redirect_url, lang_get( 'proceed' ) );
-	echo '</div>';
-
-	layout_page_end();
+	bug_group_action_print_top();
+	bug_group_action_print_results( $t_failed_ids );
+	bug_group_action_print_bottom();
 } else {
-	print_header_redirect( $t_redirect_url );
+	print_header_redirect( 'view_all_bug_page.php' );
 }

--- a/bug_actiongroup_ext.php
+++ b/bug_actiongroup_ext.php
@@ -98,20 +98,9 @@ $g_project_override = null;
 form_security_purge( $t_form_name );
 
 if( count( $t_failed_ids ) > 0 ) {
-	layout_page_header();
-	layout_page_begin();
-
-	echo '<div>';
-	$t_word_separator = lang_get( 'word_separator' );
-	foreach( $t_failed_ids as $t_id => $t_reason ) {
-		$t_label = sprintf( lang_get( 'label' ), string_get_bug_view_link( $t_id ) ) . $t_word_separator;
-		printf( "<p>%s%s</p>\n", $t_label, $t_reason );
-	}
-
-	print_link_button( 'view_all_bug_page.php', lang_get( 'proceed' ) );
-	echo '</div>';
-
-	layout_page_end();
+	bug_group_action_print_top();
+	bug_group_action_print_results( $t_failed_ids );
+	bug_group_action_print_bottom();
 } else {
 	print_header_redirect( 'view_all_bug_page.php' );
 }

--- a/core/bug_group_action_api.php
+++ b/core/bug_group_action_api.php
@@ -105,6 +105,38 @@ function bug_group_action_print_bug_list( array $p_bug_ids_array ) {
 }
 
 /**
+ * Print a table listing the failed results following a group action.
+ *
+ * @param array $p_failed_ids List of failed results [bug_id => reason for failure]
+ *
+ * @return void
+ */
+function bug_group_action_print_results( array $p_failed_ids ) {
+	$t_format = "<tr>"
+		. "\n\t" . '<td width="50%%">%s' . lang_get( 'word_separator' ) . '%s</td>'
+		. "\n\t" . '<td>%s</td>'
+		. "\n</tr>\n";
+	$t_label = lang_get( 'label' );
+
+	echo '<div><br />', PHP_EOL;
+	echo '<div class="table-responsive">', PHP_EOL;
+	echo '<table class="table table-bordered table-condensed table-striped">', PHP_EOL;
+
+	foreach( $p_failed_ids as $t_id => $t_reason ) {
+		printf( $t_format,
+			sprintf( $t_label, string_get_bug_view_link( $t_id ) ),
+			string_display_line( bug_get_field( $t_id, 'summary' ) ),
+			$t_reason
+		);
+	}
+	echo '</table>', PHP_EOL;
+	echo '</div>', PHP_EOL;
+
+	print_link_button( 'view_all_bug_page.php', lang_get( 'proceed' ) );
+	echo '</div>', PHP_EOL;
+}
+
+/**
  * Print the array of issue ids via hidden fields in the form to be passed on to
  * the bug action group action page.
  *


### PR DESCRIPTION
Standard and custom bug group actions did not provide the same user
experience when displaying error messages. bug_actiongroup.php displays
errors in a table, while bug_actiongroup_ext.php prints them with `<p>`
elements.

This commit refactors the display code on both pages, by moving it to a
new API function bug_group_action_print_results().

Also fixes an issue with the page footer, which was displayed behind the
sidebar due to invalid HTML.

Fixes [#24643](https://mantisbt.org/bugs/view.php?id=24643), [#24644](https://mantisbt.org/bugs/view.php?id=24644)