### PR TITLE
Summary layout improvements

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -585,15 +585,14 @@ function print_summary_submenu() {
 
 	if( count($t_menu_options) > 0 ) {
 		echo '<div class="space-10"></div>';
-		echo '<div class="center">';
-		echo '<div class="btn-toolbar inline">';
+		echo '<div class="col-md-12 col-xs-12 center">';
 		echo '<div class="btn-group">';
 
 		# Plugins menu items - these are cooked links
 		foreach ($t_menu_options as $t_menu_item) {
 			echo $t_menu_item;
 		}
-		echo '</div></div></div>';
+		echo '</div></div>';
 	}
 }
 

--- a/plugins/MantisGraph/pages/developer_graph.php
+++ b/plugins/MantisGraph/pages/developer_graph.php
@@ -40,6 +40,7 @@ $t_series_name = lang_get( 'bugs' );
 ?>
 
 <div class="col-md-12 col-xs-12">
+	<div class="space-10"></div>
 	<div class="widget-box widget-color-blue2">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">

--- a/plugins/MantisGraph/pages/issues_trend_graph.php
+++ b/plugins/MantisGraph/pages/issues_trend_graph.php
@@ -38,6 +38,7 @@ print_summary_submenu();
 ?>
 
 <div class="col-md-12 col-xs-12">
+	<div class="space-10"></div>
 	<div class="widget-box widget-color-blue2">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">

--- a/plugins/MantisGraph/pages/issues_trend_graph.php
+++ b/plugins/MantisGraph/pages/issues_trend_graph.php
@@ -47,21 +47,13 @@ print_summary_submenu();
 			</h4>
 		</div>
 
-        <div class="col-md-12 col-xs-12" style="padding: 20px;">
-            <div class="widget-header widget-header-small">
-                <h4 class="widget-title lighter">
-                    <i class="ace-icon fa fa-bar-chart"></i>
-                    <?php echo plugin_lang_get( 'graph_issues_trend_title' ) ?>
-                </h4>
-            </div>
 <?php
 			$t_metrics = create_cumulative_bydate();
 			if ( $t_metrics != null ) {
 				graph_cumulative_bydate( $t_metrics );
 			}
 ?>
-        </div>
-    </div>
+	</div>
 </div>
 
 <?php

--- a/plugins/MantisGraph/pages/reporter_graph.php
+++ b/plugins/MantisGraph/pages/reporter_graph.php
@@ -40,6 +40,7 @@ $t_series_name = lang_get( 'bugs' );
 ?>
 
 <div class="col-md-12 col-xs-12">
+	<div class="space-10"></div>
 	<div class="widget-box widget-color-blue2">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">


### PR DESCRIPTION
While testing #1442, I found a few minor display/layout issues with Summary and MantisGraph pages (see [25385](https://mantisbt.org/bugs/view.php?id=25385), [25386](https://mantisbt.org/bugs/view.php?id=25386) and [25387](https://mantisbt.org/bugs/view.php?id=25387) for details). 

I would propose to merge this PR at the same time as @cproensa's #1442, but they are effectively independent and older issues, so it can also be dealt with separately if you prefer.