### PR TITLE
Add missing Tag-related thresholds in manage page

### DIFF
--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1483,6 +1483,13 @@ $s_email_on_sponsorship_changed = 'E-mail on Sponsorship changed';
 $s_email_on_relationship_changed = 'E-mail on Relationship changed';
 $s_email_on_updated = 'E-mail on Updated';
 $s_email_on_monitor = 'E-mail when user starts monitoring';
+$s_view_tags = 'View tags attached to a bug';
+$s_attach_tags = 'Attach tags to a bug';
+$s_detach_tags = 'Detach tags from a bug';
+$s_detach_own_tags = 'Detach tags attached by the same user';
+$s_create_new_tags = 'Create new tags';
+$s_edit_tags = 'Edit tag names and descriptions';
+$s_edit_own_tags = 'Edit tags created by the same user';
 
 # Dynamic filters (load filter controls via AJAX upon request)
 $s_loading = 'Loading...';

--- a/manage_config_work_threshold_page.php
+++ b/manage_config_work_threshold_page.php
@@ -408,6 +408,17 @@ get_capability_row( lang_get( 'view_private_notes' ), 'private_bugnote_threshold
 get_capability_row( lang_get( 'change_view_state_own_bugnotes' ), 'bugnote_user_change_view_state_threshold' );
 get_section_end();
 
+# Tags
+get_section_begin_mcwt( lang_get( 'tags' ) );
+get_capability_row( lang_get( 'view_tags' ), 'tag_view_threshold' );
+get_capability_row( lang_get( 'attach_tags' ), 'tag_attach_threshold' );
+get_capability_row( lang_get( 'detach_tags' ), 'tag_detach_threshold' );
+get_capability_row( lang_get( 'detach_own_tags' ), 'tag_detach_own_threshold' );
+get_capability_row( lang_get( 'create_new_tags' ), 'tag_create_threshold' );
+get_capability_row( lang_get( 'edit_tags' ), 'tag_edit_threshold' );
+get_capability_row( lang_get( 'edit_own_tags' ), 'tag_edit_own_threshold' );
+get_section_end();
+
 # Others
 get_section_begin_mcwt( lang_get( 'others' ) );
 get_capability_row( lang_get( 'view' ) . ' ' . lang_get( 'changelog_link' ), 'view_changelog_threshold' );

--- a/manage_config_work_threshold_set.php
+++ b/manage_config_work_threshold_set.php
@@ -189,6 +189,16 @@ set_capability_row( 'bugnote_user_delete_threshold' );
 set_capability_row( 'private_bugnote_threshold' );
 set_capability_row( 'bugnote_user_change_view_state_threshold' );
 
+# Tags
+
+set_capability_row( 'tag_view_threshold' );
+set_capability_row( 'tag_attach_threshold' );
+set_capability_row( 'tag_detach_threshold' );
+set_capability_row( 'tag_detach_own_threshold' );
+set_capability_row( 'tag_create_threshold' );
+set_capability_row( 'tag_edit_threshold' );
+set_capability_row( 'tag_edit_own_threshold' );
+
 # Others
 set_capability_row( 'view_changelog_threshold' );
 set_capability_row( 'roadmap_view_threshold' );


### PR DESCRIPTION
Adds a new _Tags_ section in the Manage Workflow Thresholds page, between _Notes_ and _Others_

![image](https://user-images.githubusercontent.com/449891/69485979-c000d100-0e46-11ea-8053-eb92528cbf95.png)

Fixes [#26119](https://mantisbt.org/bugs/view.php?id=26119)