### PR TITLE
issue#25170: Fix security breach

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -245,7 +245,7 @@ function html_css_link( $p_filename ) {
 	if( $p_filename == basename( $p_filename ) ) {
 		$p_filename = 'css/' . $p_filename;
 	}
-	echo "\t", '<link rel="stylesheet" type="text/css" href="', string_sanitize_url( helper_mantis_url( $p_filename ), true ), '" />', "\n";
+	echo "\t", '<link rel="stylesheet" type="text/css" href="', string_sanitize_url( helper_mantis_url( $p_filename ), false ), '" />', "\n";
 }
 
 /**

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -94,7 +94,7 @@ function layout_page_header_begin( $p_page_title = null ) {
 		echo "\t",
 			'<link rel="search" type="application/opensearchdescription+xml" ',
 				'title="' . sprintf( lang_get( "opensearch_{$t_type}_description" ), $t_title ) . '" ',
-				'href="' . string_sanitize_url( 'browser_search_plugin.php?type=' . $t_type, true ) .
+				'href="' . string_sanitize_url( 'browser_search_plugin.php?type=' . $t_type, false ) .
 				'"/>',
 			"\n";
 	}


### PR DESCRIPTION
When the request contains the X-Forwarded-Host HTTP header,
in the returned HTML page, many ressources are loaded using
this Header, mainly the css one.
It means an attacker can inject it's own code.

The problem comes from two paths:

    in core/html_api.php:245 string_sanitize_url must be set to false
    in core/layout_api.php:94 same problem

You can find the description here: 
https://mantisbt.org/bugs/view.php?id=25170

Thanks,
Jean-Sébastien