### PR TITLE
Fix PHP 7.3 warning

### DIFF
--- a/core/install_helper_functions_api.php
+++ b/core/install_helper_functions_api.php
@@ -464,7 +464,7 @@ function install_stored_filter_migrate() {
 				db_param_push();
 				$t_delete_query = 'DELETE FROM {filters} WHERE id=' . db_param();
 				$t_delete_result = db_query( $t_delete_query, array( $t_row['id'] ) );
-				continue;
+				continue 2;
 		}
 
 		if( isset( $t_setting_arr[1] ) ) {


### PR DESCRIPTION
Starting from PHP 7.3, continue statements targeting switch control flow
structures generate a warning [1].

In our case, we don't want just to break the switch, but continue with
the next row of the database fetch.

Fixes #25033

[1] http://php.net/manual/en/migration73.incompatible.php