### PR TITLE
 Allow show_queries_count to be set in database

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -4341,7 +4341,7 @@ $g_global_settings = array(
 	'db_table_prefix','db_table_suffix', 'display_errors', 'form_security_validation',
 	'hostname','html_valid_tags', 'html_valid_tags_single_line', 'default_language',
 	'language_auto_map', 'fallback_language', 'login_method', 'plugins_enabled',
-	'session_save_path', 'session_validation', 'show_detailed_errors', 'show_queries_count',
+	'session_save_path', 'session_validation', 'show_detailed_errors',
 	'stop_on_errors', 'version_suffix', 'debug_email',
 	'fileinfo_magic_db_file', 'css_include_file', 'css_rtl_include_file',
 	'file_type_icons', 'path', 'short_path', 'absolute_path', 'core_path',

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -606,7 +606,7 @@ function helper_log_to_page() {
  * @return boolean
  */
 function helper_show_query_count() {
-	return ON == config_get_global( 'show_queries_count' );
+	return ON == config_get( 'show_queries_count' );
 }
 
 /**

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -602,14 +602,6 @@ function helper_log_to_page() {
 }
 
 /**
- * returns a boolean indicating whether SQL queries executed should be shown or not.
- * @return boolean
- */
-function helper_show_query_count() {
-	return ON == config_get( 'show_queries_count' );
-}
-
-/**
  * Return a URL relative to the web root, compatible with other applications
  * @param string $p_url A relative URL to a page within Mantis.
  * @return string

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -1166,26 +1166,30 @@ function layout_footer() {
 
 	event_signal( 'EVENT_LAYOUT_PAGE_FOOTER' );
 
-	if( config_get( 'show_timer' ) || config_get( 'show_memory_usage' ) || config_get_global( 'show_queries_count' ) ) {
+	$t_show_timer = config_get( 'show_timer' );
+	$t_show_memory_usage = config_get( 'show_memory_usage' );
+	$t_show_queries_count = config_get( 'show_queries_count' );
+	$t_display_debug_info = $t_show_timer || $t_show_memory_usage || $t_show_queries_count;
+
+	if( $t_display_debug_info ) {
 		echo '<div class="col-xs-12 no-padding grey">' . "\n";
 		echo '<address class="no-margin pull-right">' . "\n";
 	}
 
-
 	# Print the page execution time
-	if( config_get( 'show_timer' ) ) {
+	if( $t_show_timer ) {
 		$t_page_execution_time = sprintf( lang_get( 'page_execution_time' ), number_format( microtime( true ) - $g_request_time, 4 ) );
 		echo '<small><i class="fa fa-clock-o"></i> ' . $t_page_execution_time . '</small>&#160;&#160;&#160;&#160;' . "\n";
 	}
 
 	# Print the page memory usage
-	if( config_get( 'show_memory_usage' ) ) {
+	if( $t_show_memory_usage ) {
 		$t_page_memory_usage = sprintf( lang_get( 'memory_usage_in_kb' ), number_format( memory_get_peak_usage() / 1024 ) );
 		echo '<small><i class="fa fa-bolt"></i> ' . $t_page_memory_usage . '</small>&#160;&#160;&#160;&#160;' . "\n";
 	}
 
 	# Determine number of unique queries executed
-	if( config_get_global( 'show_queries_count' ) ) {
+	if( $t_show_queries_count ) {
 		$t_total_queries_count = count( $g_queries_array );
 		$t_unique_queries_count = 0;
 		$t_total_query_execution_time = 0;
@@ -1211,7 +1215,7 @@ function layout_footer() {
 		echo '<small><i class="fa fa-clock-o"></i> ' . $t_total_query_time . '</small>&#160;&#160;&#160;&#160;' . "\n";
 	}
 
-	if( config_get( 'show_timer' ) || config_get( 'show_memory_usage' ) || config_get_global( 'show_queries_count' ) ) {
+	if( $t_display_debug_info ) {
 		echo '</address>' . "\n";
 		echo '</div>' . "\n";
 	}


### PR DESCRIPTION
The 2nd commit `Remove unused function helper_show_query_count` could be removed from the PR if someone thinks that it could be used in 3rd party code.