### PR TITLE
Add email on monitor to config page

### DIFF
--- a/core/email_api.php
+++ b/core/email_api.php
@@ -2032,7 +2032,7 @@ function email_shutdown_function() {
  * @return array List of actions
  */
 function email_get_actions() {
-	$t_actions = array( 'updated', 'owner', 'reopened', 'deleted', 'bugnote', 'relation' );
+	$t_actions = array( 'updated', 'owner', 'reopened', 'deleted', 'bugnote', 'relation', 'monitor' );
 
 	if( config_get( 'enable_sponsorship' ) == ON ) {
 		$t_actions[] = 'sponsor';

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1479,6 +1479,7 @@ $s_email_on_deleted = 'E-mail on Deleted';
 $s_email_on_sponsorship_changed = 'E-mail on Sponsorship changed';
 $s_email_on_relationship_changed = 'E-mail on Relationship changed';
 $s_email_on_updated = 'E-mail on Updated';
+$s_email_on_monitor = 'E-mail when user starts monitoring';
 
 # Dynamic filters (load filter controls via AJAX upon request)
 $s_loading = 'Loading...';

--- a/manage_config_email_page.php
+++ b/manage_config_email_page.php
@@ -359,6 +359,7 @@ if( config_get( 'enable_email_notification' ) == ON ) {
 	}
 
 	get_capability_row_for_email( lang_get( 'email_on_relationship_changed' ), 'relation' );
+	get_capability_row_for_email( lang_get( 'email_on_monitor' ), 'monitor' );
 
 	$t_statuses = MantisEnum::getAssocArrayIndexedByValues( config_get( 'status_enum_string' ) );
 	foreach ( $t_statuses as $t_status => $t_label ) {


### PR DESCRIPTION
Email on "monitor" is an existing action, which is already configured in
config_defaults_inc, but it's not displayed in the email configuration
page.

Fixes: [#26002](https://www.mantisbt.org/bugs/view.php?id=26002)