### PR TITLE
Don't force caching of form pages

### DIFF
--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -41,8 +41,6 @@
  * @uses version_api.php
  */
 
-$g_allow_browser_cache = 1;
-
 require_once( 'core.php' );
 require_api( 'access_api.php' );
 require_api( 'authentication_api.php' );

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -49,8 +49,6 @@
  * @uses version_api.php
  */
 
-$g_allow_browser_cache = 1;
-
 require_once( 'core.php' );
 require_api( 'access_api.php' );
 require_api( 'authentication_api.php' );

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -46,8 +46,6 @@
  * @uses version_api.php
  */
 
-$g_allow_browser_cache = 1;
-
 require_once( 'core.php' );
 require_api( 'access_api.php' );
 require_api( 'authentication_api.php' );


### PR DESCRIPTION
These pages were explicitly setting a flag to make the pages cacheable.
Before the changes in 97b745dc102323c312ca27b6fcb8f838c3e50b8f
the expiration headers were not being correctly set, however after that
commit, the issue is fixed and these pages have become cacheable
This causes undesired effects.

Since the previos status of this scenario is that the pages were not
being cached anyway, we are removing the explicit $g_allow_browser_cache
flag.

Fixes: #25969