### PR TITLE
Use max length property of custom field in inputs

### DIFF
--- a/core/cfdefs/cfdef_standard.php
+++ b/core/cfdefs/cfdef_standard.php
@@ -448,11 +448,13 @@ function cfdef_input_radio( array $p_field_def, $p_custom_field_value, $p_requir
  * @return void
  */
 function cfdef_input_textbox( array $p_field_def, $p_custom_field_value, $p_required = '' ) {
-	echo '<input ' . helper_get_tab_index() . ' type="text" id="custom_field_' . $p_field_def['id'] . '" name="custom_field_' . $p_field_def['id'] . '" size="80"' . $p_required;
-	if( 0 < $p_field_def['length_max'] ) {
-		echo ' maxlength="' . $p_field_def['length_max'] . '"';
+	echo '<input ', helper_get_tab_index(), ' type="text" id="custom_field_', $p_field_def['id']
+			, '" name="custom_field_', $p_field_def['id'], '" ', $p_required;
+	if( $p_field_def['length_max'] > 0 ) {
+		echo ' maxlength="' . $p_field_def['length_max'] . '"'
+				, ' size="' .  min( 80, $p_field_def['length_max'] ) . '"';
 	} else {
-		echo ' maxlength="255"';
+		echo ' maxlength="255" size="80"';
 	}
 	if( !empty( $p_field_def['valid_regexp'] ) ) {
 		# the custom field regex is evaluated with preg_match and looks for a partial match in the string
@@ -478,8 +480,12 @@ function cfdef_input_textbox( array $p_field_def, $p_custom_field_value, $p_requ
  * @return void
  */
 function cfdef_input_textarea( array $p_field_def, $p_custom_field_value, $p_required = '' ) {
-	echo '<textarea class="form-control" ' . helper_get_tab_index() . ' id="custom_field_' . $p_field_def['id'] . '" name="custom_field_' . $p_field_def['id'] . '"' . $p_required;
-	echo ' cols="70" rows="8">' . $p_custom_field_value .'</textarea>';
+	echo '<textarea class="form-control" ', helper_get_tab_index(), ' id="custom_field_' . $p_field_def['id']
+			, '" name="custom_field_', $p_field_def['id'], '"', $p_required;
+	if( $p_field_def['length_max'] > 0 ) {
+		echo ' maxlength="', $p_field_def['length_max'], '"';
+	}
+	echo ' cols="70" rows="8">', $p_custom_field_value, '</textarea>';
 }
 
 /**


### PR DESCRIPTION
When a string, or text, type custom field has a max length defined, we
should use that for the rendered input in the form, to limit the width
of the input.

Fixes: #26141