### PR TITLE
Logic for users with only one accessible project

### DIFF
--- a/account_prefs_reset.php
+++ b/account_prefs_reset.php
@@ -84,7 +84,7 @@ if( auth_get_current_user_id() != $f_user_id ) {
 	user_ensure_unprotected( $f_user_id );
 }
 
-user_pref_delete( $f_user_id );
+user_pref_reset( $f_user_id, ALL_PROJECTS );
 
 form_security_purge( 'account_prefs_reset' );
 

--- a/account_prefs_update.php
+++ b/account_prefs_update.php
@@ -135,7 +135,7 @@ if( in_array( $t_timezone, timezone_identifiers_list() ) ) {
 
 event_signal( 'EVENT_ACCOUNT_PREF_UPDATE', array( $f_user_id ) );
 
-user_pref_set( $f_user_id, $t_prefs );
+user_pref_set( $f_user_id, $t_prefs, ALL_PROJECTS );
 
 form_security_purge( 'account_prefs_update' );
 

--- a/core/current_user_api.php
+++ b/core/current_user_api.php
@@ -272,14 +272,20 @@ function current_user_has_more_than_one_project() {
  * - If default project is not the visible one, modify it to be that project,
  *   or ALL_PROJECTS if the user has no accesible projects.
  *
+ * These changes only apply to user who can't use the project selection.
+ *
  * @return void
  */
 function current_user_modify_single_project_default() {
+	# The user must not be able to use the project selector
+	if( layout_navbar_can_show_projects_menu() ) {
+		return;
+	}
+	# The user must have one, or none, projects
 	$t_user_id = auth_get_current_user_id();
 	if( user_has_more_than_one_project( $t_user_id ) ) {
 		return;
 	}
-	# the user has one, or none, projects
 	$t_default = user_pref_get_pref( $t_user_id, 'default_project' );
 	$t_current = helper_get_current_project();
 	$t_projects = user_get_all_accessible_projects( $t_user_id );

--- a/core/current_user_api.php
+++ b/core/current_user_api.php
@@ -301,6 +301,6 @@ function current_user_modify_single_project_default() {
 		helper_set_current_project( $t_project_id );
 	}
 	if( $t_project_id != $t_default ) {
-		user_set_default_project( $t_user_id, $t_project_id );
+		user_pref_set_pref( $t_user_id, 'default_project', (int)$t_project_id, ALL_PROJECTS, false /* skip protected check */ );
 	}
 }

--- a/core/current_user_api.php
+++ b/core/current_user_api.php
@@ -253,3 +253,48 @@ function current_user_get_bug_filter( $p_project_id = null ) {
 
 	return $t_filter;
 }
+
+/**
+ * Returns true if the user has access to more that one project
+ *
+ * @return boolean
+ */
+function current_user_has_more_than_one_project() {
+	return user_has_more_than_one_project( auth_get_current_user_id() );
+}
+
+/**
+ * Checks if the user has only one, or none, visible project and modify his
+ * current and default project to be coherent.
+ * - If current project is ALL_PROJECTS, sets the the visible project as current.
+ * - If default project is ALL_PROJECTS, sets the visible project as his default
+ *   project for future sessions.
+ * - If default project is not the visible one, modify it to be that project,
+ *   or ALL_PROJECTS if the user has no accesible projects.
+ *
+ * @return void
+ */
+function current_user_modify_single_project_default() {
+	$t_user_id = auth_get_current_user_id();
+	if( user_has_more_than_one_project( $t_user_id ) ) {
+		return;
+	}
+	# the user has one, or none, projects
+	$t_default = user_pref_get_pref( $t_user_id, 'default_project' );
+	$t_current = helper_get_current_project();
+	$t_projects = user_get_all_accessible_projects( $t_user_id );
+	$t_count = count( $t_projects );
+
+	if( 0 == $t_count ) {
+		$t_project_id = ALL_PROJECTS;
+	} else {
+		$t_project_id = reset( $t_projects );
+	}
+
+	if( $t_project_id != $t_current ) {
+		helper_set_current_project( $t_project_id );
+	}
+	if( $t_project_id != $t_default ) {
+		user_set_default_project( $t_user_id, $t_project_id );
+	}
+}

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -145,11 +145,11 @@ function layout_page_header_end( $p_page_id = null) {
  * @return void
  */
 function layout_page_begin( $p_active_sidebar_page = null ) {
-	layout_navbar();
-
 	if( !db_is_connected() ) {
 		return;
 	}
+
+	layout_navbar();
 
 	layout_main_container_begin();
 

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -148,6 +148,7 @@ function layout_page_begin( $p_active_sidebar_page = null ) {
 	if( !db_is_connected() ) {
 		return;
 	}
+	current_user_modify_single_project_default();
 
 	layout_navbar();
 
@@ -515,15 +516,8 @@ function layout_navbar_projects_menu() {
 		return;
 	}
 
-	# Project Selector (hidden if only one project visible to user)
-	$t_show_project_selector = true;
-	$t_project_ids = current_user_get_accessible_projects();
-	if( count( $t_project_ids ) == 1 ) {
-		$t_project_id = (int) $t_project_ids[0];
-		if( count( current_user_get_accessible_subprojects( $t_project_id ) ) == 0 ) {
-			$t_show_project_selector = false;
-		}
-	}
+	# Project selector is only shown if there are more than one project, or is special user
+	$t_show_project_selector = current_user_has_more_than_one_project() || access_has_global_level( config_get( 'create_project_threshold' ) );
 
 	if( $t_show_project_selector ) {
 		echo '<li class="grey" id="dropdown_projects_menu">' . "\n";
@@ -543,22 +537,6 @@ function layout_navbar_projects_menu() {
 		layout_navbar_projects_list( join( ';', helper_get_current_project_trace() ), true, null, true );
 		echo '</ul>' . "\n";
 		echo '</li>' . "\n";
-	} else {
-		# User has only one project, set it as both current and default
-		if( ALL_PROJECTS == helper_get_current_project() ) {
-			helper_set_current_project( $t_project_id );
-
-			if( !current_user_is_protected() ) {
-				current_user_set_default_project( $t_project_id );
-			}
-
-			# Force reload of current page, except if we got here after
-			# creating the first project
-			$t_redirect_url = str_replace( config_get_global( 'short_path' ), '', $_SERVER['REQUEST_URI'] );
-			if( 'manage_proj_create.php' != $t_redirect_url ) {
-				html_meta_redirect( $t_redirect_url, 0, false );
-			}
-		}
 	}
 }
 

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -401,7 +401,7 @@ function project_delete( $p_project_id ) {
 	config_delete_project( $p_project_id );
 
 	# Delete any user prefs that are project specific
-	user_pref_delete_project( $p_project_id );
+	user_pref_db_delete_project( $p_project_id );
 
 	# Delete the project entry
 	db_param_push();

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1768,3 +1768,26 @@ function user_reset_password( $p_user_id, $p_send_email = true ) {
 
 	return true;
 }
+
+/**
+ * Helper function to check if the user has access to more than one project
+ * (any kind of project or subproject). This can be used to simplify logic when
+ * the user only has one project to choose from.
+ *
+ * @param integer $p_user_id	A valid user identifier.
+ * @return boolean	True if the user has access to more than one project.
+ */
+function user_has_more_than_one_project( $p_user_id ) {
+	$t_project_ids = user_get_accessible_projects( $p_user_id );
+	$t_count = count( $t_project_ids );
+	if( 0 == $t_count ) {
+		return false;
+	}
+	if( 1 == $t_count ) {
+		$t_project_id = (int) $t_project_ids[0];
+		if( count( user_get_accessible_subprojects( $p_user_id, $t_project_id ) ) == 0 ) {
+			return false;
+		}
+	}
+	return true;
+}

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -672,7 +672,7 @@ function user_delete( $p_user_id ) {
 	user_delete_profiles( $p_user_id );
 
 	# Remove associated preferences
-	user_pref_delete_all( $p_user_id );
+	user_pref_db_delete_user( $p_user_id );
 
 	# Remove project specific access levels
 	user_delete_project_specific_access_levels( $p_user_id );


### PR DESCRIPTION
commit 6c20f7e25f03e8c8b9ca426d4fc83d0929d126a9
Rewrite hide project list and default project check
    
    Previously, when a user only has one project, some things happens:
    - The project selector was hidden, as it is not useful without more
      projects.
    - A check is performed where if current project is ALL_PROJECTS, then
      current and default project are updated to the only available project.
    
    To fix issues with that implementation, the logic has been separated:
    - Helper function to check if the user has more than one project. It's
      used in layout_api to decide if the project selector must be shown.
    - Helper function to check if the user has ALL_PROJECTS as
      current/default project when only one is available. In that case,
      update current and modify default in user preferences.
    
    Fixes: #25110, #25133

commit 9b21b09f32da11332ddca0c9e3c15ccfe5f059d6
Don't apply single project logic for some users
    
    Eventhough the project selector may be hidden when there are not
    multiple projects to choose from, it is still needed for editing manage
    and configuration pages that apply to either specific project or
    ALL_PROJECTS.
    Here we add a condition that if the user has access to manage pages, the
    project selector is never hidden, and both the specific project and
    ALL_PROJECTS are available to be used.
    
    Fixes: #20054
