### PR TITLE
Drop CSP frame-ancestor: 'none' if other sources exist

### DIFF
--- a/core/http_api.php
+++ b/core/http_api.php
@@ -185,6 +185,12 @@ function http_csp_value() {
 
 	$t_csp_value = '';
 
+	# frame-ancestors can't have 'none' together with other values.
+	if( count( $g_csp['frame-ancestors'] ) > 1 ) {
+		$t_key_none = array_search( "'none'", $g_csp['frame-ancestors'] );
+		unset( $g_csp['frame-ancestors'][$t_key_none] );
+	}
+
 	foreach ( $g_csp as $t_key => $t_values ) {
 		$t_csp_value .= $t_key . ' ' . implode( ' ', $t_values ) . '; ';
 	}

--- a/core/http_api.php
+++ b/core/http_api.php
@@ -186,9 +186,12 @@ function http_csp_value() {
 	$t_csp_value = '';
 
 	# frame-ancestors can't have 'none' together with other values.
-	if( count( $g_csp['frame-ancestors'] ) > 1 ) {
-		$t_key_none = array_search( "'none'", $g_csp['frame-ancestors'] );
-		unset( $g_csp['frame-ancestors'][$t_key_none] );
+	if( isset( $g_csp['frame-ancestors'] ) ) {
+		$t_frame_ancestors = &$g_csp['frame-ancestors'];
+		if( count( $t_frame_ancestors ) > 1 ) {
+			$t_key_none = array_search( "'none'", $t_frame_ancestors );
+			unset( $t_frame_ancestors[$t_key_none] );
+		}
 	}
 
 	foreach ( $g_csp as $t_key => $t_values ) {


### PR DESCRIPTION
If both 'none' and other values (e.g. 'self') are defined for the
frame-ancestor CSP directive, http_csp_value() now drops 'none', which
is the default set by MantisBT core, and can only exist by itself.

Fixes [#26093](https://mantisbt.org/bugs/view.php?id=26093), mantisbt-plugins/BBCodePlus#72