### PR TITLE
Fix BugData object to string conversion on string_get_bug_view_url() function

### DIFF
--- a/core/string_api.php
+++ b/core/string_api.php
@@ -714,6 +714,10 @@ function string_get_bugnote_view_link( $p_bug_id, $p_bugnote_id, $p_detail_info 
  * @return string
  */
 function string_get_bug_view_url( $p_bug_id ) {
+    if ($p_bug_id instanceof BugData) {
+        $p_bug_id = $p_bug_id->id;
+    }
+
 	return 'view.php?id=' . $p_bug_id;
 }
 


### PR DESCRIPTION

Dear maintainer,

this PR fix annoying bug when you try to change bug status (e.g. change to resolve ) and add it a note,
in this case, $p_bug_id is an instance of BugData class instead a number or string causing following error:

> SYSTEM ERROR

> 'Object of class BugData could not be converted to string' in '/var/www/html/mantis/core/string_api.php' line 717

> Please use the "Back" button in your web browser to return to the previous page. There you can correct whatever problems were identified in this error or select another action. You can also click an option from the menu bar to go directly to a new section.

best regards.