### PR TITLE
REST API: Add web.config (url rewrite) for IIS

### DIFF
--- a/api/rest/web.config
+++ b/api/rest/web.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <rewrite>
+      <rules>
+        <rule name="MantisBT REST API rewrite rule" stopProcessing="true">
+          <match url="^" ignoreCase="false" />
+          <conditions>
+            <!--# Based on Slim Framework recommendation @ http://docs.slimframework.com/routing/rewrite/-->
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" ignoreCase="false" negate="true" />
+          </conditions>
+          <action type="Rewrite" url="index.php" appendQueryString="true" />
+        </rule>
+      </rules>
+    </rewrite>
+  </system.webServer>
+  <location allowOverride="true" />  
+</configuration>


### PR DESCRIPTION
To enable access to MantisBT through REST API under IIS, add an
.htaccess equivalent web.config for the url rewrite rule.
Otherwise 404 is returned on every request.
Generated with IIS-URL-Rewrite.Import(api/rest/.htaccess).

Fixes #24347