### PR TITLE
A fix for inappropriate absolute URL rewrites

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -245,7 +245,7 @@ function html_css_link( $p_filename ) {
 	if( $p_filename == basename( $p_filename ) ) {
 		$p_filename = 'css/' . $p_filename;
 	}
-	echo "\t", '<link rel="stylesheet" type="text/css" href="', string_sanitize_url( helper_mantis_url( $p_filename ), true ), '" />', "\n";
+	echo "\t", '<link rel="stylesheet" type="text/css" href="', string_sanitize_url( helper_mantis_url( $p_filename ), false ), '" />', "\n";
 }
 
 /**
@@ -279,7 +279,7 @@ function html_meta_redirect( $p_url, $p_time = null, $p_sanitize = true ) {
 
 	$t_url = config_get_global( 'path' );
 	if( $p_sanitize ) {
-		$t_url .= string_sanitize_url( $p_url );
+		$t_url .= string_sanitize_url( $p_url, false );
 	} else {
 		$t_url .= $p_url;
 	}

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -94,7 +94,7 @@ function layout_page_header_begin( $p_page_title = null ) {
 		echo "\t",
 			'<link rel="search" type="application/opensearchdescription+xml" ',
 				'title="' . sprintf( lang_get( "opensearch_{$t_type}_description" ), $t_title ) . '" ',
-				'href="' . string_sanitize_url( 'browser_search_plugin.php?type=' . $t_type, true ) .
+				'href="' . string_sanitize_url( 'browser_search_plugin.php?type=' . $t_type, false ) .
 				'"/>',
 			"\n";
 	}
@@ -362,8 +362,8 @@ function layout_login_page_begin() {
 	}
 
 	# Advertise the availability of the browser search plug-ins.
-	echo "\t", '<link rel="search" type="application/opensearchdescription+xml" title="MantisBT: Text Search" href="' . string_sanitize_url( 'browser_search_plugin.php?type=text', true) . '" />' . "\n";
-	echo "\t", '<link rel="search" type="application/opensearchdescription+xml" title="MantisBT: Issue Id" href="' . string_sanitize_url( 'browser_search_plugin.php?type=id', true) . '" />' . "\n";
+	echo "\t", '<link rel="search" type="application/opensearchdescription+xml" title="MantisBT: Text Search" href="' . string_sanitize_url( 'browser_search_plugin.php?type=text', false) . '" />' . "\n";
+	echo "\t", '<link rel="search" type="application/opensearchdescription+xml" title="MantisBT: Issue Id" href="' . string_sanitize_url( 'browser_search_plugin.php?type=id', false) . '" />' . "\n";
 	
 	html_head_javascript();
 	

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -109,7 +109,7 @@ function print_header_redirect( $p_url, $p_die = true, $p_sanitize = false, $p_a
 		}
 	} else {
 		if( $p_sanitize ) {
-			$t_url = string_sanitize_url( $p_url, true );
+			$t_url = string_sanitize_url( $p_url, false );
 		} else {
 			$t_url = config_get_global( 'path' ) . $p_url;
 		}


### PR DESCRIPTION
Setting p_return_absolute to false to prevent inappropriate absolute url rewrites.  Helped with my reverse proxy situation - and likely will help some existing tickets.  There are still some issues lingering.

https://www.mantisbt.org/bugs/view.php?id=13056
https://www.mantisbt.org/bugs/view.php?id=9333
https://www.mantisbt.org/bugs/view.php?id=24860