### PR TITLE
Use REST API full path (with index.php)

### DIFF
--- a/js/adm_config_report.js
+++ b/js/adm_config_report.js
@@ -42,7 +42,7 @@ $(document).ready( function() {
 						'project_id': container.data('project_id'),
 						'user_id': container.data('user_id')
 					};
-					content.load('api/rest/internal/config_display',req_data);
+					content.load('api/rest/index.php/internal/config_display',req_data);
 				}
 				content.show();
 			});

--- a/js/common.js
+++ b/js/common.js
@@ -176,7 +176,7 @@ $(document).ready( function() {
 				var params = {};
 				params['field'] = $this[0].id;
 				params['prefix'] = query;
-				$.getJSON('api/rest/internal/autocomplete', params, function (data) {
+				$.getJSON('api/rest/index.php/internal/autocomplete', params, function (data) {
 					var results = [];
 					$.each(data, function (i, value) {
 						results.push(value);


### PR DESCRIPTION
On web servers where URL rewriting is not properly configured, calling
REST API with the "short" URL, e.g. http://my.mantis/rest/api/issues
does not work.

To make sure that core functionality relying on REST calls (via the
'internal' route) is working is expected even when URL rewriting is not
operational, we use the full path including the index.php file:
http://my.mantis/rest/api/index.php/internal/...

Fixes [#26110](https://mantisbt.org/bugs/view.php?id=26110)