### PR TITLE
Replace mailto: by link to user profile page in view.php

### DIFF
--- a/core/cfdefs/cfdef_standard.php
+++ b/core/cfdefs/cfdef_standard.php
@@ -267,7 +267,7 @@ function cfdef_prepare_list_value_for_email( $p_value ) {
  */
 function cfdef_print_email_value( $p_value ) {
 	if( !is_blank( $p_value ) ) {
-		echo '<a href="mailto:' . string_attribute( $p_value ) . '">' . string_display_line( $p_value ) . '</a>';
+		print_email_link( $p_value, $p_value );
 	}
 }
 

--- a/core/prepare_api.php
+++ b/core/prepare_api.php
@@ -68,21 +68,45 @@ function prepare_mailto_url ( $p_email, $p_subject = '' ) {
 /**
  * return an HTML link with mailto: href.
  *
- * @param string $p_email   Email address to prepare.
- * @param string $p_text    Display text for the hyperlink.
- * @param string $p_subject Optional e-mail subject
+ * If user does not have access level required to see email addresses, the
+ * function will only return the display text (with tooltip if provided).
+ *
+ * @param string $p_email           Email address to prepare.
+ * @param string $p_text            Display text for the hyperlink.
+ * @param string $p_subject         Optional e-mail subject
+ * @param string  $p_tooltip        Optional tooltip to show.
+ * @param boolean $p_show_as_button If true, show link as button with envelope
+ *                                  icon, otherwise display a plain-text link.
  *
  * @return string
  */
-function prepare_email_link( $p_email, $p_text, $p_subject = '' ) {
+function prepare_email_link( $p_email, $p_text, $p_subject = '', $p_tooltip ='', $p_show_as_button = false ) {
+	$t_text = string_display_line( $p_text );
+	if( !is_blank( $p_tooltip ) && $p_tooltip != $p_text ) {
+		$t_tooltip = ' title="' . string_display_line( $p_tooltip ) . '"';
+	} else {
+		$t_tooltip = '';
+	}
+
 	if( !access_has_project_level( config_get( 'show_user_email_threshold' ) ) ) {
-		return string_display_line( $p_text );
+		return $t_tooltip ? '<a' . $t_tooltip . '>' . $t_text . '</a>' : $t_text;
 	}
 
 	$t_mailto = prepare_mailto_url( $p_email, $p_subject );
-	$p_text = string_display_line( $p_text );
 
-	return '<a href="' . $t_mailto . '">' . $p_text . '</a>';
+	if( $p_show_as_button ) {
+		$t_class = ' class="btn btn-primary btn-white btn-round btn-xs"';
+		$t_text = '<i class="fa fa-envelope-o"></i>' . ( $t_text ? "&nbsp;$t_text" : '' );
+	} else {
+		$t_class = '';
+	}
+
+	return sprintf( '<a href="%s"%s%s>%s</a>',
+		$t_mailto,
+		$t_tooltip,
+		$t_class,
+		$t_text
+	);
 }
 
 /**

--- a/core/prepare_api.php
+++ b/core/prepare_api.php
@@ -41,20 +41,45 @@ require_api( 'user_api.php' );
 require_api( 'version_api.php' );
 
 /**
- * return the mailto: href string link
- * @param string $p_email Email address to prepare.
- * @param string $p_text  Display text for the hyperlink.
+ * Return a ready-to-use mailto: URL.
+ *
+ * No validation is performed on the e-mail address, it is the caller's
+ * responsibility to ensure it is valid and not empty.
+ *
+ * @param string $p_email   Target e-mail address
+ * @param string $p_subject Optional e-mail subject
+ *
  * @return string
  */
-function prepare_email_link( $p_email, $p_text ) {
+function prepare_mailto_url ( $p_email, $p_subject = '' ) {
+	# If we apply string_url() to the whole mailto: link then the @ gets
+	# turned into a %40 and you can't right click in browsers to use the
+	# Copy Email Address functionality.
+	if( $p_subject ) {
+		# URL-encoding the subject is required otherwise special characters
+		# (ampersand for example) will truncate the text
+		$p_subject = '?subject=' . string_url( $p_subject );
+	}
+	$t_mailto = 'mailto:' . $p_email . $p_subject;
+
+	return string_attribute( $t_mailto );
+}
+
+/**
+ * return an HTML link with mailto: href.
+ *
+ * @param string $p_email   Email address to prepare.
+ * @param string $p_text    Display text for the hyperlink.
+ * @param string $p_subject Optional e-mail subject
+ *
+ * @return string
+ */
+function prepare_email_link( $p_email, $p_text, $p_subject = '' ) {
 	if( !access_has_project_level( config_get( 'show_user_email_threshold' ) ) ) {
 		return string_display_line( $p_text );
 	}
 
-	# If we apply string_url() to the whole mailto: link then the @
-	#  gets turned into a %40 and you can't right click in browsers to
-	#  do Copy Email Address.
-	$t_mailto = string_attribute( 'mailto:' . $p_email );
+	$t_mailto = prepare_mailto_url( $p_email, $p_subject );
 	$p_text = string_display_line( $p_text );
 
 	return '<a href="' . $t_mailto . '">' . $p_text . '</a>';

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -220,17 +220,13 @@ function print_user_with_subject( $p_user_id, $p_bug_id ) {
 		return;
 	}
 
-	$t_username = user_get_username( $p_user_id );
-	$t_name = user_get_name( $p_user_id );
+	print_user( $p_user_id );
 
-	if( user_exists( $p_user_id ) && user_get_field( $p_user_id, 'enabled' ) ) {
+	if( user_exists( $p_user_id ) && user_is_enabled( $p_user_id ) ) {
 		$t_email = user_get_email( $p_user_id );
-		print_email_link_with_subject( $t_email, $t_name, $t_username, $p_bug_id );
-	} else {
-		$t_name = string_attribute( $t_name );
-		echo '<span style="text-decoration: line-through">';
-		echo '<a title="' . $t_name . '">' . $t_username . '</a>';
-		echo '</span>';
+
+		echo '&nbsp;';
+		print_email_link_with_subject( $t_email, '', '', $p_bug_id );
 	}
 }
 
@@ -1662,13 +1658,15 @@ function get_email_link( $p_email, $p_text ) {
 /**
  * print a mailto: href link with subject
  *
- * @param string $p_email  Email Address.
- * @param string $p_text   Link text to display to user.
- * @param string $p_tooltip The tooltip to show.
- * @param string $p_bug_id The bug identifier.
+ * @param string  $p_email  Email Address.
+ * @param string  $p_text   Link text to display to user.
+ * @param string  $p_tooltip The tooltip to show.
+ * @param string  $p_bug_id The bug identifier.
+ * @param boolean $p_show_as_text By default, show link as button with envelope icon.
  * @return void
  */
-function print_email_link_with_subject( $p_email, $p_text, $p_tooltip, $p_bug_id ) {
+function print_email_link_with_subject( $p_email, $p_text, $p_tooltip, $p_bug_id, $p_show_as_text = false )
+{
 	if( !is_blank( $p_tooltip ) && $p_tooltip != $p_text ) {
 		$t_tooltip = ' title="' . $p_tooltip . '"';
 	} else {
@@ -1676,23 +1674,36 @@ function print_email_link_with_subject( $p_email, $p_text, $p_tooltip, $p_bug_id
 	}
 
 	$t_bug = bug_get( $p_bug_id, true );
-	if( !access_has_project_level( config_get( 'show_user_email_threshold', null, null, $t_bug->project_id ), $t_bug->project_id ) ) {
-		echo $t_tooltip != '' ? '<a' . $t_tooltip . '>' . $p_text . '</a>' : $p_text;
+	$t_show_user_email_threshold = config_get( 'show_user_email_threshold', null, null, $t_bug->project_id );
+	if( !access_has_project_level( $t_show_user_email_threshold, $t_bug->project_id ) ) {
+		if( $p_show_as_text && $p_text ) {
+			echo $t_tooltip ? '<a' . $t_tooltip . '>' . $p_text . '</a>' : $p_text;
+		}
 		return;
 	}
-
-	$t_subject = email_build_subject( $p_bug_id );
 
 	# If we apply string_url() to the whole mailto: link then the @
 	# gets turned into a %40 and you can't right click in browsers to
 	# do Copy Email Address.  If we don't apply string_url() to the
 	# subject text then an ampersand (for example) will truncate the text
-	$t_subject = string_url( $t_subject );
+	$t_subject = string_url( email_build_subject( $p_bug_id ) );
 	$t_email = string_url( $p_email );
 	$t_mailto = string_attribute( 'mailto:' . $t_email . '?subject=' . $t_subject );
 	$t_text = string_display( $p_text );
 
-	echo '<a href="' . $t_mailto . '"' . $t_tooltip . '>' . $t_text . '</a>';
+	if( $p_show_as_text ) {
+		$t_class = '';
+	} else {
+		$t_class = ' class="btn btn-primary btn-white btn-round btn-xs"';
+		$t_text = '<i class="fa fa-envelope-o"></i>' . ( $t_text ? "&nbsp;$t_text" : '' );
+	}
+
+	printf( '<a href="%s"%s%s>%s</a>',
+		$t_mailto,
+		$t_tooltip,
+		$t_class,
+		$t_text
+	);
 }
 
 /**

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1641,18 +1641,7 @@ function print_page_links( $p_page, $p_start, $p_end, $p_current, $p_temp_filter
  * @return void
  */
 function print_email_link( $p_email, $p_text ) {
-	echo get_email_link( $p_email, $p_text );
-}
-
-/**
- * return the mailto: href string link instead of printing it
- *
- * @param string $p_email Email Address.
- * @param string $p_text  Link text to display to user.
- * @return string
- */
-function get_email_link( $p_email, $p_text ) {
-	return prepare_email_link( $p_email, $p_text );
+	echo prepare_email_link( $p_email, $p_text );
 }
 
 /**

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -194,13 +194,18 @@ function print_avatar( $p_user_id, $p_class_prefix, $p_size = 80 ) {
 }
 
 /**
- * prints the name of the user given the id.  also makes it an email link.
+ * prints the name of the user given the id.
+ *
+ * By default, the username will become a hyperlink to View User page,
+ * but caller can decide to just print the username.
  *
  * @param integer $p_user_id A user identifier.
+ * @param boolean $p_link    Whether to add an html link (defaults to true)
+ *
  * @return void
  */
-function print_user( $p_user_id ) {
-	echo prepare_user_name( $p_user_id );
+function print_user( $p_user_id, $p_link = true ) {
+	echo prepare_user_name( $p_user_id, $p_link );
 }
 
 /**

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1651,48 +1651,24 @@ function print_email_link( $p_email, $p_text ) {
  * @param string  $p_text   Link text to display to user.
  * @param string  $p_tooltip The tooltip to show.
  * @param string  $p_bug_id The bug identifier.
- * @param boolean $p_show_as_text By default, show link as button with envelope icon.
+ * @param boolean $p_show_as_button If true, show link as button with envelope
+ *                                  icon, otherwise display a plain-text link.
  * @return void
  */
-function print_email_link_with_subject( $p_email, $p_text, $p_tooltip, $p_bug_id, $p_show_as_text = false )
+function print_email_link_with_subject( $p_email, $p_text, $p_tooltip, $p_bug_id, $p_show_as_button = true )
 {
-	if( !is_blank( $p_tooltip ) && $p_tooltip != $p_text ) {
-		$t_tooltip = ' title="' . $p_tooltip . '"';
-	} else {
-		$t_tooltip = '';
-	}
-
+	global $g_project_override;
 	$t_bug = bug_get( $p_bug_id, true );
-	$t_show_user_email_threshold = config_get( 'show_user_email_threshold', null, null, $t_bug->project_id );
-	if( !access_has_project_level( $t_show_user_email_threshold, $t_bug->project_id ) ) {
-		if( $p_show_as_text && $p_text ) {
-			echo $t_tooltip ? '<a' . $t_tooltip . '>' . $p_text . '</a>' : $p_text;
-		}
-		return;
-	}
 
-	# If we apply string_url() to the whole mailto: link then the @
-	# gets turned into a %40 and you can't right click in browsers to
-	# do Copy Email Address.  If we don't apply string_url() to the
-	# subject text then an ampersand (for example) will truncate the text
-	$t_subject = string_url( email_build_subject( $p_bug_id ) );
-	$t_email = string_url( $p_email );
-	$t_mailto = string_attribute( 'mailto:' . $t_email . '?subject=' . $t_subject );
-	$t_text = string_display( $p_text );
+	$g_project_override = $t_bug->project_id;
 
-	if( $p_show_as_text ) {
-		$t_class = '';
-	} else {
-		$t_class = ' class="btn btn-primary btn-white btn-round btn-xs"';
-		$t_text = '<i class="fa fa-envelope-o"></i>' . ( $t_text ? "&nbsp;$t_text" : '' );
-	}
-
-	printf( '<a href="%s"%s%s>%s</a>',
-		$t_mailto,
-		$t_tooltip,
-		$t_class,
-		$t_text
-	);
+	echo prepare_email_link(
+			$p_email,
+			$p_text,
+			email_build_subject( $p_bug_id ),
+			$p_tooltip,
+			$p_show_as_button
+		);
 }
 
 /**

--- a/manage_plugin_page.php
+++ b/manage_plugin_page.php
@@ -141,7 +141,8 @@ foreach ( $t_plugins_installed as $t_basename => $t_plugin ) {
 		}
 		if( !is_blank( $t_contact ) ) {
 			$t_author = '<br />' . sprintf( lang_get( 'plugin_author' ),
-				'<a href="mailto:' . string_attribute( $t_contact ) . '">' . string_display_line( $t_author ) . '</a>' );
+					prepare_email_link( $t_contact, $t_author )
+				);
 		} else {
 			$t_author = '<br />' . string_display_line( sprintf( lang_get( 'plugin_author' ), $t_author ) );
 		}
@@ -273,7 +274,8 @@ if( 0 < count( $t_plugins_available ) ) {
 			}
 			if( !is_blank( $t_contact ) ) {
 				$t_author = '<br />' . sprintf( lang_get( 'plugin_author' ),
-					'<a href="mailto:' . string_display_line( $t_contact ) . '">' . string_display_line( $t_author ) . '</a>' );
+						prepare_email_link( $t_contact, $t_author )
+					);
 			} else {
 				$t_author = '<br />' . string_display_line( sprintf( lang_get( 'plugin_author' ), $t_author ) );
 			}

--- a/print_all_bug_page_word.php
+++ b/print_all_bug_page_word.php
@@ -241,7 +241,7 @@ for( $j=0; $j < $t_row_count; $j++ ) {
 		<?php echo sprintf( lang_get( 'label' ), $t_lang_reporter ) ?>
 	</td>
 	<td>
-		<?php print_user_with_subject( $t_bug->reporter_id, $t_id ) ?>
+		<?php print_user( $t_bug->reporter_id, false ) ?>
 	</td>
 	<td class="bold">
 		<?php echo sprintf( lang_get( 'label' ), $t_lang_platform ) ?>
@@ -277,7 +277,7 @@ for( $j=0; $j < $t_row_count; $j++ ) {
 	<td>
 		<?php
 			if( access_has_bug_level( config_get( 'view_handler_threshold' ), $t_id ) ) {
-				print_user_with_subject( $t_bug->handler_id, $t_id );
+				print_user( $t_bug->handler_id, false );
 			}
 		?>
 	</td>
@@ -536,7 +536,7 @@ $t_bugnotes = bugnote_get_all_visible_bugnotes( $t_id, $t_user_bugnote_order, $t
 	<td width="12%">
 				(<?php echo bugnote_format_id( $t_bugnote->id ) ?>)
 			<br />
-				<?php print_user( $t_bugnote->reporter_id ) ?>&#160;&#160;&#160;
+				<?php print_user( $t_bugnote->reporter_id, false ) ?>&#160;&#160;&#160;
 			<br />
 				<?php echo $t_date_submitted ?>&#160;&#160;&#160;
 				<?php if( $t_bugnote->date_submitted != $t_bugnote->last_modified ) {

--- a/tests/Mantis/AllTests.php
+++ b/tests/Mantis/AllTests.php
@@ -31,6 +31,7 @@ require_once dirname( dirname( __FILE__ ) ) . '/TestConfig.php';
 require_once 'EnumTest.php';
 require_once 'HelperTest.php';
 require_once 'PluginTest.php';
+require_once 'PrepareTest.php';
 require_once 'MentionParsingTest.php';
 require_once 'StringTest.php';
 require_once 'ConfigParserTest.php';
@@ -51,6 +52,7 @@ class MantisAllTests extends PHPUnit_Framework_TestSuite {
 		$t_suite->addTestSuite( 'MantisEnumTest' );
 		$t_suite->addTestSuite( 'MantisHelperTest' );
 		$t_suite->addTestSuite( 'MantisPluginTest' );
+		$t_suite->addTestSuite( 'MantisPrepareTest' );
 		$t_suite->addTestSuite( 'MantisStringTest' );
 		$t_suite->addTestSuite( 'MentionParsingTest' );
 		$t_suite->addTestSuite( 'MantisConfigParserTest' );

--- a/tests/Mantis/ConfigParserTest.php
+++ b/tests/Mantis/ConfigParserTest.php
@@ -26,10 +26,7 @@
 /**
  * Includes
  */
-require_once dirname( dirname( __FILE__ ) ) . '/TestConfig.php';
-
-# Mantis Core required for class autoloader and constants
-require_mantis_core();
+require_once 'MantisCoreBase.php';
 
 use PHPUnit_Framework_Constraint_IsType as PHPUnit_Type;
 
@@ -44,7 +41,7 @@ use PHPUnit_Framework_Constraint_IsType as PHPUnit_Type;
  * @package    Tests
  * @subpackage ConfigParser
  */
-class MantisConfigParserTest extends PHPUnit_Framework_TestCase {
+class MantisConfigParserTest extends MantisCoreBase {
 
 	/**
 	 * Test with empty string or null

--- a/tests/Mantis/EnumTest.php
+++ b/tests/Mantis/EnumTest.php
@@ -26,8 +26,7 @@
 /**
  * Includes
  */
-require_once dirname( dirname( __FILE__ ) ) . '/TestConfig.php';
-
+require_once 'MantisCoreBase.php';
 require_once 'MantisEnum.class.php';
 
 /**
@@ -35,7 +34,8 @@ require_once 'MantisEnum.class.php';
  * @package    Tests
  * @subpackage Enum
  */
-class MantisEnumTest extends PHPUnit_Framework_TestCase {
+class MantisEnumTest extends MantisCoreBase {
+
 	const ACCESS_LEVELS_ENUM = '10:viewer,25:reporter,40:updater,55:developer,70:manager,90:administrator';
 	const ACCESS_LEVELS_ENUM_EXTRA = '10:viewer,25:reporter,40:updater,55:developer,70:manager,90:administrator,100:missing';
 	const ACCESS_LEVELS_LOCALIZED_ENUM = '10:viewer_x,25:reporter_x,40:updater_x,55:developer_x,70:manager_x,90:administrator_x,95:extra_x';

--- a/tests/Mantis/HelperTest.php
+++ b/tests/Mantis/HelperTest.php
@@ -24,17 +24,14 @@
  */
 
 # Includes
-require_once dirname( dirname( __FILE__ ) ) . '/TestConfig.php';
-
-# MantisBT Core API
-require_mantis_core();
+require_once 'MantisCoreBase.php';
 
 /**
  * Helper API tests
  * @package Tests
  * @subpackage String
  */
-class MantisHelperTest extends PHPUnit_Framework_TestCase {
+class MantisHelperTest extends MantisCoreBase {
 
 	/**
 	 * Custom assertion to evaluate whether the given exception was a

--- a/tests/Mantis/MantisCoreBase.php
+++ b/tests/Mantis/MantisCoreBase.php
@@ -1,0 +1,108 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * MantisBT Prepare API test cases
+ *
+ * @package    Tests
+ * @subpackage MantisCoreTests
+ * @copyright Copyright 2019  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ */
+
+# Includes
+require_once dirname( dirname( __FILE__ ) ) . '/TestConfig.php';
+
+# MantisBT Core API
+require_mantis_core();
+
+abstract class MantisCoreBase extends PHPUnit_Framework_TestCase {
+
+	/**
+	 * @var string Username
+	 */
+	protected static $userName = 'administrator';
+
+	/**
+	 * @var string Password
+	 */
+	protected static $password = 'root';
+
+	/**
+	 * MantisCore tests setup
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		if( array_key_exists( 'MANTIS_TESTSUITE_USERNAME', $GLOBALS ) ) {
+			self::$userName = $GLOBALS['MANTIS_TESTSUITE_USERNAME'];
+		}
+
+		if( array_key_exists( 'MANTIS_TESTSUITE_PASSWORD', $GLOBALS ) ) {
+			self::$password = $GLOBALS['MANTIS_TESTSUITE_PASSWORD'];
+		}
+	}
+
+	/**
+	 * Login as defined test suite user, with fall-back to anonymous user.
+	 *
+	 * Some tests require a logged-in user to function properly.
+	 *
+	 * @param boolean $p_anonymous true to login anonymously,
+	 *                             false (default) to login as test suite user
+	 */
+	public static function login( $p_anonymous = false ) {
+		$t_msg = '';
+		if( !$p_anonymous ) {
+			$t_logged_in = auth_attempt_script_login( self::$userName, self::$password );
+			$t_user = sprintf( "'%s' or ", self::$userName );
+		} else {
+			$t_user = '';
+			$t_logged_in = false;
+		}
+		if( !$t_logged_in ) {
+			# Login failed, try again as anonymous user
+			$t_logged_in = auth_attempt_script_login( null );
+			$t_msg = sprintf(
+				'Login as %s failed - must be logged in to perform test',
+				$t_user . 'Anonymous User'
+			);
+		}
+		self::assertTrue( $t_logged_in, $t_msg );
+	}
+
+	/**
+	 * Utility function to establish DB connection.
+	 *
+	 * PHPUnit seems to kill the connection after each test case execution;
+	 * this allows individual test cases that need the DB to reopen it easily.
+	 */
+	public static function dbConnect() {
+		global $g_hostname, $g_db_username, $g_db_password, $g_database_name,
+			   $g_use_persistent_connections;
+
+		db_connect(
+			config_get_global( 'dsn', false ),
+			$g_hostname,
+			$g_db_username,
+			$g_db_password,
+			$g_database_name,
+			$g_use_persistent_connections == ON
+		);
+	}
+
+}
+

--- a/tests/Mantis/MentionParsingTest.php
+++ b/tests/Mantis/MentionParsingTest.php
@@ -26,10 +26,7 @@
 /**
  * Includes
  */
-require_once dirname( dirname( __FILE__ ) ) . '/TestConfig.php';
-
-require_mantis_core();
-
+require_once 'MantisCoreBase.php';
 require_api( 'mention_api.php' );
 
 /**
@@ -37,7 +34,7 @@ require_api( 'mention_api.php' );
  * @package    Tests
  * @subpackage Mention
  */
-class MentionParsingTest extends PHPUnit_Framework_TestCase {
+class MentionParsingTest extends MantisCoreBase {
 
 	/**
 	 * Tests user mentions

--- a/tests/Mantis/PluginTest.php
+++ b/tests/Mantis/PluginTest.php
@@ -24,17 +24,14 @@
  */
 
 # Includes
-require_once dirname( dirname( __FILE__ ) ) . '/TestConfig.php';
-
-# MantisBT Core API
-require_mantis_core();
+require_once 'MantisCoreBase.php';
 
 /**
  * Helper API tests
  * @package Tests
  * @subpackage String
  */
-class MantisPluginTest extends PHPUnit_Framework_TestCase {
+class MantisPluginTest extends MantisCoreBase {
 
 	const MANTISCORE = 'MantisCore';
 

--- a/tests/Mantis/PrepareTest.php
+++ b/tests/Mantis/PrepareTest.php
@@ -24,15 +24,12 @@
  */
 
 # Includes
-require_once dirname( dirname( __FILE__ ) ) . '/TestConfig.php';
-
-# MantisBT Core API
-require_mantis_core();
+require_once 'MantisCoreBase.php';
 
 /**
  * MantisBT Prepare API test cases
  */
-class MantisPrepareTest extends PHPUnit_Framework_TestCase {
+class MantisPrepareTest extends MantisCoreBase {
 	const EMAIL = 'test@example.com';
 
 	/**

--- a/tests/Mantis/PrepareTest.php
+++ b/tests/Mantis/PrepareTest.php
@@ -60,4 +60,104 @@ class MantisPrepareTest extends MantisCoreBase {
 		return $t_test_data;
 	}
 
+	/**
+	 * Tests prepare_email_link()
+	 *
+	 * @dataProvider providerEmailLink
+	 * @param array $p_in  Input.
+	 * @param string $p_out Expected output.
+	 * @return void
+	 */
+	public function testEmailLink( $p_param, $p_access_level, $p_out ) {
+		# Make sure we have a DB connection
+		$this->dbConnect();
+
+		# Set threshold
+		$t_config = 'show_user_email_threshold';
+		config_set_cache( $t_config, $p_access_level, CONFIG_TYPE_INT );
+
+		$t_result = call_user_func_array( 'prepare_email_link', $p_param );
+		$this->assertEquals( $p_out, $t_result );
+	}
+
+	/**
+	 * Data provider for prepare_email_link() test.
+	 * No need to test 'subject' param, logic is already covered by testMailTo.
+	 * @see testEmailLink
+	 * @return array
+	 */
+	public function providerEmailLink() {
+		$t_email = self::EMAIL;
+		$t_text = 'Link Text';
+		$t_tooltip = 'Tooltip';
+		$t_button_classes = 'class="btn btn-primary btn-white btn-round btn-xs"';
+		$t_button_text = sprintf( '<i class="fa fa-envelope-o"></i>&nbsp;%s', $t_text );
+
+		$t_test_data = array(
+			'Basic' => array(
+				array( $t_email, $t_text, '', '', false ),
+				ANYBODY,
+				"<a href=\"mailto:$t_email\">$t_text</a>"
+			),
+			'Basic, cannot see e-mails' => array(
+				array( $t_email, $t_text, '', '', false ),
+				NOBODY,
+				$t_text
+			),
+			'With tooltip' => array(
+				array( $t_email, $t_text, '', $t_tooltip, false ),
+				ANYBODY,
+				"<a href=\"mailto:$t_email\" title=\"$t_tooltip\">$t_text</a>"
+			),
+			'With tooltip, cannot see e-mails' => array(
+				array( $t_email, $t_text, '', $t_tooltip, false ),
+				NOBODY,
+				"<a title=\"$t_tooltip\">$t_text</a>"
+			),
+			'With tooltip identical to text' => array(
+				array( $t_email, $t_text, '', $t_text, false ),
+				ANYBODY,
+				"<a href=\"mailto:$t_email\">$t_text</a>"
+			),
+			'With tooltip identical to text, cannot see e-mails' => array(
+				array( $t_email, $t_text, '', $t_text, false ),
+				NOBODY,
+				$t_text
+			),
+
+			'Button' => array(
+				array( $t_email, $t_text, '', '', true ),
+				ANYBODY,
+				"<a href=\"mailto:$t_email\" $t_button_classes>$t_button_text</a>"
+			),
+			'Button, cannot see e-mails' => array(
+				array( $t_email, $t_text, '', '', true ),
+				NOBODY,
+				$t_text
+			),
+			'Button with tooltip' => array(
+				array( $t_email, $t_text, '', $t_tooltip, true ),
+				ANYBODY,
+				"<a href=\"mailto:$t_email\" title=\"$t_tooltip\" $t_button_classes>$t_button_text</a>"
+			),
+			'Button with tooltip, cannot see e-mails' => array(
+				array( $t_email, $t_text, '', $t_tooltip, true ),
+				NOBODY,
+				"<a title=\"$t_tooltip\">$t_text</a>"
+			),
+			'Button with tooltip identical to text' => array(
+				array( $t_email, $t_text, '', $t_text, true ),
+				ANYBODY,
+				"<a href=\"mailto:$t_email\" $t_button_classes>$t_button_text</a>"
+			),
+			'Button with tooltip identical to text, cannot see e-mails' => array(
+				array( $t_email, $t_text, '', $t_text, true ),
+				NOBODY,
+				$t_text
+			),
+		);
+
+		return $t_test_data;
+	}
+
 }

--- a/tests/Mantis/PrepareTest.php
+++ b/tests/Mantis/PrepareTest.php
@@ -69,8 +69,9 @@ class MantisPrepareTest extends MantisCoreBase {
 	 * @return void
 	 */
 	public function testEmailLink( $p_param, $p_access_level, $p_out ) {
-		# Make sure we have a DB connection
+		# Make sure we have a DB connection and a logged-in user
 		$this->dbConnect();
+		$this->login();
 
 		# Set threshold
 		$t_config = 'show_user_email_threshold';

--- a/tests/Mantis/PrepareTest.php
+++ b/tests/Mantis/PrepareTest.php
@@ -1,0 +1,66 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * MantisBT Prepare API test cases
+ *
+ * @package    Tests
+ * @subpackage Prepare
+ * @copyright Copyright 2019  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ */
+
+# Includes
+require_once dirname( dirname( __FILE__ ) ) . '/TestConfig.php';
+
+# MantisBT Core API
+require_mantis_core();
+
+/**
+ * MantisBT Prepare API test cases
+ */
+class MantisPrepareTest extends PHPUnit_Framework_TestCase {
+	const EMAIL = 'test@example.com';
+
+	/**
+	 * Tests prepare_mailto_url()
+	 *
+	 * @dataProvider providerMailTo
+	 * @param array $p_in  Input.
+	 * @param string $p_out Expected output.
+	 * @return void
+	 */
+	public function testMailTo( $p_in, $p_out ) {
+		$t_result = call_user_func_array( 'prepare_mailto_url', $p_in );
+		$this->assertEquals( $p_out, $t_result );
+	}
+
+	/**
+	 * Data provider for prepare_mailto_url() test
+	 * @return array
+	 */
+	public function providerMailTo() {
+		$t_test_data = array(
+			'Basic' => array( array( self::EMAIL, ''), 'mailto:' . self::EMAIL ),
+			'Subject' => array( array( self::EMAIL, 'subject'), 'mailto:' . self::EMAIL . '?subject=subject' ),
+			'SubjectWithSpace' => array( array( self::EMAIL, 'message subject'), 'mailto:' . self::EMAIL . '?subject=message%20subject' ),
+			'SubjectWithQuestionAmp' => array( array( self::EMAIL, 'message?subject&matter'), 'mailto:' . self::EMAIL . '?subject=message%3Fsubject%26matter' ),
+		);
+
+		return $t_test_data;
+	}
+
+}

--- a/tests/Mantis/StringTest.php
+++ b/tests/Mantis/StringTest.php
@@ -24,10 +24,7 @@
  */
 
 # Includes
-require_once dirname( dirname( __FILE__ ) ) . '/TestConfig.php';
-
-# MantisBT Core API
-require_mantis_core();
+require_once 'MantisCoreBase.php';
 
 /**
  * Mantis string handling test cases
@@ -36,7 +33,7 @@ require_mantis_core();
  * @copyright Copyright 2002  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  */
-class MantisStringTest extends PHPUnit_Framework_TestCase {
+class MantisStringTest extends MantisCoreBase {
 
 	/**
 	 * Tests string_sanitize_url()

--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -29,8 +29,6 @@ ob_start();
 # Include PHPUnit dependencies ; ensure compatibility with 3.5 and 3.6
 @include_once 'PHPUnit/Framework.php';
 
-define( 'MANTIS_MAINTENANCE_MODE', true );
-
 /**
  * Parse file and retrieve distinct T_VARIABLE tokens with 'g_' prefix
  *


### PR DESCRIPTION
This fixes [#25686](https://mantisbt.org/bugs/view.php?id=25686), and replaces PR #1501, improving on @brlumen's initial submission with some refactoring of the APIs used to print the mailto: link. I also added PHPUnit tests for the new functions.

The branch includes code cleanup and minor fixes 
- [#25851](https://mantisbt.org/bugs/view.php?id=25851) Remove hyperlinks on usernames in Word export
- [#25848](https://mantisbt.org/bugs/view.php?id=25848) Remove get_email_link() API function
- [#25849](https://mantisbt.org/bugs/view.php?id=25849) New prepare_mailto_url() API function
