### PR TITLE
Fix 25370. Add hosting folder /webstat to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ api/rest/swagger
 /vendor/
 composer.phar
 
+#Hosting folders
+/webstat
+
 # Settings below are for convenience when switching branches on Dev machines
 
 # v1.2.x config files


### PR DESCRIPTION
Yes. I know that use git repository on hosting not right idea. But this simple way for testing dev version of MantisBT