### PR TITLE
Fix display of monitor/unmonitor buttons

### DIFF
--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -629,9 +629,7 @@ if( $t_flags['relationships_show'] ) {
 }
 
 # User list monitoring the bug
-if( $t_flags['monitor_show'] && isset( $t_issue['monitors'] ) ) {
-	$t_num_users = sizeof( $t_issue['monitors'] );
-
+if( $t_flags['monitor_show'] ) {
 	echo '<div class="col-md-12 col-xs-12">';
 	echo '<a id="monitors"></a>';
 	echo '<div class="space-10"></div>';
@@ -664,7 +662,7 @@ if( $t_flags['monitor_show'] && isset( $t_issue['monitors'] ) ) {
 		</th>
 		<td>
 	<?php
-			if( 0 == $t_num_users ) {
+			if( !isset( $t_issue['monitors'] ) || count( $t_issue['monitors'] ) == 0 ) {
 				echo lang_get( 'no_users_monitoring_bug' );
 			} else {
 				$t_first_user = true;

--- a/core/commands/IssueViewPageCommand.php
+++ b/core/commands/IssueViewPageCommand.php
@@ -216,6 +216,12 @@ class IssueViewPageCommand extends Command {
 			$t_flags['monitor_can_add'] = access_has_bug_level( config_get( 'monitor_add_others_bug_threshold' ), $t_issue_id ) ? true : false;
 		}
 
+		$t_monitor_flag = !$t_force_readonly && !$t_anonymous_user;
+		$t_is_monitoring = user_is_monitoring_bug( $t_user_id, $t_issue_id );
+		$t_flags['can_monitor'] = $t_monitor_flag && !$t_is_monitoring &&
+			access_has_bug_level( config_get( 'monitor_bug_threshold' ), $t_issue_id );
+		$t_flags['can_unmonitor'] = $t_monitor_flag && $t_is_monitoring;
+
 		$t_flags['attachments_show'] = in_array( 'attachments', $t_fields );
 		$t_flags['category_show'] = in_array( 'category_id', $t_fields );
 		$t_flags['eta_show'] = in_array( 'eta', $t_fields );
@@ -234,12 +240,6 @@ class IssueViewPageCommand extends Command {
 		$t_flags['can_assign'] = !$t_issue_readonly &&
 			access_has_bug_level( config_get( 'update_bug_assign_threshold', config_get( 'update_bug_threshold' ) ), $t_issue_id );
 		$t_flags['can_change_status'] = !$t_issue_readonly && access_has_bug_level( config_get( 'update_bug_status_threshold' ), $t_issue_id );
-
-		$t_monitor_flag = !$t_force_readonly && !$t_anonymous_user;
-		$t_is_monitoring = user_is_monitoring_bug( $t_user_id, $t_issue_id );
-		$t_flags['can_monitor'] = $t_monitor_flag && !$t_is_monitoring &&
-			access_has_bug_level( config_get( 'monitor_bug_threshold' ), $t_issue_id );
-		$t_flags['can_unmonitor'] = $t_monitor_flag && $t_is_monitoring;
 
 		$t_flags['can_clone'] = !$t_issue_readonly && access_has_bug_level( config_get( 'report_bug_threshold' ), $t_issue_id );
 		$t_flags['can_reopen'] = !$t_force_readonly && access_can_reopen_bug( $t_issue_data );

--- a/core/commands/IssueViewPageCommand.php
+++ b/core/commands/IssueViewPageCommand.php
@@ -216,11 +216,15 @@ class IssueViewPageCommand extends Command {
 			$t_flags['monitor_can_add'] = access_has_bug_level( config_get( 'monitor_add_others_bug_threshold' ), $t_issue_id ) ? true : false;
 		}
 
-		$t_monitor_flag = !$t_force_readonly && !$t_anonymous_user;
-		$t_is_monitoring = user_is_monitoring_bug( $t_user_id, $t_issue_id );
-		$t_flags['can_monitor'] = $t_monitor_flag && !$t_is_monitoring &&
-			access_has_bug_level( config_get( 'monitor_bug_threshold' ), $t_issue_id );
-		$t_flags['can_unmonitor'] = $t_monitor_flag && $t_is_monitoring;
+		if( !$t_force_readonly && !$t_anonymous_user ) {
+			$t_is_monitoring = user_is_monitoring_bug( $t_user_id, $t_issue_id );
+			$t_flags['can_monitor'] =  !$t_is_monitoring &&
+				access_has_bug_level( config_get( 'monitor_bug_threshold' ), $t_issue_id );
+			$t_flags['can_unmonitor'] = $t_is_monitoring;
+		} else {
+			$t_flags['can_monitor'] = false;
+			$t_flags['can_unmonitor'] = false;
+		}
 
 		$t_flags['attachments_show'] = in_array( 'attachments', $t_fields );
 		$t_flags['category_show'] = in_array( 'category_id', $t_fields );

--- a/core/commands/IssueViewPageCommand.php
+++ b/core/commands/IssueViewPageCommand.php
@@ -235,10 +235,11 @@ class IssueViewPageCommand extends Command {
 			access_has_bug_level( config_get( 'update_bug_assign_threshold', config_get( 'update_bug_threshold' ) ), $t_issue_id );
 		$t_flags['can_change_status'] = !$t_issue_readonly && access_has_bug_level( config_get( 'update_bug_status_threshold' ), $t_issue_id );
 
-		$t_flags['can_monitor'] = !$t_force_readonly && !$t_anonymous_user &&
+		$t_monitor_flag = !$t_force_readonly && !$t_anonymous_user;
+		$t_is_monitoring = user_is_monitoring_bug( $t_user_id, $t_issue_id );
+		$t_flags['can_monitor'] = $t_monitor_flag && !$t_is_monitoring &&
 			access_has_bug_level( config_get( 'monitor_bug_threshold' ), $t_issue_id );
-		$t_flags['can_unmonitor'] = !$t_force_readonly && !$t_anonymous_user &&
-			user_is_monitoring_bug( auth_get_current_user_id(), $t_issue_id );
+		$t_flags['can_unmonitor'] = $t_monitor_flag && $t_is_monitoring;
 
 		$t_flags['can_clone'] = !$t_issue_readonly && access_has_bug_level( config_get( 'report_bug_threshold' ), $t_issue_id );
 		$t_flags['can_reopen'] = !$t_force_readonly && access_can_reopen_bug( $t_issue_data );


### PR DESCRIPTION
The monitor button should only be displayed when the current user is not
yet monitoring the issue.

Likewise for the unmonitor button when the user is indeed monitoring it.

Fixes [#26123](https://mantisbt.org/bugs/view.php?id=26123)

_Users monitoring this issue_ section should be shown even if nobody is monitoring the issue, as it allows privileged users to add other users to the issue's monitoring list.

Fixes [#26125](https://mantisbt.org/bugs/view.php?id=26125)