### PR TITLE
Fix plugin_get_current() when used in MantisColumn classes

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -2220,7 +2220,9 @@ function bug_clear_cache_all( $p_bug_id = null ) {
 
 	$t_plugin_objects = columns_get_plugin_columns();
 	foreach( $t_plugin_objects as $t_plugin_column ) {
+                plugin_push_current($t_plugin_column->plugin_name);
 		$t_plugin_column->clear_cache();
+                plugin_pop_current();
 	}
 	return true;
 }
@@ -2252,7 +2254,9 @@ function bug_cache_columns_data( array $p_bugs, array $p_selected_columns ) {
 
 		if( column_is_plugin_column( $t_column ) ) {
 			$plugin_objects = columns_get_plugin_columns();
+                        plugin_push_current($plugin_objects[$t_column]->plugin_name);
 			$plugin_objects[$t_column]->cache( $p_bugs );
+                        plugin_pop_current();
 			continue;
 		}
 

--- a/core/classes/BugFilterQuery.class.php
+++ b/core/classes/BugFilterQuery.class.php
@@ -1643,7 +1643,9 @@ class BugFilterQuery extends DbQuery {
 				$t_plugin_columns = columns_get_plugin_columns();
 				$t_column_object = $t_plugin_columns[$c_sort];
 
+                                plugin_push_current( $t_column_object->plugin_name );
 				$t_clauses = $t_column_object->sortquery( $c_dir );
+                                plugin_pop_current();
 				if( is_array( $t_clauses ) ) {
 					if( isset( $t_clauses['join'] ) ) {
 						$this->add_join( $t_clauses['join'] );

--- a/core/classes/MantisColumn.class.php
+++ b/core/classes/MantisColumn.class.php
@@ -43,6 +43,14 @@ abstract class MantisColumn {
 	 * the column will properly implement the sortquery() method.
 	 */
 	public $sortable = false;
+        
+        /**
+         * Plugin name.
+         * Provides correct operation plugin_push_current()
+         * Initialized by the MantisBT kernel during the execution of 
+         * function columns_get_plugin_columns()
+         */
+        public $plugin_name = '';
 
 	/**
 	 * Build the SQL query elements 'join' and 'order' as used by

--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -176,6 +176,7 @@ function columns_get_plugin_columns() {
 						} else {
 							continue;
 						}
+                                                $t_column_object->plugin_name = $t_plugin;
 						$t_column_name = mb_strtolower( $t_plugin . '_' . $t_column_object->column );
 						$s_column_array[$t_column_name] = $t_column_object;
 					}
@@ -1136,13 +1137,15 @@ function print_column_title_plugin( $p_column, $p_column_object, $p_sort, $p_dir
  * @access public
  */
 function print_column_plugin( $p_column_object, BugData $p_bug, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
-	if( $p_columns_target != COLUMNS_TARGET_CSV_PAGE ) {
+	plugin_push_current($p_column_object->plugin_name);
+        if( $p_columns_target != COLUMNS_TARGET_CSV_PAGE ) {
 		echo '<td class="column-plugin">';
 		$p_column_object->display( $p_bug, $p_columns_target );
 		echo '</td>';
 	} else {
 		$p_column_object->display( $p_bug, $p_columns_target );
 	}
+        plugin_pop_current();
 }
 
 /**

--- a/core/csv_api.php
+++ b/core/csv_api.php
@@ -170,7 +170,9 @@ function csv_format_plugin_column_value( $p_column, BugData $p_bug ) {
 		$t_value = '';
 	} else {
 		$t_column_object = $t_plugin_columns[$p_column];
+                plugin_push_current($t_column_object->plugin_name);
 		$t_value = $t_column_object->value( $p_bug );
+                plugin_pop_current();
 	}
 
 	return csv_escape_string( $t_value );

--- a/core/excel_api.php
+++ b/core/excel_api.php
@@ -541,7 +541,9 @@ function excel_format_plugin_column_value( $p_column, BugData $p_bug ) {
 		$t_value = '';
 	} else {
 		$t_column_object = $t_plugin_columns[$p_column];
+                plugin_push_current($t_column_object->plugin_name);
 		$t_value = $t_column_object->value( $p_bug );
+                plugin_pop_current();
 	}
 
 	return excel_prepare_string( $t_value );

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1204,7 +1204,10 @@ function filter_get_query_sort_data( array &$p_filter, $p_show_sticky, array $p_
 			$t_plugin_columns = columns_get_plugin_columns();
 			$t_column_object = $t_plugin_columns[$c_sort];
 
+                        plugin_push_current( $t_column_object->plugin_name );
 			$t_clauses = $t_column_object->sortquery( $c_dir );
+                        plugin_pop_current();
+                        
 			if( is_array( $t_clauses ) ) {
 				if( isset( $t_clauses['join'] ) ) {
 					$p_query_clauses['join'][] = $t_clauses['join'];


### PR DESCRIPTION
Added field 'plugin_name' in MantisColumn.
Added initialization of the field 'plugin_name' to columns_get_plugin_columns()
Concluded between plugin_push_current() and plugin_pop_current() functions are clear_cache(), cache(), display(), value(), sortquery() wherever these functions are called.

At first glance, and after tests, including on my plug-in, I believe that this PR will not cause compatibility errors with already released plug-ins.

Fixes #25677