### PR TITLE
Don't cache status_config.php when it's not populated

### DIFF
--- a/core/http_api.php
+++ b/core/http_api.php
@@ -99,27 +99,38 @@ function http_content_disposition_header( $p_filename, $p_inline = false ) {
 
 /**
  * Set caching headers that will allow or prevent browser caching.
- * @param boolean $p_allow_caching Allow caching.
+ * Use an explicit true/false value for the parameter to force the caching behavior.
+ * Otherwise, use null or omit the oparameter to use default behavior.
+ * The default behavior is to not cache, or the specified in the option $g_allow_browser_cache
+ * @param null|boolean $p_allow_caching Force or not caching. Omitting or null, will use default behavior.
  * @return void
  */
-function http_caching_headers( $p_allow_caching = false ) {
+function http_caching_headers( $p_allow_caching = null ) {
 	global $g_allow_browser_cache;
 
-	# Headers to prevent caching
-	# with option to bypass if running from script
-	if( !headers_sent() ) {
-		if( $p_allow_caching || ( isset( $g_allow_browser_cache ) && ON == $g_allow_browser_cache ) ) {
+	if( headers_sent() ) {
+		return;
+	}
+
+	if( $p_allow_caching === null ) {
+		$t_allow_caching = ( isset( $g_allow_browser_cache ) && ON == $g_allow_browser_cache );
+	} else {
+		$t_allow_caching = $p_allow_caching;
+	}
+
+	if( $t_allow_caching ) {
 			if( is_browser_internet_explorer() ) {
 				header( 'Cache-Control: private, proxy-revalidate' );
 			} else {
 				header( 'Cache-Control: private, must-revalidate' );
 			}
-		} else {
-			header( 'Cache-Control: no-store, no-cache, must-revalidate' );
-		}
-
+			# set an expire time to +10 days
+			header( 'Expires: ' . gmdate( 'D, d M Y H:i:s \G\M\T', time()+864000 ) );
+	} else {
+		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
 		header( 'Expires: ' . gmdate( 'D, d M Y H:i:s \G\M\T', time() ) );
 		header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s \G\M\T', time() ) );
+
 	}
 }
 

--- a/css/status_config.php
+++ b/css/status_config.php
@@ -75,6 +75,7 @@ $t_referer_page = array_key_exists( 'HTTP_REFERER', $_SERVER )
 
 if( $t_referer_page == auth_login_page() ) {
 	# custom status colors not needed.
+	http_caching_headers( false );
 	exit;
 }
 
@@ -86,6 +87,7 @@ switch( $t_referer_page ) {
 	case 'account_update.php':
 		# We don't need custom status colors on login page, and this is
 		# actually causing an error since we're not authenticated yet.
+		http_caching_headers( false );
 		exit;
 }
 

--- a/css/status_config.php
+++ b/css/status_config.php
@@ -28,19 +28,8 @@
 # Prevent output of HTML in the content if errors occur
 define( 'DISABLE_INLINE_ERROR_REPORTING', true );
 
-$t_allow_caching = isset( $_GET['cache_key'] );
-if( $t_allow_caching ) {
-	# Suppress default headers. This allows caching as defined in server configuration
-	$g_bypass_headers = true;
-}
-
 @require_once( dirname( dirname( __FILE__ ) ) . '/core.php' );
 require_api( 'config_api.php' );
-
-if( $t_allow_caching ) {
-	# if standard headers were bypassed, add security headers, at least
-	http_security_headers();
-}
 
 /**
  * Send correct MIME Content-Type header for css content.
@@ -89,6 +78,11 @@ switch( $t_referer_page ) {
 		# actually causing an error since we're not authenticated yet.
 		http_caching_headers( false );
 		exit;
+}
+
+# rewrite headers to allow caching
+if( gpc_isset( 'cache_key' ) ) {
+	http_caching_headers( true );
 }
 
 $t_status_string = config_get( 'status_enum_string' );

--- a/javascript_config.php
+++ b/javascript_config.php
@@ -27,19 +27,8 @@
 # Prevent output of HTML in the content if errors occur
 define( 'DISABLE_INLINE_ERROR_REPORTING', true );
 
-$t_allow_caching = isset( $_GET['cache_key'] );
-if( $t_allow_caching ) {
-	# Suppress default headers. This allows caching as defined in server configuration
-	$g_bypass_headers = true;
-}
-
 require_once( 'core.php' );
 require_api( 'config_api.php' );
-
-if( $t_allow_caching ) {
-	# if standard headers were bypassed, add security headers, at least
-	http_security_headers();
-}
 
 /**
  * Print array of configuration option->values for javascript.
@@ -59,6 +48,10 @@ header( 'Content-Type: application/javascript; charset=UTF-8' );
 # http://blogs.msdn.com/b/ie/archive/2008/07/02/ie8-security-part-v-comprehensive-protection.aspx
 header( 'X-Content-Type-Options: nosniff' );
 
+# rewrite headers to allow caching
+if( gpc_isset( 'cache_key' ) ) {
+	http_caching_headers( true );
+}
 
 # WARNING: DO NOT EXPOSE SENSITIVE CONFIGURATION VALUES!
 #

--- a/javascript_translations.php
+++ b/javascript_translations.php
@@ -28,19 +28,8 @@
 # Prevent output of HTML in the content if errors occur
 define( 'DISABLE_INLINE_ERROR_REPORTING', true );
 
-$t_allow_caching = isset( $_GET['cache_key'] );
-if( $t_allow_caching ) {
-	# Suppress default headers. This allows caching as defined in server configuration
-	$g_bypass_headers = true;
-}
-
 require_once( 'core.php' );
 require_api( 'lang_api.php' );
-
-if( $t_allow_caching ) {
-	# if standard headers were bypassed, add security headers, at least
-	http_security_headers();
-}
 
 /**
  * Print Language translation for javascript
@@ -59,6 +48,11 @@ header( 'Content-Type: application/javascript; charset=UTF-8' );
 # Don't let Internet Explorer second-guess our content-type, as per
 # http://blogs.msdn.com/b/ie/archive/2008/07/02/ie8-security-part-v-comprehensive-protection.aspx
 header( 'X-Content-Type-Options: nosniff' );
+
+# rewrite headers to allow caching
+if( gpc_isset( 'cache_key' ) ) {
+	http_caching_headers( true );
+}
 
 echo "var translations = new Array();\n";
 print_translation( 'time_tracking_stopwatch_start' );

--- a/plugin.php
+++ b/plugin.php
@@ -27,21 +27,11 @@
  * @uses plugin_api.php
  */
 
-$t_allow_caching = isset( $_GET['cache_key'] );
-if( $t_allow_caching ) {
-	# Suppress default headers. This allows caching as defined in server configuration
-	$g_bypass_headers = true;
-}
-
 require_once( 'core.php' );
 require_api( 'config_api.php' );
 require_api( 'constant_inc.php' );
 require_api( 'gpc_api.php' );
 require_api( 'plugin_api.php' );
-
-if( $t_allow_caching ) {
-	http_security_headers();
-}
 
 $t_plugin_path = config_get_global( 'plugin_path' );
 
@@ -73,6 +63,11 @@ $t_page = $t_plugin_path . $t_basename . '/pages/' . $t_action . '.php';
 if( !is_file( $t_page ) ) {
 	error_parameters( $t_basename, $t_action );
 	trigger_error( ERROR_PLUGIN_PAGE_NOT_FOUND, ERROR );
+}
+
+# rewrite headers to allow caching
+if( gpc_isset( 'cache_key' ) ) {
+	http_caching_headers( true );
 }
 
 plugin_push_current( $t_basename );


### PR DESCRIPTION
When the dynamic css file `status_config.php` can't be generated, force a no-caching header to avoid the client caching a wrong version of this file.

Fixes: #24189