### PR TITLE
Add newline after <textarea> tags

### DIFF
--- a/account_prof_edit_page.php
+++ b/account_prof_edit_page.php
@@ -126,7 +126,10 @@ if( profile_is_global( $f_profile_id ) ) {
 		<?php echo lang_get( 'additional_description' ) ?>
 	</th>
 	<td>
-		<textarea class="form-control" name="description" cols="60" rows="8"><?php echo string_textarea( $v_description ) ?></textarea>
+		<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+		<textarea class="form-control" name="description" cols="60" rows="8">
+<?php echo string_textarea( $v_description ) ?>
+</textarea>
 	</td>
 </tr>
 </table>

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -567,7 +567,10 @@ if( $t_show_attachments ) {
 			<span class="required">*</span><label for="description"><?php print_documentation_link( 'description' ) ?></label>
 		</th>
 		<td>
-			<textarea class="form-control" <?php echo helper_get_tab_index() ?> id="description" name="description" cols="80" rows="10" required><?php echo string_textarea( $f_description ) ?></textarea>
+			<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+			<textarea class="form-control" <?php echo helper_get_tab_index() ?> id="description" name="description" cols="80" rows="10" required>
+<?php echo string_textarea( $f_description ) ?>
+</textarea>
 		</td>
 	</tr>
 
@@ -577,7 +580,10 @@ if( $t_show_attachments ) {
 				<label for="steps_to_reproduce"><?php print_documentation_link( 'steps_to_reproduce' ) ?></label>
 			</th>
 			<td>
-				<textarea class="form-control" <?php echo helper_get_tab_index() ?> id="steps_to_reproduce" name="steps_to_reproduce" cols="80" rows="10"><?php echo string_textarea( $f_steps_to_reproduce ) ?></textarea>
+				<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+				<textarea class="form-control" <?php echo helper_get_tab_index() ?> id="steps_to_reproduce" name="steps_to_reproduce" cols="80" rows="10">
+<?php echo string_textarea( $f_steps_to_reproduce ) ?>
+</textarea>
 			</td>
 		</tr>
 <?php } ?>
@@ -588,7 +594,10 @@ if( $t_show_attachments ) {
 			<label for="additional_info"><?php print_documentation_link( 'additional_information' ) ?></label>
 		</th>
 		<td>
-			<textarea class="form-control" <?php echo helper_get_tab_index() ?> id="additional_info" name="additional_info" cols="80" rows="10"><?php echo string_textarea( $f_additional_info ) ?></textarea>
+			<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+			<textarea class="form-control" <?php echo helper_get_tab_index() ?> id="additional_info" name="additional_info" cols="80" rows="10">
+<?php echo string_textarea( $f_additional_info ) ?>
+</textarea>
 		</td>
 	</tr>
 <?php } ?>

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -642,7 +642,9 @@ if( $t_show_description ) {
 	echo '<tr>';
 	echo '<th class="category"><label for="description">' . lang_get( 'description' ) . '</label></th>';
 	echo '<td colspan="5">';
-	echo '<textarea class="form-control" ', helper_get_tab_index(), ' cols="80" rows="10" id="description" name="description">', $t_description_textarea, '</textarea>';
+	echo '<textarea class="form-control" ', helper_get_tab_index(),
+		' cols="80" rows="10" id="description" name="description">', "\n",
+		$t_description_textarea, '</textarea>';
 	echo '</td></tr>';
 }
 
@@ -651,7 +653,9 @@ if( $t_show_steps_to_reproduce ) {
 	echo '<tr>';
 	echo '<th class="category"><label for="steps_to_reproduce">' . lang_get( 'steps_to_reproduce' ) . '</label></th>';
 	echo '<td colspan="5">';
-	echo '<textarea class="form-control" ', helper_get_tab_index(), ' cols="80" rows="10" id="steps_to_reproduce" name="steps_to_reproduce">', $t_steps_to_reproduce_textarea, '</textarea>';
+	echo '<textarea class="form-control" ', helper_get_tab_index(),
+		' cols="80" rows="10" id="steps_to_reproduce" name="steps_to_reproduce">', "\n",
+		$t_steps_to_reproduce_textarea, '</textarea>';
 	echo '</td></tr>';
 }
 
@@ -660,7 +664,9 @@ if( $t_show_additional_information ) {
 	echo '<tr>';
 	echo '<th class="category"><label for="additional_information">' . lang_get( 'additional_information' ) . '</label></th>';
 	echo '<td colspan="5">';
-	echo '<textarea class="form-control" ', helper_get_tab_index(), ' cols="80" rows="10" id="additional_information" name="additional_information">', $t_additional_information_textarea, '</textarea>';
+	echo '<textarea class="form-control" ', helper_get_tab_index(),
+		' cols="80" rows="10" id="additional_information" name="additional_information">', "\n",
+		$t_additional_information_textarea, '</textarea>';
 	echo '</td></tr>';
 }
 

--- a/manage_columns_inc.php
+++ b/manage_columns_inc.php
@@ -109,7 +109,10 @@ if( $t_account_page ) {
 					<?php echo lang_get( 'all_columns_title' )?>
 				</td>
 				<td>
-					<textarea class="form-control"  id="all-columns" <?php echo helper_get_tab_index() ?> name="all_columns" readonly="readonly" cols="80" rows="5"><?php echo $t_all ?></textarea>
+					<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+					<textarea class="form-control"  id="all-columns" <?php echo helper_get_tab_index() ?> name="all_columns" readonly="readonly" cols="80" rows="5">
+<?php echo $t_all ?>
+</textarea>
 				</td>
 			</tr>
 			<tr>
@@ -117,7 +120,10 @@ if( $t_account_page ) {
 					<?php echo lang_get( 'view_issues_columns_title' )?>
 				</td>
 				<td>
-					<textarea class="form-control" id="view-issues-columns" <?php echo helper_get_tab_index() ?> name="view_issues_columns" cols="80" rows="5"><?php echo $t_view_issues ?></textarea>
+					<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+					<textarea class="form-control" id="view-issues-columns" <?php echo helper_get_tab_index() ?> name="view_issues_columns" cols="80" rows="5">
+<?php echo $t_view_issues ?>
+</textarea>
 				</td>
 			</tr>
 			<tr>
@@ -125,7 +131,10 @@ if( $t_account_page ) {
 					<?php echo lang_get( 'print_issues_columns_title' )?>
 				</td>
 				<td>
-					<textarea class="form-control" id="print-issues-columns" <?php echo helper_get_tab_index() ?> name="print_issues_columns" cols="80" rows="5"><?php echo $t_print_issues ?></textarea>
+					<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+					<textarea class="form-control" id="print-issues-columns" <?php echo helper_get_tab_index() ?> name="print_issues_columns" cols="80" rows="5">
+<?php echo $t_print_issues ?>
+</textarea>
 				</td>
 			</tr>
 			<tr>
@@ -133,7 +142,10 @@ if( $t_account_page ) {
 					<?php echo lang_get( 'csv_columns_title' )?>
 				</td>
 				<td>
-					<textarea class="form-control" id="csv-columns" <?php echo helper_get_tab_index() ?> name="csv_columns" cols="80" rows="5"><?php echo $t_csv ?></textarea>
+					<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+					<textarea class="form-control" id="csv-columns" <?php echo helper_get_tab_index() ?> name="csv_columns" cols="80" rows="5">
+<?php echo $t_csv ?>
+</textarea>
 				</td>
 			</tr>
 			<tr>
@@ -141,7 +153,9 @@ if( $t_account_page ) {
 					<?php echo lang_get( 'excel_columns_title' )?>
 				</td>
 				<td>
-					<textarea class="form-control" id="excel-columns" <?php echo helper_get_tab_index() ?> name="excel_columns" cols="80" rows="5"><?php echo $t_excel ?></textarea>
+					<textarea class="form-control" id="excel-columns" <?php echo helper_get_tab_index() ?> name="excel_columns" cols="80" rows="5">
+						<?php echo $t_excel ?>
+					</textarea>
 				</td>
 			</tr>
 		</fieldset>

--- a/manage_custom_field_edit_page.php
+++ b/manage_custom_field_edit_page.php
@@ -126,7 +126,10 @@ $t_definition = custom_field_get_definition( $f_field_id );
 				<input type="text" id="custom-field-default-value" name="default_value" class="input-sm" size="32" maxlength="255" value="<?php echo string_attribute( $t_definition['default_value'] ) ?>" />
 			</div>
 			<div class="textarea">
-				<textarea disabled="disabled" id="custom-field-default-value-textarea" name="default_value" class="form-control" cols="80" rows="10"><?php echo string_attribute( $t_definition['default_value'] ) ?></textarea>
+				<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+				<textarea disabled="disabled" id="custom-field-default-value-textarea" name="default_value" class="form-control" cols="80" rows="10">
+<?php echo string_attribute( $t_definition['default_value'] ) ?>
+</textarea>
 			</div>
 		</td>
 	</tr>

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -187,7 +187,10 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 					<?php echo lang_get( 'description' ) ?>
 				</td>
 				<td>
-					<textarea class="form-control" id="project-description" name="description" cols="70" rows="5"><?php echo string_textarea( $t_row['description'] ) ?></textarea>
+					<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+					<textarea class="form-control" id="project-description" name="description" cols="70" rows="5">
+<?php echo string_textarea( $t_row['description'] ) ?>
+</textarea>
 				</td>
 			</tr>
 

--- a/manage_proj_ver_edit_page.php
+++ b/manage_proj_ver_edit_page.php
@@ -109,7 +109,10 @@ print_manage_menu( 'manage_proj_ver_edit_page.php' );
 					<?php echo lang_get( 'description' ) ?>
 				</td>
 				<td>
-					<textarea class="form-control" id="proj-version-description" name="description" cols="60" rows="5"><?php echo string_attribute( $t_version->description ) ?></textarea>
+					<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+					<textarea class="form-control" id="proj-version-description" name="description" cols="60" rows="5">
+<?php echo string_attribute( $t_version->description ) ?>
+</textarea>
 				</td>
 			</tr>
 			<tr>

--- a/news_edit_page.php
+++ b/news_edit_page.php
@@ -124,7 +124,10 @@ layout_page_begin( 'main_page.php' );
 					<span class="required">*</span> <?php echo lang_get( 'body' ) ?>
 				</td>
 				<td>
-					<textarea class="form-control" id="news-update-body" name="body" cols="60" rows="10" required><?php echo $v_body ?></textarea>
+					<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+					<textarea class="form-control" id="news-update-body" name="body" cols="60" rows="10" required>
+<?php echo $v_body ?>
+</textarea>
 				</td>
 			</tr>
 			<tr>

--- a/proj_doc_edit_page.php
+++ b/proj_doc_edit_page.php
@@ -110,7 +110,10 @@ print_doc_menu();
 		<?php echo lang_get( 'description' ) ?>
 	</th>
 	<td>
-		<textarea class="form-control" name="description" cols="60" rows="7"><?php echo $v_description ?></textarea>
+		<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+		<textarea class="form-control" name="description" cols="60" rows="7">
+<?php echo $v_description ?>
+</textarea>
 	</td>
 </tr>
 <tr>

--- a/tag_update_page.php
+++ b/tag_update_page.php
@@ -140,7 +140,10 @@ layout_page_begin();
 					<?php echo lang_get( 'tag_description' ) ?>
 				</td>
 				<td>
-					<textarea class="form-control" id="tag-description" name="description" <?php echo helper_get_tab_index() ?> cols="80" rows="6"><?php echo string_textarea( $t_description ) ?></textarea>
+					<?php # Newline after opening textarea tag is intentional, see #25839 ?>
+					<textarea class="form-control" id="tag-description" name="description" <?php echo helper_get_tab_index() ?> cols="80" rows="6">
+<?php echo string_textarea( $t_description ) ?>
+</textarea>
 				</td>
 			</tr>
 		</fieldset>


### PR DESCRIPTION
The HTML 5 specification states that "Newlines at the start of textarea
elements are ignored as an authoring convenience." [1]

To avoid altering user data (e.g. issue description, steps to reproduce,
etc.) having leading newline(s) when editing and saving, the markup of
all pages displaying user content in textarea tags has been modified to
add a newline after the opening tag.

Fixes [#25839](https://mantisbt.org/bugs/view.php?id=25839)

[1]: https://www.w3.org/TR/html52/syntax.html#the-in-body-insertion-mode