### PR TITLE
Fix not all issues returned via REST API.

### DIFF
--- a/api/rest/restcore/issues_rest.php
+++ b/api/rest/restcore/issues_rest.php
@@ -107,8 +107,8 @@ function rest_issue_get( \Slim\Http\Request $p_request, \Slim\Http\Response $p_r
 				$t_issues = mc_filter_get_issues(
 					'', '', $t_project_id, $t_filter_id, $t_page_number, $t_page_size );
 			} else {
-				$t_issues = mc_project_get_issues(
-					'', '', $t_project_id, $t_page_number, $t_page_size );
+				$t_issues = mc_filter_get_issues(
+					'', '', $t_project_id, FILTER_STANDARD_ANY, $t_page_number, $t_page_size );
 			}
 
 			$t_result = array( 'issues' => $t_issues );

--- a/api/soap/mc_filter_api.php
+++ b/api/soap/mc_filter_api.php
@@ -181,7 +181,7 @@ function mc_filter_get_issues( $p_username, $p_password, $p_project_id, $p_filte
 	if( is_numeric( $p_filter_id ) ) {
 		$t_filter = filter_get( $p_filter_id );
 	} else {
-		$t_filter = filter_standard_get( $p_filter_id, $t_user_id );
+		$t_filter = filter_standard_get( $p_filter_id, $t_user_id, $p_project_id );
 	}
 
 	if( $t_filter === null ) {

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -484,6 +484,7 @@ define( 'FILTER_MATCH_ALL', 0 );
 define( 'FILTER_MATCH_ANY', 1 );
 
 # Standard Filters
+define( 'FILTER_STANDARD_ANY', 'any' );
 define( 'FILTER_STANDARD_ASSIGNED', 'assigned' );
 define( 'FILTER_STANDARD_UNASSIGNED', 'unassigned' );
 define( 'FILTER_STANDARD_REPORTED', 'reported' );

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -3167,6 +3167,25 @@ function filter_create_recently_modified( $p_days, $p_filter = null ) {
 }
 
 /**
+ * Create a filter for getting issues assigned to the specified project.
+ * @param integer $p_project_id The project id or ALL_PROJECTS.
+ * @return mixed A valid filter.
+ */
+function filter_create_any( $p_project_id ) {
+	$t_filter = filter_get_default();
+
+	$t_filter[FILTER_PROPERTY_HANDLER_ID] = array( '0' => META_FILTER_ANY );
+	$t_filter[FILTER_PROPERTY_STATUS] = array( '0' => META_FILTER_ANY );
+	$t_filter[FILTER_PROPERTY_HIDE_STATUS] = META_FILTER_NONE;
+
+	if( $p_project_id != ALL_PROJECTS ) {
+		$t_filter[FILTER_PROPERTY_PROJECT_ID] = array( '0' => $p_project_id );
+	}
+
+	return filter_ensure_valid_filter( $t_filter );
+}
+
+/**
  * Create a filter for getting issues assigned to the specified project and user that
  * are not yet resolved.
  *
@@ -3808,11 +3827,18 @@ function filter_get( $p_filter_id, array $p_default = null ) {
  * Return a standard filter
  * @param string $p_filter_name     The name of the filter
  * @param integer|null $p_user_id   A user id to build this filter. Null for current user
+ * @param integer|null $p_project_id	 A project id to build this filter.  Null for current project
  * @return null|boolean|array       null filter not found, false invalid filter, otherwise the filter.
  */
-function filter_standard_get( $p_filter_name, $p_user_id = null ) {
+function filter_standard_get( $p_filter_name, $p_user_id = null, $p_project_id = null ) {
 	$p_filter_name = strtolower( $p_filter_name );
-	$t_project_id = helper_get_current_project();
+
+	if( null === $p_project_id ) {
+		$t_project_id = helper_get_current_project();
+	} else {
+		$t_project_id = $p_project_id;
+	}
+
 	if( null === $p_user_id ) {
 		$t_user_id = auth_get_current_user_id();
 	} else {
@@ -3820,6 +3846,9 @@ function filter_standard_get( $p_filter_name, $p_user_id = null ) {
 	}
 
 	switch( $p_filter_name ) {
+		case FILTER_STANDARD_ANY:
+			$t_filter = filter_create_any( $t_project_id );
+			break;
 		case FILTER_STANDARD_ASSIGNED:
 			$t_filter = filter_create_assigned_to_unresolved( $t_project_id, $t_user_id );
 			break;


### PR DESCRIPTION
Currently an implicit current/default filter is applied. And therefore, the
returned issue list might lack a lot of issues assigned to the project. For
the default filter that's actually only 'closed' issues, for the current that
might be all (any filter with empty results).

- Add FILTER_STANDARD_ANY
- Add filter_create_any to filter_api
- Handle FILTER_STANDARD_ANY in filter_standard_get 
- Use in issues_rest, if the request doesn't contain a filter_id

Fixes #25102