### PR TITLE
Change version date validator to work with date format cofigured by user

### DIFF
--- a/core/version_api.php
+++ b/core/version_api.php
@@ -111,13 +111,14 @@ class VersionData {
 					if( $p_value == '' ) {
 						$t_value = date_get_null();
 					} else {
-						$t_value = strtotime( $p_value );
+						$t_value = DateTime::createFromFormat( config_get('normal_date_format'), $p_value );
 						if( $t_value === false ) {
 							throw new ClientException(
 								"Invalid date format '$p_value'",
 								ERROR_INVALID_DATE_FORMAT,
 								array( $p_value ) );
 						}
+						$t_value = $t_value->getTimestamp();
 					}
 				}
 		}


### PR DESCRIPTION
Some countries work with date formats that strtotime won't recognize as
a valid format, so the validator need to use the user configured format
to validate if date is valid.