### PR TITLE
Optimize summary queries

### DIFF
--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -736,3 +736,6 @@ define( 'DB_TYPE_MYSQL', 1 );
 define( 'DB_TYPE_PGSQL', 2 );
 define( 'DB_TYPE_MSSQL', 3 );
 define( 'DB_TYPE_ORACLE', 4 );
+
+# Database special capabilities identifiers
+define( 'DB_CAPABILITY_WINDOW_FUNCTIONS', 1 );


### PR DESCRIPTION
Further improvements for summary page performance, targeting queries that use bug history table.

To put the recent changes of summary page in perspective:
my locally measured times, in a summary page for 50k issues.
MariaDB 10.3

  | Total DB time | Total page time
-- | -- | --
Release-2,19,0 | 13,1623 | 14,4944
  | 12,4130 | 13,5943
  | 12,3068 | 13,4926
  |   |  
master | 4,4554 | 5,8133
  | 4,3266 | 5,5710
  | 4,2514 | 5,4992
  |   |  
This PR | 1,5704 | 1,8281
  | 1,4995 | 1,7396
  | 1,4600 | 1,7086

Fixes [#25693](https://www.mantisbt.org/bugs/view.php?id=25693)

