### PR TITLE
Add file with default value 'null' for user id

### DIFF
--- a/core/file_api.php
+++ b/core/file_api.php
@@ -78,7 +78,7 @@ function file_attach_files( $p_bug_id, $p_files, $p_bugnote_id = 0 ) {
 				'bug',
 				'', /* title */
 				'', /* desc */
-				0, /* user_id */
+				null, /* user_id */
 				0, /* date_added */
 				0, /* skip_bug_update */
 				$p_bugnote_id );


### PR DESCRIPTION
This ensures that the file attachment is added with a reference to the
current user.

Regression introduced by 255dfdf261c42adb76c4f3b6a157186afe999f9b,
caused attachments uploaded together with the issue's submission to be
linked to user '0' instead of the reporter.

Fixes [#26128](https://mantisbt.org/bugs/view.php?id=26128)