### PR TITLE
ADD MAIN MENU DROPDOWN BUTTON

### DIFF
--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -886,6 +886,7 @@ function layout_options_for_sidebar( $p_menu_options, $p_active_sidebar_page ) {
 	foreach( $p_menu_options as $t_menu_option ) {
 		$t_icon = isset( $t_menu_option['icon'] ) ? $t_menu_option['icon'] : 'fa-plug';
 		if( !isset( $t_menu_option['url'] ) || !isset( $t_menu_option['title'] ) ) {
+			layout_sidebar_dropdown_menu($t_menu_option);
 			continue;
 		}
 
@@ -899,6 +900,38 @@ function layout_options_for_sidebar( $p_menu_options, $p_active_sidebar_page ) {
 	}
 }
 
+/**
+ * Print dropdown menu item
+ * @param array  $p_menu_options menu item of group
+ * @return void
+ */
+function layout_sidebar_dropdown_menu( $p_menu_options ) {
+	echo '<li class="dropdown">' . "\n";
+   	echo '<a class="dropdown-toggle" data-toggle="dropdown" href="#">' . "\n";
+   	echo '<i class="menu-icon fa fa-plug"></i>' . "\n";
+   	echo '<span class="menu-text">Plugins</span>' . "\n";
+   	echo '<span class="caret"></span>';
+   	echo '</a>' . "\n";
+        echo '<ul class="dropdown-menu" >';
+	foreach( $p_menu_options as $t_menu_option ) {
+		
+			$t_icon = isset( $t_menu_option['icon'] ) ? $t_menu_option['icon'] : 'fa-plug';
+			if( !isset( $t_menu_option['url'] ) || !isset( $t_menu_option['title'] ) ) {
+				continue;
+			}
+
+			if( isset( $t_menu_option['access_level'] ) ) {
+				if( !access_has_project_level( $t_menu_option['access_level'] ) ) {
+					continue;
+				}
+			}
+
+			layout_sidebar_menu( $t_menu_option['url'], $t_menu_option['title'], $t_icon, $p_active_sidebar_page );
+		
+	}
+	echo '</ul>';
+	echo '</li>' . "\n";
+}
 /**
  * Print sidebar opening elements
  * @return void

--- a/js/common.js
+++ b/js/common.js
@@ -35,6 +35,7 @@ if (a!= -1) {
 style_display = 'block';
 
 $(document).ready( function() {
+    $('.dropdown-toggle').dropdown();
     $('.collapse-open').show();
     $('.collapse-closed').hide();
     $('.collapse-link').click( function(event) {


### PR DESCRIPTION
Since mantis 2.X if we want to add a plugin button for non manager, we need to use EVENT MAIN MENU.
But we are limited by the number of button that our resolution can integrate.

So this pull request allow to integrate a dropdown button and so allow un bigger number of button

This pull request is possible thanks to the new EVENT MAIN MENU FILTER.
With this event you can get the array of all main menu button and so integer inside an array of array for each plugin.

Picture available : https://ibb.co/m9mwM4p
