### PR TITLE
Filter summary

### DIFF
--- a/core/classes/DbQuery.class.php
+++ b/core/classes/DbQuery.class.php
@@ -293,6 +293,7 @@ class DbQuery {
 			trigger_error( ERROR_DB_QUERY_FAILED, ERROR );
 			$this->db_result = false;
 		}
+		$this->current_row = null;
 		return $this->db_result;
 	}
 

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -856,11 +856,12 @@ function print_doc_menu( $p_page = '' ) {
 }
 
 /**
- * Print the menu for the summary section
+ * Print the menu for the summary section.
  * @param string $p_page Specifies the current page name so it's link can be disabled.
+ * @param array $p_filter Filter array, the one in use for summary pages.
  * @return void
  */
-function print_summary_menu( $p_page = '' ) {
+function print_summary_menu( $p_page = '', array $p_filter = null ) {
 	# Plugin / Event added options
 	$t_event_menu_options = event_signal( 'EVENT_MENU_SUMMARY' );
 	$t_menu_options = array();
@@ -880,10 +881,12 @@ function print_summary_menu( $p_page = '' ) {
 
 	echo '<ul class="nav nav-tabs padding-18">' . "\n";
 
+	$t_filter_param = $p_filter ? filter_get_temporary_key_param( $p_filter ) : null;
 	foreach ( $t_pages as $t_page ) {
 		$t_active =  $t_page['url'] == $p_page ? 'active' : '';
+		$t_link = $t_filter_param ? helper_url_combine( $t_page['url'], $t_filter_param ) : $t_page['url'];
 		echo '<li class="' . $t_active . '">' . "\n";
-		echo '<a href="'. helper_mantis_url( $t_page['url'] ) .'">' . "\n";
+		echo '<a href="'. helper_mantis_url( $t_link ) .'">' . "\n";
 		echo lang_get( $t_page['label'] );
 		echo '</a>' . "\n";
 		echo '</li>' . "\n";

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -898,6 +898,8 @@ function print_summary_menu( $p_page = '', array $p_filter = null ) {
 	}
 
 	echo '</ul>' . "\n";
+
+	summary_print_filter_info( $p_filter );
 }
 
 /**

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -1343,3 +1343,38 @@ function summary_get_filter() {
 	}
 	return $t_filter;
 }
+
+/**
+ * Print filter related information for summary page.
+ * If a filter has been applied, display a notice, bug count, link to view issues.
+ * @param array $p_filter Filter array.
+ * @return void
+ */
+function summary_print_filter_info( array $p_filter = null ) {
+	if( null === $p_filter ) {
+		return;
+	}
+	# If filter is temporary, then it has been provided explicitly.
+	# When no filter is specified for summary page, we receive a defaulted filter
+	# which don't have any specific id.
+	if( !filter_is_temporary( $p_filter ) ) {
+		return;
+	}
+	$t_filter_query = filter_cache_subquery( $p_filter );
+	$t_bug_count = $t_filter_query->get_bug_count();
+	$t_view_issues_link = helper_url_combine( 'view_all_bug_page.php', filter_get_temporary_key_param( $p_filter ) );
+	?>
+	<div class="space-10"></div>
+	<div class="col-md-12 col-xs-12">
+		<p>
+			<span class="alert-warning">
+			<?php
+			echo '<a href="' , $t_view_issues_link , '" title="' , lang_get( 'view_bugs_link' ) , '">';
+			echo lang_get( 'summary_notice_filter_is_applied' ) , '&nbsp;' , '( ' , $t_bug_count , ' ' , lang_get( 'bugs' ) , ' )';
+			echo '</a>';
+			?>
+			</span>
+		</p>
+	</div>
+	<?php
+}

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -81,17 +81,22 @@ function summary_helper_print_row( $p_label, $p_open, $p_resolved, $p_closed, $p
  * acted on by the user ( reported, handled or commented on )
  *
  * @param integer $p_user_id A valid user identifier.
+ * @param array $p_filter Filter array.
  * @return string
  */
-function summary_helper_get_developer_label( $p_user_id ) {
+function summary_helper_get_developer_label( $p_user_id, array $p_filter = null ) {
 	$t_user = string_display_line( user_get_name( $p_user_id ) );
 
-	return '<a class="subtle" href="view_all_set.php?type=' . FILTER_ACTION_PARSE_NEW . '&amp;temporary=y
-			&amp;' . FILTER_PROPERTY_REPORTER_ID . '=' . $p_user_id . '
-			&amp;' . FILTER_PROPERTY_HANDLER_ID . '=' . $p_user_id . '
-			&amp;' . FILTER_PROPERTY_NOTE_USER_ID . '=' . $p_user_id . '
-			&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '
-			&amp;' . FILTER_PROPERTY_MATCH_TYPE . '=' . FILTER_MATCH_ANY . '">' . $t_user . '</a>';
+	$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
+	$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+
+	return '<a class="subtle" href="' . $t_link_prefix
+		. '&amp;' . FILTER_PROPERTY_REPORTER_ID . '=' . $p_user_id
+		. '&amp;' . FILTER_PROPERTY_HANDLER_ID . '=' . $p_user_id
+		. '&amp;' . FILTER_PROPERTY_NOTE_USER_ID . '=' . $p_user_id
+		. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE
+		. '&amp;' . FILTER_PROPERTY_MATCH_TYPE . '=' . FILTER_MATCH_ANY
+		. '">' . $t_user . '</a>';
 
 }
 
@@ -144,16 +149,16 @@ function summary_helper_build_buglinks( $p_bug_link, &$p_bugs_open, &$p_bugs_res
 	$t_closed_val = config_get( 'bug_closed_status_threshold' );
 
 	if( 0 < $p_bugs_open ) {
-		$p_bugs_open = $p_bug_link . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_resolved_val . '">' . $p_bugs_open . '</a>';
+		$p_bugs_open = '<a class="subtle" href="' . $p_bug_link . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_resolved_val . '">' . $p_bugs_open . '</a>';
 	}
 	if( 0 < $p_bugs_resolved ) {
-		$p_bugs_resolved = $p_bug_link . '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_resolved_val . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_closed_val . '">' . $p_bugs_resolved . '</a>';
+		$p_bugs_resolved = '<a class="subtle" href="' . $p_bug_link . '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_resolved_val . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_closed_val . '">' . $p_bugs_resolved . '</a>';
 	}
 	if( 0 < $p_bugs_closed ) {
-		$p_bugs_closed = $p_bug_link . '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_closed_val . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">' . $p_bugs_closed . '</a>';
+		$p_bugs_closed = '<a class="subtle" href="' . $p_bug_link . '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_closed_val . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">' . $p_bugs_closed . '</a>';
 	}
 	if( 0 < $p_bugs_total ) {
-		$p_bugs_total = $p_bug_link . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">' . $p_bugs_total . '</a>';
+		$p_bugs_total = '<a class="subtle" href="' . $p_bug_link . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">' . $p_bugs_total . '</a>';
 	}	
 }
 
@@ -190,8 +195,8 @@ function summary_print_by_enum( $p_enum, array $p_filter = null ) {
 	if( ' 1<>1' == $t_project_filter ) {
 		return;
 	}
-
-	$t_filter_prefix = config_get( 'bug_count_hyperlink_prefix' );
+	$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
+	$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
 
 	$t_status_query = ( 'status' == $p_enum ) ? '' : ' ,status ';
 	$t_query = new DBQuery();
@@ -244,15 +249,14 @@ function summary_print_by_enum( $p_enum, array $p_filter = null ) {
 		$t_bugs_total = $t_bugs_open + $t_bugs_resolved + $t_bugs_closed;
 		$t_bugs_ratio = summary_helper_get_bugratio( $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total_count);
 
-		$t_bug_link = '<a class="subtle" href="' . $t_filter_prefix . '&amp;'
-			. $t_filter_property . '=' . $t_enum;
+		$t_bug_link = $t_link_prefix . '&amp;' . $t_filter_property . '=' . $t_enum;
 
 		if( !is_blank( $t_bug_link ) ) {
 			$t_resolved_val = config_get( 'bug_resolved_status_threshold' );
 			$t_closed_val = config_get( 'bug_closed_status_threshold' );
 			
 			if( 0 < $t_bugs_open ) {
-				$t_bugs_open = $t_bug_link
+				$t_bugs_open = '<a class="subtle" href="' . $t_bug_link
 					. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_resolved_val . '">'
 					. $t_bugs_open . '</a>';
 			} else {
@@ -261,7 +265,7 @@ function summary_print_by_enum( $p_enum, array $p_filter = null ) {
 				}
 			}
 			if( 0 < $t_bugs_resolved ) {
-				$t_bugs_resolved = $t_bug_link
+				$t_bugs_resolved = '<a class="subtle" href="' . $t_bug_link
 					# Only add status filter if not already part of the link
 					. ( 'status' != $p_enum ? '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_resolved_val : '' )
 					. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_closed_val . '">'
@@ -272,7 +276,7 @@ function summary_print_by_enum( $p_enum, array $p_filter = null ) {
 				}
 			}
 			if( 0 < $t_bugs_closed ) {
-				$t_bugs_closed = $t_bug_link
+				$t_bugs_closed = '<a class="subtle" href="' . $t_bug_link
 					# Only add status filter if not already part of the link
 					. ( 'status' != $p_enum ? '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_closed_val : '' )
 					. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">'
@@ -283,7 +287,7 @@ function summary_print_by_enum( $p_enum, array $p_filter = null ) {
 				}
 			}
 			if( 0 < $t_bugs_total ) {
-				$t_bugs_total = $t_bug_link
+				$t_bugs_total = '<a class="subtle" href="' . $t_bug_link
 					. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '='
 					. META_FILTER_NONE . '">' . $t_bugs_total . '</a>';
 			}	
@@ -384,8 +388,12 @@ function summary_print_by_date( array $p_date_array, array $p_filter = null ) {
 		$t_resolved_count = summary_resolved_bug_count_by_date( $t_days, $p_filter );
 
 		$t_start_date = mktime( 0, 0, 0, date( 'm' ), ( date( 'd' ) - $t_days ), date( 'Y' ) );
-		$t_new_bugs_link = '<a class="subtle" href="' . config_get( 'bug_count_hyperlink_prefix' )
-				. '&amp;' . FILTER_PROPERTY_FILTER_BY_DATE_SUBMITTED . '=on'
+
+		$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
+		$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+
+		$t_new_bugs_link = $t_link_prefix
+				. '&amp;' . FILTER_PROPERTY_FILTER_BY_DATE_SUBMITTED . '=' . ON
 				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_START_YEAR . '=' . date( 'Y', $t_start_date )
 				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_START_MONTH . '=' . date( 'm', $t_start_date )
 				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_START_DAY . '=' . date( 'd', $t_start_date )
@@ -395,7 +403,7 @@ function summary_print_by_date( array $p_date_array, array $p_filter = null ) {
 		echo '    <td class="width50">' . $t_days . '</td>' . "\n";
 
 		if( $t_new_count > 0 ) {
-			echo '    <td class="align-right">' . $t_new_bugs_link . $t_new_count . '</a></td>' . "\n";
+			echo '    <td class="align-right"><a class="subtle" href="' . $t_new_bugs_link . $t_new_count . '</a></td>' . "\n";
 		} else {
 			echo '    <td class="align-right">' . $t_new_count . '</td>' . "\n";
 		}
@@ -587,8 +595,11 @@ function summary_print_by_developer( array $p_filter = null ) {
 		$t_bugs_total = $t_bugs_open + $t_bugs_resolved + $t_bugs_closed;
 		$t_bugs_ratio = summary_helper_get_bugratio( $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total_count);
 
-		$t_bug_link = '<a class="subtle" href="' . config_get( 'bug_count_hyperlink_prefix' ) . '&amp;' . FILTER_PROPERTY_HANDLER_ID . '=' . $t_label;
-		$t_label = summary_helper_get_developer_label( $t_label );
+		$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
+		$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+
+		$t_bug_link = $t_link_prefix . '&amp;' . FILTER_PROPERTY_HANDLER_ID . '=' . $t_label;
+		$t_label = summary_helper_get_developer_label( $t_label, $p_filter );
 		summary_helper_build_buglinks( $t_bug_link, $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total );
 		summary_helper_print_row( $t_label, $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total, $t_bugs_ratio[0], $t_bugs_ratio[1] );
 	}
@@ -673,18 +684,21 @@ function summary_print_by_reporter( array $p_filter = null ) {
 		if( 0 < $t_bugs_total ) {
 			$t_user = string_display_line( user_get_name( $v_reporter_id ) );
 
-			$t_bug_link = '<a class="subtle" href="' . config_get( 'bug_count_hyperlink_prefix' ) . '&amp;' . FILTER_PROPERTY_REPORTER_ID . '=' . $v_reporter_id;
+			$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
+			$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+
+			$t_bug_link = $t_link_prefix . '&amp;' . FILTER_PROPERTY_REPORTER_ID . '=' . $v_reporter_id;
 			if( 0 < $t_bugs_open ) {
-				$t_bugs_open = $t_bug_link . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_resolved_val . '">' . $t_bugs_open . '</a>';
+				$t_bugs_open = '<a class="subtle" href="' . $t_bug_link . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_resolved_val . '">' . $t_bugs_open . '</a>';
 			}
 			if( 0 < $t_bugs_resolved ) {
-				$t_bugs_resolved = $t_bug_link . '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_resolved_val . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_closed_val . '">' . $t_bugs_resolved . '</a>';
+				$t_bugs_resolved = '<a class="subtle" href="' . $t_bug_link . '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_resolved_val . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_closed_val . '">' . $t_bugs_resolved . '</a>';
 			}
 			if( 0 < $t_bugs_closed ) {
-				$t_bugs_closed = $t_bug_link . '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_closed_val . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">' . $t_bugs_closed . '</a>';
+				$t_bugs_closed = '<a class="subtle" href="' . $t_bug_link . '&amp;' . FILTER_PROPERTY_STATUS . '=' . $t_closed_val . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">' . $t_bugs_closed . '</a>';
 			}
 			if( 0 < $t_bugs_total ) {
-				$t_bugs_total = $t_bug_link . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">' . $t_bugs_total . '</a>';
+				$t_bugs_total = '<a class="subtle" href="' . $t_bug_link . '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">' . $t_bugs_total . '</a>';
 			}
 
 			summary_helper_print_row( $t_user, $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total, $t_bugs_ratio[0], $t_bugs_ratio[1] );
@@ -746,7 +760,10 @@ function summary_print_by_category( array $p_filter = null ) {
 		$t_bugs_total = $t_bugs_open + $t_bugs_resolved + $t_bugs_closed;
 		$t_bugs_ratio = summary_helper_get_bugratio( $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total_count);
 
-		$t_bug_link = '<a class="subtle" href="' . config_get( 'bug_count_hyperlink_prefix' ) . '&amp;' . FILTER_PROPERTY_CATEGORY_ID . '=' . urlencode( $t_label );
+		$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
+		$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+
+		$t_bug_link = $t_link_prefix . '&amp;' . FILTER_PROPERTY_CATEGORY_ID . '=' . urlencode( $t_label );
 		summary_helper_build_buglinks( $t_bug_link, $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total );
 		summary_helper_print_row( string_display_line( $t_label ), $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total, $t_bugs_ratio[0], $t_bugs_ratio[1] );
 	}
@@ -890,7 +907,10 @@ function summary_print_developer_resolution( $p_resolution_enum_string, array $p
 
 	$t_threshold_fixed = config_get( 'bug_resolution_fixed_threshold' );
 	$t_threshold_notfixed = config_get( 'bug_resolution_not_fixed_threshold' );
-	$t_filter_prefix = config_get( 'bug_count_hyperlink_prefix' );
+
+	$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
+	$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+
 	$t_row_count = 0;
 
 	# We now have a multi dimensional array of users and resolutions, with the value of each resolution for each user
@@ -905,7 +925,7 @@ function summary_print_developer_resolution( $p_resolution_enum_string, array $p
 			echo '<tr>';
 			$t_row_count++;
 			echo '<td>';
-			echo summary_helper_get_developer_label( $t_handler_id );
+			echo summary_helper_get_developer_label( $t_handler_id, $p_filter );
 			echo "</td>\n";
 
 			# We need to track the percentage of bugs that are considered fixed, as well as
@@ -921,11 +941,11 @@ function summary_print_developer_resolution( $p_resolution_enum_string, array $p
 
 				echo '<td class="align-right">';
 				if( 0 < $t_res_bug_count ) {
-					$t_bug_link = '<a class="subtle" href="' . $t_filter_prefix .
+					$t_bug_link = $t_link_prefix .
 						'&amp;' . FILTER_PROPERTY_HANDLER_ID . '=' . $t_handler_id .
 						'&amp;' . FILTER_PROPERTY_RESOLUTION . '=' . $c_res_s[$j] .
-						'&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">';
-					echo $t_bug_link . $t_res_bug_count . '</a>';
+						'&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE;
+					echo '<a class="subtle" href="' . $t_bug_link . '">' . $t_res_bug_count . '</a>';
 				} else {
 					echo $t_res_bug_count;
 				}
@@ -945,7 +965,7 @@ function summary_print_developer_resolution( $p_resolution_enum_string, array $p
 
 			# Display Total
 			echo '<td class="align-right">';
-			$t_bug_link =  $t_filter_prefix .
+			$t_bug_link =  $t_link_prefix .
 				'&amp;' . FILTER_PROPERTY_HANDLER_ID . '=' . $t_handler_id .
 				'&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE;
 			echo '<a class="subtle" href="' . $t_bug_link . '">' . $t_total . '</a>';
@@ -1022,7 +1042,10 @@ function summary_print_reporter_resolution( $p_resolution_enum_string, array $p_
 
 	$t_threshold_fixed = config_get( 'bug_resolution_fixed_threshold' );
 	$t_threshold_notfixed = config_get( 'bug_resolution_not_fixed_threshold' );
-	$t_filter_prefix = config_get( 'bug_count_hyperlink_prefix' );
+
+	$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
+	$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+
 	$t_row_count = 0;
 
 	# We now have a multi dimensional array of users and resolutions, with the value of each resolution for each user
@@ -1058,7 +1081,7 @@ function summary_print_reporter_resolution( $p_resolution_enum_string, array $p_
 
 				echo '<td class="align-right">';
 				if( 0 < $t_res_bug_count ) {
-					$t_bug_link = $t_filter_prefix .
+					$t_bug_link = $t_link_prefix .
 						'&amp;' . FILTER_PROPERTY_REPORTER_ID . '=' . $t_reporter_id .
 						'&amp;' . FILTER_PROPERTY_RESOLUTION . '=' . $c_res_s[$j] .
 						'&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE;
@@ -1082,7 +1105,7 @@ function summary_print_reporter_resolution( $p_resolution_enum_string, array $p_
 
 			# Display Total
 			echo '<td class="align-right">';
-			$t_bug_link =  $t_filter_prefix .
+			$t_bug_link =  $t_link_prefix .
 				'&amp;' . FILTER_PROPERTY_REPORTER_ID . '=' . $t_reporter_id .
 				'&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE;
 			echo '<a class="subtle" href="' . $t_bug_link . '">' . $t_total_user_bugs . '</a>';

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -87,8 +87,7 @@ function summary_helper_print_row( $p_label, $p_open, $p_resolved, $p_closed, $p
 function summary_helper_get_developer_label( $p_user_id, array $p_filter = null ) {
 	$t_user = string_display_line( user_get_name( $p_user_id ) );
 
-	$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
-	$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+	$t_link_prefix = summary_get_link_prefix( $p_filter );
 
 	return '<a class="subtle" href="' . $t_link_prefix
 		. '&amp;' . FILTER_PROPERTY_REPORTER_ID . '=' . $p_user_id
@@ -195,8 +194,7 @@ function summary_print_by_enum( $p_enum, array $p_filter = null ) {
 	if( ' 1<>1' == $t_project_filter ) {
 		return;
 	}
-	$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
-	$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+	$t_link_prefix = summary_get_link_prefix( $p_filter );
 
 	$t_status_query = ( 'status' == $p_enum ) ? '' : ' ,status ';
 	$t_query = new DBQuery();
@@ -464,8 +462,7 @@ function summary_print_by_developer( array $p_filter = null ) {
 		$t_bugs_total = $t_bugs_open + $t_bugs_resolved + $t_bugs_closed;
 		$t_bugs_ratio = summary_helper_get_bugratio( $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total_count);
 
-		$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
-		$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+		$t_link_prefix = summary_get_link_prefix( $p_filter );
 
 		$t_bug_link = $t_link_prefix . '&amp;' . FILTER_PROPERTY_HANDLER_ID . '=' . $t_label;
 		$t_label = summary_helper_get_developer_label( $t_label, $p_filter );
@@ -553,8 +550,7 @@ function summary_print_by_reporter( array $p_filter = null ) {
 		if( 0 < $t_bugs_total ) {
 			$t_user = string_display_line( user_get_name( $v_reporter_id ) );
 
-			$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
-			$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+			$t_link_prefix = summary_get_link_prefix( $p_filter );
 
 			$t_bug_link = $t_link_prefix . '&amp;' . FILTER_PROPERTY_REPORTER_ID . '=' . $v_reporter_id;
 			if( 0 < $t_bugs_open ) {
@@ -629,8 +625,7 @@ function summary_print_by_category( array $p_filter = null ) {
 		$t_bugs_total = $t_bugs_open + $t_bugs_resolved + $t_bugs_closed;
 		$t_bugs_ratio = summary_helper_get_bugratio( $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total_count);
 
-		$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
-		$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+		$t_link_prefix = summary_get_link_prefix( $p_filter );
 
 		$t_bug_link = $t_link_prefix . '&amp;' . FILTER_PROPERTY_CATEGORY_ID . '=' . urlencode( $t_label );
 		summary_helper_build_buglinks( $t_bug_link, $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total );
@@ -777,8 +772,7 @@ function summary_print_developer_resolution( $p_resolution_enum_string, array $p
 	$t_threshold_fixed = config_get( 'bug_resolution_fixed_threshold' );
 	$t_threshold_notfixed = config_get( 'bug_resolution_not_fixed_threshold' );
 
-	$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
-	$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+	$t_link_prefix = summary_get_link_prefix( $p_filter );
 
 	$t_row_count = 0;
 
@@ -912,8 +906,7 @@ function summary_print_reporter_resolution( $p_resolution_enum_string, array $p_
 	$t_threshold_fixed = config_get( 'bug_resolution_fixed_threshold' );
 	$t_threshold_notfixed = config_get( 'bug_resolution_not_fixed_threshold' );
 
-	$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
-	$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+	$t_link_prefix = summary_get_link_prefix( $p_filter );
 
 	$t_row_count = 0;
 
@@ -1411,10 +1404,10 @@ function summary_print_by_date( array $p_date_array, array $p_filter = null ) {
 	foreach( $t_date_array as $t_ix => $t_days ) {
 		$t_new_count = $t_open_count_array[$t_ix];
 		$t_resolved_count = $t_resolved_count_array[$t_ix];
-
 		$t_start_date = mktime( 0, 0, 0, date( 'm' ), ( date( 'd' ) - $t_days ), date( 'Y' ) );
-		$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
-		$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+
+		$t_link_prefix = summary_get_link_prefix( $p_filter );
+
 		$t_new_bugs_link = $t_link_prefix
 				. '&amp;' . FILTER_PROPERTY_FILTER_BY_DATE_SUBMITTED . '=' . ON
 				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_START_YEAR . '=' . date( 'Y', $t_start_date )
@@ -1448,4 +1441,11 @@ function summary_print_by_date( array $p_date_array, array $p_filter = null ) {
 		echo '    <td class="align-right' . $t_style . '">' . $t_balance . "</td>\n";
 		echo '</tr>' . "\n";
 	}
+}
+
+function summary_get_link_prefix( array $p_filter = null ) {
+	$t_filter_action = filter_is_temporary( $p_filter ) ? FILTER_ACTION_PARSE_ADD : FILTER_ACTION_PARSE_NEW;
+	$t_link_prefix = 'view_all_set.php?type=' . $t_filter_action . '&temporary=y&new=1';
+	$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+	return $t_link_prefix;
 }

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -533,7 +533,8 @@ function summary_print_by_reporter( array $p_filter = null ) {
 				'open' => 0,
 				'resolved' => 0,
 				'closed' => 0,
-				'total' => 0
+				'total' => 0,
+				'reporter_id' => $t_reporter_id
 				);
 		}
 		$t_bugcount = (int)$t_row['bugcount'];
@@ -558,11 +559,17 @@ function summary_print_by_reporter( array $p_filter = null ) {
 				);
 	}
 
+	# sort based on total issue count
+	# note that after array_multisort, we lose the numeric indexes, but we stored
+	# the reporter id inside each sub-array
+	array_multisort ( array_column( $t_reporter_stats, 'total' ), SORT_DESC, $t_reporter_stats );
+
 	# print results
-	foreach( $t_reporter_stats as $t_reporter_id => $t_stats ) {
+	foreach( $t_reporter_stats as $t_stats ) {
 		if( $t_stats['total'] == 0 ) {
 			continue;
 		}
+		$t_reporter_id = $t_stats['reporter_id'];
 		$t_user = string_display_line( user_get_name( $t_reporter_id ) );
 		$t_link_prefix = summary_get_link_prefix( $p_filter );
 

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -1297,7 +1297,8 @@ function summary_by_dates_resolved_bug_count( array $p_date_array, array $p_filt
 	}
 	$t_sql_ranges .= ' ELSE -1 END';
 
-	$t_sql = 'SELECT ' . $t_sql_ranges . ' AS date_range, COUNT( b.id ) AS range_count'
+	$t_sql = 'SELECT date_range, COUNT( id ) AS range_count	FROM ('
+		. ' SELECT b.id, ' . $t_sql_ranges . ' AS date_range'
 		. '	FROM {bug} b LEFT JOIN {bug_history} h'
 		. ' ON b.id = h.bug_id AND h.type = :hist_type AND h.field_name = :hist_field'
 		. ' WHERE b.status >= :int_st_resolved'
@@ -1316,7 +1317,7 @@ function summary_by_dates_resolved_bug_count( array $p_date_array, array $p_filt
 		$t_sql .= ' AND b.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
-	$t_sql .= ' GROUP BY date_range';
+	$t_sql .= ' ) subquery GROUP BY date_range';
 	$t_query->sql( $t_sql );
 
 	$t_count_array = array();
@@ -1368,7 +1369,8 @@ function summary_by_dates_open_bug_count( array $p_date_array, array $p_filter =
 	}
 	$t_sql_ranges .= ' ELSE -1 END';
 
-	$t_sql = 'SELECT ' . $t_sql_ranges . ' AS date_range, COUNT( b.id ) AS range_count'
+	$t_sql = 'SELECT date_range, COUNT( id ) AS range_count	FROM ('
+		. ' SELECT b.id, ' . $t_sql_ranges . ' AS date_range'
 		. '	FROM {bug} b LEFT JOIN {bug_history} h ON b.id = h.bug_id '
 		. ' WHERE ( h.type = :type_new'
 		. ' OR h.type = :type_st AND h.field_name = :field_st'
@@ -1387,7 +1389,7 @@ function summary_by_dates_open_bug_count( array $p_date_array, array $p_filter =
 		$t_sql .= ' AND b.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
-	$t_sql .= ' GROUP BY date_range';
+	$t_sql .= ' ) subquery GROUP BY date_range';
 	$t_query->sql( $t_sql );
 
 	$t_count_array = array();

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -1299,7 +1299,7 @@ function summary_by_dates_resolved_bug_count( array $p_date_array, array $p_filt
 
 	$t_sql = 'SELECT date_range, COUNT( id ) AS range_count	FROM ('
 		. ' SELECT b.id, ' . $t_sql_ranges . ' AS date_range'
-		. '	FROM {bug} b LEFT JOIN {bug_history} h'
+		. ' FROM {bug} b LEFT JOIN {bug_history} h'
 		. ' ON b.id = h.bug_id AND h.type = :hist_type AND h.field_name = :hist_field'
 		. ' WHERE b.status >= :int_st_resolved'
 		. ' AND h.old_value < :int_st_resolved'
@@ -1371,7 +1371,7 @@ function summary_by_dates_open_bug_count( array $p_date_array, array $p_filter =
 
 	$t_sql = 'SELECT date_range, COUNT( id ) AS range_count	FROM ('
 		. ' SELECT b.id, ' . $t_sql_ranges . ' AS date_range'
-		. '	FROM {bug} b LEFT JOIN {bug_history} h ON b.id = h.bug_id '
+		. ' FROM {bug} b LEFT JOIN {bug_history} h ON b.id = h.bug_id '
 		. ' WHERE ( h.type = :type_new'
 		. ' OR h.type = :type_st AND h.field_name = :field_st'
 		. ' AND h.old_value >= :int_st_resolved AND h.new_value < :int_st_resolved'

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -298,137 +298,6 @@ function summary_print_by_enum( $p_enum, array $p_filter = null ) {
 }
 
 /**
- * prints the bugs submitted in the last X days (default is 1 day) for the current project.
- * A filter can be used to limit the visibility.
- *
- * @param integer $p_num_days A number of days.
- * @param array $p_filter Filter array.
- * @return integer
- */
-function summary_new_bug_count_by_date( $p_num_days = 1, array $p_filter = null ) {
-	$c_time_length = (int)$p_num_days * SECONDS_PER_DAY;
-
-	$t_project_id = helper_get_current_project();
-
-	$t_specific_where = helper_project_specific_where( $t_project_id );
-	if( ' 1<>1' == $t_specific_where ) {
-		return 0;
-	}
-
-	$t_query = new DBQuery();
-	$t_sql = 'SELECT COUNT(*) FROM {bug}'
-		. ' WHERE ' . db_helper_compare_time( ':now', '<=', 'date_submitted', $c_time_length )
-		. ' AND ' . $t_specific_where;
-	$t_query->bind( 'now', db_now() );
-	if( !empty( $p_filter ) ) {
-		$t_subquery = filter_cache_subquery( $p_filter );
-		$t_sql .= ' AND {bug}.id IN :filter';
-		$t_query->bind( 'filter', $t_subquery );
-	}
-	$t_query->sql( $t_sql );
-
-	return $t_query->value();
-}
-
-/**
- * Returns the number of bugs resolved in the last X days (default is 1 day) for the current project.
- * A filter can be used to limit the visibility.
- *
- * @param integer $p_num_days Anumber of days.
- * @param array $p_filter Filter array.
- * @return integer
- */
-function summary_resolved_bug_count_by_date( $p_num_days = 1, array $p_filter = null ) {
-	$t_resolved = config_get( 'bug_resolved_status_threshold' );
-
-	$c_time_length = (int)$p_num_days * SECONDS_PER_DAY;
-
-	$t_project_id = helper_get_current_project();
-
-	$t_specific_where = helper_project_specific_where( $t_project_id );
-	if( ' 1<>1' == $t_specific_where ) {
-		return 0;
-	}
-	$t_query = new DBQuery();
-	$t_sql = 'SELECT COUNT( DISTINCT b.id )'
-		. '	FROM {bug} b LEFT JOIN {bug_history} h'
-		. ' ON b.id = h.bug_id AND h.type = :hist_type AND h.field_name = :hist_field'
-		. ' WHERE b.status >= :status_resolved'
-		. ' AND h.old_value < :status_resolved'
-		. ' AND h.new_value >= :status_resolved'
-		. ' AND ' . db_helper_compare_time( ':now', '<=', 'date_modified', $c_time_length )
-		. ' AND ' . $t_specific_where;
-	$t_query->bind( array (
-		'hist_type' => NORMAL_TYPE,
-		'hist_field' => 'status',
-		'status_resolved' => (int)$t_resolved,
-		'now' => db_now()
-		) );
-	if( !empty( $p_filter ) ) {
-		$t_subquery = filter_cache_subquery( $p_filter );
-		$t_sql .= ' AND b.id IN :filter';
-		$t_query->bind( 'filter', $t_subquery );
-	}
-	$t_query->sql( $t_sql );
-
-	return $t_query->value();
-}
-
-/**
- * This function shows the number of bugs submitted in the last X days.
- * A filter can be used to limit the visibility.
- *
- * @param array $p_date_array An array of integers representing days is passed in.
- * @param array $p_filter Filter array.
- * @return void
- */
-function summary_print_by_date( array $p_date_array, array $p_filter = null ) {
-	foreach( $p_date_array as $t_days ) {
-		$t_new_count = summary_new_bug_count_by_date( $t_days, $p_filter );
-		$t_resolved_count = summary_resolved_bug_count_by_date( $t_days, $p_filter );
-
-		$t_start_date = mktime( 0, 0, 0, date( 'm' ), ( date( 'd' ) - $t_days ), date( 'Y' ) );
-
-		$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
-		$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
-
-		$t_new_bugs_link = $t_link_prefix
-				. '&amp;' . FILTER_PROPERTY_FILTER_BY_DATE_SUBMITTED . '=' . ON
-				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_START_YEAR . '=' . date( 'Y', $t_start_date )
-				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_START_MONTH . '=' . date( 'm', $t_start_date )
-				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_START_DAY . '=' . date( 'd', $t_start_date )
-				. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">';
-
-		echo '<tr>' . "\n";
-		echo '    <td class="width50">' . $t_days . '</td>' . "\n";
-
-		if( $t_new_count > 0 ) {
-			echo '    <td class="align-right"><a class="subtle" href="' . $t_new_bugs_link . $t_new_count . '</a></td>' . "\n";
-		} else {
-			echo '    <td class="align-right">' . $t_new_count . '</td>' . "\n";
-		}
-		echo '    <td class="align-right">' . $t_resolved_count . '</td>' . "\n";
-
-		$t_balance = $t_new_count - $t_resolved_count;
-		$t_style = '';
-		if( $t_balance > 0 ) {
-
-			# we are talking about bugs: a balance > 0 is "negative" for the project...
-			$t_style = ' red';
-			$t_balance = sprintf( '%+d', $t_balance );
-
-			# "+" modifier added in PHP >= 4.3.0
-		} else if( $t_balance < 0 ) {
-			$t_style = ' green';
-			$t_balance = sprintf( '%+d', $t_balance );
-		}
-
-		echo '    <td class="align-right' . $t_style . '">' . $t_balance . "</td>\n";
-		echo '</tr>' . "\n";
-	}
-}
-
-/**
  * Print list of open bugs with the highest activity score the score is calculated assigning
  * one "point" for each history event associated with the bug.
  * A filter can be used to limit the visibility.
@@ -1377,4 +1246,206 @@ function summary_print_filter_info( array $p_filter = null ) {
 		</p>
 	</div>
 	<?php
+}
+
+/**
+ * Calculate the number of "resolve" issues actions in the last X days.
+ * This includes each and succesive resolution transitions.
+ * A filter can be used to limit the visibility.
+ *
+ * @param array $p_date_array An array of integers representing days is passed in.
+ * @param array $p_filter Filter array.
+ * @return array	Accumulated count for each day range
+ */
+function summary_by_dates_resolved_bug_count( array $p_date_array, array $p_filter = null ) {
+	$t_project_id = helper_get_current_project();
+	$t_specific_where = helper_project_specific_where( $t_project_id );
+	$t_resolved = config_get( 'bug_resolved_status_threshold' );
+
+	$t_date_array = array_values( $p_date_array );
+	sort( $t_date_array );
+	$t_query = new DBQuery();
+
+	$t_prev_days = 0;
+	$t_now = db_now();
+	$t_sql_ranges = 'CASE';
+	foreach( $t_date_array as $t_ix => $t_days ) {
+		$c_days = (int)$t_days;
+		$t_range_start = $t_now - $c_days * SECONDS_PER_DAY + 1;
+		$t_range_end = $t_now - $t_prev_days * SECONDS_PER_DAY;
+		$t_sql_ranges .= ' WHEN h.date_modified'
+				. ' BETWEEN ' . $t_query->param( $t_range_start )
+				. ' AND ' . $t_query->param( $t_range_end )
+				. ' THEN ' . $t_ix;
+		$t_prev_days = $c_days;
+	}
+	$t_sql_ranges .= ' ELSE -1 END';
+
+	$t_sql = 'SELECT ' . $t_sql_ranges . ' AS date_range, COUNT( b.id ) AS range_count'
+		. '	FROM {bug} b LEFT JOIN {bug_history} h'
+		. ' ON b.id = h.bug_id AND h.type = :hist_type AND h.field_name = :hist_field'
+		. ' WHERE b.status >= :int_st_resolved'
+		. ' AND h.old_value < :int_st_resolved'
+		. ' AND h.new_value >= :int_st_resolved'
+		. ' AND h.date_modified > :mint_ime'
+		. ' AND ' . $t_specific_where;
+	$t_query->bind( array (
+		'hist_type' => NORMAL_TYPE,
+		'hist_field' => 'status',
+		'int_st_resolved' => (int)$t_resolved,
+		'mint_ime' => $t_now - $t_prev_days * SECONDS_PER_DAY
+		) );
+	if( !empty( $p_filter ) ) {
+		$t_subquery = filter_cache_subquery( $p_filter );
+		$t_sql .= ' AND b.id IN :filter';
+		$t_query->bind( 'filter', $t_subquery );
+	}
+	$t_sql .= ' GROUP BY date_range';
+	$t_query->sql( $t_sql );
+
+	$t_count_array = array();
+	foreach( $t_date_array as $t_ix => $t_value ) {
+		$t_count_array[$t_ix] = 0;
+	}
+	# count is accumulated
+	$t_count = 0;
+	while( $t_row = $t_query->fetch() ) {
+		$t_index = $t_row['date_range'];
+		if( $t_index >= 0 ) {
+			$t_count += $t_row['range_count'];
+			$t_count_array[$t_index] = $t_count;
+		}
+	}
+	return $t_count_array;
+}
+
+/**
+ * Calculate the number of "open" issues actions in the last X days.
+ * This includes each issue submission, and it's succesive reopen transitions.
+ * A filter can be used to limit the visibility.
+ *
+ * @param array $p_date_array An array of integers representing days is passed in.
+ * @param array $p_filter Filter array.
+ * @return array	Accumulated count for each day range
+ */
+function summary_by_dates_open_bug_count( array $p_date_array, array $p_filter = null ) {
+	$t_project_id = helper_get_current_project();
+	$t_specific_where = helper_project_specific_where( $t_project_id );
+	$t_resolved = config_get( 'bug_resolved_status_threshold' );
+
+	$t_date_array = array_values( $p_date_array );
+	sort( $t_date_array );
+	$t_query = new DBQuery();
+
+	$t_prev_days = 0;
+	$t_now = db_now();
+	$t_sql_ranges = 'CASE';
+	foreach( $t_date_array as $t_ix => $t_days ) {
+		$c_days = (int)$t_days;
+		$t_range_start = $t_now - $c_days * SECONDS_PER_DAY + 1;
+		$t_range_end = $t_now - $t_prev_days * SECONDS_PER_DAY;
+		$t_sql_ranges .= ' WHEN h.date_modified'
+				. ' BETWEEN ' . $t_query->param( $t_range_start )
+				. ' AND ' . $t_query->param( $t_range_end )
+				. ' THEN ' . $t_ix;
+		$t_prev_days = $c_days;
+	}
+	$t_sql_ranges .= ' ELSE -1 END';
+
+	$t_sql = 'SELECT ' . $t_sql_ranges . ' AS date_range, COUNT( b.id ) AS range_count'
+		. '	FROM {bug} b LEFT JOIN {bug_history} h ON b.id = h.bug_id '
+		. ' WHERE ( h.type = :type_new'
+		. ' OR h.type = :type_st AND h.field_name = :field_st'
+		. ' AND h.old_value >= :int_st_resolved AND h.new_value < :int_st_resolved'
+		. ' ) AND h.date_modified > :mint_ime'
+		. ' AND ' . $t_specific_where;
+	$t_query->bind( array (
+		'type_new' => NEW_BUG,
+		'type_st' => NORMAL_TYPE,
+		'field_st' => 'status',
+		'int_st_resolved' => (int)$t_resolved,
+		'mint_ime' => $t_now - $t_prev_days * SECONDS_PER_DAY
+		) );
+	if( !empty( $p_filter ) ) {
+		$t_subquery = filter_cache_subquery( $p_filter );
+		$t_sql .= ' AND b.id IN :filter';
+		$t_query->bind( 'filter', $t_subquery );
+	}
+	$t_sql .= ' GROUP BY date_range';
+	$t_query->sql( $t_sql );
+
+	$t_count_array = array();
+	foreach( $t_date_array as $t_ix => $t_value ) {
+		$t_count_array[$t_ix] = 0;
+	}
+	# count is accumulated
+	$t_count = 0;
+	while( $t_row = $t_query->fetch() ) {
+		$t_index = $t_row['date_range'];
+		if( $t_index >= 0 ) {
+			$t_count += $t_row['range_count'];
+			$t_count_array[$t_index] = $t_count;
+		}
+	}
+	return $t_count_array;
+}
+
+/**
+ * This function shows the number of "open" and "resolve" issues actions in the
+ * last X days. This includes each issue submission, and it's succesive resolve
+ * and reopen transitions.
+ * A filter can be used to limit the visibility.
+ *
+ * @param array $p_date_array An array of integers representing days is passed in.
+ * @param array $p_filter Filter array.
+ * @return void
+ */
+function summary_print_by_date( array $p_date_array, array $p_filter = null ) {
+	# clean and sort dates array
+	$t_date_array = array_values( $p_date_array );
+	sort( $t_date_array );
+
+	$t_open_count_array = summary_by_dates_open_bug_count( $t_date_array, $p_filter );
+	$t_resolved_count_array = summary_by_dates_resolved_bug_count( $t_date_array, $p_filter );
+
+	foreach( $t_date_array as $t_ix => $t_days ) {
+		$t_new_count = $t_open_count_array[$t_ix];
+		$t_resolved_count = $t_resolved_count_array[$t_ix];
+
+		$t_start_date = mktime( 0, 0, 0, date( 'm' ), ( date( 'd' ) - $t_days ), date( 'Y' ) );
+		$t_link_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_ADD . '&temporary=y&new=1';
+		$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
+		$t_new_bugs_link = $t_link_prefix
+				. '&amp;' . FILTER_PROPERTY_FILTER_BY_DATE_SUBMITTED . '=' . ON
+				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_START_YEAR . '=' . date( 'Y', $t_start_date )
+				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_START_MONTH . '=' . date( 'm', $t_start_date )
+				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_START_DAY . '=' . date( 'd', $t_start_date )
+				. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">';
+		echo '<tr>' . "\n";
+		echo '    <td class="width50">' . $t_days . '</td>' . "\n";
+
+		if( $t_new_count > 0 ) {
+			echo '    <td class="align-right"><a class="subtle" href="' . $t_new_bugs_link . $t_new_count . '</a></td>' . "\n";
+		} else {
+			echo '    <td class="align-right">' . $t_new_count . '</td>' . "\n";
+		}
+		echo '    <td class="align-right">' . $t_resolved_count . '</td>' . "\n";
+
+		$t_balance = $t_new_count - $t_resolved_count;
+		$t_style = '';
+		if( $t_balance > 0 ) {
+
+			# we are talking about bugs: a balance > 0 is "negative" for the project...
+			$t_style = ' red';
+			$t_balance = sprintf( '%+d', $t_balance );
+
+			# "+" modifier added in PHP >= 4.3.0
+		} else if( $t_balance < 0 ) {
+			$t_style = ' green';
+			$t_balance = sprintf( '%+d', $t_balance );
+		}
+
+		echo '    <td class="align-right' . $t_style . '">' . $t_balance . "</td>\n";
+		echo '</tr>' . "\n";
+	}
 }

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -509,6 +509,9 @@ function summary_print_by_reporter( array $p_filter = null ) {
 		}
 	}
 
+	if( empty( $t_reporters ) ) {
+		return;
+	}
 	user_cache_array_rows( $t_reporters );
 
 	$t_query = new DBQuery();

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -1126,8 +1126,10 @@ function summary_helper_get_time_stats( $p_project_id, array $p_filter = null ) 
 	$t_query = new DBQuery();
 	$t_sql = 'SELECT b.id, b.date_submitted, b.last_updated, MAX(h.date_modified) as hist_update, b.status'
 		. ' FROM {bug} b LEFT JOIN {bug_history} h'
-		. ' ON b.id = h.bug_id  AND h.type = :hist_type AND h.field_name = :hist_field AND h.new_value = :status_resolved'
-		. ' WHERE b.status >= :status_resolved AND ' . $t_specific_where;
+		. ' ON b.id = h.bug_id  AND h.type = :hist_type AND h.field_name = :hist_field'
+		. ' WHERE b.status >= :status_resolved'
+		. ' AND h.new_value >= :status_resolved AND h.old_value < :status_resolved'
+		. ' AND ' . $t_specific_where;
 	$t_query->bind( array(
 		'hist_type' => 0,
 		'hist_field' => 'status',

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -198,7 +198,7 @@ function summary_print_by_enum( $p_enum, array $p_filter = null ) {
 	$t_sql = 'SELECT COUNT(id) as bugcount, ' . $p_enum . ' ' . $t_status_query
 		. ' FROM {bug} WHERE ' . $t_project_filter;
 	if( !empty( $p_filter ) ) {
-		$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND {bug}.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
@@ -317,7 +317,7 @@ function summary_new_bug_count_by_date( $p_num_days = 1, array $p_filter = null 
 		. ' AND ' . $t_specific_where;
 	$t_query->bind( 'now', db_now() );
 	if( !empty( $p_filter ) ) {
-		$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND {bug}.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
@@ -361,7 +361,7 @@ function summary_resolved_bug_count_by_date( $p_num_days = 1, array $p_filter = 
 		'now' => db_now()
 		) );
 	if( !empty( $p_filter ) ) {
-		$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND b.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
@@ -441,7 +441,7 @@ function summary_print_by_activity( array $p_filter = null ) {
 		. ' WHERE b.status < ' . $t_query->param( (int)$t_resolved )
 		. ' AND ' . $t_specific_where;
 	if( !empty( $p_filter ) ) {
-		$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND b.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
@@ -503,7 +503,7 @@ function summary_print_by_age( array $p_filter = null ) {
 	$t_sql = 'SELECT * FROM {bug} WHERE status < ' . $t_query->param( (int)$t_resolved )
 		. ' AND ' . $t_specific_where;
 	if( !empty( $p_filter ) ) {
-		$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND {bug}.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
@@ -555,7 +555,7 @@ function summary_print_by_developer( array $p_filter = null ) {
 	$t_sql = 'SELECT COUNT(id) as bugcount, handler_id, status'
 		. ' FROM {bug} WHERE handler_id>0 AND ' . $t_specific_where;
 	if( !empty( $p_filter ) ) {
-		$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND {bug}.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
@@ -613,7 +613,7 @@ function summary_print_by_reporter( array $p_filter = null ) {
 	$t_query = new DBQuery();
 	$t_sql = 'SELECT reporter_id, COUNT(*) as num FROM {bug} WHERE ' . $t_specific_where;
 	if( !empty( $p_filter ) ) {
-		$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND {bug}.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
@@ -641,7 +641,7 @@ function summary_print_by_reporter( array $p_filter = null ) {
 			. ' WHERE reporter_id= :reporter AND ' . $t_specific_where;
 		$t_query->bind( 'reporter', (int)$v_reporter_id );
 		if( !empty( $p_filter ) ) {
-			$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+			$t_subquery = filter_cache_subquery( $p_filter );
 			$t_sql .= ' AND {bug}.id IN :filter';
 			$t_query->bind( 'filter', $t_subquery );
 		}
@@ -715,7 +715,7 @@ function summary_print_by_category( array $p_filter = null ) {
 		. ' FROM {bug} b JOIN {category} c ON b.category_id=c.id'
 		. ' WHERE b.' . $t_specific_where;
 	if( !empty( $p_filter ) ) {
-		$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND b.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
@@ -781,7 +781,7 @@ function summary_print_by_project( array $p_projects = array(), $p_level = 0, ar
 		$t_query = new DBQuery();
 		$t_sql = 'SELECT project_id, status, COUNT( status ) AS bugcount FROM {bug}';
 		if( !empty( $p_filter ) ) {
-			$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+			$t_subquery = filter_cache_subquery( $p_filter );
 			$t_sql .= ' WHERE {bug}.id IN :filter';
 			$t_query->bind( 'filter', $t_subquery );
 		}
@@ -857,7 +857,7 @@ function summary_print_developer_resolution( $p_resolution_enum_string, array $p
 	$t_sql = 'SELECT COUNT(id) as bugcount, handler_id, resolution'
 		. ' FROM {bug} WHERE ' . $t_specific_where;
 	if( !empty( $p_filter ) ) {
-		$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND {bug}.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
@@ -993,7 +993,7 @@ function summary_print_reporter_resolution( $p_resolution_enum_string, array $p_
 	$t_sql = 'SELECT COUNT(id) as bugcount, reporter_id, resolution'
 		. ' FROM {bug} WHERE ' . $t_specific_where;
 	if( !empty( $p_filter ) ) {
-		$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND {bug}.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
@@ -1136,7 +1136,7 @@ function summary_print_reporter_effectiveness( $p_severity_enum_string, $p_resol
 	$t_sql = 'SELECT COUNT(id) as bugcount, reporter_id, resolution, severity'
 		. ' FROM {bug} WHERE ' . $t_specific_where;
 	if( !empty( $p_filter ) ) {
-		$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND {bug}.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
@@ -1249,7 +1249,7 @@ function summary_helper_get_time_stats( $p_project_id, array $p_filter = null ) 
 		'status_resolved' => (int)$t_resolved
 		) );
 	if( !empty( $p_filter ) ) {
-		$t_subquery = new BugFilterQuery( $p_filter, BugFilterQuery::QUERY_TYPE_IDS );
+		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND b.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -1405,15 +1405,25 @@ function summary_print_by_date( array $p_date_array, array $p_filter = null ) {
 		$t_new_count = $t_open_count_array[$t_ix];
 		$t_resolved_count = $t_resolved_count_array[$t_ix];
 		$t_start_date = mktime( 0, 0, 0, date( 'm' ), ( date( 'd' ) - $t_days ), date( 'Y' ) );
+		$t_end_date = mktime( 0, 0, 0 ) + SECONDS_PER_DAY;
 
 		$t_link_prefix = summary_get_link_prefix( $p_filter );
 
+		# if we come from a filter, don't clear status properties
+		if( !filter_is_temporary( $p_filter ) ) {
+			$t_status_prop = '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE;
+		} else {
+			$t_status_prop = '';
+		}
 		$t_new_bugs_link = $t_link_prefix
 				. '&amp;' . FILTER_PROPERTY_FILTER_BY_DATE_SUBMITTED . '=' . ON
 				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_START_YEAR . '=' . date( 'Y', $t_start_date )
 				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_START_MONTH . '=' . date( 'm', $t_start_date )
 				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_START_DAY . '=' . date( 'd', $t_start_date )
-				. '&amp;' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">';
+				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_END_YEAR . '=' . date( 'Y', $t_end_date )
+				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_END_MONTH . '=' . date( 'm', $t_end_date )
+				. '&amp;' . FILTER_PROPERTY_DATE_SUBMITTED_END_DAY . '=' . date( 'd', $t_end_date )
+				. $t_status_prop . '">';
 		echo '<tr>' . "\n";
 		echo '    <td class="width50">' . $t_days . '</td>' . "\n";
 

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -1158,13 +1158,14 @@ function summary_helper_get_time_stats( $p_project_id, array $p_filter = null ) 
 	$t_sql = 'SELECT b.id, b.date_submitted, b.last_updated, MAX(h.date_modified) as hist_update, b.status'
 		. ' FROM {bug} b LEFT JOIN {bug_history} h'
 		. ' ON b.id = h.bug_id  AND h.type = :hist_type AND h.field_name = :hist_field'
-		. ' WHERE b.status >= :status_resolved'
-		. ' AND h.new_value >= :status_resolved AND h.old_value < :status_resolved'
+		. ' WHERE b.status >= :int_resolved'
+		. ' AND h.new_value >= :str_resolved AND h.old_value < :str_resolved'
 		. ' AND ' . $t_specific_where;
 	$t_query->bind( array(
 		'hist_type' => 0,
 		'hist_field' => 'status',
-		'status_resolved' => (int)$t_resolved
+		'int_resolved' => (int)$t_resolved,
+		'str_resolved' => (string)$t_resolved
 		) );
 	if( !empty( $p_filter ) ) {
 		$t_subquery = filter_cache_subquery( $p_filter );

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -1262,15 +1262,14 @@ function summary_print_filter_info( array $p_filter = null ) {
 	?>
 	<div class="space-10"></div>
 	<div class="col-md-12 col-xs-12">
-		<p>
-			<span class="alert-warning">
-			<?php
-			echo '<a href="' , $t_view_issues_link , '" title="' , lang_get( 'view_bugs_link' ) , '">';
-			echo lang_get( 'summary_notice_filter_is_applied' ) , '&nbsp;' , '( ' , $t_bug_count , ' ' , lang_get( 'bugs' ) , ' )';
-			echo '</a>';
-			?>
-			</span>
-		</p>
+		<div class="alert alert-warning center">
+		<?php
+		echo '<a href="', $t_view_issues_link, '" title="', lang_get( 'view_bugs_link' ), '">';
+		echo lang_get( 'summary_notice_filter_is_applied' ), '&nbsp;',
+			'(', $t_bug_count, ' ', lang_get( 'bugs' ) , ')';
+		echo '</a>';
+		?>
+		</div>
 	</div>
 	<?php
 }

--- a/docbook/Admin_Guide/en-US/Page_Descriptions.xml
+++ b/docbook/Admin_Guide/en-US/Page_Descriptions.xml
@@ -885,6 +885,11 @@
                                 <entry>threshold to view the roadmap</entry>
                             </row>
                             <row>
+                                <entry>View Summary</entry>
+                                <entry>$g_view_summary_threshold</entry>
+                                <entry>threshold to view the summary</entry>
+                            </row>
+                            <row>
                                 <entry>View Assigned To</entry>
                                 <entry>$g_view_handler_threshold</entry>
                                 <entry>threshold to see who is handling an issue</entry>

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1195,6 +1195,7 @@ $s_developer_stats = 'Developer Stats';
 $s_reporter_stats = 'Reporter Stats';
 $s_orct = '(open/resolved/closed/total)';
 $s_summary_header = 'open/resolved/closed/total/resolved ratio/ratio';
+$s_summary_notice_filter_is_applied = 'A filter has been applied';
 
 # view_all_bug_page.php
 $s_any = 'any';

--- a/manage_config_work_threshold_page.php
+++ b/manage_config_work_threshold_page.php
@@ -410,6 +410,7 @@ get_section_end();
 get_section_begin_mcwt( lang_get( 'others' ) );
 get_capability_row( lang_get( 'view' ) . ' ' . lang_get( 'changelog_link' ), 'view_changelog_threshold' );
 get_capability_row( lang_get( 'view' ) . ' ' . lang_get( 'roadmap_link' ), 'roadmap_view_threshold' );
+get_capability_row( lang_get( 'view' ) . ' ' . lang_get( 'summary_link' ), 'view_summary_threshold' );
 get_capability_row( lang_get( 'view' ) . ' ' . lang_get( 'assigned_to' ), 'view_handler_threshold' );
 get_capability_row( lang_get( 'view' ) . ' ' . lang_get( 'bug_history' ), 'view_history_threshold' );
 get_capability_row( lang_get( 'send_reminders' ), 'bug_reminder_threshold' );

--- a/manage_config_work_threshold_set.php
+++ b/manage_config_work_threshold_set.php
@@ -190,6 +190,7 @@ set_capability_row( 'bugnote_user_change_view_state_threshold' );
 # Others
 set_capability_row( 'view_changelog_threshold' );
 set_capability_row( 'roadmap_view_threshold' );
+set_capability_row( 'view_summary_threshold' );
 set_capability_row( 'view_handler_threshold' );
 set_capability_row( 'view_history_threshold' );
 set_capability_row( 'bug_reminder_threshold' );

--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -147,16 +147,18 @@ class MantisGraphPlugin extends MantisPlugin  {
 	 * @return array
 	 */
 	function summary_submenu() {
+		$t_filter = summary_get_filter();
+		$t_filter_param = filter_get_temporary_key_param( $t_filter );
 		return array(
-            '<a class="btn btn-sm btn-primary btn-white" href="' . helper_mantis_url( 'summary_page.php' ) . '"> <i class="fa fa-table"></i> ' . plugin_lang_get( 'synthesis_link' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . plugin_page( 'developer_graph.php' ) . '"> <i class="fa fa-bar-chart"></i> ' . lang_get( 'by_developer' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . plugin_page( 'reporter_graph.php' ) . '"> <i class="fa fa-bar-chart"></i> ' . lang_get( 'by_reporter' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . plugin_page( 'status_graph.php' ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'status_link' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . plugin_page( 'resolution_graph.php' ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'resolution_link' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . plugin_page( 'priority_graph.php' ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'priority_link' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . plugin_page( 'severity_graph.php' ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'severity_link' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . plugin_page( 'category_graph.php' ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'category_link' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . plugin_page( 'issues_trend_graph.php' ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'issue_trends_link' ) . '</a>',
+            '<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( helper_mantis_url( 'summary_page.php' ), $t_filter_param ) . '"> <i class="fa fa-table"></i> ' . plugin_lang_get( 'synthesis_link' ) . '</a>',
+			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'developer_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . lang_get( 'by_developer' ) . '</a>',
+			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'reporter_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . lang_get( 'by_reporter' ) . '</a>',
+			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'status_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'status_link' ) . '</a>',
+			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'resolution_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'resolution_link' ) . '</a>',
+			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'priority_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'priority_link' ) . '</a>',
+			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'severity_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'severity_link' ) . '</a>',
+			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'category_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'category_link' ) . '</a>',
+			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'issues_trend_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'issue_trends_link' ) . '</a>',
 		);
 	}
 }

--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -18,8 +18,6 @@
  * @copyright Copyright 2002  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  */
 
-require_once( __DIR__ . '/core/graph_api.php' );
-
 /**
  * Mantis Graph plugin
  */
@@ -42,6 +40,16 @@ class MantisGraphPlugin extends MantisPlugin  {
 		$this->author = 'MantisBT Team';
 		$this->contact = 'mantisbt-dev@lists.sourceforge.net';
 		$this->url = 'http://www.mantisbt.org';
+	}
+
+	/**
+	 * Plugin initialization
+	 * @return void
+	 */
+	function init() {
+		plugin_require_api( 'core/graph_api.php' );
+		plugin_require_api( 'core/Period.php' );
+		require_api( 'summary_api.php' );
 	}
 
 	/**
@@ -127,10 +135,10 @@ class MantisGraphPlugin extends MantisPlugin  {
 				html_javascript_cdn_link('https://cdnjs.cloudflare.com/ajax/libs/Chart.js/' . CHARTJS_VERSION . '/Chart.min.js', CHARTJS_HASH);
 				html_javascript_cdn_link('https://cdnjs.cloudflare.com/ajax/libs/Chart.js/' . CHARTJS_VERSION . '/Chart.bundle.min.js', CHARTJSBUNDLE_HASH);
 			} else {
-				echo '<script src="' . plugin_file('chart-' . CHARTJS_VERSION . '.min.js') . '"></script>';
-				echo '<script src="' . plugin_file('chart.bundle-' . CHARTJS_VERSION . '.min.js') . '"></script>';
+				echo '<script type="text/javascript" src="' . plugin_file('chart-' . CHARTJS_VERSION . '.min.js') . '"></script>';
+				echo '<script type="text/javascript" src="' . plugin_file('chart.bundle-' . CHARTJS_VERSION . '.min.js') . '"></script>';
 			}
-			echo '<script src="' . plugin_file("MantisGraph.js") . '"></script>';
+			echo '<script type="text/javascript" src="' . plugin_file("MantisGraph.js") . '"></script>';
 		}
 	}
 

--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -149,16 +149,65 @@ class MantisGraphPlugin extends MantisPlugin  {
 	function summary_submenu() {
 		$t_filter = summary_get_filter();
 		$t_filter_param = filter_get_temporary_key_param( $t_filter );
-		return array(
-            '<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( helper_mantis_url( 'summary_page.php' ), $t_filter_param ) . '"> <i class="fa fa-table"></i> ' . plugin_lang_get( 'synthesis_link' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'developer_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . lang_get( 'by_developer' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'reporter_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . lang_get( 'by_reporter' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'status_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'status_link' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'resolution_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'resolution_link' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'priority_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'priority_link' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'severity_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'severity_link' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'category_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'category_link' ) . '</a>',
-			'<a class="btn btn-sm btn-primary btn-white" href="' . helper_url_combine( plugin_page( 'issues_trend_graph.php' ), $t_filter_param ) . '"> <i class="fa fa-bar-chart"></i> ' . plugin_lang_get( 'issue_trends_link' ) . '</a>',
-		);
+		$t_param_page = explode( '/', gpc_get_string( 'page', '' ) );
+		$t_plugin_page_current = end( $t_param_page );
+
+		# Core should implement the automatic highlighting of active links, but that requires
+		# changing the format of the menu and submenu events.
+		# For now, it's responsability of the plugin to detect and render each link properly.
+		$t_menu_items = array();
+		$t_menu_items[] = array( 'icon' => 'fa-table', 'title' => plugin_lang_get( 'synthesis_link' ),
+			'url' => helper_url_combine( helper_mantis_url( 'summary_page.php' ), $t_filter_param ) );
+
+		$t_menu_items[] = array( 'icon' => 'fa-bar-chart', 'title' => lang_get( 'by_developer' ),
+			'url' => helper_url_combine( plugin_page( 'developer_graph.php' ), $t_filter_param ),
+			'plugin_page' => 'developer_graph.php' );
+
+		$t_menu_items[] = array( 'icon' => 'fa-bar-chart', 'title' => lang_get( 'by_reporter' ),
+			'url' => helper_url_combine( plugin_page( 'reporter_graph.php' ), $t_filter_param ),
+			'plugin_page' => 'reporter_graph.php' );
+
+		$t_menu_items[] = array( 'icon' => 'fa-bar-chart', 'title' => plugin_lang_get( 'status_link' ),
+			'url' => helper_url_combine( plugin_page( 'status_graph.php' ), $t_filter_param ),
+			'plugin_page' => 'status_graph.php' );
+
+		$t_menu_items[] = array( 'icon' => 'fa-bar-chart', 'title' => plugin_lang_get( 'resolution_link' ),
+			'url' => helper_url_combine( plugin_page( 'resolution_graph.php' ), $t_filter_param ),
+			'plugin_page' => 'resolution_graph.php' );
+
+		$t_menu_items[] = array( 'icon' => 'fa-bar-chart', 'title' => plugin_lang_get( 'priority_link' ),
+			'url' => helper_url_combine( plugin_page( 'priority_graph.php' ), $t_filter_param ),
+			'plugin_page' => 'priority_graph.php' );
+
+		$t_menu_items[] = array( 'icon' => 'fa-bar-chart', 'title' => plugin_lang_get( 'severity_link' ),
+			'url' => helper_url_combine( plugin_page( 'severity_graph.php' ), $t_filter_param ),
+			'plugin_page' => 'severity_graph.php' );
+
+		$t_menu_items[] = array( 'icon' => 'fa-bar-chart', 'title' => plugin_lang_get( 'category_link' ),
+			'url' => helper_url_combine( plugin_page( 'category_graph.php' ), $t_filter_param ),
+			'plugin_page' => 'category_graph.php' );
+
+		$t_menu_items[] = array( 'icon' => 'fa-bar-chart', 'title' => plugin_lang_get( 'issue_trends_link' ),
+			'url' => helper_url_combine( plugin_page( 'issues_trend_graph.php' ), $t_filter_param ),
+			'plugin_page' => 'issues_trend_graph.php' );
+
+		$t_html_links = array();
+		foreach( $t_menu_items as $t_item ) {
+			$t_class_active = '';
+			if( isset( $t_item['plugin_page'] ) )  {
+				if( $t_item['plugin_page'] == $t_plugin_page_current ) {
+					$t_class_active = ' active';
+				}
+			} else {
+				if( 'summary_page.php' == basename( $_SERVER['SCRIPT_NAME'] ) ) {
+					$t_class_active = ' active';
+				}
+			}
+			$t_html = '<a class="btn btn-sm btn-primary btn-white' . $t_class_active . '" href="' . $t_item['url'] . '">';
+			$t_html .= ' <i class="fa ' . $t_item['icon'] . '"></i> ';
+			$t_html .= $t_item['title'] . '</a>';
+			$t_html_links[] = $t_html;
+		}
+		return $t_html_links;
 	}
 }

--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -283,7 +283,7 @@ function create_developer_resolved_summary( array $p_filter = null ) {
 	$t_handler_array = array();
 	$t_handler_ids = array();
 	while( $t_row = $t_query->fetch() ) {
-		$t_handler_array[$t_row['handler_id']] = $t_row['count'];
+		$t_handler_array[$t_row['handler_id']] = (int)$t_row['count'];
 		$t_handler_ids[] = $t_row['handler_id'];
 	}
 
@@ -331,7 +331,7 @@ function create_developer_open_summary( array $p_filter = null ) {
 	$t_handler_array = array();
 	$t_handler_ids = array();
 	while( $t_row = $t_query->fetch() ) {
-		$t_handler_array[$t_row['handler_id']] = $t_row['count'];
+		$t_handler_array[$t_row['handler_id']] = (int)$t_row['count'];
 		$t_handler_ids[] = $t_row['handler_id'];
 	}
 
@@ -384,7 +384,7 @@ function create_reporter_summary( array $p_filter = null, $p_limit = null ) {
 	$t_reporter_arr = array();
 	$t_reporters = array();
 	while( $t_row = $t_query->fetch() ) {
-		$t_reporter_arr[$t_row['reporter_id']] = $t_row['count'];
+		$t_reporter_arr[$t_row['reporter_id']] = (int)$t_row['count'];
 		$t_reporters[] = $t_row['reporter_id'];
 	}
 
@@ -433,7 +433,7 @@ function create_category_summary( array $p_filter = null ) {
 		$t_cat_id = $t_row['id'];
 		$t_query_cnt->bind( 'cat_id', (int)$t_cat_id );
 		$t_query_cnt->execute();
-		$t_bugcount = $t_query_cnt->value();
+		$t_bugcount = (int)$t_query_cnt->value();
 
 		if( isset($t_metrics[$t_cat_name]) ) {
 			$t_metrics[$t_cat_name] = $t_metrics[$t_cat_name] + $t_bugcount;

--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -125,11 +125,10 @@ function graph_status_colors_to_colors() {
  * Generate Bar Graph
  *
  * @param array   $p_metrics      Graph Data.
- * @param string  $p_series_name  The name of the data series.
  * @param integer $p_wfactor      Width factor for graph chart. Eg: 2 to make it double wide
  * @return void
  */
-function graph_bar( array $p_metrics, $p_series_name, $p_wfactor = 1 ) {
+function graph_bar( array $p_metrics, $p_wfactor = 1 ) {
 	static $s_id = 0;
 
 	$s_id++;

--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -223,17 +223,18 @@ function graph_cumulative_bydate( array $p_metrics ) {
 }
 
 /**
- * summarize metrics by a single ENUM field in the bug table
+ * Summarize metrics by a single ENUM field in the bug table.
  *
  * @param string $p_enum_string Enumeration string.
  * @param string $p_enum        Enumeration field.
  * @param array  $p_exclude_codes Array of codes to exclude from the enum.
+ * @param array  $p_filter      Filter array.
  * @return array
  */
-function create_bug_enum_summary( $p_enum_string, $p_enum, array $p_exclude_codes = array() ) {
+function create_bug_enum_summary( $p_enum_string, $p_enum, array $p_exclude_codes = array(), array $p_filter = null ) {
 	$t_project_id = helper_get_current_project();
 	$t_user_id = auth_get_current_user_id();
-	$t_specific_where = ' AND ' . helper_project_specific_where( $t_project_id, $t_user_id );
+	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
 
 	$t_metrics = array();
 	$t_assoc_array = MantisEnum::getAssocArrayIndexedByValues( $p_enum_string );
@@ -242,12 +243,20 @@ function create_bug_enum_summary( $p_enum_string, $p_enum, array $p_exclude_code
 		trigger_error( ERROR_DB_FIELD_NOT_FOUND, ERROR );
 	}
 
+	$t_query = new DBQuery();
+	$t_sql = 'SELECT COUNT(*) FROM {bug} WHERE ' . $p_enum . ' = :enum_value AND ' . $t_specific_where;
+	if( !empty( $p_filter ) ) {
+		$t_subquery = filter_cache_subquery( $p_filter );
+		$t_sql .= ' AND {bug}.id IN :filter';
+		$t_query->bind( 'filter', $t_subquery );
+	}
+	$t_query->sql( $t_sql );
 	foreach ( $t_assoc_array as $t_value => $t_label ) {
-		$t_query = 'SELECT COUNT(*) FROM {bug} WHERE ' . $p_enum . '=' . db_param() . ' ' . $t_specific_where;
-		$t_result = db_query( $t_query, array( $t_value ) );
-
 		if ( !in_array( $t_value, $p_exclude_codes ) ) {
-			$t_metrics[$t_label] = db_result( $t_result, 0 );
+			$t_query->bind( 'enum_value', $t_value );
+			$t_query->execute();
+			$t_result = $t_query->value();
+			$t_metrics[$t_label] = $t_result;
 		}
 	}
 
@@ -256,10 +265,10 @@ function create_bug_enum_summary( $p_enum_string, $p_enum, array $p_exclude_code
 
 /**
  * Calculate distribution of issues by statuses excluding closed status.
- *
+ * @param array $p_filter Filter array.
  * @return array An array with keys being status names and values being number of issues with such status.
  */
-function create_bug_status_summary() {
+function create_bug_status_summary( array $p_filter = null ) {
 	$t_status_enum = config_get( 'status_enum_string' );
 	$t_statuses = MantisEnum::getValues( $t_status_enum );
 	$t_closed_threshold = config_get( 'bug_closed_status_threshold' );
@@ -271,27 +280,39 @@ function create_bug_status_summary() {
 		}
 	}
 
-	return create_bug_enum_summary( lang_get( 'status_enum_string' ), 'status', $t_closed_statuses );
+	return create_bug_enum_summary( lang_get( 'status_enum_string' ), 'status', $t_closed_statuses, $p_filter );
 }
 
 /**
  * Create summary for issues resolved by a developer
+ * @param array $p_filter Filter array.
  * @return array with key being username and value being # of issues fixed.
  */
-function create_developer_resolved_summary() {
+function create_developer_resolved_summary( array $p_filter = null ) {
 	$t_project_id = helper_get_current_project();
 	$t_user_id = auth_get_current_user_id();
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
 	$t_resolved_status_threshold = config_get( 'bug_resolved_status_threshold' );
 
-	$t_query = 'SELECT handler_id, count(*) as count FROM {bug} WHERE ' . $t_specific_where . ' AND handler_id <> ' .
-		db_param() . ' AND status >= ' . db_param() . ' AND resolution = ' . db_param() .
-		' GROUP BY handler_id ORDER BY count DESC';
-	$t_result = db_query( $t_query, array( NO_USER, $t_resolved_status_threshold, FIXED ), 20 );
+	$t_query = new DBQuery();
+	$t_sql = 'SELECT handler_id, count(*) as count FROM {bug} WHERE ' . $t_specific_where
+		. ' AND handler_id <> :nouser AND status >= :status_resolved AND resolution = :resolution_fixed';
+	if( !empty( $p_filter ) ) {
+		$t_subquery = filter_cache_subquery( $p_filter );
+		$t_sql .= ' AND {bug}.id IN :filter';
+		$t_query->bind( 'filter', $t_subquery );
+	}
+	$t_sql .= ' GROUP BY handler_id ORDER BY count DESC';
+	$t_query->sql( $t_sql );
+	$t_query->bind( array(
+		'nouser' => NO_USER,
+		'status_resolved' => (int)$t_resolved_status_threshold,
+		'resolution_fixed' => FIXED
+		) );
 
 	$t_handler_array = array();
 	$t_handler_ids = array();
-	while( $t_row = db_fetch_array( $t_result ) ) {
+	while( $t_row = $t_query->fetch() ) {
 		$t_handler_array[$t_row['handler_id']] = $t_row['count'];
 		$t_handler_ids[] = $t_row['handler_id'];
 	}
@@ -313,21 +334,33 @@ function create_developer_resolved_summary() {
 
 /**
  * Create summary for issues opened by a developer
+ * @param array $p_filter Filter array.
  * @return array with key being username and value being # of issues fixed.
  */
-function create_developer_open_summary() {
+function create_developer_open_summary( array $p_filter = null ) {
 	$t_project_id = helper_get_current_project();
 	$t_user_id = auth_get_current_user_id();
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
 	$t_resolved_status_threshold = config_get( 'bug_resolved_status_threshold' );
 
-	$t_query = 'SELECT handler_id, count(*) as count FROM {bug} WHERE ' . $t_specific_where . ' AND handler_id <> ' .
-		db_param() . ' AND status < ' . db_param() . ' GROUP BY handler_id ORDER BY count DESC';
-	$t_result = db_query( $t_query, array( NO_USER, $t_resolved_status_threshold ) );
+	$t_query = new DBQuery();
+	$t_sql = 'SELECT handler_id, count(*) as count FROM {bug} WHERE ' . $t_specific_where
+		. ' AND handler_id <> :nouser AND status < :status_resolved';
+	if( !empty( $p_filter ) ) {
+		$t_subquery = filter_cache_subquery( $p_filter );
+		$t_sql .= ' AND {bug}.id IN :filter';
+		$t_query->bind( 'filter', $t_subquery );
+	}
+	$t_sql .= ' GROUP BY handler_id ORDER BY count DESC';
+	$t_query->sql( $t_sql );
+	$t_query->bind( array(
+		'nouser' => NO_USER,
+		'status_resolved' => (int)$t_resolved_status_threshold
+		) );
 
 	$t_handler_array = array();
 	$t_handler_ids = array();
-	while( $t_row = db_fetch_array( $t_result ) ) {
+	while( $t_row = $t_query->fetch() ) {
 		$t_handler_array[$t_row['handler_id']] = $t_row['count'];
 		$t_handler_ids[] = $t_row['handler_id'];
 	}
@@ -349,20 +382,29 @@ function create_developer_open_summary() {
 
 /**
  * Create summary table of reporters
+ * @param array $p_filter Filter array.
  * @return array
  */
-function create_reporter_summary() {
+function create_reporter_summary( array $p_filter = null ) {
 	$t_project_id = helper_get_current_project();
 	$t_user_id = auth_get_current_user_id();
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
 
-	$t_query = 'SELECT reporter_id, count(*) as count FROM {bug} WHERE ' . $t_specific_where . ' AND resolution = ' .
-		db_param() . ' GROUP BY reporter_id ORDER BY count DESC';
-	$t_result = db_query( $t_query, array( FIXED ), 20 );
+	$t_query = new DBQuery();
+	$t_sql = 'SELECT reporter_id, count(*) as count FROM {bug} WHERE ' . $t_specific_where
+		. ' AND resolution = :resolution_fixed';
+	if( !empty( $p_filter ) ) {
+		$t_subquery = filter_cache_subquery( $p_filter );
+		$t_sql .= ' AND {bug}.id IN :filter';
+		$t_query->bind( 'filter', $t_subquery );
+	}
+	$t_sql .= ' GROUP BY reporter_id ORDER BY count DESC';
+	$t_query->sql( $t_sql );
+	$t_query->bind( 'resolution_fixed', FIXED );
 
 	$t_reporter_arr = array();
 	$t_reporters = array();
-	while( $t_row = db_fetch_array( $t_result ) ) {
+	while( $t_row = $t_query->fetch() ) {
 		$t_reporter_arr[$t_row['reporter_id']] = $t_row['count'];
 		$t_reporters[] = $t_row['reporter_id'];
 	}
@@ -384,30 +426,41 @@ function create_reporter_summary() {
 
 /**
  * Create summary table of categories
+ * @param array $p_filter Filter array.
  * @return array
  */
-function create_category_summary() {
+function create_category_summary( array $p_filter = null ) {
 	$t_project_id = helper_get_current_project();
 	$t_user_id = auth_get_current_user_id();
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
 
-	$t_query = 'SELECT id, name FROM {category}
-				WHERE ' . $t_specific_where . ' OR project_id=' . ALL_PROJECTS . '
-				ORDER BY name';
-	$t_result = db_query( $t_query );
-	$t_category_count = db_num_rows( $t_result );
+	$t_query_cat = new DBQuery();
+	$t_sql = 'SELECT id, name FROM {category} WHERE ' . $t_specific_where
+			. ' OR project_id = :all_projects';
+	$t_query_cat->sql( $t_sql );
+	$t_query_cat->bind( 'all_projects', ALL_PROJECTS );
 
 	$t_metrics = array();
-	while( $t_row = db_fetch_array( $t_result ) ) {
+	$t_query_cnt = new DBQuery();
+	$t_query_cnt->sql( 'SELECT COUNT(*) FROM {bug} WHERE category_id = :cat_id AND ' . $t_specific_where );
+	if( !empty( $p_filter ) ) {
+		$t_subquery = filter_cache_subquery( $p_filter );
+		$t_query_cnt->append_sql( ' AND {bug}.id IN :filter' );
+		$t_query_cnt->bind( 'filter', $t_subquery );
+	}
+
+	while( $t_row = $t_query_cat->fetch() ) {
 		$t_cat_name = $t_row['name'];
 		$t_cat_id = $t_row['id'];
-		$t_query = 'SELECT COUNT(*) FROM {bug} WHERE category_id=' . db_param() . ' AND ' . $t_specific_where;
-		$t_result2 = db_query( $t_query, array( $t_cat_id ) );
+		$t_query_cnt->bind( 'cat_id', (int)$t_cat_id );
+		$t_query_cnt->execute();
+		$t_bugcount = $t_query_cnt->value();
+
 		if( isset($t_metrics[$t_cat_name]) ) {
-			$t_metrics[$t_cat_name] = $t_metrics[$t_cat_name] + db_result( $t_result2, 0, 0 );
+			$t_metrics[$t_cat_name] = $t_metrics[$t_cat_name] + $t_bugcount;
 		} else {
-			if( db_result( $t_result2, 0, 0 ) > 0 ) {
-			    $t_metrics[$t_cat_name] = db_result( $t_result2, 0, 0 );
+			if( $t_bugcount > 0 ) {
+			    $t_metrics[$t_cat_name] = $t_bugcount;
 			}
 		}
 	}
@@ -417,9 +470,10 @@ function create_category_summary() {
 
 /**
  * Create cumulative graph by date
+ * @param array $p_filter Filter array.
  * @return array | null
  */
-function create_cumulative_bydate() {
+function create_cumulative_bydate( array $p_filter = null ) {
 	$t_clo_val = config_get( 'bug_closed_status_threshold' );
 	$t_res_val = config_get( 'bug_resolved_status_threshold' );
 
@@ -427,11 +481,25 @@ function create_cumulative_bydate() {
 	$t_user_id = auth_get_current_user_id();
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
 
-	# Get all the submitted dates
-	$t_query = 'SELECT date_submitted FROM {bug} WHERE ' . $t_specific_where . ' ORDER BY date_submitted';
-	$t_result = db_query( $t_query );
+	# For this metric to make sense, we need to remove the filter properties related to status
+	if( $p_filter ) {
+		$p_filter[FILTER_PROPERTY_STATUS] = array( META_FILTER_ANY );
+		$p_filter[FILTER_PROPERTY_HIDE_STATUS] = array( META_FILTER_NONE );
+	}
 
-	while( $t_row = db_fetch_array( $t_result ) ) {
+	# Get all the submitted dates
+	$t_query = new DBQuery();
+	$t_sql = 'SELECT date_submitted FROM {bug} WHERE ' . $t_specific_where;
+	if( $p_filter ) {
+		$t_subquery = filter_cache_subquery( $p_filter );
+		$t_sql .= ' AND {bug}.id IN :filter';
+		$t_query->bind( 'filter', $t_subquery );
+	}
+	$t_sql .= ' ORDER BY date_submitted';
+	$t_query->sql( $t_sql );
+
+	$t_calc_metrics = array();
+	while( $t_row = $t_query->fetch() ) {
 		# rationalise the timestamp to a day to reduce the amount of data
 		$t_date = $t_row['date_submitted'];
 		$t_date = (int)( $t_date / SECONDS_PER_DAY );
@@ -445,23 +513,30 @@ function create_cumulative_bydate() {
 
 	# ## Get all the dates where a transition from not resolved to resolved may have happened
 	#    also, get the last updated date for the bug as this may be all the information we have
-	$t_query = 'SELECT {bug}.id, last_updated, date_modified, new_value, old_value
-			FROM {bug} LEFT JOIN {bug_history}
-			ON {bug}.id = {bug_history}.bug_id
-			WHERE ' . $t_specific_where . '
-						AND {bug}.status >= ' . db_param() . '
-						AND ( ( {bug_history}.new_value >= ' . db_param() . '
-								AND {bug_history}.old_value < ' . db_param() . '
-								AND {bug_history}.field_name = \'status\' )
-						OR {bug_history}.id is NULL )
-			ORDER BY {bug}.id, date_modified ASC';
-	$t_result = db_query( $t_query, array( $t_res_val, (string)$t_res_val, (string)$t_res_val ) );
-	$t_bug_count = db_num_rows( $t_result );
+	$t_query = new DBQuery();
+	$t_sql = 'SELECT {bug}.id, last_updated, date_modified, new_value, old_value'
+		. ' FROM {bug} LEFT JOIN {bug_history} ON {bug}.id = {bug_history}.bug_id'
+		. ' WHERE ' . $t_specific_where
+		. ' AND {bug}.status >= :int_resolved'
+		. ' AND ( ( {bug_history}.new_value >= :str_resolved AND {bug_history}.old_value < :str_resolved AND {bug_history}.field_name = :field_name )'
+		. ' OR {bug_history}.id is NULL )';
+	if( $p_filter ) {
+		$t_subquery = filter_cache_subquery( $p_filter );
+		$t_sql .= ' AND {bug}.id IN :filter';
+		$t_query->bind( 'filter', $t_subquery );
+	}
+	$t_sql .= ' ORDER BY {bug}.id, date_modified ASC';
+	$t_query->sql( $t_sql );
+	$t_query->bind( array(
+		'int_resolved' => (int)$t_res_val,
+		'str_resolved' => (string)$t_res_val,
+		'field_name' => 'status'
+		) );
 
 	$t_last_id = 0;
 	$t_last_date = 0;
 
-	while( $t_row = db_fetch_array( $t_result ) ) {
+	while( $t_row = $t_query->fetch() ) {
 		$t_id = $t_row['id'];
 
 		# if h_last_updated is NULL, there were no appropriate history records

--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -411,10 +411,18 @@ function create_developer_open_summary( array $p_filter = null ) {
 
 /**
  * Create summary table of reporters
- * @param array $p_filter Filter array.
+ * @param array $p_filter    Filter array.
+ * @param integer $p_limit   Number of records to return.
  * @return array
  */
-function create_reporter_summary( array $p_filter = null ) {
+function create_reporter_summary( array $p_filter = null, $p_limit = null ) {
+	# set deafult
+	if( !$p_limit ) {
+		$t_limit = 25;
+	} else {
+		$t_limit = $p_limit < 1 ? -1 : $p_limit;
+	}
+
 	$t_project_id = helper_get_current_project();
 	$t_user_id = auth_get_current_user_id();
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
@@ -430,6 +438,7 @@ function create_reporter_summary( array $p_filter = null ) {
 	$t_sql .= ' GROUP BY reporter_id ORDER BY count DESC';
 	$t_query->sql( $t_sql );
 	$t_query->bind( 'resolution_fixed', FIXED );
+	$t_query->set_limit( $t_limit );
 
 	$t_reporter_arr = array();
 	$t_reporters = array();

--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -125,22 +125,12 @@ function graph_status_colors_to_colors() {
  * Generate Bar Graph
  *
  * @param array   $p_metrics      Graph Data.
- * @param string  $p_title        Title.
  * @param string  $p_series_name  The name of the data series.
- * @param string  $p_color        The bar color.
  * @param integer $p_wfactor      Width factor for graph chart. Eg: 2 to make it double wide
  * @return void
  */
-function graph_bar( array $p_metrics, $p_title = '', $p_series_name, $p_color = null, $p_wfactor = null ) {
+function graph_bar( array $p_metrics, $p_series_name, $p_wfactor = 1 ) {
 	static $s_id = 0;
-
-	# set defaults
-	if( !$p_color ) {
-		$p_color = '#fcbdbd';
-	}
-	if( !$p_wfactor ) {
-		$p_wfactor = 1;
-	}
 
 	$s_id++;
 	$t_labels = array_keys( $p_metrics );
@@ -163,10 +153,9 @@ function graph_bar( array $p_metrics, $p_title = '', $p_series_name, $p_color = 
  * Function that displays pie charts
  *
  * @param array         $p_metrics       Graph Data.
- * @param string        $p_title         Title.
  * @return void
  */
-function graph_pie( array $p_metrics, $p_title = '' ) {
+function graph_pie( array $p_metrics ) {
 	static $s_id = 0;
 
 	$s_id++;
@@ -196,13 +185,8 @@ function graph_pie( array $p_metrics, $p_title = '' ) {
  * @param integer $p_wfactor      Width factor for graph chart. Eg: 2 to make it double wide
  * @return void
  */
-function graph_cumulative_bydate( array $p_metrics, $p_wfactor = null ) {
+function graph_cumulative_bydate( array $p_metrics, $p_wfactor = 1 ) {
 	static $s_id = 0;
-
-	# set defaults
-	if( !$p_wfactor ) {
-		$p_wfactor = 1;
-	}
 
 	$s_id++;
 

--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -269,15 +269,24 @@ function create_bug_enum_summary( $p_enum_string, $p_enum, array $p_exclude_code
  * @return array An array with keys being status names and values being number of issues with such status.
  */
 function create_bug_status_summary( array $p_filter = null ) {
-	$t_status_enum = config_get( 'status_enum_string' );
-	$t_statuses = MantisEnum::getValues( $t_status_enum );
-	$t_closed_threshold = config_get( 'bug_closed_status_threshold' );
+	# When the provided filter is temporary, it's a filter that was explicitly applied to summary pages.
+	# Otherwise, it's a filter created by default by summary api.
+	# In that case, or if no filter has been provided, keep legacy behaviour where we exclude
+	# closed status in this graph
+	if( null === $p_filter || !filter_is_temporary( $p_filter ) ) {
+		$t_status_enum = config_get( 'status_enum_string' );
+		$t_statuses = MantisEnum::getValues( $t_status_enum );
+		$t_closed_threshold = config_get( 'bug_closed_status_threshold' );
 
-	$t_closed_statuses = array();
-	foreach( $t_statuses as $t_status_code ) {
-		if ( $t_status_code >= $t_closed_threshold ) {
-			$t_closed_statuses[] = $t_status_code;
+		$t_closed_statuses = array();
+		foreach( $t_statuses as $t_status_code ) {
+			if ( $t_status_code >= $t_closed_threshold ) {
+				$t_closed_statuses[] = $t_status_code;
+			}
 		}
+	} else {
+	# when explicitly using a filter, do not exclude any status, to match the expected filter results
+		$t_closed_statuses = array();
 	}
 
 	return create_bug_enum_summary( lang_get( 'status_enum_string' ), 'status', $t_closed_statuses, $p_filter );

--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -25,44 +25,6 @@
  */
 
 /**
- * Converts an array of php strings into an array of javascript strings without [].
- * @param array $p_strings The array of strings
- * @return string The js code for the array without [], e.g. "a", "b", "c"
- */
-function graph_strings_array( array $p_strings ) {
-	$t_js_labels = '';
-
-	foreach ( $p_strings as $t_label ) {
-		if ( $t_js_labels !== '' ) {
-			$t_js_labels .= ', ';
-		}
-
-		$t_js_labels .= '"' . $t_label . '"';
-	}
-
-	return $t_js_labels;
-}
-
-/**
- * Converts an array of php numbers into an array of javascript numbers without [].
- * @param  array $p_values The array of values.
- * @return string The js code for the array without [], e.g. 1, 2, 3.
- */
-function graph_numeric_array( array $p_values ) {
-	$t_js_values = '';
-
-	foreach( $p_values as $t_value ) {
-		if ( $t_js_values !== '' ) {
-			$t_js_values .= ', ';
-		}
-
-		$t_js_values .= $t_value;
-	}
-
-	return $t_js_values;
-}
-
-/**
  * Converts an html color (e.g. #fcbdbd) to rgba.
  * @param string  $p_color The html color
  * @param float   $p_alpha    The value (e.g. 0.2)
@@ -132,19 +94,16 @@ function graph_bar( array $p_metrics, $p_wfactor = 1 ) {
 	static $s_id = 0;
 
 	$s_id++;
-	$t_labels = array_keys( $p_metrics );
-	$t_js_labels = graph_strings_array( $t_labels );
-
-	$t_values = array_values( $p_metrics );
-	$t_js_values = graph_numeric_array( $t_values );
+	$t_json_labels = json_encode( array_keys( $p_metrics ) );
+	$t_json_values = json_encode( array_values( $p_metrics ) );
 
 	$t_width = 500 * $p_wfactor;
 	$t_height = 400;
 
 ?>
 	<canvas id="barchart<?php echo $s_id ?>" width="<?php echo $t_width ?>" height="<?php echo $t_height ?>"
-		data-labels="[<?php echo htmlspecialchars( $t_js_labels, ENT_QUOTES ) ?>]"
-		data-values="[<?php echo $t_js_values ?>]" />
+		data-labels="<?php echo htmlspecialchars( $t_json_labels, ENT_QUOTES ) ?>"
+		data-values="<?php echo htmlspecialchars( $t_json_values, ENT_QUOTES ) ?>" />
 <?php
 }
 
@@ -159,19 +118,16 @@ function graph_pie( array $p_metrics ) {
 
 	$s_id++;
 
-	$t_labels = array_keys( $p_metrics );
-	$t_js_labels = graph_strings_array( $t_labels );
-
-	$t_values = array_values( $p_metrics );
-	$t_js_values = graph_numeric_array( $t_values );
+	$t_json_labels = json_encode( array_keys( $p_metrics ) );
+	$t_json_values = json_encode( array_values( $p_metrics ) );
 
 	$t_colors = graph_status_colors_to_colors();
 	$t_background_colors = graph_colors_to_rgbas( $t_colors, 1.0 );
 	$t_border_colors = graph_colors_to_rgbas( $t_colors, 1 );
 ?>
 	<canvas id="piechart<?php echo $s_id ?>" width="500" height="400"
-		data-labels="[<?php echo htmlspecialchars( $t_js_labels, ENT_QUOTES ) ?>]"
-		data-values="[<?php echo $t_js_values ?>]"
+		data-labels="<?php echo htmlspecialchars( $t_json_labels, ENT_QUOTES ) ?>"
+		data-values="<?php echo htmlspecialchars( $t_json_values, ENT_QUOTES ) ?>"
 		data-background-colors="[<?php echo htmlspecialchars( $t_background_colors, ENT_QUOTES ) ?>]"
 		data-border-colors="[<?php echo htmlspecialchars( $t_border_colors, ENT_QUOTES ) ?>]" />
 <?php
@@ -191,16 +147,16 @@ function graph_cumulative_bydate( array $p_metrics, $p_wfactor = 1 ) {
 
 	$t_labels = array_keys( $p_metrics[0] );
 	$t_formatted_labels = array_map( function($label) { return date( 'Ymd', $label ); }, $t_labels );
-	$t_js_labels = graph_strings_array( $t_formatted_labels );
+	$t_json_labels = json_encode( $t_formatted_labels );
 
 	$t_values = array_values( $p_metrics[0] );
-	$t_opened_values = graph_numeric_array( $t_values );
+	$t_opened_values = json_encode( $t_values );
 
 	$t_values = array_values( $p_metrics[1] );
-	$t_resolved_values = graph_numeric_array( $t_values );
+	$t_resolved_values = json_encode( $t_values );
 
 	$t_values = array_values( $p_metrics[2] );
-	$t_still_open_values = graph_numeric_array( $t_values );
+	$t_still_open_values = json_encode( $t_values );
 
 	$t_colors = graph_status_colors_to_colors();
 	$t_background_colors = graph_colors_to_rgbas( $t_colors, 0.2 );
@@ -214,13 +170,13 @@ function graph_cumulative_bydate( array $p_metrics, $p_wfactor = 1 ) {
 	$t_height = 400;
 ?>
 	<canvas id="linebydate<?php echo $s_id ?>" width="<?php echo $t_width ?>" height="<?php echo $t_height ?>"
-			data-labels="[<?php echo htmlspecialchars( $t_js_labels, ENT_QUOTES ) ?>]"
+			data-labels="<?php echo htmlspecialchars( $t_json_labels, ENT_QUOTES ) ?>"
 			data-opened-label="<?php echo $t_legend_opened ?>"
-			data-opened-values="[<?php echo $t_opened_values ?>]"
+			data-opened-values="<?php echo htmlspecialchars( $t_opened_values, ENT_QUOTES ) ?>"
 			data-resolved-label="<?php echo $t_legend_resolved ?>"
-			data-resolved-values="[<?php echo $t_resolved_values ?>]"
+			data-resolved-values="<?php echo htmlspecialchars( $t_resolved_values, ENT_QUOTES ) ?>"
 			data-still-open-label="<?php echo $t_legend_still_open ?>"
-			data-still-open-values="[<?php echo $t_still_open_values ?>]" />
+			data-still-open-values="<?php echo htmlspecialchars( $t_still_open_values, ENT_QUOTES ) ?>" />
 <?php
 
 }

--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -128,10 +128,19 @@ function graph_status_colors_to_colors() {
  * @param string  $p_title        Title.
  * @param string  $p_series_name  The name of the data series.
  * @param string  $p_color        The bar color.
+ * @param integer $p_wfactor      Width factor for graph chart. Eg: 2 to make it double wide
  * @return void
  */
-function graph_bar( array $p_metrics, $p_title = '', $p_series_name, $p_color = '#fcbdbd' ) {
+function graph_bar( array $p_metrics, $p_title = '', $p_series_name, $p_color = null, $p_wfactor = null ) {
 	static $s_id = 0;
+
+	# set defaults
+	if( !$p_color ) {
+		$p_color = '#fcbdbd';
+	}
+	if( !$p_wfactor ) {
+		$p_wfactor = 1;
+	}
 
 	$s_id++;
 	$t_labels = array_keys( $p_metrics );
@@ -140,8 +149,11 @@ function graph_bar( array $p_metrics, $p_title = '', $p_series_name, $p_color = 
 	$t_values = array_values( $p_metrics );
 	$t_js_values = graph_numeric_array( $t_values );
 
+	$t_width = 500 * $p_wfactor;
+	$t_height = 400;
+
 ?>
-	<canvas id="barchart<?php echo $s_id ?>" width="500" height="400"
+	<canvas id="barchart<?php echo $s_id ?>" width="<?php echo $t_width ?>" height="<?php echo $t_height ?>"
 		data-labels="[<?php echo htmlspecialchars( $t_js_labels, ENT_QUOTES ) ?>]"
 		data-values="[<?php echo $t_js_values ?>]" />
 <?php
@@ -181,10 +193,16 @@ function graph_pie( array $p_metrics, $p_title = '' ) {
  * Cumulative line graph
  *
  * @param array   $p_metrics      Graph Data.
+ * @param integer $p_wfactor      Width factor for graph chart. Eg: 2 to make it double wide
  * @return void
  */
-function graph_cumulative_bydate( array $p_metrics ) {
+function graph_cumulative_bydate( array $p_metrics, $p_wfactor = null ) {
 	static $s_id = 0;
+
+	# set defaults
+	if( !$p_wfactor ) {
+		$p_wfactor = 1;
+	}
 
 	$s_id++;
 
@@ -209,8 +227,10 @@ function graph_cumulative_bydate( array $p_metrics ) {
 	$t_legend_resolved = plugin_lang_get( 'legend_resolved' );
 	$t_legend_still_open = plugin_lang_get( 'legend_still_open' );
 
+	$t_width = 500 * $p_wfactor;
+	$t_height = 400;
 ?>
-	<canvas id="linebydate<?php echo $s_id ?>" width="500" height="400"
+	<canvas id="linebydate<?php echo $s_id ?>" width="<?php echo $t_width ?>" height="<?php echo $t_height ?>"
 			data-labels="[<?php echo htmlspecialchars( $t_js_labels, ENT_QUOTES ) ?>]"
 			data-opened-label="<?php echo $t_legend_opened ?>"
 			data-opened-values="[<?php echo $t_opened_values ?>]"

--- a/plugins/MantisGraph/pages/category_graph.php
+++ b/plugins/MantisGraph/pages/category_graph.php
@@ -29,11 +29,12 @@ layout_page_header();
 
 layout_page_begin( 'summary_page.php' );
 
-print_summary_menu( 'summary_page.php' );
+$t_filter = summary_get_filter();
+print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 
 $t_series_name = lang_get( 'bugs' );
-$t_metrics = create_category_summary();
+$t_metrics = create_category_summary( $t_filter );
 ?>
     
 <div class="col-md-12 col-xs-12">

--- a/plugins/MantisGraph/pages/category_graph.php
+++ b/plugins/MantisGraph/pages/category_graph.php
@@ -23,10 +23,6 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( 'core.php' );
-
-plugin_require_api( 'core/graph_api.php' );
-
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 
 layout_page_header();

--- a/plugins/MantisGraph/pages/category_graph.php
+++ b/plugins/MantisGraph/pages/category_graph.php
@@ -49,11 +49,11 @@ $t_metrics = create_category_summary( $t_filter );
 		</div>
 
 		<div class="col-md-6 col-xs-12">
-			<?php graph_bar( $t_metrics, lang_get( 'by_category' ), $t_series_name ); ?>
+			<?php graph_bar( $t_metrics, $t_series_name ); ?>
 		</div>
 
 		<div class="col-md-6 col-xs-12">
-			<?php graph_pie( $t_metrics, plugin_lang_get( 'by_category_pct' ) ); ?>
+			<?php graph_pie( $t_metrics ); ?>
 		</div>
 	</div>
 </div>

--- a/plugins/MantisGraph/pages/category_graph.php
+++ b/plugins/MantisGraph/pages/category_graph.php
@@ -38,23 +38,24 @@ $t_metrics = create_category_summary( $t_filter );
 ?>
     
 <div class="col-md-12 col-xs-12">
-<div class="space-10"></div>
+	<div class="space-10"></div>
 
-<div class="widget-box widget-color-blue2">
-<div class="widget-header widget-header-small">
-	<h4 class="widget-title lighter">
-		<i class="ace-icon fa fa-bar-chart-o"></i>
-		<?php echo plugin_lang_get( 'graph_imp_category_title' ) ?>
-	</h4>
-</div>
+	<div class="widget-box widget-color-blue2">
+		<div class="widget-header widget-header-small">
+			<h4 class="widget-title lighter">
+				<i class="ace-icon fa fa-bar-chart-o"></i>
+				<?php echo plugin_lang_get( 'graph_imp_category_title' ) ?>
+			</h4>
+		</div>
 
-<?php
-graph_bar( $t_metrics, lang_get( 'by_category' ), $t_series_name );
-# echo '<div class="space-10"></div>';
-# graph_pie( $t_metrics, plugin_lang_get( 'by_category_pct' ) );
-?>
+		<div class="col-md-6 col-xs-12">
+			<?php graph_bar( $t_metrics, lang_get( 'by_category' ), $t_series_name ); ?>
+		</div>
 
-</div>
+		<div class="col-md-6 col-xs-12">
+			<?php graph_pie( $t_metrics, plugin_lang_get( 'by_category_pct' ) ); ?>
+		</div>
+	</div>
 </div>
 
 <?php

--- a/plugins/MantisGraph/pages/category_graph.php
+++ b/plugins/MantisGraph/pages/category_graph.php
@@ -33,7 +33,6 @@ $t_filter = summary_get_filter();
 print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 
-$t_series_name = lang_get( 'bugs' );
 $t_metrics = create_category_summary( $t_filter );
 ?>
     
@@ -49,7 +48,7 @@ $t_metrics = create_category_summary( $t_filter );
 		</div>
 
 		<div class="col-md-6 col-xs-12">
-			<?php graph_bar( $t_metrics, $t_series_name ); ?>
+			<?php graph_bar( $t_metrics ); ?>
 		</div>
 
 		<div class="col-md-6 col-xs-12">

--- a/plugins/MantisGraph/pages/developer_graph.php
+++ b/plugins/MantisGraph/pages/developer_graph.php
@@ -29,7 +29,8 @@ layout_page_header();
 
 layout_page_begin( 'summary_page.php' );
 
-print_summary_menu( 'summary_page.php' );
+$t_filter = summary_get_filter();
+print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 
 $t_series_name = lang_get( 'bugs' );
@@ -54,7 +55,7 @@ $t_series_name = lang_get( 'bugs' );
             </div>
 
 <?php
-            $t_metrics = create_developer_resolved_summary();
+            $t_metrics = create_developer_resolved_summary( $t_filter );
             graph_bar( $t_metrics, lang_get( 'by_developer' ), $t_series_name );
 ?>
         </div>
@@ -68,7 +69,7 @@ $t_series_name = lang_get( 'bugs' );
             </div>
 
 <?php
-            $t_metrics = create_developer_open_summary();
+            $t_metrics = create_developer_open_summary( $t_filter );
             graph_bar( $t_metrics, lang_get( 'by_developer' ), $t_series_name );
 ?>
         </div>

--- a/plugins/MantisGraph/pages/developer_graph.php
+++ b/plugins/MantisGraph/pages/developer_graph.php
@@ -23,10 +23,6 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( 'core.php' );
-
-plugin_require_api( 'core/graph_api.php' );
-
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 
 layout_page_header();

--- a/plugins/MantisGraph/pages/developer_graph.php
+++ b/plugins/MantisGraph/pages/developer_graph.php
@@ -32,8 +32,6 @@ layout_page_begin( 'summary_page.php' );
 $t_filter = summary_get_filter();
 print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
-
-$t_series_name = lang_get( 'bugs' );
 ?>
 
 <div class="col-md-12 col-xs-12">
@@ -56,7 +54,7 @@ $t_series_name = lang_get( 'bugs' );
 
 <?php
             $t_metrics = create_developer_resolved_summary( $t_filter );
-            graph_bar( $t_metrics, $t_series_name );
+            graph_bar( $t_metrics );
 ?>
         </div>
 
@@ -70,7 +68,7 @@ $t_series_name = lang_get( 'bugs' );
 
 <?php
             $t_metrics = create_developer_open_summary( $t_filter );
-            graph_bar( $t_metrics, $t_series_name );
+            graph_bar( $t_metrics );
 ?>
         </div>
     </div>

--- a/plugins/MantisGraph/pages/developer_graph.php
+++ b/plugins/MantisGraph/pages/developer_graph.php
@@ -56,7 +56,7 @@ $t_series_name = lang_get( 'bugs' );
 
 <?php
             $t_metrics = create_developer_resolved_summary( $t_filter );
-            graph_bar( $t_metrics, lang_get( 'by_developer' ), $t_series_name );
+            graph_bar( $t_metrics, $t_series_name );
 ?>
         </div>
 
@@ -70,7 +70,7 @@ $t_series_name = lang_get( 'bugs' );
 
 <?php
             $t_metrics = create_developer_open_summary( $t_filter );
-            graph_bar( $t_metrics, lang_get( 'by_developer' ), $t_series_name );
+            graph_bar( $t_metrics, $t_series_name );
 ?>
         </div>
     </div>

--- a/plugins/MantisGraph/pages/issues_trend_bycategory_table.php
+++ b/plugins/MantisGraph/pages/issues_trend_bycategory_table.php
@@ -23,11 +23,6 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( 'core.php' );
-
-plugin_require_api( 'core/Period.php' );
-plugin_require_api( 'core/graph_api.php' );
-
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 
 $t_interval = new Period();

--- a/plugins/MantisGraph/pages/issues_trend_bystatus_table.php
+++ b/plugins/MantisGraph/pages/issues_trend_bystatus_table.php
@@ -22,11 +22,6 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( 'core.php' );
-
-plugin_require_api( 'core/Period.php' );
-plugin_require_api( 'core/graph_api.php' );
-
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 
 $t_interval = new Period();

--- a/plugins/MantisGraph/pages/issues_trend_graph.php
+++ b/plugins/MantisGraph/pages/issues_trend_graph.php
@@ -47,7 +47,7 @@ print_summary_submenu();
 <?php
 			$t_metrics = create_cumulative_bydate( $t_filter );
 			if ( $t_metrics != null ) {
-				graph_cumulative_bydate( $t_metrics );
+				graph_cumulative_bydate( $t_metrics, 2 /*wfactor*/ );
 			}
 ?>
 	</div>

--- a/plugins/MantisGraph/pages/issues_trend_graph.php
+++ b/plugins/MantisGraph/pages/issues_trend_graph.php
@@ -23,10 +23,6 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( 'core.php' );
-
-plugin_require_api( 'core/graph_api.php' );
-
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 
 layout_page_header();

--- a/plugins/MantisGraph/pages/issues_trend_graph.php
+++ b/plugins/MantisGraph/pages/issues_trend_graph.php
@@ -29,7 +29,8 @@ layout_page_header();
 
 layout_page_begin( 'summary_page.php' );
 
-print_summary_menu( 'summary_page.php' );
+$t_filter = summary_get_filter();
+print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 ?>
 
@@ -44,7 +45,7 @@ print_summary_submenu();
 		</div>
 
 <?php
-			$t_metrics = create_cumulative_bydate();
+			$t_metrics = create_cumulative_bydate( $t_filter );
 			if ( $t_metrics != null ) {
 				graph_cumulative_bydate( $t_metrics );
 			}

--- a/plugins/MantisGraph/pages/issues_trend_page.php
+++ b/plugins/MantisGraph/pages/issues_trend_page.php
@@ -29,14 +29,6 @@
  * @uses plugin_api.php
  */
 
-require_once( 'core.php' );
-plugin_require_api( 'core/Period.php' );
-require_api( 'access_api.php' );
-require_api( 'config_api.php' );
-require_api( 'gpc_api.php' );
-require_api( 'html_api.php' );
-require_api( 'plugin_api.php' );
-
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 
 $f_interval = gpc_get_int( 'interval', 0 );

--- a/plugins/MantisGraph/pages/priority_graph.php
+++ b/plugins/MantisGraph/pages/priority_graph.php
@@ -23,10 +23,6 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( 'core.php' );
-
-plugin_require_api( 'core/graph_api.php' );
-
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 
 layout_page_header();

--- a/plugins/MantisGraph/pages/priority_graph.php
+++ b/plugins/MantisGraph/pages/priority_graph.php
@@ -49,11 +49,11 @@ $t_metrics = create_bug_enum_summary( lang_get( 'priority_enum_string' ), 'prior
 </div>
 
 <div class="col-md-6 col-xs-12">
-<?php graph_bar( $t_metrics, lang_get( 'by_priority' ), $t_series_name ); ?>
+<?php graph_bar( $t_metrics, $t_series_name ); ?>
 </div>
 
 <div class="col-md-6 col-xs-12">
-<?php graph_pie( $t_metrics, plugin_lang_get( 'by_priority_pct' ) ); ?>
+<?php graph_pie( $t_metrics ); ?>
 </div>
 
 </div>

--- a/plugins/MantisGraph/pages/priority_graph.php
+++ b/plugins/MantisGraph/pages/priority_graph.php
@@ -29,11 +29,12 @@ layout_page_header();
 
 layout_page_begin( 'summary_page.php' );
 
-print_summary_menu( 'summary_page.php' );
+$t_filter = summary_get_filter();
+print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 
 $t_series_name = lang_get( 'bugs' );
-$t_metrics = create_bug_enum_summary( lang_get( 'priority_enum_string' ), 'priority' );
+$t_metrics = create_bug_enum_summary( lang_get( 'priority_enum_string' ), 'priority', array(), $t_filter );
 ?>
 
 <div class="col-md-12 col-xs-12">

--- a/plugins/MantisGraph/pages/priority_graph.php
+++ b/plugins/MantisGraph/pages/priority_graph.php
@@ -33,7 +33,6 @@ $t_filter = summary_get_filter();
 print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 
-$t_series_name = lang_get( 'bugs' );
 $t_metrics = create_bug_enum_summary( lang_get( 'priority_enum_string' ), 'priority', array(), $t_filter );
 ?>
 
@@ -49,7 +48,7 @@ $t_metrics = create_bug_enum_summary( lang_get( 'priority_enum_string' ), 'prior
 </div>
 
 <div class="col-md-6 col-xs-12">
-<?php graph_bar( $t_metrics, $t_series_name ); ?>
+<?php graph_bar( $t_metrics ); ?>
 </div>
 
 <div class="col-md-6 col-xs-12">

--- a/plugins/MantisGraph/pages/reporter_graph.php
+++ b/plugins/MantisGraph/pages/reporter_graph.php
@@ -23,10 +23,6 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( 'core.php' );
-
-plugin_require_api( 'core/graph_api.php' );
-
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 
 layout_page_header();

--- a/plugins/MantisGraph/pages/reporter_graph.php
+++ b/plugins/MantisGraph/pages/reporter_graph.php
@@ -55,7 +55,7 @@ $t_series_name = lang_get( 'bugs' );
             </div>
 <?php
             $t_metrics = create_reporter_summary( $t_filter );
-            graph_bar( $t_metrics, lang_get( 'by_reporter' ), $t_series_name );
+            graph_bar( $t_metrics, lang_get( 'by_reporter' ), $t_series_name, null, 2 /*wfactor*/ );
 ?>
         </div>
     </div>

--- a/plugins/MantisGraph/pages/reporter_graph.php
+++ b/plugins/MantisGraph/pages/reporter_graph.php
@@ -46,7 +46,7 @@ $t_series_name = lang_get( 'bugs' );
 			</h4>
 		</div>
 
-        <div class="col-md-6 col-xs-12" style="padding: 20px;">
+        <div class="col-md-12 col-xs-12" style="padding: 20px;">
             <div class="widget-header widget-header-small">
                 <h4 class="widget-title lighter">
                     <i class="ace-icon fa fa-bar-chart"></i>

--- a/plugins/MantisGraph/pages/reporter_graph.php
+++ b/plugins/MantisGraph/pages/reporter_graph.php
@@ -32,8 +32,6 @@ layout_page_begin( 'summary_page.php' );
 $t_filter = summary_get_filter();
 print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
-
-$t_series_name = lang_get( 'bugs' );
 ?>
 
 <div class="col-md-12 col-xs-12">
@@ -55,7 +53,7 @@ $t_series_name = lang_get( 'bugs' );
             </div>
 <?php
             $t_metrics = create_reporter_summary( $t_filter );
-            graph_bar( $t_metrics, $t_series_name, 2 /*wfactor*/ );
+            graph_bar( $t_metrics, 2 /*wfactor*/ );
 ?>
         </div>
     </div>

--- a/plugins/MantisGraph/pages/reporter_graph.php
+++ b/plugins/MantisGraph/pages/reporter_graph.php
@@ -29,7 +29,8 @@ layout_page_header();
 
 layout_page_begin( 'summary_page.php' );
 
-print_summary_menu( 'summary_page.php' );
+$t_filter = summary_get_filter();
+print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 
 $t_series_name = lang_get( 'bugs' );
@@ -53,7 +54,7 @@ $t_series_name = lang_get( 'bugs' );
                 </h4>
             </div>
 <?php
-            $t_metrics = create_reporter_summary();
+            $t_metrics = create_reporter_summary( $t_filter );
             graph_bar( $t_metrics, lang_get( 'by_reporter' ), $t_series_name );
 ?>
         </div>

--- a/plugins/MantisGraph/pages/reporter_graph.php
+++ b/plugins/MantisGraph/pages/reporter_graph.php
@@ -55,7 +55,7 @@ $t_series_name = lang_get( 'bugs' );
             </div>
 <?php
             $t_metrics = create_reporter_summary( $t_filter );
-            graph_bar( $t_metrics, lang_get( 'by_reporter' ), $t_series_name, null, 2 /*wfactor*/ );
+            graph_bar( $t_metrics, $t_series_name, 2 /*wfactor*/ );
 ?>
         </div>
     </div>

--- a/plugins/MantisGraph/pages/resolution_graph.php
+++ b/plugins/MantisGraph/pages/resolution_graph.php
@@ -23,10 +23,6 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( 'core.php' );
-
-plugin_require_api( 'core/graph_api.php' );
-
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 
 layout_page_header();

--- a/plugins/MantisGraph/pages/resolution_graph.php
+++ b/plugins/MantisGraph/pages/resolution_graph.php
@@ -29,11 +29,12 @@ layout_page_header();
 
 layout_page_begin( 'summary_page.php' );
 
-print_summary_menu( 'summary_page.php' );
+$t_filter = summary_get_filter();
+print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 
 $t_series_name = lang_get( 'bugs' );
-$t_metrics = create_bug_enum_summary( lang_get( 'resolution_enum_string' ), 'resolution' );
+$t_metrics = create_bug_enum_summary( lang_get( 'resolution_enum_string' ), 'resolution', array(), $t_filter );
 ?>
 
 <div class="col-md-12 col-xs-12">

--- a/plugins/MantisGraph/pages/resolution_graph.php
+++ b/plugins/MantisGraph/pages/resolution_graph.php
@@ -49,11 +49,11 @@ $t_metrics = create_bug_enum_summary( lang_get( 'resolution_enum_string' ), 'res
 </div>
 
 <div class="col-md-6 col-xs-12">
-	<?php graph_bar( $t_metrics, lang_get( 'by_resolution' ), $t_series_name ); ?>
+	<?php graph_bar( $t_metrics, $t_series_name ); ?>
 </div>
 
 <div class="col-md-6 col-xs-12">
-	<?php graph_pie( $t_metrics, plugin_lang_get( 'by_resolution_pct' ) ); ?>
+	<?php graph_pie( $t_metrics ); ?>
 </div>
 </div>
 </div>

--- a/plugins/MantisGraph/pages/resolution_graph.php
+++ b/plugins/MantisGraph/pages/resolution_graph.php
@@ -33,7 +33,6 @@ $t_filter = summary_get_filter();
 print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 
-$t_series_name = lang_get( 'bugs' );
 $t_metrics = create_bug_enum_summary( lang_get( 'resolution_enum_string' ), 'resolution', array(), $t_filter );
 ?>
 
@@ -49,7 +48,7 @@ $t_metrics = create_bug_enum_summary( lang_get( 'resolution_enum_string' ), 'res
 </div>
 
 <div class="col-md-6 col-xs-12">
-	<?php graph_bar( $t_metrics, $t_series_name ); ?>
+	<?php graph_bar( $t_metrics ); ?>
 </div>
 
 <div class="col-md-6 col-xs-12">

--- a/plugins/MantisGraph/pages/severity_graph.php
+++ b/plugins/MantisGraph/pages/severity_graph.php
@@ -48,11 +48,11 @@ $t_metrics = create_bug_enum_summary( lang_get( 'severity_enum_string' ), 'sever
             </div>
 
             <div class="col-md-6 col-xs-12">
-                <?php graph_bar( $t_metrics, lang_get( 'by_severity' ), $t_series_name ); ?>
+                <?php graph_bar( $t_metrics, $t_series_name ); ?>
             </div>
 
             <div class="col-md-6 col-xs-12">
-                <?php graph_pie( $t_metrics, plugin_lang_get( 'by_severity_pct' ) ); ?>
+                <?php graph_pie( $t_metrics ); ?>
             </div>
         </div>
     </div>

--- a/plugins/MantisGraph/pages/severity_graph.php
+++ b/plugins/MantisGraph/pages/severity_graph.php
@@ -22,10 +22,6 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( 'core.php' );
-
-plugin_require_api( 'core/graph_api.php' );
-
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 
 layout_page_header();

--- a/plugins/MantisGraph/pages/severity_graph.php
+++ b/plugins/MantisGraph/pages/severity_graph.php
@@ -28,11 +28,12 @@ layout_page_header();
 
 layout_page_begin( 'summary_page.php' );
 
-print_summary_menu( 'summary_page.php' );
+$t_filter = summary_get_filter();
+print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 
 $t_series_name = lang_get( 'bugs' );
-$t_metrics = create_bug_enum_summary( lang_get( 'severity_enum_string' ), 'severity' );
+$t_metrics = create_bug_enum_summary( lang_get( 'severity_enum_string' ), 'severity', array(), $t_filter );
 ?>
 
     <div class="col-md-12 col-xs-12">

--- a/plugins/MantisGraph/pages/severity_graph.php
+++ b/plugins/MantisGraph/pages/severity_graph.php
@@ -32,7 +32,6 @@ $t_filter = summary_get_filter();
 print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 
-$t_series_name = lang_get( 'bugs' );
 $t_metrics = create_bug_enum_summary( lang_get( 'severity_enum_string' ), 'severity', array(), $t_filter );
 ?>
 
@@ -48,7 +47,7 @@ $t_metrics = create_bug_enum_summary( lang_get( 'severity_enum_string' ), 'sever
             </div>
 
             <div class="col-md-6 col-xs-12">
-                <?php graph_bar( $t_metrics, $t_series_name ); ?>
+                <?php graph_bar( $t_metrics ); ?>
             </div>
 
             <div class="col-md-6 col-xs-12">

--- a/plugins/MantisGraph/pages/status_graph.php
+++ b/plugins/MantisGraph/pages/status_graph.php
@@ -47,11 +47,11 @@ $t_metrics = create_bug_status_summary( $t_filter );
             </div>
 
             <div class="col-md-6 col-xs-12">
-            <?php graph_bar( $t_metrics, lang_get( 'by_status' ), $t_series_name ); ?>
+            <?php graph_bar( $t_metrics, $t_series_name ); ?>
             </div>
 
             <div class="col-md-6 col-xs-12">
-            <?php graph_pie( $t_metrics, plugin_lang_get( 'by_status_pct' ) ); ?>
+            <?php graph_pie( $t_metrics ); ?>
             </div>
         </div>
     </div>

--- a/plugins/MantisGraph/pages/status_graph.php
+++ b/plugins/MantisGraph/pages/status_graph.php
@@ -31,7 +31,6 @@ $t_filter = summary_get_filter();
 print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 
-$t_series_name = lang_get( 'bugs' );
 $t_metrics = create_bug_status_summary( $t_filter );
 ?>
 
@@ -47,7 +46,7 @@ $t_metrics = create_bug_status_summary( $t_filter );
             </div>
 
             <div class="col-md-6 col-xs-12">
-            <?php graph_bar( $t_metrics, $t_series_name ); ?>
+            <?php graph_bar( $t_metrics ); ?>
             </div>
 
             <div class="col-md-6 col-xs-12">

--- a/plugins/MantisGraph/pages/status_graph.php
+++ b/plugins/MantisGraph/pages/status_graph.php
@@ -27,11 +27,12 @@ access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 layout_page_header();
 layout_page_begin( 'summary_page.php' );
 
-print_summary_menu( 'summary_page.php' );
+$t_filter = summary_get_filter();
+print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 
 $t_series_name = lang_get( 'bugs' );
-$t_metrics = create_bug_status_summary();
+$t_metrics = create_bug_status_summary( $t_filter );
 ?>
 
     <div class="col-md-12 col-xs-12">

--- a/plugins/MantisGraph/pages/status_graph.php
+++ b/plugins/MantisGraph/pages/status_graph.php
@@ -22,10 +22,6 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( 'core.php' );
-
-plugin_require_api( 'core/graph_api.php' );
-
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 
 layout_page_header();

--- a/summary_page.php
+++ b/summary_page.php
@@ -58,7 +58,9 @@ $g_project_override = $f_project_id;
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 
-$t_time_stats = summary_helper_get_time_stats( $f_project_id );
+$t_filter = summary_get_filter();
+
+$t_time_stats = summary_helper_get_time_stats( $f_project_id, $t_filter );
 
 $t_summary_header_arr = explode( '/', lang_get( 'summary_header' ) );
 
@@ -105,7 +107,7 @@ print_summary_submenu();
 				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
-		<?php summary_print_by_project(); ?>
+		<?php summary_print_by_project( array(), null, null, $t_filter ); ?>
 	</table>
 	</div>
 
@@ -119,7 +121,7 @@ print_summary_submenu();
 				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
-		<?php summary_print_by_enum( 'status' ) ?>
+		<?php summary_print_by_enum( 'status', $t_filter ) ?>
 	</table>
 	</div>
 
@@ -133,7 +135,7 @@ print_summary_submenu();
 				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
-		<?php summary_print_by_enum( 'severity' ) ?>
+		<?php summary_print_by_enum( 'severity', $t_filter ) ?>
 	</table>
 	</div>
 
@@ -147,7 +149,7 @@ print_summary_submenu();
 				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
-		<?php summary_print_by_category() ?>
+		<?php summary_print_by_category( $t_filter ) ?>
 	</table>
 	</div>
 
@@ -193,7 +195,7 @@ print_summary_submenu();
 				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
-		<?php summary_print_by_developer() ?>
+		<?php summary_print_by_developer( $t_filter ) ?>
 	</table>
 </div>
 </div>
@@ -213,7 +215,7 @@ print_summary_submenu();
 				<th class="align-right"><?php echo lang_get( 'balance' ); ?></th>
 			</tr>
 		</thead>
-		<?php summary_print_by_date( config_get( 'date_partitions' ) ) ?>
+		<?php summary_print_by_date( config_get( 'date_partitions' ), $t_filter ) ?>
 	</table>
 	</div>
 
@@ -227,7 +229,7 @@ print_summary_submenu();
 				<th class="align-right"><?php echo lang_get( 'score' ); ?></th>
 			</tr>
 		</thead>
-		<?php summary_print_by_activity() ?>
+		<?php summary_print_by_activity( $t_filter ) ?>
 	</table>
 	</div>
 
@@ -241,7 +243,7 @@ print_summary_submenu();
 				<th class="align-right"><?php echo lang_get( 'days' ); ?></th>
 			</tr>
 		</thead>
-		<?php summary_print_by_age() ?>
+		<?php summary_print_by_age( $t_filter ) ?>
 	</table>
 	</div>
 
@@ -255,7 +257,7 @@ print_summary_submenu();
 				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
-		<?php summary_print_by_enum( 'resolution' ) ?>
+		<?php summary_print_by_enum( 'resolution', $t_filter ) ?>
 	</table>
 	</div>
 
@@ -269,7 +271,7 @@ print_summary_submenu();
 				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
-		<?php summary_print_by_enum( 'priority' ) ?>
+		<?php summary_print_by_enum( 'priority', $t_filter ) ?>
 	</table>
 	</div>
 
@@ -283,7 +285,7 @@ print_summary_submenu();
 				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
-		<?php summary_print_by_reporter() ?>
+		<?php summary_print_by_reporter( $t_filter ) ?>
 	</table>
 	</div>
 
@@ -299,7 +301,7 @@ print_summary_submenu();
 				<th class="align-right"><?php echo lang_get( 'total' ); ?></th>
 			</tr>
 		</thead>
-		<?php summary_print_reporter_effectiveness( config_get( 'severity_enum_string' ), config_get( 'resolution_enum_string' ) ) ?>
+		<?php summary_print_reporter_effectiveness( config_get( 'severity_enum_string' ), config_get( 'resolution_enum_string' ), $t_filter ) ?>
 	</table>
 	</div>
 
@@ -327,7 +329,7 @@ print_summary_submenu();
 				?>
 			</tr>
 		</thead>
-		<?php summary_print_reporter_resolution( config_get( 'resolution_enum_string' ) ) ?>
+		<?php summary_print_reporter_resolution( config_get( 'resolution_enum_string' ), $t_filter ) ?>
 	</table>
 	</div>
 
@@ -350,7 +352,7 @@ print_summary_submenu();
 				?>
 			</tr>
 		</thead>
-		<?php summary_print_developer_resolution( config_get( 'resolution_enum_string' ) ) ?>
+		<?php summary_print_developer_resolution( config_get( 'resolution_enum_string' ), $t_filter ) ?>
 	</table>
 	</div>
 

--- a/summary_page.php
+++ b/summary_page.php
@@ -75,7 +75,7 @@ layout_page_header( lang_get( 'summary_link' ) );
 
 layout_page_begin( __FILE__ );
 
-print_summary_menu( 'summary_page.php' );
+print_summary_menu( 'summary_page.php', $t_filter );
 print_summary_submenu();
 ?>
 

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -61,10 +61,10 @@ list( $t_dir, ) = explode( ',', $g_filter['dir'] );
 
 $g_checkboxes_exist = false;
 
-
+$t_current_project = helper_get_current_project();
 # Improve performance by caching category data in one pass
-if( helper_get_current_project() > 0 ) {
-	category_get_all_rows( helper_get_current_project() );
+if( $t_current_project > 0 ) {
+	category_get_all_rows( $t_current_project );
 }
 
 $g_columns = helper_get_columns_to_view( COLUMNS_TARGET_VIEW_PAGE );
@@ -121,7 +121,9 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 			print_small_button( 'print_all_bug_page.php' . $t_filter_param, lang_get( 'print_all_bug_page_link' ) );
 			print_small_button( 'csv_export.php' . $t_filter_param, lang_get( 'csv_export' ) );
 			print_small_button( 'excel_xml_export.php' . $t_filter_param, lang_get( 'excel_export' ) );
-			print_small_button( $t_summary_link, lang_get( 'summary_link' ) );
+			if( access_has_project_level( config_get( 'view_summary_threshold' ), $t_current_project ) ) {
+				print_small_button( $t_summary_link, lang_get( 'summary_link' ) );
+			}
 
 			$t_event_menu_options = $t_links = event_signal('EVENT_MENU_FILTER');
 

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -117,6 +117,7 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 			print_small_button( 'print_all_bug_page.php' . $t_filter_param, lang_get( 'print_all_bug_page_link' ) );
 			print_small_button( 'csv_export.php' . $t_filter_param, lang_get( 'csv_export' ) );
 			print_small_button( 'excel_xml_export.php' . $t_filter_param, lang_get( 'excel_export' ) );
+			print_small_button( 'summary_page.php' . $t_filter_param, lang_get( 'summary_link' ) );
 
 			$t_event_menu_options = $t_links = event_signal('EVENT_MENU_FILTER');
 

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -112,12 +112,16 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 			<div class="btn-group pull-left">
 		<?php
 			$t_filter_param = filter_get_temporary_key_param( $t_filter );
-			$t_filter_param = ( empty( $t_filter_param ) ? '' : '?' ) . $t_filter_param;
+			if( empty( $t_filter_param ) ) {
+				$t_summary_link = 'view_all_set.php?summary=1&temporary=y';
+			} else {
+				$t_summary_link = 'summary_page.php?' . $t_filter_param;
+			}
 			# -- Print and Export links --
 			print_small_button( 'print_all_bug_page.php' . $t_filter_param, lang_get( 'print_all_bug_page_link' ) );
 			print_small_button( 'csv_export.php' . $t_filter_param, lang_get( 'csv_export' ) );
 			print_small_button( 'excel_xml_export.php' . $t_filter_param, lang_get( 'excel_export' ) );
-			print_small_button( 'summary_page.php' . $t_filter_param, lang_get( 'summary_link' ) );
+			print_small_button( $t_summary_link, lang_get( 'summary_link' ) );
 
 			$t_event_menu_options = $t_links = event_signal('EVENT_MENU_FILTER');
 

--- a/view_all_set.php
+++ b/view_all_set.php
@@ -88,8 +88,8 @@ if( $f_isset_temporary ) {
 	$t_temp_filter = filter_is_temporary( $t_setting_arr );
 }
 
-if( $f_isset_new_key ) {
-	# use type 2 wich keeps current filter values
+if( $f_type == -1 && $f_isset_new_key ) {
+	# use an action that keeps current filter values
 	$f_type = FILTER_ACTION_PARSE_ADD;
 }
 

--- a/view_all_set.php
+++ b/view_all_set.php
@@ -57,11 +57,16 @@ auth_ensure_user_authenticated();
 
 $f_type					= gpc_get_int( 'type', -1 );
 $f_source_query_id		= gpc_get_int( 'source_query_id', -1 );
-$f_print				= gpc_get_bool( 'print' );
 $f_isset_temporary		= gpc_isset( 'temporary' );
 $f_make_temporary		= gpc_get_bool( 'temporary' );
 $f_project_id			= gpc_get_int( 'set_project_id', -1 );
 
+# flags to redirect after changing the filter
+# 'print' will redirect to print_all_bug_page.php
+# 'summary' will redirect to summary_page.php
+# otherwise, the default redirect is to view_all_bug_page.php
+$f_print				= gpc_get_bool( 'print' );
+$f_summary				= gpc_get_bool( 'summary' );
 
 # Get the filter in use
 $t_setting_arr = current_user_get_bug_filter();
@@ -182,9 +187,11 @@ if( !$t_temp_filter ) {
 	filter_set_project_filter( $t_setting_arr, $t_project_id );
 }
 
-# redirect to print_all or view_all page
+# evaluate redirect
 if( $f_print ) {
 	$t_redirect_url = 'print_all_bug_page.php';
+} elseif( $f_summary ) {
+	$t_redirect_url = 'summary_page.php';
 } else {
 	$t_redirect_url = 'view_all_bug_page.php';
 }

--- a/view_all_set.php
+++ b/view_all_set.php
@@ -59,6 +59,8 @@ $f_type					= gpc_get_int( 'type', -1 );
 $f_source_query_id		= gpc_get_int( 'source_query_id', -1 );
 $f_isset_temporary		= gpc_isset( 'temporary' );
 $f_make_temporary		= gpc_get_bool( 'temporary' );
+$f_isset_new_key		= gpc_isset( 'new' );
+$f_force_new_key		= gpc_get_bool( 'new' );
 $f_project_id			= gpc_get_int( 'set_project_id', -1 );
 
 # flags to redirect after changing the filter
@@ -86,6 +88,11 @@ if( $f_isset_temporary ) {
 	$t_temp_filter = filter_is_temporary( $t_setting_arr );
 }
 
+if( $f_isset_new_key ) {
+	# use type 2 wich keeps current filter values
+	$f_type = FILTER_ACTION_PARSE_ADD;
+}
+
 if( $f_type == -1 ) {
 	print_header_redirect( 'view_all_bug_page.php' );
 }
@@ -95,12 +102,13 @@ if( ( $f_type == FILTER_ACTION_LOAD ) && ( $f_source_query_id == -1 ) ) {
 	$f_type = FILTER_ACTION_RESET;
 }
 
-$t_previous_temporary_key = filter_get_temporary_key( $t_setting_arr );
-
 # If user can't use persistent filters, force the creation of a temporary filter
 if( !filter_user_can_use_persistent( auth_get_current_user_id() ) ) {
 	$t_temp_filter = true;
 }
+
+$t_previous_temporary_key = filter_get_temporary_key( $t_setting_arr );
+$t_force_new_key = $t_temp_filter && $f_force_new_key;
 
 # Clear the source query id.  Since we have entered new filter criteria.
 if( isset( $t_setting_arr['_source_query_id'] ) ) {
@@ -126,7 +134,6 @@ switch( $f_type ) {
 	case FILTER_ACTION_PARSE_ADD:
 		log_event( LOG_FILTERING, 'view_all_set.php: Parse incremental filter values' );
 		$t_setting_arr = filter_gpc_get( $t_setting_arr );
-
 		break;
 
 	# Fetch a stored filter from database
@@ -199,9 +206,13 @@ if( $f_print ) {
 if( $t_temp_filter ) {
 	# keeping the $t_previous_temporary_key, and using it to save back the filter
 	# The key inside the filter array may have been deleted as part of some actions
-	# Note, if we reset the key here, a new filter will be created after each action.
+	# Note, if we reset the key here, a new filter will be created after each filter change.
 	# This adds a lot of orphaned filters to session store, but would allow consistency
 	# through browser back button, for example.
+	if( $t_force_new_key ) {
+		$t_previous_temporary_key = null;
+		unset( $t_setting_arr['_temporary_key'] );
+	}
 	$t_temporary_key = filter_temporary_set( $t_setting_arr, $t_previous_temporary_key );
 	$t_redirect_url = $t_redirect_url . '?' . filter_get_temporary_key_param( $t_temporary_key );
 }


### PR DESCRIPTION
Implement filter functionality on Summary pages (and MantisGraph). There are not many changes in UI, but the core is there for future improvements.

As a start, a "summary" button is added to the view issues page, that opens the summary for the current applied filter. Once in the summary, all filters in use are temporary, to allow following the view links without effects on current persistent filters for view issues page.

![seleccion_315](https://user-images.githubusercontent.com/14123811/50918789-7c28f700-1441-11e9-9709-cca7d21a944e.png)

Summary shows an indication that a filter is applied:

![seleccion_316](https://user-images.githubusercontent.com/14123811/50918841-995dc580-1441-11e9-8b22-8ca55ccdf385.png)


Additionally
- Some fixes and adjustments for summary and graphs presentation
- Some queries has been rewritten to improve performance

Example: performance in a project with 55k issues:
Before:
```
Unique queries executed: 61
Total queries executed: 62
Total query execution time: 19.8188 seconds
```
After:
```
Unique queries executed: 41
Total queries executed: 42
Total query execution time: 6.8595 seconds
```
