### PR TITLE
Fix rest issues with project specific filter id

### DIFF
--- a/api/rest/restcore/issues_rest.php
+++ b/api/rest/restcore/issues_rest.php
@@ -102,6 +102,8 @@ function rest_issue_get( \Slim\Http\Request $p_request, \Slim\Http\Response $p_r
 			$p_response = $p_response->withStatus( HTTP_STATUS_NOT_FOUND, $t_message );
 		} else {
 			$t_filter_id = trim( $p_request->getParam( 'filter_id', '' ) );
+			# set the current project to correctly account for user permissions
+			helper_set_current_project( $t_project_id );
 
 			if( !empty( $t_filter_id ) ) {
 				$t_issues = mc_filter_get_issues(


### PR DESCRIPTION
The current project must be set for correctly checking permissions and
retrieving the filter.

Fixes: #26195