### PR TITLE
Fix show obsolete versions

### DIFF
--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -834,9 +834,9 @@ function mci_custom_field_type_name( $p_type_id ) {
  * @return array The project versions.
  */
 function mci_project_versions( $p_project_id ) {
-	# use null, true as the fastest way (no additional where clause in query)
+	# use VERSION_ALL, true as the fastest way (no additional where clause in query)
 	# to get all released / non-released and obsolete / non-obsolete versions
-	$t_versions = version_get_all_rows( $p_project_id, null, true );
+	$t_versions = version_get_all_rows( $p_project_id, VERSION_ALL, true );
 	$t_results = array();
 
 	foreach( $t_versions as $t_version ) {

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -834,9 +834,9 @@ function mci_custom_field_type_name( $p_type_id ) {
  * @return array The project versions.
  */
 function mci_project_versions( $p_project_id ) {
-	# use null, null as the fastest way (no additional where clause in query)
+	# use null, true as the fastest way (no additional where clause in query)
 	# to get all released / non-released and obsolete / non-obsolete versions
-	$t_versions = version_get_all_rows( $p_project_id, null, null );
+	$t_versions = version_get_all_rows( $p_project_id, null, true );
 	$t_results = array();
 
 	foreach( $t_versions as $t_version ) {

--- a/changelog_page.php
+++ b/changelog_page.php
@@ -245,7 +245,7 @@ foreach( $t_project_ids as $t_project_id ) {
 	$t_resolved = config_get( 'bug_resolved_status_threshold' );
 
 	# grab versions info for later use, excluding obsolete ones
-	$t_version_rows = version_get_all_rows( $t_project_id, null, false );
+	$t_version_rows = version_get_all_rows( $t_project_id, VERSION_ALL, false );
 
 	# cache category info, but ignore the results for now
 	category_get_all_rows( $t_project_id );

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -852,11 +852,13 @@ function print_os_build_option_list( $p_os_build, $p_user_id = null ) {
  *
  * @param string              $p_version       The currently selected version.
  * @param integer|array|null  $p_project_ids   A project id, or array of ids, or null to use current project.
- * @param integer             $p_released      Null to get all, 1: only released, 0: only future versions.
- * @param boolean             $p_leading_blank Allow selection of no version.
+ * @param integer             $p_released      One of VERSION_ALL, VERSION_FUTURE or VERSION_RELEASED
+ *                                             to define which versions to include in the list (defaults to ALL).
+ * @param boolean $p_leading_blank Allow selection of no version.
+ *
  * @return void
  */
-function print_version_option_list( $p_version = '', $p_project_ids = null, $p_released = null, $p_leading_blank = true ) {
+function print_version_option_list( $p_version = '', $p_project_ids = null, $p_released = VERSION_ALL, $p_leading_blank = true ) {
 	if( null === $p_project_ids ) {
 		$p_project_ids = helper_get_current_project();
 	}

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -862,7 +862,7 @@ function print_version_option_list( $p_version = '', $p_project_ids = null, $p_r
 	}
 	$t_project_ids = is_array( $p_project_ids ) ? $p_project_ids : array( $p_project_ids );
 
-	$t_versions = version_get_all_rows( $t_project_ids, $p_released, null );
+	$t_versions = version_get_all_rows( $t_project_ids, $p_released, true );
 
 	# Ensure the selected version (if specified) is included in the list
 	# Note: Filter API specifies selected versions as an array

--- a/core/version_api.php
+++ b/core/version_api.php
@@ -492,7 +492,11 @@ function version_remove_all( $p_project_id ) {
  * Return all versions for the specified project or projects list
  * Returned versions are ordered by reverse 'date_order'
  * @param integer|array $p_project_ids  A valid project id, or array of ids
- * @param boolean $p_released   Whether to include released versions.
+ * @param boolean $p_released   Whether to show only released, unreleased, or both.
+ *                  For this parameter, use constants defined as:
+ *                  VERSION_ALL (null): returns any
+ *                  VERSION_FUTURE (false): returns only unreleased versions
+ *                  VERSION_RELEASED (true): returns only released versions
  * @param boolean $p_obsolete   Whether to include obsolete versions.
  * @param boolean $p_inherit    True to include versions from parent projects,
  *                              false not to, or null to use configuration
@@ -530,7 +534,7 @@ function version_get_all_rows( $p_project_ids, $p_released = null, $p_obsolete =
 		if( !empty( $g_cache_versions_project[$t_project_id]) ) {
 			foreach( $g_cache_versions_project[$t_project_id] as $t_id ) {
 				$t_version_row = version_cache_row( $t_id );
-				if( $p_obsolete == false && (int)$t_version_row['obsolete'] == 1 ) {
+				if( $p_obsolete === false && (int)$t_version_row['obsolete'] == 1 ) {
 					continue;
 				}
 				if( $p_released !== null ) {

--- a/core/version_api.php
+++ b/core/version_api.php
@@ -577,7 +577,7 @@ function version_get_id( $p_version, $p_project_id = null, $p_inherit = null ) {
 		$c_project_id = (int)$p_project_id;
 	}
 
-	$t_versions = version_get_all_rows( $c_project_id, null /* released: any */, true /* incl. obsolete */ ,  $p_inherit );
+	$t_versions = version_get_all_rows( $c_project_id, VERSION_ALL, true /* incl. obsolete */ ,  $p_inherit );
 	foreach( $t_versions as $t_version ) {
 		if( $t_version['version'] === $p_version ) {
 			return $t_version['id'];

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -492,7 +492,7 @@ if ( config_get( 'subprojects_enabled') == ON ) {
 		<div class="widget-body">
 		<div class="widget-main no-padding">
 	<?php
-	$t_versions = version_get_all_rows( $f_project_id, null, true );
+	$t_versions = version_get_all_rows( $f_project_id, VERSION_ALL, true );
 	if( count( $t_versions ) > 0 ) { ?>
 	<div class="table-responsive">
 		<table id="versions" class="table table-striped table-bordered table-condensed">

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -492,7 +492,7 @@ if ( config_get( 'subprojects_enabled') == ON ) {
 		<div class="widget-body">
 		<div class="widget-main no-padding">
 	<?php
-	$t_versions = version_get_all_rows( $f_project_id, null, null );
+	$t_versions = version_get_all_rows( $f_project_id, null, true );
 	if( count( $t_versions ) > 0 ) { ?>
 	<div class="table-responsive">
 		<table id="versions" class="table table-striped table-bordered table-condensed">


### PR DESCRIPTION
Fix version_get_all_rows for a default parameter value of "null".
Regression caused by 46c77ace319216aa6403af4130b83b4deb801b3c

Fixes: [#25661](https://www.mantisbt.org/bugs/view.php?id=25661)