### PR TITLE
Revert "Don’t show completely empty notes"

### DIFF
--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -490,12 +490,6 @@ function bugnote_get_all_visible_bugnotes( $p_bug_id, $p_user_bugnote_order, $p_
 			# If the access level specified is not enough to see time tracking information
 			# then reset it to 0.
 			if( !$t_time_tracking_visible ) {
-				# If the time tracking is the only data in the note, then skip it.
-				if( is_blank( $t_bugnote->note ) ) {
-					continue;
-				}
-
-				# otherwise, don't return the time tracking information so that it is not visible.
 				$t_bugnote->time_tracking = 0;
 			}
 


### PR DESCRIPTION
After implementing the linking of notes and attachments, attachments
linked to a note without text are not displayed to some users becasue of
the time tracking logic, even if that functionality is not enabled.

This reverts commit 1ed44a96567e23da446f2678a717360f678d2d00.

Fixes: #26294