### PR TITLE
Fix projects searchbox outside of scrollable list

### DIFF
--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -592,13 +592,6 @@ function layout_navbar_projects_list( $p_project_id = null, $p_include_all_proje
 	$t_project_ids = user_get_accessible_projects( $t_user_id );
 	$t_can_report = true;
 
-	if( $p_include_all_projects && $p_filter_project_id !== ALL_PROJECTS ) {
-		echo ALL_PROJECTS == $p_project_id ? '<li class="active">' : '<li>';
-		echo '<a href="' . helper_mantis_url( 'set_project.php' ) . '?project_id=' . ALL_PROJECTS . '">';
-		echo lang_get( 'all_projects' ) . ' </a></li>' . "\n";
-		echo '<li class="divider"></li>' . "\n";
-	}
-
 	echo '<li>';
 	echo '<div class="projects-searchbox">';
 	echo '<input class="search form-control input-md" placeholder="' . lang_get( 'search' ) . '" />';
@@ -608,6 +601,13 @@ function layout_navbar_projects_list( $p_project_id = null, $p_include_all_proje
 	echo '<li>';
 	echo '<div class="scrollable-menu">';
 	echo '<ul class="list dropdown-yellow no-margin">';
+
+	if( $p_include_all_projects && $p_filter_project_id !== ALL_PROJECTS ) {
+		echo ALL_PROJECTS == $p_project_id ? '<li class="active">' : '<li>';
+		echo '<a href="' . helper_mantis_url( 'set_project.php' ) . '?project_id=' . ALL_PROJECTS . '">';
+		echo lang_get( 'all_projects' ) . ' </a></li>' . "\n";
+		echo '<li class="divider"></li>' . "\n";
+	}
 
 	foreach( $t_project_ids as $t_id ) {
 		if( $p_can_report_only ) {

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -528,7 +528,7 @@ function layout_navbar_projects_menu() {
 	echo ' <i class="ace-icon fa fa-angle-down bigger-110"></i>' . "\n";
 	echo '</a>' . "\n";
 
-	echo '<ul class="dropdown-menu dropdown-menu-right dropdown-yellow dropdown-caret dropdown-close scrollable-menu">' . "\n";
+	echo '<ul id="projects-list" class=" dropdown-menu dropdown-menu-right dropdown-yellow dropdown-caret dropdown-close">' . "\n";
 	layout_navbar_projects_list( join( ';', helper_get_current_project_trace() ), true, null, true );
 	echo '</ul>' . "\n";
 	echo '</li>' . "\n";
@@ -600,10 +600,13 @@ function layout_navbar_projects_list( $p_project_id = null, $p_include_all_proje
 	}
 
 	echo '<li>';
-	echo '<div id="projects-list">';
 	echo '<div class="projects-searchbox">';
 	echo '<input class="search form-control input-md" placeholder="' . lang_get( 'search' ) . '" />';
 	echo '</div>';
+	echo '</li>';
+	echo '<li class="divider"></li>' . "\n";
+	echo '<li>';
+	echo '<div class="scrollable-menu">';
 	echo '<ul class="list dropdown-yellow no-margin">';
 
 	foreach( $t_project_ids as $t_id ) {

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -321,7 +321,7 @@ textarea.input-xs, select.input-xs[multiple] {
 
 .scrollable-menu {
     height: auto;
-    max-height: 500px;
+    max-height: 435px;
     overflow-x: hidden;
 }
 

--- a/js/common.js
+++ b/js/common.js
@@ -48,13 +48,78 @@ $(document).ready( function() {
         ToggleDiv( t_div );
     });
 
-    var options = {
-    	valueNames: [ 'project-link' ]
-    };
-    var list = new List('projects-list', options);
-    if(list.items.length <= 10) {
-    	$('#projects-list .searchbox').hide();
-    }
+	/**
+	 * Manage the navbar project menu initializacion and events
+	 * for focus and key presses.
+	 */
+
+	/* initialize the list */
+	var projects_list_options = {
+		valueNames: [ 'project-link' ]
+	};
+	var listprojects = new List('projects-list', projects_list_options);
+	if( listprojects.items.length <= 10 ) {
+		$('#projects-list .projects-searchbox').hide();
+	}
+
+	/**
+	 * Events to manage focus when displaying the dropdown.
+	 * - Focus on the active item to position the scrollable list on that item.
+	 * - If there is no items to show, focus on the search box.
+	 */
+	$(document).on('shown.bs.dropdown', '#dropdown_projects_menu', function() {
+		var li_active = $(this).find('.dropdown-menu li.active a');
+		if( li_active.length ) {
+			li_active.focus();
+		} else {
+			$('#projects-list .search').focus();
+		}
+	});
+
+	/**
+	 * When pressing a key in the search box, targeted at navigating the list,
+	 * switch focus to the list.
+	 * When pressing Escape, close the dropdown.
+	 */
+	$('#projects-list .search').keydown( function(event){
+		switch (event.key) {
+			case 'ArrowDown':
+			case 'ArrowUp':
+			case 'Down':
+			case 'Up':
+			case 'PageDown':
+			case 'PageUp':
+				var list = $('#projects-list .list');
+				if( list.find('li.active').length ) {
+					list.find('li.active a').focus();
+				} else {
+					list.find('li a').first().focus();
+				}
+				break;
+			case 'Escape':
+				$('#dropdown_projects_menu').removeClass('open');
+		}
+	});
+
+	/**
+	 * When pressing a key in the list, which is not targeted at navigating the list,
+	 * for example, typing a string, toggle focus to the search box.
+	 */
+	$('#projects-list .list').keydown( function(event){
+		switch (event.key) {
+			case 'Enter':
+			case 'ArrowDown':
+			case 'ArrowUp':
+			case 'Down':
+			case 'Up':
+			case 'PageDown':
+			case 'PageUp':
+			case 'Home':
+			case 'End':
+				return;
+		}
+		$('#projects-list .search').focus();
+	});
 
     $('.widget-box').on('shown.ace.widget' , function(event) {
        var t_id = $(this).attr('id');
@@ -460,10 +525,6 @@ $(document).ready( function() {
 			$('tr[id=bugnote-attach-files]').show();
 		}
 	});
-
-	$(document).on('shown.bs.dropdown', '#dropdown_projects_menu', function() {
-		$(this).find(".dropdown-menu li.active a").focus();
-	 });
 
 	/**
 	 * Manage visiblity on hover trigger objects


### PR DESCRIPTION
In the navbar menu for project selection, fix the search box, and "all
projects" item, outside of the scrollable area for the list of
individual projects.

Fixes: [#23037](https://mantisbt.org/bugs/view.php?id=23037)