### PR TITLE
Status color boxes should not have background css set

### DIFF
--- a/account_sponsor_page.php
+++ b/account_sponsor_page.php
@@ -186,9 +186,9 @@ if( $t_sponsor_count === 0 ) {
 		}
 
 		# choose color based on status
-		$t_status_label = html_get_status_css_class( $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
+		$t_status_css = html_get_status_css_bg( $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
 
-		echo '<tr class="' . $t_status_label .  '">';
+		echo '<tr class="' . $t_status_css .  '">';
 		echo '<td><a href="' . string_get_bug_view_url( $t_sponsor_row['bug'] ) . '">' . bug_format_id( $t_sponsor_row['bug'] ) . '</a></td>';
 		echo '<td>' . string_display_line( project_get_field( $t_bug->project_id, 'name' ) ) . '&#160;</td>';
 		echo '<td>' . $t_released_label . '&#160;</td>';
@@ -314,9 +314,9 @@ if( $t_sponsor_count === 0 ) {
 		}
 
 		# choose color based on status
-		$t_status_label = html_get_status_css_class( $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
+		$t_status_css = html_get_status_css_bg( $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
 
-		echo '<tr class="' . $t_status_label .  '">';
+		echo '<tr class="' . $t_status_css .  '">';
 		echo '<td><a href="' . string_get_bug_view_url( $t_sponsor_row['bug'] ) . '">' . bug_format_id( $t_sponsor_row['bug'] ) . '</a></td>';
 		echo '<td>' . string_display_line( project_get_field( $t_bug->project_id, 'name' ) ) . '&#160;</td>';
 		echo '<td>' . $t_released_label . '&#160;</td>';

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -416,9 +416,10 @@ if( $t_show_status || $t_show_resolution ) {
 		echo '<th class="category"><label for="status">' . lang_get( 'status' ) . '</label></th>';
 
 		# choose color based on status
-		$t_status_css = html_get_status_css_bg( $t_bug->status );
+		$t_status_css = html_get_status_css_fg( $t_bug->status );
 
-		echo '<td class="' . $t_status_css .  '">';
+		echo '<td class="bug-status">';
+		echo '<i class="fa fa-square fa-status-box ' . $t_status_css . '"></i> ';
 		print_status_option_list( 'status', $t_bug->status,
 			access_can_close_bug( $t_bug ),
 			$t_bug->project_id );

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -416,9 +416,9 @@ if( $t_show_status || $t_show_resolution ) {
 		echo '<th class="category"><label for="status">' . lang_get( 'status' ) . '</label></th>';
 
 		# choose color based on status
-		$t_status_label = html_get_status_css_class( $t_bug->status );
+		$t_status_css = html_get_status_css_bg( $t_bug->status );
 
-		echo '<td class="' . $t_status_label .  '">';
+		echo '<td class="' . $t_status_css .  '">';
 		print_status_option_list( 'status', $t_bug->status,
 			access_can_close_bug( $t_bug ),
 			$t_bug->project_id );

--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -473,10 +473,10 @@ if( $t_show_status || $t_show_resolution ) {
 		echo '<th class="bug-status category">', lang_get( 'status' ), '</th>';
 
 		# choose color based on status
-		$t_status_label = html_get_status_css_class( $t_bug->status );
+		$t_status_css = html_get_status_css_fg( $t_bug->status );
 
 		echo '<td class="bug-status">';
-		echo '<i class="fa fa-square fa-status-box ' . $t_status_label . '"></i> ';
+		echo '<i class="fa fa-square fa-status-box ' . $t_status_css . '"></i> ';
 		echo $t_status, '</td>';
 	} else {
 		$t_spacer += 2;

--- a/core/bug_group_action_api.php
+++ b/core/bug_group_action_api.php
@@ -97,8 +97,8 @@ function bug_group_action_print_bug_list( array $p_bug_ids_array ) {
 
 	foreach( $p_bug_ids_array as $t_bug_id ) {
 		# choose color based on status
-		$t_status_label = html_get_status_css_class( bug_get_field( $t_bug_id, 'status' ), auth_get_current_user_id(), bug_get_field( $t_bug_id, 'project_id' ) );
-		$t_lead = '<i class="fa fa-square fa-status-box ' . $t_status_label . '"></i> ';
+		$t_status_css = html_get_status_css_fg( bug_get_field( $t_bug_id, 'status' ), auth_get_current_user_id(), bug_get_field( $t_bug_id, 'project_id' ) );
+		$t_lead = '<i class="fa fa-square fa-status-box ' . $t_status_css . '"></i> ';
 		$t_lead .= ' ' . string_get_bug_view_link( $t_bug_id );
 		echo sprintf( "<tr> <td>%s</td> <td>%s</td> </tr>\n", $t_lead, string_attribute( bug_get_field( $t_bug_id, 'summary' ) ) );
 	}

--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -1389,10 +1389,10 @@ function print_column_resolution( BugData $p_bug, $p_columns_target = COLUMNS_TA
 function print_column_status( BugData $p_bug, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
 	$t_current_user = auth_get_current_user_id();
 	# choose color based on status
-	$status_label = html_get_status_css_class( $p_bug->status, $t_current_user, $p_bug->project_id );
+	$t_status_css = html_get_status_css_fg( $p_bug->status, $t_current_user, $p_bug->project_id );
 	echo '<td class="column-status">';
 	echo '<div class="align-left">';
-	echo '<i class="fa fa-square fa-status-box ' . $status_label . '"></i> ';
+	echo '<i class="fa fa-square fa-status-box ' . $t_status_css . '"></i> ';
 	printf( '<span title="%s">%s</span>',
 		get_enum_element( 'resolution', $p_bug->resolution, $t_current_user, $p_bug->project_id ),
 		get_enum_element( 'status', $p_bug->status, $t_current_user, $p_bug->project_id )

--- a/core/custom_function_api.php
+++ b/core/custom_function_api.php
@@ -102,11 +102,11 @@ function custom_function_default_changelog_print_issue( $p_issue_id, $p_issue_le
 	}
 
 	# choose color based on status
-	$status_label = html_get_status_css_class( $t_bug->status, $t_current_user, $t_bug->project_id );
+	$t_status_css = html_get_status_css_fg( $t_bug->status, $t_current_user, $t_bug->project_id );
 	$t_status_title = string_attribute( get_enum_element( 'status', bug_get_field( $t_bug->id, 'status' ), $t_bug->project_id ) );;
 
 	echo utf8_str_pad( '', $p_issue_level * 36, '&#160;' );
-	echo '<i class="fa fa-square fa-status-box ' . $status_label . '" title="' . $t_status_title . '"></i> ';
+	echo '<i class="fa fa-square fa-status-box ' . $t_status_css . '" title="' . $t_status_title . '"></i> ';
 	echo string_get_bug_view_link( $p_issue_id, false );
 	echo ': <span class="label label-light">', $t_category, '</span> ' , string_display_line_links( $t_bug->summary );
 	if( $t_bug->handler_id > 0
@@ -161,11 +161,11 @@ function custom_function_default_roadmap_print_issue( $p_issue_id, $p_issue_leve
 	}
 
 	# choose color based on status
-	$status_label = html_get_status_css_class( $t_bug->status, $t_current_user, $t_bug->project_id );
+	$t_status_css = html_get_status_css_fg( $t_bug->status, $t_current_user, $t_bug->project_id );
 	$t_status_title = string_attribute( get_enum_element( 'status', bug_get_field( $t_bug->id, 'status' ), $t_bug->project_id ) );;
 
 	echo utf8_str_pad( '', $p_issue_level * 36, '&#160;' );
-	echo '<i class="fa fa-square fa-status-box ' . $status_label . '" title="' . $t_status_title . '"></i> ';
+	echo '<i class="fa fa-square fa-status-box ' . $t_status_css . '" title="' . $t_status_title . '"></i> ';
 	echo string_get_bug_view_link( $p_issue_id, false );
 	echo ': <span class="label label-light">', $t_category, '</span> ', $t_strike_start, string_display_line_links( $t_bug->summary ), $t_strike_end;
 	if( $t_bug->handler_id > 0

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1401,8 +1401,16 @@ function html_get_status_css_bg( $p_status, $p_user = null, $p_project = null ) 
  * @param integer $p_user    A valid user identifier.
  * @param integer $p_project A valid project identifier.
  * @return string
+ *
+ * @deprecated 2.21.0 Use html_get_status_css_fg() or html_get_status_css_bg() instead
  */
 function html_get_status_css_class( $p_status, $p_user = null, $p_project = null ) {
+	error_parameters(
+		__FUNCTION__ . '()',
+		'html_get_status_css_fg() or html_get_status_css_bg()'
+	);
+	trigger_error( ERROR_DEPRECATED_SUPERSEDED, DEPRECATED );
+
 	$t_class = html_get_status_css_fg( $p_status, $p_user, $p_project )
 		. ' '
 		. html_get_status_css_bg( $p_status, $p_user, $p_project );

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1353,7 +1353,9 @@ function html_buttons_view_bug_page( $p_bug_id ) {
 }
 
 /**
- * get the css class name for the given status, user and project
+ * Get the foreground color CSS class for the given status, user and project.
+ * @see html_get_status_css_bg() for background color
+ *
  * @param integer $p_status  An enumeration value.
  * @param integer $p_user    A valid user identifier.
  * @param integer $p_project A valid project identifier.
@@ -1364,13 +1366,48 @@ function html_buttons_view_bug_page( $p_bug_id ) {
  * This is due to the dynamic css for color coding (css/status_config.php).
  * Build CSS including project or even user-specific colors ?
  */
-function html_get_status_css_class( $p_status, $p_user = null, $p_project = null ) {
+function html_get_status_css_fg( $p_status, $p_user = null, $p_project = null ) {
 	$t_status_enum = config_get( 'status_enum_string', null, $p_user, $p_project );
 	if( MantisEnum::hasValue( $t_status_enum, $p_status ) ) {
-		return 'status-' . $p_status . '-color';
+		return 'status-' . $p_status . '-fg';
 	} else {
 		return '';
 	}
+}
+
+/**
+ * Get the background color CSS class for the given status, user and project.
+ * @see html_get_status_css_fg() for foreground color
+ *
+ * @param integer $p_status  An enumeration value.
+ * @param integer $p_user    A valid user identifier.
+ * @param integer $p_project A valid project identifier.
+ *
+ * @return string
+ */
+function html_get_status_css_bg( $p_status, $p_user = null, $p_project = null ) {
+	$t_status_enum = config_get( 'status_enum_string', null, $p_user, $p_project );
+	if( MantisEnum::hasValue( $t_status_enum, $p_status ) ) {
+		return 'status-' . $p_status . '-bg';
+	} else {
+		return '';
+	}
+}
+
+/**
+ * Get the css class name for the given status, user and project.
+ *
+ * @param integer $p_status  An enumeration value.
+ * @param integer $p_user    A valid user identifier.
+ * @param integer $p_project A valid project identifier.
+ * @return string
+ */
+function html_get_status_css_class( $p_status, $p_user = null, $p_project = null ) {
+	$t_class = html_get_status_css_fg( $p_status, $p_user, $p_project )
+		. ' '
+		. html_get_status_css_bg( $p_status, $p_user, $p_project );
+
+	return trim( $t_class );
 }
 
 /**

--- a/core/relationship_api.php
+++ b/core/relationship_api.php
@@ -765,9 +765,9 @@ function relationship_get_details( $p_bug_id, BugRelationshipData $p_relationshi
 	$t_relationship_info_html = $t_td . string_no_break( $t_relationship_descr ) . '&#160;</td>';
 	if( $p_html_preview == false ) {
 		# choose color based on status
-		$status_label = html_get_status_css_class( $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
+		$t_status_css = html_get_status_css_fg( $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
 		$t_relationship_info_html .= '<td><a href="' . string_get_bug_view_url( $t_related_bug_id ) . '">' . string_display_line( bug_format_id( $t_related_bug_id ) ) . '</a></td>';
-		$t_relationship_info_html .= '<td><i class="fa fa-square fa-status-box ' . $status_label . '"></i> ';
+		$t_relationship_info_html .= '<td><i class="fa fa-square fa-status-box ' . $t_status_css . '"></i> ';
 		$t_relationship_info_html .= '<span class="issue-status" title="' . string_attribute( $t_resolution_string ) . '">' . string_display_line( $t_status_string ) . '</span></td>';
 	} else {
 		$t_relationship_info_html .= $t_td . string_display_line( bug_format_id( $t_related_bug_id ) ) . '</td>';

--- a/css/status_config.php
+++ b/css/status_config.php
@@ -94,11 +94,10 @@ $t_statuses = MantisEnum::getAssocArrayIndexedByValues( $t_status_string );
 $t_colors = config_get( 'status_colors' );
 
 foreach( $t_statuses as $t_id => $t_label ) {
-	$t_css_class = html_get_status_css_class( $t_id );
-
 	# Status color class
 	if( array_key_exists( $t_label, $t_colors ) ) {
-		echo '.' . $t_css_class
-			. " { color: {$t_colors[$t_label]}; background-color: {$t_colors[$t_label]}; }\n";
+		$t_color = $t_colors[$t_label];
+		echo '.' . html_get_status_css_fg( $t_id ) . " { color: {$t_color}; }\n";
+		echo '.' . html_get_status_css_bg( $t_id ) . " { background-color: {$t_color}; }\n";
 	}
 }

--- a/js/common.js
+++ b/js/common.js
@@ -519,6 +519,26 @@ $(document).ready( function() {
 		var listobject =  new List( this, listoptions );
 		$(this).data('listobject',listobject).data('listoptions',listoptions).addClass('listjs-table');
 	});
+
+	/**
+	 * Change status color box's color when a different status is selected.
+	 * To achieve that we need to store the current value in a data attribute,
+	 * to compute the class name to remove in the change event.
+	 */
+	var statusColor = $('#status');
+	// Store current value
+	statusColor.data('prev', statusColor.val());
+	statusColor.change(function () {
+		function getColorClassName (statusCode) {
+			return  'status-' + statusCode + '-fg';
+		}
+
+		var me = $(this);
+		me.siblings('i')
+			.removeClass(getColorClassName(me.data('prev')))
+			.addClass(getColorClassName(me.val()));
+		me.data('prev', me.val());
+	});
 });
 
 function setBugLabel() {

--- a/my_view_inc.php
+++ b/my_view_inc.php
@@ -346,9 +346,9 @@ for( $i = 0;$i < $t_count; $i++ ) {
 			echo '<br />';
 
 			# choose color based on status
-			$status_label = html_get_status_css_class( $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
+			$t_status_css = html_get_status_css_fg( $t_bug->status, auth_get_current_user_id(), $t_bug->project_id );
 			$t_status = string_attribute( get_enum_element( 'status', bug_get_field( $t_bug->id, 'status' ), $t_bug->project_id ) );
-			echo '<i class="fa fa-square fa-status-box ' . $status_label . '" title="' . $t_status . '"></i> ';
+			echo '<i class="fa fa-square fa-status-box ' . $t_status_css . '" title="' . $t_status . '"></i> ';
 
 			if( !bug_is_readonly( $t_bug->id ) && access_has_bug_level( $t_update_bug_threshold, $t_bug->id ) ) {
 				echo '<a class="edit" href="' . string_get_bug_update_url( $t_bug->id ) . '"><i class="fa fa-pencil bigger-130 padding-2 grey" title="' . lang_get( 'update_bug_button' ) . '"></i></a>';


### PR DESCRIPTION
Changes:
- add new html_get_status_css_fg() / html_get_status_css_bg() functions
- define new, distinct status color classes (_status-XX-fg_ and _status-XX-bg_) to replace the single _status-XX-color_ used previously
- update MantisBT pages to use the new classes / API functions
- deprecate html_get_status_css_class() (could be used by 3rd party plug-ins)
- code cleanup (renaming variables)

Fixes [#23550](https://mantisbt.org/bugs/view.php?id=23550)

Note: this PR is build on top of #1482, which should be merged first.
