### PR TITLE
Fix test case to expect one history entry

### DIFF
--- a/tests/soap/IssueHistoryTest.php
+++ b/tests/soap/IssueHistoryTest.php
@@ -100,7 +100,7 @@ class IssueHistoryTest extends SoapBase {
 	/**
 	 * A test case that tests the following:
 	 * 1. Creates a new issue with non-default status and resolution
-	 * 2. Validates that history entries are created for the status and resolution
+	 * 2. Validates that a single history entry is created.
 	 * @return void
 	 */
 	function testCreatedIssueWithNonDefaultStatusAndResolutionHasHistoryEntries() {
@@ -114,29 +114,7 @@ class IssueHistoryTest extends SoapBase {
 
 		$t_issue_history = $this->getIssueHistory( $t_issue_id );
 
-		$this->assertEquals( 3, count( $t_issue_history ) );
-
-		# History entries logged simultaneously may not be returned in
-		# the same order, so we need to individually check for each one
-		foreach( $t_issue_history as $t_entry ) {
-			if( $t_entry->type != NORMAL_TYPE ) {
-				# Ignore unwanted history types
-				continue;
-			}
-			$t_field = $t_entry->field;
-			switch( $t_field ) {
-				case 'status':
-					$t_old_value = NEW_;
-					break;
-				case 'resolution':
-					$t_old_value = OPEN;
-					break;
-				default:
-					# We shouldn't get there, but just in case...
-					continue 2;
-			}
-			$this->assertPropertyHistoryEntry( $t_entry, $t_field, $t_issue_to_add[$t_field]['id'], $t_old_value );
-		}
+		$this->assertEquals( 1, count( $t_issue_history ) );
 	}
 
 	/**


### PR DESCRIPTION
NOTE: not tested since SOAP tests not working on my dev machine at the moment.

When creating an issue with non-default status/resolution, check that a single entry is created.

Fixes #25962