### PR TITLE
Fixes for Config report page

### DIFF
--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -233,19 +233,21 @@ $t_edit_action = in_array( $f_edit_action, $t_valid_actions )
 # Apply filters
 
 # Get users in db having specific configs
-$t_query = 'SELECT DISTINCT user_id FROM {config} WHERE user_id <> ' . db_param() ;
-$t_result = db_query( $t_query, array( ALL_USERS ) );
+$t_query = new DbQuery( 'SELECT DISTINCT user_id FROM {config} WHERE user_id <> :all_users',
+		array( 'all_users' => ALL_USERS ) );
+# build result as: array( [id]=>id, ... )
+$t_user_ids = array_column( $t_query->fetch_all(), 'user_id', 'user_id' );
+
 if( $t_filter_user_value != META_FILTER_NONE && $t_filter_user_value != ALL_USERS ) {
 	# Make sure the filter value exists in the list
-	$t_users_list[$t_filter_user_value] = user_get_name( $t_filter_user_value );
-} else {
-	$t_users_list = array();
+	$t_user_ids[$t_filter_user_value] = $t_filter_user_value;
 }
-while( $t_row = db_fetch_array( $t_result ) ) {
-	$t_user_id = $t_row['user_id'];
-	$t_users_list[$t_user_id] = user_get_name( $t_user_id );
-}
-asort( $t_users_list );
+user_cache_array_rows( $t_user_ids );
+
+# build array for user names
+$t_users_list = array_map( 'user_get_name', $t_user_ids );
+asort( $t_users_list, SORT_NATURAL | SORT_FLAG_CASE );
+
 # Prepend '[any]' and 'All Users' to the list
 $t_users_list = array(
 		META_FILTER_NONE => '[' . lang_get( 'any' ) . ']',

--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -282,28 +282,25 @@ while( $t_row = db_fetch_array( $t_result ) ) {
 	$t_configs_list[$v_config_id] = $v_config_id;
 }
 
-# Build filter's where clause
-$t_where = '';
-$t_param = array();
+# Build config query
+$t_sql = 'SELECT config_id, user_id, project_id, type, value, access_reqd'
+		. ' FROM {config} WHERE 1=1';
 if( $t_filter_user_value != META_FILTER_NONE ) {
-	$t_where .= ' AND user_id = ' . db_param();
-	$t_param[] = $t_filter_user_value;
+	$t_sql .= ' AND user_id = :user_id';
 }
 if( $t_filter_project_value != META_FILTER_NONE ) {
-	$t_where .= ' AND project_id = ' . db_param();
-	$t_param[] = $t_filter_project_value;
+	$t_sql .= ' AND project_id = :project_id';
 }
 if( $t_filter_config_value != META_FILTER_NONE ) {
-	$t_where .= ' AND config_id = ' . db_param();
-	$t_param[] = $t_filter_config_value;
+	$t_sql .= ' AND config_id = :config_id';
 }
-if( $t_where != '' ) {
-	$t_where = ' WHERE 1=1 ' . $t_where;
-}
-
-$t_query = 'SELECT config_id, user_id, project_id, type, value, access_reqd
-	FROM {config} ' . $t_where . ' ORDER BY user_id, project_id, config_id ';
-$t_result = db_query( $t_query, $t_param );
+$t_sql .= ' ORDER BY user_id, project_id, config_id ';
+$t_params = array(
+	'user_id' => $t_filter_user_value,
+	'project_id' => $t_filter_project_value,
+	'config_id' => $t_filter_config_value
+	);
+$t_config_query = new DbQuery( $t_sql, $t_params );
 ?>
 
 <div class="col-md-12 col-xs-12">
@@ -423,7 +420,7 @@ $t_result = db_query( $t_query, $t_param );
 # db contains a large number of configurations
 $t_form_security_token = form_security_token( 'adm_config_delete' );
 
-while( $t_row = db_fetch_array( $t_result ) ) {
+while( $t_row = $t_config_query->fetch() ) {
 	extract( $t_row, EXTR_PREFIX_ALL, 'v' );
 
 ?>


### PR DESCRIPTION
Fix adm_config_report user list
    
    The code to build the user dropdown list have some issues:
    - Missing db_param_push()
    - Calls to get user names are not cached generating a lot of separate
      queries for individual user ids
    - User names are not properly ordered in the dropdown list, as it's
      sorting with a case sensitive mode.

Fix adm_config_report query
    
    The main query has a missing db_param_push(), but because of how the
    query is built, it should only be used only when any of the conditions
    are actually adding a parameter.
    To simplyfy, the query has been rewritten with the new syntax.

Fixes: #25454, #25455, #25456
