### PR TITLE
Simplify Configuration Report page

### DIFF
--- a/adm_config_page.php
+++ b/adm_config_page.php
@@ -1,0 +1,302 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mantis Configuration. View, edit, update a configuration option.
+ * @package MantisBT
+ * @copyright Copyright 2000 - 2002  Kenzaburo Ito - kenito@300baud.org
+ * @copyright Copyright 2002  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ *
+ * @uses core.php
+ * @uses access_api
+ * @uses config_api
+ * @uses constant_inc.php
+ * @uses error_api
+ * @uses form_api
+ * @uses gpc_api
+ * @uses helper_api
+ * @uses lang_api
+ * @uses layout_api
+ * @uses print_api
+ * @uses string_api
+ * @uses user_api
+ */
+
+require_once( 'core.php' );
+require_api( 'access_api.php' );
+require_api( 'config_api.php' );
+require_api( 'constant_inc.php' );
+require_api( 'error_api.php' );
+require_api( 'form_api.php' );
+require_api( 'gpc_api.php' );
+require_api( 'helper_api.php' );
+require_api( 'lang_api.php' );
+require_api( 'layout_api.php' );
+require_api( 'print_api.php' );
+require_api( 'string_api.php' );
+require_api( 'user_api.php' );
+
+access_ensure_global_level( config_get( 'view_configuration_threshold' ) );
+$t_has_write_access = access_has_global_level( config_get( 'set_configuration_threshold' ) );
+
+layout_page_header( lang_get( 'configuration_report' ) );
+layout_page_begin( 'manage_overview_page.php' );
+
+print_manage_menu( PAGE_CONFIG_DEFAULT );
+print_manage_config_menu( 'adm_config_report.php' );
+
+# Get request values
+$f_edit_user_id         = gpc_get_int( 'user_id', ALL_USERS );
+$f_edit_project_id      = gpc_get_int( 'project_id', ALL_PROJECTS );
+$f_edit_option          = gpc_get_string( 'config_option', null );
+$f_edit_action          = gpc_get_string( 'action', MANAGE_CONFIG_ACTION_VIEW );
+
+# Ensure we exclusively use one of the defined, valid actions (XSS protection)
+$t_valid_actions = array(
+	MANAGE_CONFIG_ACTION_CREATE,
+	MANAGE_CONFIG_ACTION_CLONE,
+	MANAGE_CONFIG_ACTION_EDIT,
+	MANAGE_CONFIG_ACTION_VIEW
+);
+$t_edit_action = in_array( $f_edit_action, $t_valid_actions )
+	? $f_edit_action
+	: MANAGE_CONFIG_ACTION_CREATE;
+
+# if not creating a new option, the option name is required
+if( MANAGE_CONFIG_ACTION_CREATE != $t_edit_action && null == $f_edit_option ) {
+	error_parameters( 'config_option' );
+	trigger_error( ERROR_EMPTY_FIELD, ERROR );
+}
+
+# see if the user can modify configuration options
+$t_modify = MANAGE_CONFIG_ACTION_VIEW != $t_edit_action
+		&& $t_has_write_access
+		&& config_can_delete( $f_edit_option );
+
+# if can't modify, switch antion to "view"
+if( !$t_modify ) {
+	$t_edit_action = MANAGE_CONFIG_ACTION_VIEW;
+}
+
+$t_action_label = lang_get( 'set_configuration_option_action_' . $t_edit_action );
+
+if( MANAGE_CONFIG_ACTION_CREATE != $t_edit_action ) {
+	# retrieve existing config data from database for this option
+	$t_query = new DbQuery( 'SELECT * FROM {config} WHERE config_id = :config AND user_id = :user AND project_id = :project' );
+	$t_query->bind_values(  array(
+			'config' => $f_edit_option,
+			'user' => $f_edit_user_id,
+			'project' => $f_edit_project_id
+		) );
+	$t_config_row = $t_query->fetch();
+
+	if( !$t_config_row ) {
+		# this error will be triggered if the exact config combination does not exist in database
+		error_parameters( $f_edit_option );
+		trigger_error( ERROR_CONFIG_OPT_NOT_FOUND, ERROR );
+	}
+	$t_option_user_id = (int)$t_config_row['user_id'];
+	$t_option_project_id = (int)$t_config_row['project_id'];
+	$t_option_id = $t_config_row['config_id'];
+	$t_option_type = $t_config_row['type'];
+	$t_option_value = $t_config_row['value'];
+} else {
+	# action is MANAGE_CONFIG_ACTION_CREATE
+	# prepare new or default values
+	$t_option_user_id = $f_edit_user_id;
+	$t_option_project_id = $f_edit_project_id;
+	$t_option_id = $f_edit_option;
+	$t_option_type = CONFIG_TYPE_DEFAULT;
+	$t_option_value = '';
+
+	if( null != $t_option_id ) {
+		# if an option has been provided,
+		# make sure that configuration option specified is a valid one.
+		$t_not_found_value = '***CONFIG OPTION NOT FOUND***';
+		if( config_get( $t_option_id, $t_not_found_value ) === $t_not_found_value ) {
+			error_parameters( $t_option_id );
+			trigger_error( ERROR_CONFIG_OPT_NOT_FOUND, ERROR );
+		}
+	}
+}
+
+?>
+
+<div class="col-md-12 col-xs-12">
+	<div class="space-10"></div>
+
+	<div id="config-edit-div">
+		<form id="config_set_form" method="post" action="<?php echo ( $t_modify? 'adm_config_set.php' : '' ) ?>">
+
+			<!-- Title -->
+			<div class="widget-box widget-color-blue2">
+				<div class="widget-header widget-header-small">
+					<h4 class="widget-title lighter">
+						<i class="ace-icon fa fa-sliders"></i>
+						<?php echo $t_action_label; ?>
+					</h4>
+				</div>
+
+				<div class="widget-body">
+					<div class="widget-main no-padding">
+						<div id="config-edit-div" class="form-container">
+							<div class="table-responsive">
+
+		<table class="table table-bordered table-condensed table-striped">
+			<fieldset>
+				<?php
+					if( $t_modify ) {
+						echo form_security_field( 'adm_config_set' );
+					}
+				?>
+
+				<!-- Username -->
+				<tr>
+					<td class="category">
+						<?php echo lang_get( 'username' ) ?>
+					</td>
+					<td>
+						<?php
+						if( $t_modify ) {
+						?>
+						<select id="config-user-id" name="user_id" class="input-sm">
+							<option value="<?php echo ALL_USERS; ?>"
+								<?php check_selected( $t_option_user_id, ALL_USERS ) ?>>
+								<?php echo lang_get( 'all_users' ); ?>
+							</option>
+							<?php print_user_option_list( $t_option_user_id ) ?>
+						</select>
+						<input type="hidden" name="original_user_id" value="<?php echo $t_option_user_id; ?>" />
+						<?php
+						} else {
+							$t_username = ALL_USERS == $t_option_user_id ? lang_get( 'all_users' ) : user_get_name( $t_option_user_id );
+							echo string_display_line( $t_username );
+						}
+						?>
+					</td>
+				</tr>
+
+				<!-- Project -->
+				<tr>
+					<td class="category">
+						<?php echo lang_get( 'project_name' ) ?>
+					</td>
+					<td>
+						<?php
+						if( $t_modify ) {
+						?>
+						<select id="config-project-id" name="project_id" class="input-sm">
+							<option value="<?php echo ALL_PROJECTS; ?>"
+								<?php check_selected( $t_option_project_id, ALL_PROJECTS ); ?>>
+								<?php echo lang_get( 'all_projects' ); ?>
+							</option>
+							<?php print_project_option_list( $t_option_project_id, false ) ?>
+						</select>
+						<input type="hidden" name="original_project_id" value="<?php echo $t_option_project_id; ?>" />
+						<?php
+						} else {
+							echo string_display_line( project_get_name( $t_option_project_id ) );
+						}
+						?>
+					</td>
+				</tr>
+
+				<!-- Config option name -->
+				<tr>
+					<td class="category">
+						<?php echo lang_get( 'configuration_option' ) ?>
+					</td>
+					<td>
+						<?php
+						if( $t_modify ) {
+						?>
+						<input type="text" name="config_option" class="input-sm"
+							   value="<?php echo string_display_line( $t_option_id ); ?>"
+							   size="64" maxlength="64" />
+						<input type="hidden" name="original_config_option" value="<?php echo string_display_line( $t_option_id ); ?>" />
+						<?php
+						} else {
+							echo string_display_line( $t_option_id );
+						}
+						?>
+					</td>
+				</tr>
+
+				<!-- Option type -->
+				<tr>
+					<td class="category">
+						<?php echo lang_get( 'configuration_option_type' ) ?>
+					</td>
+					<td>
+						<?php
+						if( $t_modify ) {
+						?>
+						<select id="config-type" name="type" class="input-sm">
+							<?php print_option_list_from_array( config_get_types(), $t_option_type ); ?>
+						</select>
+						<?php
+						} else {
+							echo string_display_line( config_get_type_string( $t_option_type ) );
+						}
+						?>
+					</td>
+				</tr>
+
+				<!-- Option Value -->
+				<tr>
+					<td class="category">
+						<?php echo lang_get( 'configuration_option_value' ) ?>
+					</td>
+					<td>
+						<?php
+						if( $t_modify ) {
+						?>
+						<textarea class="form-control" name="value" cols="80" rows="10"><?php
+							echo config_get_value_as_string( $t_option_type, $t_option_value, false );
+							?></textarea>
+						<?php
+						} else {
+							echo config_get_value_as_string( $t_option_type, $t_option_value, true );
+						}
+						?>
+					</td>
+				</tr>
+			</fieldset>
+		</table>
+							</div>
+
+						</div>
+						<div class="widget-toolbox padding-4 clearfix">
+						<?php
+						if( $t_modify ) {
+						?>
+							<input type="hidden" name="action" value="<?php echo $t_edit_action; ?>" />
+							<input type="submit" name="config_set" class="btn btn-primary btn-white btn-round"
+								value="<?php echo $t_action_label; ?>"/>
+						<?php
+						}
+						?>
+						</div>
+					</div>
+				</div>
+			</div>
+		</form>
+	</div>
+</div>
+
+<?php
+layout_page_end();

--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -326,7 +326,7 @@ $t_config_query = new DbQuery( $t_sql, $t_params );
 		print_link_button( $t_url_new, $t_label );
 		?>
 	</div>
-<div class="table-responsive">
+<div class="table-responsive sortable">
 	<table class="table table-striped table-bordered table-condensed table-hover">
 		<thead>
 			<tr>
@@ -337,7 +337,7 @@ $t_config_query = new DbQuery( $t_sql, $t_params );
 				<th><?php echo lang_get( 'configuration_option_value' ) ?></th>
 				<th><?php echo lang_get( 'access_level' ) ?></th>
 				<?php if( $t_read_write_access ) { ?>
-				<th><?php echo lang_get( 'actions' ) ?></th>
+				<th class="no-sort"><?php echo lang_get( 'actions' ) ?></th>
 				<?php } ?>
 			</tr>
 		</thead>

--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -317,6 +317,13 @@ $t_config_query = new DbQuery( $t_sql, $t_params );
 
 <div class="widget-body">
 <div class="widget-main no-padding">
+	<div class="widget-toolbox padding-8 clearfix">
+		<?php
+		$t_url_new = 'adm_config_page.php?action=' . MANAGE_CONFIG_ACTION_CREATE;
+		$t_label = lang_get( 'set_configuration_option_action_' . MANAGE_CONFIG_ACTION_CREATE );
+		print_link_button( $t_url_new, $t_label );
+		?>
+	</div>
 <div class="table-responsive">
 	<table class="table table-striped table-bordered table-condensed table-hover">
 		<thead>

--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -202,7 +202,8 @@ while( $t_row = db_fetch_array( $t_result ) ) {
 }
 
 # Build config query
-$t_sql = 'SELECT config_id, user_id, project_id, type, value, access_reqd'
+$t_sql = 'SELECT config_id, user_id, project_id, type, access_reqd,'
+		. ' CASE type WHEN :complex THEN null ELSE value END AS value'
 		. ' FROM {config} WHERE 1=1';
 if( $t_filter_user_value != META_FILTER_NONE ) {
 	$t_sql .= ' AND user_id = :user_id';
@@ -217,7 +218,8 @@ $t_sql .= ' ORDER BY user_id, project_id, config_id ';
 $t_params = array(
 	'user_id' => $t_filter_user_value,
 	'project_id' => $t_filter_project_value,
-	'config_id' => $t_filter_config_value
+	'config_id' => $t_filter_config_value,
+	'complex' => CONFIG_TYPE_COMPLEX
 	);
 $t_config_query = new DbQuery( $t_sql, $t_params );
 ?>

--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -63,43 +63,6 @@ layout_page_begin( 'manage_overview_page.php' );
 print_manage_menu( PAGE_CONFIG_DEFAULT );
 print_manage_config_menu( 'adm_config_report.php' );
 
-$t_config_types = array(
-	CONFIG_TYPE_DEFAULT => 'default',
-	CONFIG_TYPE_INT     => 'integer',
-	CONFIG_TYPE_FLOAT   => 'float',
-	CONFIG_TYPE_COMPLEX => 'complex',
-	CONFIG_TYPE_STRING  => 'string',
-);
-
-/**
- * returns the configuration type for a given configuration type id
- * @param integer $p_type Configuration type identifier to check.
- * @return string configuration type
- */
-function get_config_type( $p_type ) {
-	global $t_config_types;
-
-	if( array_key_exists( $p_type, $t_config_types ) ) {
-		return $t_config_types[$p_type];
-	} else {
-		return $t_config_types[CONFIG_TYPE_DEFAULT];
-	}
-}
-
-/**
- * Generate an html option list for the given array
- * @param array  $p_array        Array.
- * @param string $p_filter_value The selected value.
- * @return void
- */
-function print_option_list_from_array( array $p_array, $p_filter_value ) {
-	foreach( $p_array as $t_key => $t_value ) {
-		echo '<option value="' . $t_key . '"';
-		check_selected( (string)$p_filter_value, (string)$t_key );
-		echo '>' . string_attribute( $t_value ) . '</option>' . "\n";
-	}
-}
-
 /**
  * Ensures the given config is valid
  * @param string $p_config Configuration name
@@ -162,24 +125,6 @@ if( $t_filter_save ) {
 		}
 	}
 }
-
-# Get config edit values
-$t_edit_user_id         = gpc_get_int( 'user_id', $t_filter_user_value == META_FILTER_NONE ? ALL_USERS : $t_filter_user_value );
-$t_edit_project_id      = gpc_get_int( 'project_id', $t_filter_project_value == META_FILTER_NONE ? ALL_PROJECTS : $t_filter_project_value );
-$t_edit_option          = gpc_get_string( 'config_option', $t_filter_config_value == META_FILTER_NONE ? '' : $t_filter_config_value );
-$t_edit_type            = gpc_get_string( 'type', CONFIG_TYPE_DEFAULT );
-$t_edit_value           = gpc_get_string( 'value', '' );
-
-$f_edit_action          = gpc_get_string( 'action', MANAGE_CONFIG_ACTION_CREATE );
-# Ensure we exclusively use one of the defined, valid actions (XSS protection)
-$t_valid_actions = array(
-	MANAGE_CONFIG_ACTION_CREATE,
-	MANAGE_CONFIG_ACTION_CLONE,
-	MANAGE_CONFIG_ACTION_EDIT
-);
-$t_edit_action = in_array( $f_edit_action, $t_valid_actions )
-	? $f_edit_action
-	: MANAGE_CONFIG_ACTION_CREATE;
 
 # Apply filters
 
@@ -397,10 +342,18 @@ $t_form_security_token = form_security_token( 'adm_config_delete' );
 while( $t_row = $t_config_query->fetch() ) {
 	extract( $t_row, EXTR_PREFIX_ALL, 'v' );
 
+	# For complex values, the content is not rendered
 	if( CONFIG_TYPE_COMPLEX == $v_type ) {
+		$t_url_params = array(
+					'user_id'       => $v_user_id,
+					'project_id'    => $v_project_id,
+					'config_option' => $v_config_id,
+					'action'        => MANAGE_CONFIG_ACTION_VIEW
+				);
+		$t_url_view = helper_url_combine( 'adm_config_page.php', http_build_query( $t_url_params ) );
 		$t_html_value = '<div class="adm_config_expand" data-config_id="' . $v_config_id . '"'
 				. ' data-project_id="' . $v_project_id . '" data-user_id="' . $v_user_id . '">'
-				. '<span class ="expand_show"><a href="#" class="toggle small">[' . lang_get( 'show_content' ) . ']</a></span>'
+				. '<span class ="expand_show"><a href="' . $t_url_view . '" class="toggle small">[' . lang_get( 'show_content' ) . ']</a></span>'
 				. '<span class ="expand_hide hidden"><a href="#" class="toggle small">[' . lang_get( 'hide_content' ) . ']</a></span>'
 				. '<div class="expand_content"></div>'
 				. '</div>';
@@ -416,7 +369,7 @@ while( $t_row = $t_config_query->fetch() ) {
 				</td>
 				<td><?php echo string_display_line( project_get_name( $v_project_id, false ) ) ?></td>
 				<td><?php echo string_display_line( $v_config_id ) ?></td>
-				<td><?php echo string_display_line( get_config_type( $v_type ) ) ?></td>
+				<td><?php echo string_display_line( config_get_type_string( $v_type ) ) ?></td>
 				<td style="overflow-x:auto;"><?php echo $t_html_value ?></td>
 				<td><?php echo get_enum_element( 'access_levels', $v_access_reqd ) ?></td>
 <?php
@@ -426,36 +379,24 @@ while( $t_row = $t_config_query->fetch() ) {
 	<div class="btn-group inline visible-on-hover">
 <?php
 		if( config_can_delete( $v_config_id ) ) {
-			# Update button (will populate edit form at page bottom)
-			echo '<div class="pull-left">';
-			print_form_button(
-				'#config_set_form',
-				lang_get( 'edit_link' ),
-				array(
+			$t_action_params = array(
 					'user_id'       => $v_user_id,
 					'project_id'    => $v_project_id,
 					'config_option' => $v_config_id,
-					'type'          => $v_type,
-					'value'         => $v_value,
-					'action'        => MANAGE_CONFIG_ACTION_EDIT,
-				),
-				OFF );
+				);
+
+			# Update button
+			$t_action_params['action'] = MANAGE_CONFIG_ACTION_EDIT;
+			$t_url_edit = helper_url_combine( 'adm_config_page.php', http_build_query( $t_action_params ) );
+			echo '<div class="pull-left">';
+			print_link_button( $t_url_edit, lang_get( 'edit_link' ), 'btn-xs' );
 			echo '</div>';
 
 			# Clone button
 			echo '<div class="pull-left">';
-			print_form_button(
-				'#config_set_form',
-				lang_get( 'create_child_bug_button' ),
-				array(
-					'user_id'       => $v_user_id,
-					'project_id'    => $v_project_id,
-					'config_option' => $v_config_id,
-					'type'          => $v_type,
-					'value'         => $v_value,
-					'action'        => MANAGE_CONFIG_ACTION_CLONE,
-				),
-				OFF );
+			$t_action_params['action'] = MANAGE_CONFIG_ACTION_CLONE;
+			$t_url_clone = helper_url_combine( 'adm_config_page.php', http_build_query( $t_action_params ) );
+			print_link_button( $t_url_clone, lang_get( 'create_child_bug_button' ), 'btn-xs' );
 			echo '</div>';
 
 			# Delete button
@@ -490,131 +431,6 @@ while( $t_row = $t_config_query->fetch() ) {
 </div>
 </div>
 </div>
-
-<?php
-# Only display the edit form if user is authorized to change configuration
-if( $t_read_write_access ) {
-?>
-
-<!-- Config Set Form -->
-<div class="space-10"></div>
-
-<?php
-	if( config_can_delete( $t_edit_option ) ) {
-		$t_action_label = lang_get( 'set_configuration_option_action_' . $t_edit_action );
-?>
-
-<div id="config-edit-div">
-<form id="config_set_form" method="post" action="adm_config_set.php">
-
-		<!-- Title -->
-		<div class="widget-box widget-color-blue2">
-		<div class="widget-header widget-header-small">
-		<h4 class="widget-title lighter">
-			<i class="ace-icon fa fa-sliders"></i>
-			<?php echo $t_action_label; ?>
-			</h4>
-		</div>
-
-	<div class="widget-body">
-		<div class="widget-main no-padding">
-
-		<div id="config-edit-div" class="form-container">
-		<div class="table-responsive">
-		<table class="table table-bordered table-condensed table-striped">
-		<fieldset>
-		<?php echo form_security_field( 'adm_config_set' ) ?>
-
-		<!-- Username -->
-		<tr>
-			<td class="category">
-				<?php echo lang_get( 'username' ) ?>
-			</td>
-			<td>
-				<select id="config-user-id" name="user_id" class="input-sm">
-					<option value="<?php echo ALL_USERS; ?>"
-						<?php check_selected( $t_edit_user_id, ALL_USERS ) ?>>
-						<?php echo lang_get( 'all_users' ); ?>
-					</option>
-					<?php print_user_option_list( $t_edit_user_id ) ?>
-				</select>
-				<input type="hidden" name="original_user_id" value="<?php echo $t_edit_user_id; ?>" />
-			</td>
-		</tr>
-
-			<!-- Project -->
-			<tr>
-				<td class="category">
-					<?php echo lang_get( 'project_name' ) ?>
-				</td>
-				<td>
-					<select id="config-project-id" name="project_id" class="input-sm">
-						<option value="<?php echo ALL_PROJECTS; ?>"
-							<?php check_selected( $t_edit_project_id, ALL_PROJECTS ); ?>>
-							<?php echo lang_get( 'all_projects' ); ?>
-						</option>
-						<?php print_project_option_list( $t_edit_project_id, false ) ?>
-					</select>
-					<input type="hidden" name="original_project_id" value="<?php echo $t_edit_project_id; ?>" />
-				</td>
-			</tr>
-
-			<!-- Config option name -->
-			<tr>
-				<td class="category">
-					<?php echo lang_get( 'configuration_option' ) ?>
-				</td>
-				<td>
-					<input type="text" name="config_option" class="input-sm"
-						   value="<?php echo string_display_line( $t_edit_option ); ?>"
-						   size="64" maxlength="64" />
-					<input type="hidden" name="original_config_option" value="<?php echo string_display_line( $t_edit_option ); ?>" />
-				</td>
-			</tr>
-
-			<!-- Option type -->
-			<tr>
-				<td class="category">
-					<?php echo lang_get( 'configuration_option_type' ) ?>
-				</td>
-				<td>
-					<select id="config-type" name="type" class="input-sm">
-						<?php print_option_list_from_array( $t_config_types, $t_edit_type ); ?>
-					</select>
-				</td>
-			</tr>
-
-			<!-- Option Value -->
-			<tr>
-				<td class="category">
-					<?php echo lang_get( 'configuration_option_value' ) ?>
-				</td>
-				<td>
-					<textarea class="form-control" name="value" cols="80" rows="10"><?php
-						echo config_get_value_as_string( $t_edit_type, $t_edit_value, false );
-						?></textarea>
-				</td>
-			</tr>
-		</fieldset>
-	</table>
-	</div>
-
-	</div>
-		<div class="widget-toolbox padding-4 clearfix">
-			<input type="hidden" name="action" value="<?php echo $t_edit_action; ?>" />
-			<input type="submit" name="config_set" class="btn btn-primary btn-white btn-round"
-				value="<?php echo $t_action_label; ?>"/>
-		</div>
-	</div>
-	</div>
-	</div>
-</form>
-</div>
-
-<?php
-	} # end if config_can_delete
-} # end if user can change config (read-write access)
-?>
 
 </div>
 

--- a/core/config_api.php
+++ b/core/config_api.php
@@ -786,3 +786,27 @@ function config_get_value_as_string( $p_type, $p_value, $p_for_display = true ) 
 		return string_attribute( $t_output );
 	}
 }
+
+function config_get_types() {
+	return array(
+		CONFIG_TYPE_DEFAULT => 'default',
+		CONFIG_TYPE_INT     => 'integer',
+		CONFIG_TYPE_FLOAT   => 'float',
+		CONFIG_TYPE_COMPLEX => 'complex',
+		CONFIG_TYPE_STRING  => 'string',
+		);
+}
+
+/**
+ * returns the configuration type for a given configuration type id
+ * @param integer $p_type Configuration type identifier to check.
+ * @return string configuration type
+ */
+function config_get_type_string( $p_type ) {
+	$t_config_types = config_get_types();
+	if( array_key_exists( $p_type, $t_config_types ) ) {
+		return $t_config_types[$p_type];
+	} else {
+		return $t_config_types[CONFIG_TYPE_DEFAULT];
+	}
+}

--- a/core/config_api.php
+++ b/core/config_api.php
@@ -739,3 +739,50 @@ function config_cache_all() {
 		$g_cache_config_access[$t_config][$t_user][$t_project] = $t_row['access_reqd'];
 	}
 }
+
+/**
+ * Display a given config value appropriately
+ * @param integer $p_type        Configuration type id.
+ * @param mixed   $p_value       Configuration value.
+ * @param boolean $p_for_display Whether to pass the value via string attribute for web browser display.
+ * @return void
+ */
+function config_get_value_as_string( $p_type, $p_value, $p_for_display = true ) {
+	$t_corrupted = false;
+
+	switch( $p_type ) {
+		case CONFIG_TYPE_DEFAULT:
+			return '';
+		case CONFIG_TYPE_FLOAT:
+			return (string)(float)$p_value;
+		case CONFIG_TYPE_INT:
+			return (string)(integer)$p_value;
+		case CONFIG_TYPE_STRING:
+			$t_value = string_html_specialchars( config_eval( $p_value ) );
+			if( $p_for_display ) {
+				$t_value = '<p id="adm-config-value">\'' . string_nl2br( $t_value ) . '\'</p>';
+			}
+			return $t_value;
+		case CONFIG_TYPE_COMPLEX:
+			$t_value = @json_decode( $p_value, true );
+			if( $t_value === false ) {
+				$t_corrupted = true;
+			}
+			break;
+		default:
+			$t_value = config_eval( $p_value );
+			break;
+	}
+
+	if( $t_corrupted ) {
+		$t_output = $p_for_display ? lang_get( 'configuration_corrupted' ) : '';
+	} else {
+		$t_output = var_export( $t_value, true );
+	}
+
+	if( $p_for_display ) {
+		return '<pre id="adm-config-value">' . string_attribute( $t_output ) . '</pre>';
+	} else {
+		return string_attribute( $t_output );
+	}
+}

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -729,6 +729,7 @@ define( 'PAGE_CONFIG_DEFAULT', 'adm_permissions_report.php' );
 define( 'MANAGE_CONFIG_ACTION_CREATE', 'create' );
 define( 'MANAGE_CONFIG_ACTION_CLONE', 'clone' );
 define( 'MANAGE_CONFIG_ACTION_EDIT', 'edit' );
+define( 'MANAGE_CONFIG_ACTION_VIEW', 'view' );
 
 # Database functional type identifiers.
 define( 'DB_TYPE_UNDEFINED', 0 );

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -2141,3 +2141,17 @@ function print_button( $p_action_page, $p_label, array $p_args_to_post = null, $
 	trigger_error( ERROR_DEPRECATED_SUPERSEDED, DEPRECATED );
 	print_form_button( $p_action_page, $p_label, $p_args_to_post, $p_security_token );
 }
+
+/**
+ * Generate an html option list for the given array
+ * @param array  $p_array        Array.
+ * @param string $p_filter_value The selected value.
+ * @return void
+ */
+function print_option_list_from_array( array $p_array, $p_filter_value ) {
+	foreach( $p_array as $t_key => $t_value ) {
+		echo '<option value="' . $t_key . '"';
+		check_selected( (string)$p_filter_value, (string)$t_key );
+		echo '>' . string_attribute( $t_value ) . '</option>' . "\n";
+	}
+}

--- a/js/adm_config_report.js
+++ b/js/adm_config_report.js
@@ -1,0 +1,49 @@
+/*
+# Mantis - a php based bugtracking system
+
+# Copyright 2000 - 2002  Kenzaburo Ito - kenito@300baud.org
+# Copyright 2002 MantisBT Team   - mantisbt-dev@lists.sourceforge.net
+
+# Mantis is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Mantis is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Mantis.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+$(document).ready( function() {
+	$('.adm_config_expand .expand_hide').hide().removeClass('hidden');
+	$('.adm_config_expand .expand_hide .toggle')
+			.click(function(event) {
+				event.preventDefault();
+				var container = $(this).closest('.adm_config_expand');
+				container.find('.expand_hide').hide();
+				container.find('.expand_show').show();
+				container.find('.expand_content').hide();
+			});
+	$('.adm_config_expand .expand_show .toggle')
+			.click(function(event) {
+				event.preventDefault();
+				var container = $(this).closest('.adm_config_expand');
+				container.find('.expand_hide').show();
+				container.find('.expand_show').hide();
+				// Load contents if not already done and display
+				var content = container.find('.expand_content');
+				if (content[0].childElementCount == 0) {
+					var req_data = {
+						'config_id': container.data('config_id'),
+						'project_id': container.data('project_id'),
+						'user_id': container.data('user_id')
+					};
+					content.load('api/rest/internal/config_display',req_data);
+				}
+				content.show();
+			});
+});

--- a/js/common.js
+++ b/js/common.js
@@ -553,7 +553,13 @@ $(document).ready( function() {
 		}
 		var th_count = ths.length
 		var options_valuenames = [];
+		var exclude_index = [];
 		ths.each(function(index){
+			if( $(this).hasClass('no-sort') ) {
+				// if the column says no sorting, save this index for later checks and skip
+				exclude_index.push(index);
+				return;
+			}
 			// wrap the contents into a crafted div
 			var new_div = $('<div />').addClass('sort')
 					.attr('data-sort','sortkey_'+index)
@@ -571,6 +577,10 @@ $(document).ready( function() {
 				return;
 			}
 			tds.each(function(index){
+				if( exclude_index.indexOf(index) >= 0 ) {
+					// if this column was marked as no-sorting, skip.
+					return;
+				}
 				$(this).addClass( 'sortkey_'+index ).attr( 'data-sortval', $(this).text() );
 			});
 		});

--- a/js/common.js
+++ b/js/common.js
@@ -546,12 +546,19 @@ $(document).ready( function() {
 	 */
 	$('.table-responsive.sortable').each(function(){
 		var jtable = $(this).find('table').first();
-		var ths = jtable.find('thead th');
+		var ths = jtable.find('thead > tr > th');
 		if( !ths.length ) {
 			// exit if there is no headers
 			return;
 		}
 		var th_count = ths.length
+
+		var trs = jtable.find('tbody > tr');
+		if( trs.length > 1000 ) {
+			// don't run on big tables to avoid perfomance issues in client side
+			return;
+		}
+
 		var options_valuenames = [];
 		var exclude_index = [];
 		ths.each(function(index){
@@ -569,9 +576,8 @@ $(document).ready( function() {
 
 			options_valuenames.push( { name:'sortkey_'+index, attr:'data-sortval' } );
 		});
-		var trs = jtable.find('tbody tr');
 		trs.each(function(){
-			var tds = $(this).find('td');
+			var tds = $(this).children('td');
 			if( tds.length != th_count ) {
 				// exit if different number of cells than headers, possibly colspan, etc
 				return;

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -841,6 +841,7 @@ $s_configuration_corrupted = 'The configuration in the database is corrupted.';
 $s_set_configuration_option_action_create = 'Create Configuration Option';
 $s_set_configuration_option_action_edit = 'Edit Configuration Option';
 $s_set_configuration_option_action_clone = 'Clone Configuration Option';
+$s_set_configuration_option_action_view = 'View Configuration Option';
 
 # manage_plugin_page.php
 $s_plugin = 'Plugin';


### PR DESCRIPTION
To save page space, don't show complex values in adm_config_report page. Use an on-demand retrieval of the content through a rest api call.
Create a new page for viewing and editing configuration options from adm_config_report page. This also serves as fallback for viewing complex values that now are not displayed in the main report, in case javascript is not available to populate it through rest api calls.