### PR TITLE
Pre-fill tags from master bug when cloning

### DIFF
--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -605,7 +605,20 @@ if( $t_show_attachments ) {
 			<label for="attach_tag"><?php echo lang_get( 'tag_attach_long' ) ?></label>
 		</th>
 		<td>
-			<?php print_tag_input( '' ); ?>
+			<?php
+				if( $f_master_bug_id > 0 ) {
+					// pre-fill tag string when cloning from master bug
+					$tags = [];
+					foreach(tag_bug_get_attached($f_master_bug_id) as $tag) {
+						array_push($tags, $tag["name"]);
+					}
+					$tag_string = implode(config_get('tag_separator'), $tags);
+					print_tag_input( $f_master_bug_id, $tag_string );
+				} else {
+					// otherwise show just the default empty string
+					print_tag_input( '' );
+				}
+			?>
 		</td>
 	</tr>
 <?php

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -607,15 +607,17 @@ if( $t_show_attachments ) {
 		<td>
 			<?php
 				if( $f_master_bug_id > 0 ) {
-					// pre-fill tag string when cloning from master bug
-					$tags = [];
-					foreach(tag_bug_get_attached($f_master_bug_id) as $tag) {
-						array_push($tags, $tag["name"]);
+					# pre-fill tag string when cloning from master bug
+					$t_tags = [];
+					foreach( tag_bug_get_attached( $f_master_bug_id ) as $t_tag ) {
+						array_push( $t_tags, $t_tag["name"] );
 					}
-					$tag_string = implode(config_get('tag_separator'), $tags);
-					print_tag_input( $f_master_bug_id, $tag_string );
+					$t_tag_string = implode(
+						config_get( 'tag_separator' ), $t_tags
+					);
+					print_tag_input( $f_master_bug_id, $t_tag_string );
 				} else {
-					// otherwise show just the default empty string
+					# otherwise show just the default empty string
 					print_tag_input( '' );
 				}
 			?>

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -615,7 +615,7 @@ if( $t_show_attachments ) {
 					$t_tag_string = implode(
 						config_get( 'tag_separator' ), $t_tags
 					);
-					print_tag_input( $f_master_bug_id, $t_tag_string );
+					print_tag_input( 0, $t_tag_string );
 				} else {
 					# otherwise show just the default empty string
 					print_tag_input( '' );


### PR DESCRIPTION
When cloning a bug  I expect *everything* to be cloned, even tags, however I don't see the tags as if in an existing issue, so the next reasonable solution was to just pre-fill the input for tags.

With this I can even decide what tags to include before the bug is created so I don't need to waste time with copying the tags on DB level and then remove them one-by-one, instead I can skip the writing completely and proceed as if I'm creating a new bug which writes only the desired tags.