### PR TITLE
Manage project page improvements

### DIFF
--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -254,7 +254,8 @@ if ( config_get( 'subprojects_enabled') == ON ) {
 			<fieldset>
 				<?php echo form_security_field( 'manage_proj_subproj_add' ) ?>
 				<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
-				<select name="subproject_id" class="input-sm"><?php
+				<select name="subproject_id" class="input-sm" required>
+				<option selected disabled value=""><?php echo '[', lang_get( 'select_project_button' ), ']' ?></option><?php
 				$t_all_subprojects = project_hierarchy_get_subprojects( $f_project_id, true );
 				$t_all_subprojects[] = $f_project_id;
 				$t_manage_access = config_get( 'manage_project_threshold' );

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -655,13 +655,16 @@ if( access_has_project_level( config_get( 'custom_field_link_threshold' ), $f_pr
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
 			<select name="field_id" class="input-sm">
 				<?php
-					$t_custom_fields = custom_field_get_ids();
+					$t_cf_defs = array();
+					foreach( custom_field_get_ids() as $t_cfid ) {
+						$t_cf_defs[] = custom_field_get_definition( $t_cfid );
+					}
+					$t_custom_fields = multi_sort( $t_cf_defs, 'name' );
 
-					foreach( $t_custom_fields as $t_field_id )
+					foreach( $t_custom_fields as $t_field )
 					{
-						if( !custom_field_is_linked( $t_field_id, $f_project_id ) ) {
-							$t_desc = custom_field_get_definition( $t_field_id );
-							echo "<option value=\"$t_field_id\">" . string_attribute( lang_get_defaulted( $t_desc['name'] ) ) . '</option>' ;
+						if( !custom_field_is_linked( $t_field['id'], $f_project_id ) ) {
+							echo '<option value="', $t_field['id'], '">', string_attribute( lang_get_defaulted( $t_field['name'] ) ), '</option>' ;
 						}
 					}
 				?>


### PR DESCRIPTION
Improvements for Manage project page
- Sort custom field names in dropdown. [26368](https://mantisbt.org/bugs/view.php?id=26368)
- Use empty default selection for project list in subprojects section. [26367](https://mantisbt.org/bugs/view.php?id=26367)
