### PR TITLE
log_event() create log file if it does not exist

### DIFF
--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -107,18 +107,24 @@ function log_event( $p_level, $p_msg ) {
 			break;
 		case 'file':
 			if( isset( $t_modifiers ) ) {
-				# Log the event, suppress errors in case the file is not writable
-				$t_log_writable = @error_log( $t_php_event . PHP_EOL, 3, $t_modifiers );
+				static $s_log_writable = null;
 
-				if( !$t_log_writable ) {
-					# Display a one-time warning message and write it to PHP system log as well.
-					# Note: to ensure the error is shown regardless of $g_display_error settings,
-					# we manually set the message and log it with error_log_delayed(), which will
-					# cause it to be displayed at page bottom.
-					error_parameters( $t_modifiers );
-					$t_message = error_string( ERROR_LOGFILE_NOT_WRITABLE );
-					error_log_delayed( $t_message );
-					error_log( 'MantisBT - ' . htmlspecialchars_decode( $t_message ) );
+				if( $s_log_writable ) {
+					error_log( $t_php_event . PHP_EOL, 3, $t_modifiers );
+				} elseif( $s_log_writable === null ) {
+					# Try to log the event, suppress errors in case the file is not writable
+					$s_log_writable = @error_log( $t_php_event . PHP_EOL, 3, $t_modifiers );
+
+					if( !$s_log_writable ) {
+						# Display a one-time warning message and write it to PHP system log as well.
+						# Note: to ensure the error is shown regardless of $g_display_error settings,
+						# we manually set the message and log it with error_log_delayed(), which will
+						# cause it to be displayed at page bottom.
+						error_parameters( $t_modifiers );
+						$t_message = error_string( ERROR_LOGFILE_NOT_WRITABLE );
+						error_log_delayed( $t_message );
+						error_log( 'MantisBT - ' . htmlspecialchars_decode( $t_message ) );
+					}
 				}
 			}
 			break;

--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -107,23 +107,18 @@ function log_event( $p_level, $p_msg ) {
 			break;
 		case 'file':
 			if( isset( $t_modifiers ) ) {
-				# Detect if the log file is writable; if not, issue a one-time warning
-				static $s_log_writable = null;
-				if( $s_log_writable === null ) {
-					$s_log_writable = is_writable( $t_modifiers );
-					if( !$s_log_writable ) {
-						# Display warning message and write it in PHP system log as well.
-						# Note: to ensure the error is shown regardless of $g_display_error settings,
-						# we manually set the message and log it with error_log_delayed(), which will
-						# cause it to be displayed at page bottom.
-						error_parameters( $t_modifiers );
-						$t_message = error_string( ERROR_LOGFILE_NOT_WRITABLE );
-						error_log_delayed( $t_message );
-						error_log( 'MantisBT - ' . htmlspecialchars_decode( $t_message ) );
-					}
-				}
-				if( $s_log_writable ) {
-					error_log( $t_php_event . PHP_EOL, 3, $t_modifiers );
+				# Log the event, suppress errors in case the file is not writable
+				$t_log_writable = @error_log( $t_php_event . PHP_EOL, 3, $t_modifiers );
+
+				if( !$t_log_writable ) {
+					# Display a one-time warning message and write it to PHP system log as well.
+					# Note: to ensure the error is shown regardless of $g_display_error settings,
+					# we manually set the message and log it with error_log_delayed(), which will
+					# cause it to be displayed at page bottom.
+					error_parameters( $t_modifiers );
+					$t_message = error_string( ERROR_LOGFILE_NOT_WRITABLE );
+					error_log_delayed( $t_message );
+					error_log( 'MantisBT - ' . htmlspecialchars_decode( $t_message ) );
 				}
 			}
 			break;


### PR DESCRIPTION
This is a regression from issue [#19642](https://mantisbt.org/bugs/view.php?id=19642) (PR #1483). When MantisBT tries to write an
event to a log file that does not already exist, a warning is printed
and the file is not created even if PHP process has write access to the
directory. The event is added to the PHP system log.

Instead of relying on is_writable(), the code now calls error_log() with
errors suppressed, then checks the result of the function call to
determine if the operation was successful or not.

Fixes [#25734](https://mantisbt.org/bugs/view.php?id=25734)
