### PR TITLE
Add filter for the “last updated“ date in the soap api

### DIFF
--- a/api/soap/mantisconnect.wsdl
+++ b/api/soap/mantisconnect.wsdl
@@ -296,6 +296,12 @@
    <xsd:element name="end_day" type="xsd:integer" minOccurs="0"/>
    <xsd:element name="end_month" type="xsd:integer" minOccurs="0"/>
    <xsd:element name="end_year" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="last_update_start_day" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="last_update_start_month" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="last_update_start_year" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="last_update_end_day" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="last_update_end_month" type="xsd:integer" minOccurs="0"/>
+   <xsd:element name="last_update_end_year" type="xsd:integer" minOccurs="0"/>
    <xsd:element name="tag_string" type="tns:StringArray" minOccurs="0"/>
    <xsd:element name="tag_select" type="tns:IntegerArray" minOccurs="0"/>
    <xsd:element name="custom_fields" type="tns:FilterCustomFieldArray" minOccurs="0"/>

--- a/api/soap/mc_filter_api.php
+++ b/api/soap/mc_filter_api.php
@@ -61,6 +61,12 @@ $g_soap_api_to_filter_names = array(
 	'end_day' => FILTER_PROPERTY_DATE_SUBMITTED_END_DAY,
 	'end_month' => FILTER_PROPERTY_DATE_SUBMITTED_END_MONTH,
 	'end_year' => FILTER_PROPERTY_DATE_SUBMITTED_END_YEAR,
+	'last_update_start_day' => FILTER_PROPERTY_LAST_UPDATED_START_DAY,
+	'last_update_start_month' => FILTER_PROPERTY_LAST_UPDATED_START_MONTH,
+	'last_update_start_year' => FILTER_PROPERTY_LAST_UPDATED_START_YEAR,
+	'last_update_end_day' => FILTER_PROPERTY_LAST_UPDATED_END_DAY,
+	'last_update_end_month' => FILTER_PROPERTY_LAST_UPDATED_END_MONTH,
+	'last_update_end_year' => FILTER_PROPERTY_LAST_UPDATED_END_YEAR,
 	'tag_string' => FILTER_PROPERTY_TAG_STRING,
 	'tag_select' => FILTER_PROPERTY_TAG_SELECT,
 );
@@ -350,6 +356,14 @@ function mci_filter_search_get_rows( $p_user_id, $p_filter_search, $p_page_numbe
 		|| isset ( $t_filter[FILTER_PROPERTY_DATE_SUBMITTED_END_YEAR] ) ) {
 		$t_filter[FILTER_PROPERTY_FILTER_BY_DATE_SUBMITTED] = 'on';
 	}
+	if( isset ( $t_filter[FILTER_PROPERTY_LAST_UPDATED_START_DAY] ) 
+		|| isset ( $t_filter[FILTER_PROPERTY_LAST_UPDATED_START_MONTH] ) 
+		|| isset ( $t_filter[FILTER_PROPERTY_LAST_UPDATED_START_YEAR] ) 
+		|| isset ( $t_filter[FILTER_PROPERTY_LAST_UPDATED_END_DAY] ) 
+		|| isset ( $t_filter[FILTER_PROPERTY_LAST_UPDATED_END_MONTH] ) 
+		|| isset ( $t_filter[FILTER_PROPERTY_LAST_UPDATED_END_YEAR] ) ) {
+		$t_filter[FILTER_PROPERTY_FILTER_BY_LAST_UPDATED_DATE] = 'on';
+}
 
 	$t_filter = filter_ensure_valid_filter( $t_filter );
 


### PR DESCRIPTION
Currently the soap method `mc_filter_search_issues` allows to filter
the result set by the “sumbitted” date of the issue. But not with the
“last updated” date.

For a task, we need to get the latest updated issues, to execute some
business logic. Therefore expand the soap api, with this additional
filter, so that's now also posssible to filter the result-set of the
search with the last “updated date”.

- Add this new filter to the `mc_filter_api`, simular like the
  “submitted date”.
- Add it also the the wsdl, so that this new api is documented for
  other programms.