### PR TITLE
Fix column width in manage_proj_edit_page

### DIFF
--- a/js/manage_proj_edit_page.js
+++ b/js/manage_proj_edit_page.js
@@ -83,6 +83,9 @@ function try_hide_input( div ) {
 
 
 $(document).ready( function() {
+	if( !$('#manage-project-users-list .listjs-table').length ) {
+		return;
+	}
 
 	$('#manage-project-users-form-toolbox').removeClass('hidden');
 

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -767,7 +767,7 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 									<tr>
 										<th><div class="sort" role="button" data-sort="key-name"><?php echo lang_get( 'username' ) ?></div></th>
 										<th><div class="sort" role="button" data-sort="key-email"><?php echo lang_get( 'email' ) ?></div></th>
-										<th><div class="sort" role="button" data-sort="key-access"><?php echo lang_get( 'access_level' ) ?></div></th>
+										<th class="col-md-4"><div class="sort" role="button" data-sort="key-access"><?php echo lang_get( 'access_level' ) ?></div></th>
 										<th><?php echo lang_get( 'remove_link' ) ?></th>
 									</tr>
 								</thead>

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -859,10 +859,10 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 						</div>
 					</form>
 				</div>
-			</div>
 	<?php
 	} // end if user count > 0
 	?>
+			</div>
 			<div class="widget-toolbox padding-8 clearfix">
 	<?php
 	# You need global or project-specific permissions to remove users


### PR DESCRIPTION
This is related to PR #1449 
Clicking on the edit area for user access level makes the column jump in width and it's a bit confusing.
No tracker issue, since hasn't been released yet?

In manage_proj_edit_page.php, in the redesigned section for user
assignments the column width varies when showing and hiding the access
level dropdowns.
By making this column a fixed width, the location of contents is more
predictable.