### PR TITLE
Align SOAP API return values with WSDL

### DIFF
--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -553,7 +553,8 @@ function mc_project_version_update( $p_username, $p_password, $p_version_id, std
 	$t_version_data->date_order = $t_date_order;
 	$t_version_data->obsolete = $t_obsolete;
 
-	return version_update( $t_version_data );
+	version_update( $t_version_data );
+	return true;
 }
 
 /**

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -593,7 +593,8 @@ function mc_project_version_delete( $p_username, $p_password, $p_version_id ) {
 		return mci_fault_access_denied( $t_user_id );
 	}
 
-	return version_remove( $p_version_id );
+	version_remove( $p_version_id );
+	return true;
 }
 
 /**


### PR DESCRIPTION
Following changes in 1.3.0-beta.1, there were discrepancies in mc_project_version_update() and mc_project_version_delete().

Fixes [#25470](https://mantisbt.org/bugs/view.php?id=25470)
