### PR TITLE
Enable password managers detect usernames

### DIFF
--- a/login_password_page.php
+++ b/login_password_page.php
@@ -213,13 +213,12 @@ if( config_get_global( 'admin_checks' ) == ON && file_exists( dirname( __FILE__ 
 				echo '<input type="hidden" name="install" value="true" />';
 			}
 
-			echo '<input type="hidden" name="username" value="', string_html_specialchars( $t_username ), '" />';
 
 			echo sprintf( lang_get( 'enter_password' ), string_html_specialchars( $t_username ) );
 
 			# CSRF protection not required here - form does not result in modifications
 			?>
-
+			<input hidden readonly type="text" name="username" class="hidden" tabindex="-1" value="<?php echo string_html_specialchars( $t_username ) ?>" id="hidden_username" />
 			<label for="password" class="block clearfix">
 				<span class="block input-icon input-icon-right">
 					<input id="password" name="password" type="password" placeholder="<?php echo lang_get( 'password' ) ?>"


### PR DESCRIPTION
Make the username field a locked non-visible field, instead of type
"hidden" input. This way the password managers present in browsers can
detect the different username values and remember them separately.
The problem is that inputs with type="hidden" are ignored by these
agents.

Fixes: #24896