### PR TITLE
Link attachments to notes in database

### DIFF
--- a/admin/schema.php
+++ b/admin/schema.php
@@ -884,6 +884,10 @@ $g_upgrade[209] = array( 'AlterColumnSQL', array( db_get_table( 'api_token' ), "
 
 # Release marker: 1.3.0
 
+$g_upgrade[210] = array( 'AddColumnSQL', array( db_get_table( 'bug_file' ), "
+	bugnote_id			I		UNSIGNED NOTNULL DEFAULT '0' " ) );
+
+# Release marker: 2.23.0
 
 # ----------------------------------------------------------------------------
 # End of schema definition, clear local variables

--- a/admin/schema.php
+++ b/admin/schema.php
@@ -884,8 +884,11 @@ $g_upgrade[209] = array( 'AlterColumnSQL', array( db_get_table( 'api_token' ), "
 
 # Release marker: 1.3.0
 
+# 0 - file was added pre-2.23.0 and not explicitly linked to an issue or a note.
+# null - file was added by 2.23.0 release or newer and associated with the issue.
+# otherwise - file was added or linked by 2.23.0 release or newer and associated with an issue note.
 $g_upgrade[210] = array( 'AddColumnSQL', array( db_get_table( 'bug_file' ), "
-	bugnote_id			I		UNSIGNED NOTNULL DEFAULT '0' " ) );
+	bugnote_id			I		UNSIGNED DEFAULT '0' " ) );
 
 # Release marker: 2.23.0
 

--- a/bugnote_add.php
+++ b/bugnote_add.php
@@ -44,38 +44,24 @@ $f_files = gpc_get_file( 'ufile', array() );
 
 $t_query = array( 'issue_id' => $f_bug_id );
 
-if( count( $f_files ) > 0 && is_blank( $f_text ) && helper_duration_to_minutes( $f_duration ) == 0 ) {
-	$t_payload = array(
-		'files' => helper_array_transpose( $f_files )
-	);
+$t_payload = array(
+	'text' => $f_text,
+	'view_state' => array(
+		'id' => gpc_get_bool( 'private' ) ? VS_PRIVATE : VS_PUBLIC
+	),
+	'time_tracking' => array(
+		'duration' => $f_duration
+	),
+	'files' => helper_array_transpose( $f_files )
+);
 
-	$t_data = array(
-		'query' => $t_query,
-		'payload' => $t_payload,
-	);
+$t_data = array(
+	'query' => $t_query,
+	'payload' => $t_payload,
+);
 
-	$t_command = new IssueFileAddCommand( $t_data );
-	$t_command->execute();
-} else {
-	$t_payload = array(
-		'text' => $f_text,
-		'view_state' => array(
-			'id' => gpc_get_bool( 'private' ) ? VS_PRIVATE : VS_PUBLIC
-		),
-		'time_tracking' => array(
-			'duration' => $f_duration
-		),
-		'files' => helper_array_transpose( $f_files )
-	);
-
-	$t_data = array(
-		'query' => $t_query,
-		'payload' => $t_payload,
-	);
-
-	$t_command = new IssueNoteAddCommand( $t_data );
-	$t_command->execute();
-}
+$t_command = new IssueNoteAddCommand( $t_data );
+$t_command->execute();
 
 form_security_purge( 'bugnote_add' );
 

--- a/bugnote_set_view_state.php
+++ b/bugnote_set_view_state.php
@@ -26,6 +26,7 @@
  * @uses access_api.php
  * @uses authentication_api.php
  * @uses bug_api.php
+ * @uses bug_activity_api.php
  * @uses bugnote_api.php
  * @uses config_api.php
  * @uses constant_inc.php
@@ -39,6 +40,7 @@
 
 require_once( 'core.php' );
 require_api( 'access_api.php' );
+require_api( 'bug_activity_api.php' );
 require_api( 'authentication_api.php' );
 require_api( 'bug_api.php' );
 require_api( 'bugnote_api.php' );
@@ -80,6 +82,7 @@ if( $t_user_id == auth_get_current_user_id() ) {
 	access_ensure_bugnote_level( config_get( 'change_view_status_threshold' ), $f_bugnote_id );
 }
 
+bug_activity_bugnote_link_attachments( $f_bugnote_id );
 bugnote_set_view_state( $f_bugnote_id, $f_private );
 
 form_security_purge( 'bugnote_set_view_state' );

--- a/bugnote_view_inc.php
+++ b/bugnote_view_inc.php
@@ -269,6 +269,8 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 	<td class="<?php echo $t_activity['style'] ?>">
 	<?php
 		if( $t_activity['type'] == ENTRY_TYPE_NOTE ) {
+			$t_add_space = false;
+
 			switch ( $t_activity['note']->note_type ) {
 				case REMINDER:
 					echo '<strong>';
@@ -294,19 +296,24 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 					}
 
 					echo '</strong><br /><br />';
+					$t_add_space = true;
 					break;
 
 				case TIME_TRACKING:
 					if( $t_show_time_tracking ) {
 						echo '<div class="time-tracked label label-grey label-sm">', lang_get( 'time_tracking_time_spent' ) . ' ' . $t_time_tracking_hhmm, '</div>';
 						echo '<div class="clearfix"></div>';
+						$t_add_space = true;
 					}
 					break;
 			}
 
-			echo string_display_links( $t_activity['note']->note );
+			if( !is_blank( $t_activity['note']->note ) ) {
+				echo string_display_links( $t_activity['note']->note );
+				$t_add_space = true;
+			}
 
-			if( isset( $t_activity['attachments'] ) && count( $t_activity['attachments'] ) > 0 ) {
+			if( $t_add_space && isset( $t_activity['attachments'] ) && count( $t_activity['attachments'] ) > 0 ) {
 				echo '<br /><br />';
 			}
 		} else {

--- a/core/bug_activity_api.php
+++ b/core/bug_activity_api.php
@@ -269,3 +269,22 @@ function bug_activity_combine( $p_entries ) {
 	return $t_combined_entries;
 }
 
+/**
+ * Link attachments that are part of the bugnote activity.
+ * This converts heuristic links into explicit ones.
+ *
+ * @param integer $p_bugnote_id The bugnote id.
+ * @return void
+ */
+function bug_activity_bugnote_link_attachments( $p_bugnote_id ) {
+	$t_bug_id = bugnote_get_field( $p_bugnote_id, 'bug_id' );
+	$t_activities = bug_activity_get_all( $t_bug_id, /* include_attachments */ true );
+	foreach( $t_activities['activities'] as $t_activity ) {
+		if( (int)$t_activity['id'] == (int)$p_bugnote_id && count( $t_activity['attachments'] ) > 0 ) {
+			foreach( $t_activity['attachments'] as $t_attachment ) {
+				file_link_to_bugnote( $t_attachment['id'], $p_bugnote_id );
+			}
+		}
+	}
+}
+

--- a/core/bug_activity_api.php
+++ b/core/bug_activity_api.php
@@ -279,12 +279,21 @@ function bug_activity_combine( $p_entries ) {
 function bug_activity_bugnote_link_attachments( $p_bugnote_id ) {
 	$t_bug_id = bugnote_get_field( $p_bugnote_id, 'bug_id' );
 	$t_activities = bug_activity_get_all( $t_bug_id, /* include_attachments */ true );
+
+	$t_files = array();
 	foreach( $t_activities['activities'] as $t_activity ) {
-		if( (int)$t_activity['id'] == (int)$p_bugnote_id && count( $t_activity['attachments'] ) > 0 ) {
+		if( (int)$t_activity['id'] == (int)$p_bugnote_id ) {
 			foreach( $t_activity['attachments'] as $t_attachment ) {
-				file_link_to_bugnote( $t_attachment['id'], $p_bugnote_id );
+				file_link_to_bugnote( (int)$t_attachment['id'], $p_bugnote_id );
+				$t_files[] = $t_attachment;
 			}
 		}
+	}
+
+	# explicitly link the attached files history events to the bugnote to control
+	# there visibility based on the view state of the bugnote.
+	foreach( $t_files as $t_file ) {
+		history_link_file_to_bugnote( $t_bug_id, $t_file['display_name'], $p_bugnote_id );
 	}
 }
 

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1720,7 +1720,7 @@ function bug_get_bugnote_stats( $p_bug_id ) {
  */
 function bug_get_attachments( $p_bug_id ) {
 	db_param_push();
-	$t_query = 'SELECT id, title, diskfile, filename, filesize, file_type, date_added, user_id
+	$t_query = 'SELECT id, title, diskfile, filename, filesize, file_type, date_added, user_id, bugnote_id
 		                FROM {bug_file}
 		                WHERE bug_id=' . db_param() . '
 		                ORDER BY date_added';

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -253,10 +253,6 @@ function bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking = '0:00', $p_
 			}
 
 			$c_type = TIME_TRACKING;
-		} else if( is_blank( $p_bugnote_text ) ) {
-			# This is not time tracking (i.e. it's a normal bugnote)
-			# @todo should we not trigger an error in this case ?
-			return false;
 		}
 	}
 

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -312,7 +312,7 @@ function bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking = '0:00', $p_
 
 	# Event integration
 	if( $p_trigger_event ) {
-		event_signal( 'EVENT_BUGNOTE_ADD', array( $p_bug_id, $t_bugnote_id ) );
+		event_signal( 'EVENT_BUGNOTE_ADD', array( $p_bug_id, $t_bugnote_id, 'files' => array() ) );
 	}
 
 	# only send email if the text is not blank, otherwise, it is just recording of time without a comment.

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -34,6 +34,7 @@
  * @uses email_api.php
  * @uses error_api.php
  * @uses event_api.php
+ * @uses file_api.php
  * @uses helper_api.php
  * @uses history_api.php
  * @uses lang_api.php
@@ -53,6 +54,7 @@ require_api( 'database_api.php' );
 require_api( 'email_api.php' );
 require_api( 'error_api.php' );
 require_api( 'event_api.php' );
+require_api( 'file_api.php' );
 require_api( 'helper_api.php' );
 require_api( 'history_api.php' );
 require_api( 'lang_api.php' );
@@ -370,6 +372,9 @@ function bugnote_delete( $p_bugnote_id ) {
 
 	# log deletion of bug
 	history_log_event_special( $t_bug_id, BUGNOTE_DELETED, bugnote_format_id( $p_bugnote_id ) );
+
+	# Delete attachments linked to bugnote in the db (i.e. bugnote_id is set)
+	file_delete_bugnote_attachments( $t_bug_id, $p_bugnote_id );
 
 	# Event integration
 	event_signal( 'EVENT_BUGNOTE_DELETED', array( $t_bug_id, $p_bugnote_id ) );

--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -228,10 +228,11 @@ function bugnote_is_user_reporter( $p_bugnote_id, $p_user_id ) {
  * @param integer $p_last_modified   Last modification date (defaults to now()).
  * @param boolean $p_skip_bug_update Skip bug last modification update (useful when importing bugs/bugnotes).
  * @param boolean $p_log_history     Log changes to bugnote history (defaults to true).
+ * @param boolean $p_trigger_event   Trigger extensibility event.
  * @return boolean|integer false or indicating bugnote id added
  * @access public
  */
-function bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking = '0:00', $p_private = false, $p_type = BUGNOTE, $p_attr = '', $p_user_id = null, $p_send_email = true, $p_date_submitted = 0, $p_last_modified = 0, $p_skip_bug_update = false, $p_log_history = true ) {
+function bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking = '0:00', $p_private = false, $p_type = BUGNOTE, $p_attr = '', $p_user_id = null, $p_send_email = true, $p_date_submitted = 0, $p_last_modified = 0, $p_skip_bug_update = false, $p_log_history = true, $p_trigger_event = true ) {
 	$c_bug_id = (int)$p_bug_id;
 	$c_time_tracking = helper_duration_to_minutes( $p_time_tracking );
 	$c_type = (int)$p_type;
@@ -305,12 +306,14 @@ function bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking = '0:00', $p_
 	}
 
 	# log new bug
-	if( true == $p_log_history ) {
+	if( $p_log_history ) {
 		history_log_event_special( $p_bug_id, BUGNOTE_ADDED, bugnote_format_id( $t_bugnote_id ) );
 	}
 
 	# Event integration
-	event_signal( 'EVENT_BUGNOTE_ADD', array( $p_bug_id, $t_bugnote_id ) );
+	if( $p_trigger_event ) {
+		event_signal( 'EVENT_BUGNOTE_ADD', array( $p_bug_id, $t_bugnote_id ) );
+	}
 
 	# only send email if the text is not blank, otherwise, it is just recording of time without a comment.
 	if( true == $p_send_email && !is_blank( $t_bugnote_text ) ) {

--- a/core/commands/IssueAddCommand.php
+++ b/core/commands/IssueAddCommand.php
@@ -355,7 +355,7 @@ class IssueAddCommand extends Command {
 		}
 
 		# Handle the file upload
-		file_attach_files( $t_issue_id, $this->files );
+		file_attach_files( $t_issue_id, $this->files, /* bugnote_id */ null );
 
 		# Handle custom field submission
 		mci_issue_set_custom_fields( $t_issue_id, $t_issue['custom_fields'], /* history log insert */ false );

--- a/core/commands/IssueNoteAddCommand.php
+++ b/core/commands/IssueNoteAddCommand.php
@@ -278,7 +278,7 @@ class IssueNoteAddCommand extends Command {
 		email_bugnote_add( $t_note_id, $t_file_infos, /* user_exclude_ids */ $t_user_ids_that_got_mention_notifications );
 
 		# Event integration
-		event_signal( 'EVENT_BUGNOTE_ADD', array( $this->issue->id, $t_note_id ) );
+		event_signal( 'EVENT_BUGNOTE_ADD', array( $this->issue->id, $t_note_id, 'files' => $t_file_infos ) );
 
 		return array( 'id' => $t_note_id );
 	}

--- a/core/commands/IssueNoteAddCommand.php
+++ b/core/commands/IssueNoteAddCommand.php
@@ -242,9 +242,6 @@ class IssueNoteAddCommand extends Command {
 			$g_project_override = $this->issue->project_id;
 		}
 
-		# Handle the file upload
-		$t_file_infos = file_attach_files( $this->issue->id, $this->files );
-
 		# We always set the note time to BUGNOTE, and the API will overwrite it with TIME_TRACKING
 		# if time tracking is not 0 and the time tracking feature is enabled.
 		$t_note_id = bugnote_add(
@@ -256,9 +253,13 @@ class IssueNoteAddCommand extends Command {
 			/* attr */ '',
 			/* user_id */ $this->reporterId,
 			/* send_email */ false );
+
 		if( !$t_note_id ) {
 			throw new ClientException( "Unable to add note", ERROR_GENERIC );
 		}
+
+		# Handle the file upload
+		$t_file_infos = file_attach_files( $this->issue->id, $this->files, $t_note_id );
 
 		# Process the mentions in the added note
 		$t_user_ids_that_got_mention_notifications = bugnote_process_mentions( $this->issue->id, $t_note_id, $this->payload( 'text' ) );

--- a/core/commands/IssueNoteAddCommand.php
+++ b/core/commands/IssueNoteAddCommand.php
@@ -150,18 +150,6 @@ class IssueNoteAddCommand extends Command {
 
 		$t_files_included = !empty( $this->files );
 
-		if( $t_files_included ) {
-			# The UI hides the attach controls when the note is marked as private to avoid disclosure of
-			# attachments.  Attaching files to private notes can be re-enabled as proper support for protecting
-			# private attachments is implemented.
-			if( $this->private && count( $this->files ) > 0 ) {
-				throw new ClientException(
-					'Private notes with attachments not allowed',
-					ERROR_INVALID_FIELD_VALUE,
-					array( 'files' ) );
-			}
-		}
-
 		$t_time_tracking = $this->payload( 'time_tracking' );
 		if( is_array( $t_time_tracking ) && isset( $t_time_tracking['duration'] ) ) {
 			$this->time_tracking = $t_time_tracking['duration'];

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -471,6 +471,25 @@ function file_delete_attachments( $p_bug_id ) {
 }
 
 /**
+ * Delete all files that are associated with the given bug note.
+ * @param integer $p_bug_id A bug identifier.
+ * @param integer $p_bugnote_id A bugnote identifier.
+ * @return boolean
+ */
+function file_delete_bugnote_attachments( $p_bug_id, $p_bugnote_id ) {
+	db_param_push();
+	$t_query = 'SELECT id, diskfile, filename FROM {bug_file} WHERE bug_id=' . db_param() . ' AND bugnote_id=' . db_param();
+	$t_result = db_query( $t_query, array( $p_bug_id, $p_bugnote_id ) );
+
+	while( $t_row = db_fetch_array( $t_result ) ) {
+		file_delete( (int)$t_row['id'] );
+	}
+
+	# db_query() errors on failure so:
+	return true;
+}
+
+/**
  * Delete files by project
  * @param integer $p_project_id A project identifier.
  * @return void

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -60,9 +60,10 @@ $g_cache_file_count = array();
  *
  * @param int $p_bug_id    The bug id.
  * @param array $p_files   The array of files, if null, then do nothing.
+ * @param int $p_bugnote_id The bugnote id, or 0 if issue attachments.
  * @return array Array of file info arrays.
  */
-function file_attach_files( $p_bug_id, $p_files ) {
+function file_attach_files( $p_bug_id, $p_files, $p_bugnote_id = 0 ) {
 	if( $p_files === null || count( $p_files ) == 0 ) {
 		return array();
 	}
@@ -70,7 +71,17 @@ function file_attach_files( $p_bug_id, $p_files ) {
 	$t_file_infos = array();
 	foreach( $p_files as $t_file ) {
 		if( !empty( $t_file['name'] ) ) {
-			$t_file_infos[] = file_add( $p_bug_id, $t_file, 'bug' );
+			# $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p_desc = '', $p_user_id = null, $p_date_added = 0, $p_skip_bug_update = false, $p_bugnote_id = 0
+			$t_file_infos[] = file_add(
+				$p_bug_id,
+				$t_file,
+				'bug',
+				'', /* title */
+				'', /* desc */
+				0, /* user_id */
+				0, /* date_added */
+				0, /* skip_bug_update */
+				$p_bugnote_id );
 		}
 	}
 
@@ -687,9 +698,10 @@ function file_is_name_unique( $p_name, $p_bug_id, $p_table = 'bug' ) {
  * @param integer $p_user_id         User id (defaults to current user).
  * @param integer $p_date_added      Date added.
  * @param boolean $p_skip_bug_update Skip bug last modification update (useful when importing bug attachments).
+ * @param int     $p_bugnote_id      The bugnote id or 0 if associated with the issue.
  * @return array The file info array (keys: name, size)
  */
-function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p_desc = '', $p_user_id = null, $p_date_added = 0, $p_skip_bug_update = false ) {
+function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p_desc = '', $p_user_id = null, $p_date_added = 0, $p_skip_bug_update = false, $p_bugnote_id = 0 ) {
 	$t_file_info = array();
 
 	if( !isset( $p_file['error'] ) ) {
@@ -839,11 +851,14 @@ function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p
 		'file_type'   => $p_file['type'],
 		'date_added'  => $p_date_added,
 		'user_id'     => (int)$p_user_id,
+		'bugnote_id'  => (int)$p_bugnote_id
 	);
+
 	# Oracle has to update BLOBs separately
 	if( !db_is_oracle() ) {
 		$t_param['content'] = $c_content;
 	}
+
 	$t_query_param = db_param();
 	for( $i = 1; $i < count( $t_param ); $i++ ) {
 		$t_query_param .= ', ' . db_param();

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -905,6 +905,8 @@ function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p
 		( ' . $t_query_param . ' )';
 	db_query( $t_query, array_values( $t_param ) );
 
+	$t_file_info['id'] = db_insert_id( $t_file_table );
+
 	if( db_is_oracle() ) {
 		db_update_blob( $t_file_table, 'content', $c_content, "diskfile='$t_unique_name'" );
 	}

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -886,7 +886,7 @@ function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p
 		'file_type'   => $p_file['type'],
 		'date_added'  => $p_date_added,
 		'user_id'     => (int)$p_user_id,
-		'bugnote_id'  => (int)$p_bugnote_id
+		'bugnote_id'  => is_null( $p_bugnote_id ) ? null : (int)$p_bugnote_id
 	);
 
 	# Oracle has to update BLOBs separately

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -382,7 +382,7 @@ function file_get_visible_attachments( $p_bug_id ) {
 			continue;
 		}
 
-		$t_id = $t_row['id'];
+		$t_id = (int)$t_row['id'];
 		$t_filename = $t_row['filename'];
 		$t_filesize = $t_row['filesize'];
 		$t_diskfile = file_normalize_attachment_path( $t_row['diskfile'], bug_get_field( $p_bug_id, 'project_id' ) );
@@ -392,11 +392,11 @@ function file_get_visible_attachments( $p_bug_id ) {
 		$t_attachment['id'] = $t_id;
 		$t_attachment['user_id'] = $t_user_id;
 		$t_attachment['display_name'] = file_get_display_name( $t_filename );
-		$t_attachment['size'] = $t_filesize;
+		$t_attachment['size'] = (int)$t_filesize;
 		$t_attachment['date_added'] = $t_date_added;
 		$t_attachment['diskfile'] = $t_diskfile;
 		$t_attachment['file_type'] = $t_row['file_type'];
-		$t_attachment['bugnote_id'] = $t_row['bugnote_id'];
+		$t_attachment['bugnote_id'] = (int)$t_row['bugnote_id'];
 
 		$t_attachment['can_download'] = file_can_download_bug_attachments( $p_bug_id, (int)$t_row['user_id'] );
 		$t_attachment['can_delete'] = file_can_delete_bug_attachments( $p_bug_id, (int)$t_row['user_id'] );

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -482,7 +482,7 @@ function file_delete_bugnote_attachments( $p_bug_id, $p_bugnote_id ) {
 	$t_result = db_query( $t_query, array( $p_bug_id, $p_bugnote_id ) );
 
 	while( $t_row = db_fetch_array( $t_result ) ) {
-		file_delete( (int)$t_row['id'] );
+		file_delete( (int)$t_row['id'], 'bug', $p_bugnote_id );
 	}
 
 	# db_query() errors on failure so:
@@ -556,9 +556,10 @@ function file_get_field( $p_file_id, $p_field_name, $p_table = 'bug' ) {
  * Delete File
  * @param integer $p_file_id File identifier.
  * @param string  $p_table   Table identifier.
+ * @param integer $p_bugnote_id The bugnote id the file is attached to or 0 if attached to issue.
  * @return boolean
  */
-function file_delete( $p_file_id, $p_table = 'bug' ) {
+function file_delete( $p_file_id, $p_table = 'bug', $p_bugnote_id = 0 ) {
 	$t_upload_method = config_get( 'file_upload_method' );
 
 	$c_file_id = (int)$p_file_id;
@@ -581,7 +582,7 @@ function file_delete( $p_file_id, $p_table = 'bug' ) {
 
 	if( 'bug' == $p_table ) {
 		# log file deletion
-		history_log_event_special( $t_bug_id, FILE_DELETED, file_get_display_name( $t_filename ) );
+		history_log_event_special( $t_bug_id, FILE_DELETED, file_get_display_name( $t_filename ), $p_bugnote_id );
 	}
 
 	$t_file_table = db_get_table( $p_table . '_file' );
@@ -901,7 +902,7 @@ function file_add( $p_bug_id, array $p_file, $p_table = 'bug', $p_title = '', $p
 		}
 
 		# log file added to bug history
-		history_log_event_special( $p_bug_id, FILE_ADDED, $t_file_name );
+		history_log_event_special( $p_bug_id, FILE_ADDED, $t_file_name, $p_bugnote_id );
 	}
 
 	return $t_file_info;

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -490,6 +490,20 @@ function file_delete_bugnote_attachments( $p_bug_id, $p_bugnote_id ) {
 }
 
 /**
+ * Link the specified file to the specified bugnote.
+ * 
+ * @param integer $p_file_id The file id.
+ * @param integer $p_bugnote_id A bugnote identifier.
+ * @return void
+ */
+function file_link_to_bugnote( $p_file_id, $p_bugnote_id ) {
+	db_param_push();
+
+	$t_query = 'UPDATE {bug_file} SET bugnote_id=' . db_param() . ' WHERE id=' . db_param();
+	db_query( $t_query, array( $p_bugnote_id, $p_file_id ) );
+}
+
+/**
  * Delete files by project
  * @param integer $p_project_id A project identifier.
  * @return void

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -396,6 +396,7 @@ function file_get_visible_attachments( $p_bug_id ) {
 		$t_attachment['date_added'] = $t_date_added;
 		$t_attachment['diskfile'] = $t_diskfile;
 		$t_attachment['file_type'] = $t_row['file_type'];
+		$t_attachment['bugnote_id'] = $t_row['bugnote_id'];
 
 		$t_attachment['can_download'] = file_can_download_bug_attachments( $p_bug_id, (int)$t_row['user_id'] );
 		$t_attachment['can_delete'] = file_can_delete_bug_attachments( $p_bug_id, (int)$t_row['user_id'] );

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -424,6 +424,18 @@ function history_get_event_from_row( $p_result, $p_user_id = null, $p_check_acce
 			if( !access_has_bug_level( config_get( 'view_attachments_threshold', null, $t_user_id, $t_project_id ), $v_bug_id, $t_user_id ) ) {
 				continue;
 			}
+
+			# Files were originally just associated with the issue, then association with specific bugnotes
+			# was added, so handled legacy and new way of handling attachments.
+			if( !empty( $v_new_value ) && (int)$v_new_value != 0 ) {
+				if( !bugnote_exists( $v_new_value ) ) {
+					continue;
+				}
+	
+				if( !access_has_bug_level( config_get( 'private_bugnote_threshold', null, $t_user_id, $t_project_id ), $v_bug_id, $t_user_id ) && ( bugnote_get_field( $v_new_value, 'view_state' ) == VS_PRIVATE ) ) {
+					continue;
+				}
+			}
 		}
 
 		# monitoring

--- a/core/history_api.php
+++ b/core/history_api.php
@@ -981,3 +981,22 @@ function history_delete( $p_bug_id ) {
 	$t_query = 'DELETE FROM {bug_history} WHERE bug_id=' . db_param();
 	db_query( $t_query, array( $p_bug_id ) );
 }
+
+/**
+ * Link the file added/deleted history events that match the specified bug_id and filename
+ * with the specified bugnote id.
+ *
+ * @param integer $p_bug_id The bug id.
+ * @param string $p_filename The filename dot extension (display name).
+ * @param integer $p_bugnote_id The bugnote id.
+ * @return void
+ */
+function history_link_file_to_bugnote( $p_bug_id, $p_filename, $p_bugnote_id ) {
+	db_param_push();
+	$t_query = 'UPDATE {bug_history} SET new_value = ' . db_param() .
+		' WHERE bug_id=' . db_param() . ' AND old_value=' . db_param() .
+		' AND (type=' . db_param() . ' OR type=' . db_param() . ')';
+
+	db_query( $t_query, array( (int)$p_bugnote_id, (int)$p_bug_id, $p_filename, FILE_ADDED, FILE_DELETED ) );
+}
+

--- a/docbook/Developers_Guide/en-US/Events_Reference_Bug.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference_Bug.xml
@@ -439,8 +439,9 @@
 
 				<itemizedlist>
 					<title>Parameters</title>
-					<listitem><para>&lt;Integer&gt;: Bug ID</para></listitem>
-					<listitem><para>&lt;Integer&gt;: Bugnote ID</para></listitem>
+					<listitem><para>&lt;Integer&gt;: (Key = 0) Bug ID</para></listitem>
+					<listitem><para>&lt;Integer&gt;: (Key = 1) Bugnote ID</para></listitem>
+					<listitem><para>&lt;array&gt;: (Key = "files") Files info (name, size, id), starting 2.23.0</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>

--- a/js/common.js
+++ b/js/common.js
@@ -519,10 +519,8 @@ $(document).ready( function() {
 	$('input[name=private].ace').bind("click", function() {
 		if ($(this).is(":checked")){
 			$('textarea[name=bugnote_text]').addClass("bugnote-private");
-			$('tr[id=bugnote-attach-files]').hide();
 		} else {
 			$('textarea[name=bugnote_text]').removeClass("bugnote-private");
-			$('tr[id=bugnote-attach-files]').show();
 		}
 	});
 


### PR DESCRIPTION
This is work in progress that is published to get feedback.

The change in db is to add a nullable `bugnote_id` (unsigned integer) to the bug file table with default value of 0.
- 0: old file uploads - no explicit association.
- null: file explicitly associated with the issue (not notes).
- non-zero: file explicitly associated with an issue note.

**Fixes the following:**

- [21733](https://www.mantisbt.org/bugs/view.php?id=21733): Attachments should be linkable to notes in db
- [24577](https://www.mantisbt.org/bugs/view.php?id=24577): When deleting a note made of 2 images (attachments) + text, delete operation has to be requested 3 times, not one
- [25935](https://www.mantisbt.org/bugs/view.php?id=25935): Warning for users when making public notes with attachments private
- [9802](https://www.mantisbt.org/bugs/view.php?id=9802): Private attachments
- [22817](https://www.mantisbt.org/bugs/view.php?id=22817): "private bugnotes" as default setting prevents uploading further attachments
- [25960](https://www.mantisbt.org/bugs/view.php?id=25960): Add files information to EVENT_BUGNOTE_ADD event

**Features:**

- It is now possible to upload attachments to private notes.
- Newly submitted notes with attachments are explicitly linked in the db.
- Deleting a note deletes associated attachments (explicit or implicit).
- Switching a note to private/public converts implicit links to explicit links and marks the note and its associated attachments as private/public.
- History entry related to attachments now include the bugnote id that the attachment is associated with.  This is used to determine visibility of the history entry.  Not currently visible in UI.
- The history entries related to adding files to notes are hidden if user doesn't have access to associated notes and files.
- If a note and its associated files is deleted, then the note add and delete will remain in history, but file add/remove will not longer be visible if user doesn't have access to private notes (since there is no way to know which notes this file was associated with and its private/public status).
- Support submitting private attachments without a note.  An empty note is created and files are associated with it.  This also enables changing from private to public and vice versa.

**Not Supported:**

- Upgrading the db to convert all implicit links between notes and attachments (based on submission time with notes) into explicit links.  Such conversion happens when user takes specific actions notes with implicit attachments.