### PR TITLE
Add autofocus to the project-list searchbar

### DIFF
--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -602,7 +602,7 @@ function layout_navbar_projects_list( $p_project_id = null, $p_include_all_proje
 	echo '<li>';
 	echo '<div id="projects-list">';
 	echo '<div class="projects-searchbox">';
-	echo '<input class="search form-control input-md" placeholder="' . lang_get( 'search' ) . '" />';
+	echo '<input class="search form-control input-md" autofocus="autofocus" placeholder="' . lang_get( 'search' ) . '" />';
 	echo '</div>';
 	echo '<ul class="list dropdown-yellow no-margin">';
 

--- a/js/common.js
+++ b/js/common.js
@@ -386,7 +386,9 @@ $(document).ready( function() {
 
 	$(document).on('shown.bs.dropdown', '#dropdown_projects_menu', function() {
 		$(this).find(".dropdown-menu li.active a").focus();
-	 });
+		/* Add autofocus support for IE */
+		$('[autofocus]:not(:focus)').eq(0).focus();
+	});
 
 	/**
 	 * Manage visiblity on hover trigger objects


### PR DESCRIPTION
- Add autofocus to the project-list searchbar
We use this in our Mantis application and it saves some time when searching, so I figured it'd be a good feature.