### PR TITLE
Fix filtering for "none" in multivalued custom fields

### DIFF
--- a/core/classes/BugFilterQuery.class.php
+++ b/core/classes/BugFilterQuery.class.php
@@ -1364,23 +1364,28 @@ class BugFilterQuery extends DbQuery {
 				foreach( $t_field as $t_filter_member ) {
 					$t_filter_member = stripslashes( $t_filter_member );
 					if( filter_field_is_none( $t_filter_member ) ) {
-						# coerce filter value if selecting META_FILTER_NONE so it will match empty fields
-						$t_filter_member = '';
-
 						# but also add those _not_ present in the custom field string table
-						array_push( $t_filter_array, $t_table_name . '.value IS NULL' );
-					}
+						$t_filter_array[] = $t_table_name . '.value IS NULL';
 
-					switch( $t_def['type'] ) {
-						case CUSTOM_FIELD_TYPE_CHECKBOX:
-						case CUSTOM_FIELD_TYPE_MULTILIST:
-							$t_filter_array[] = $this->sql_like( $t_table_name . '.value', '%|' . $t_filter_member . '|%' );
-							break;
-						case CUSTOM_FIELD_TYPE_TEXTAREA:
-							$t_filter_array[] = $this->sql_like( $t_table_name . '.text', '%' . $t_filter_member . '%' );
-							break;
-						default:
-							$t_filter_array[] = $t_table_name . '.value = ' . $this->param( $t_filter_member );
+						switch( $t_def['type'] ) {
+							case CUSTOM_FIELD_TYPE_TEXTAREA:
+								$t_filter_array[] = $t_table_name . '.text = ' . $this->param( '' );
+								break;
+							default;
+								$t_filter_array[] = $t_table_name . '.value = ' . $this->param( '' );
+						}
+					} else {
+						switch( $t_def['type'] ) {
+							case CUSTOM_FIELD_TYPE_CHECKBOX:
+							case CUSTOM_FIELD_TYPE_MULTILIST:
+								$t_filter_array[] = $this->sql_like( $t_table_name . '.value', '%|' . $t_filter_member . '|%' );
+								break;
+							case CUSTOM_FIELD_TYPE_TEXTAREA:
+								$t_filter_array[] = $this->sql_like( $t_table_name . '.text', '%' . $t_filter_member . '%' );
+								break;
+							default:
+								$t_filter_array[] = $t_table_name . '.value = ' . $this->param( $t_filter_member );
+						}
 					}
 				}
 				$t_custom_where_clause .= '(' . implode( ' OR ', $t_filter_array );

--- a/core/filter_form_api.php
+++ b/core/filter_form_api.php
@@ -1958,7 +1958,7 @@ function print_filter_custom_field( $p_field_id, array $p_filter = null ) {
 			check_selected( $p_filter['custom_fields'][$p_field_id], META_FILTER_ANY, false );
 			echo '>[' . lang_get( 'any' ) . ']</option>';
 			# don't show META_FILTER_NONE for enumerated types as it's not possible for them to be blank
-			if( !in_array( $t_cfdef['type'], array( CUSTOM_FIELD_TYPE_ENUM, CUSTOM_FIELD_TYPE_LIST, CUSTOM_FIELD_TYPE_MULTILIST ) ) ) {
+			if( !in_array( $t_cfdef['type'], array( CUSTOM_FIELD_TYPE_ENUM, CUSTOM_FIELD_TYPE_LIST ) ) ) {
 				echo '<option value="' . META_FILTER_NONE . '"';
 				check_selected( $p_filter['custom_fields'][$p_field_id], META_FILTER_NONE, false );
 				echo '>[' . lang_get( 'none' ) . ']</option>';


### PR DESCRIPTION
- Allows to use the value "none" in custom fields of type multiselection list
- Fix the filter query for searching "none" in mutivalued custom fields
  that can be empty. Those are: checkbox and multiselection list.

Fixes: #21712, #26030