### PR TITLE
Fix view state references

### DIFF
--- a/bug_actiongroup_page.php
+++ b/bug_actiongroup_page.php
@@ -409,7 +409,7 @@ if( $t_multiple_projects ) {
 						<label class="lbl padding-6"><?php echo lang_get( 'private' ); ?></label>
 <?php
 			} else {
-				echo get_enum_element( 'project_view_state', $t_default_bugnote_view_status );
+				echo get_enum_element( 'view_state', $t_default_bugnote_view_status );
 			}
 ?>
 					</td>

--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -355,7 +355,7 @@ layout_page_begin();
 			<label class="lbl padding-6" for="bugnote_add_view_status"><?php echo lang_get( 'private' ) ?></label>
 <?php
 		} else {
-			echo get_enum_element( 'project_view_state', $t_default_bugnote_view_status );
+			echo get_enum_element( 'view_state', $t_default_bugnote_view_status );
 		}
 ?>
 				</td>

--- a/manage_proj_create_page.php
+++ b/manage_proj_create_page.php
@@ -146,7 +146,7 @@ $f_parent_id = gpc_get( 'parent_id', null );
 				</td>
 				<td>
 					<select id="project-view-state" name="view_state" class="input-sm">
-						<?php print_enum_string_option_list( 'view_state', config_get( 'default_project_view_status', null, ALL_USERS, ALL_PROJECTS ) ) ?>
+						<?php print_enum_string_option_list( 'project_view_state', config_get( 'default_project_view_status', null, ALL_USERS, ALL_PROJECTS ) ) ?>
 					</select>
 				</td>
 			</tr>

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -158,7 +158,7 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 				</td>
 				<td>
 					<select id="project-view-state" name="view_state" class="input-sm">
-						<?php print_enum_string_option_list( 'view_state', (int)$t_row['view_state']) ?>
+						<?php print_enum_string_option_list( 'project_view_state', (int)$t_row['view_state']) ?>
 					</select>
 				</td>
 			</tr>


### PR DESCRIPTION
At the moment we have two configs that related to view state enum:

- `view_state` - which is used for issue and issue notes view state.
- `project_view_state` - which is used for projects.

This commit fixes cases where the wrong view state was used for the scenario at hand.
In the future, we may want to consider have a different view state enum for issues vs. issue notes.

Fixes #10411