### PR TITLE
Truncate values before writing to database history table

### DIFF
--- a/core/history_api.php
+++ b/core/history_api.php
@@ -81,7 +81,12 @@ function history_log_event_direct( $p_bug_id, $p_field_name, $p_old_value, $p_ne
 		}
 
 		$c_field_name = $p_field_name;
-		$c_old_value = ( is_null( $p_old_value ) ? '' : (string)$p_old_value );
+
+		if( is_null( $p_old_value ) ) {
+			$c_old_value = '';
+		} else {
+			$c_old_value = mb_strimwidth( $p_old_value, 0, DB_FIELD_SIZE_HISTORY_VALUE, '...' );
+		}
 		if( is_null( $p_new_value ) ) {
 			$c_new_value = '';
 		} else {
@@ -123,12 +128,15 @@ function history_log_event_special( $p_bug_id, $p_type, $p_old_value = '', $p_ne
 	$t_user_id = auth_get_current_user_id();
 
 	if( is_null( $p_old_value ) ) {
-		$p_old_value = '';
-	}
-	if( is_null( $p_new_value ) ) {
-		$p_new_value = '';
+		$c_old_value = '';
 	} else {
-		$p_new_value = mb_strimwidth( $p_new_value, 0, DB_FIELD_SIZE_HISTORY_VALUE, '...' );
+		$c_old_value = mb_strimwidth( $p_old_value, 0, DB_FIELD_SIZE_HISTORY_VALUE, '...' );
+	}
+
+	if( is_null( $p_new_value ) ) {
+		$c_new_value = '';
+	} else {
+		$c_new_value = mb_strimwidth( $p_new_value, 0, DB_FIELD_SIZE_HISTORY_VALUE, '...' );
 	}
 
 	db_param_push();
@@ -136,7 +144,7 @@ function history_log_event_special( $p_bug_id, $p_type, $p_old_value = '', $p_ne
 					( user_id, bug_id, date_modified, type, old_value, new_value, field_name )
 				VALUES
 					( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ',' . db_param() . ', ' . db_param() . ')';
-	db_query( $t_query, array( $t_user_id, $p_bug_id, db_now(), $p_type, $p_old_value, $p_new_value, '' ) );
+	db_query( $t_query, array( $t_user_id, $p_bug_id, db_now(), $p_type, $c_old_value, $c_new_value, '' ) );
 }
 
 /**


### PR DESCRIPTION
TEXTAREA custom fields can contain more than 255 characters.
Changing such fields fails, as the old value can't be stored
in history table.

This change fixes the issue by truncating the string.

Fixes #25002