### PR TITLE
Enhance roadmap progress bar look & feel

### DIFF
--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -546,6 +546,18 @@ input.typeahead.scrollable ~ .tt-menu {
 	font-size: 60%;
 	vertical-align: top;
 }
+
+.progress {
+    background:#bbb;
+}
+.progress.progress-large {
+    height: 32px;
+}
+.progress.progress-large[data-percent]:after {
+    line-height:32px;
+    font-size:18px;
+}
+
 /* Small devices (tablets, 768px and up) */
 @media (min-width: 768px) {
     .page-content {

--- a/roadmap_page.php
+++ b/roadmap_page.php
@@ -359,7 +359,7 @@ foreach( $t_project_ids as $t_project_id ) {
 
 			echo '<div class="space-4"></div>';
 			echo '<div class="col-md-7 col-xs-12 no-padding">';
-			echo '<div class="progress progress-large progress-striped active" data-percent="' . $t_progress . '%" >';
+			echo '<div class="progress progress-large progress-striped" data-percent="' . $t_progress . '%" >';
 			echo '<div style="width:' . $t_progress . '%;" class="progress-bar progress-bar-success"></div>';
 			echo '</div></div>';
 			echo '<div class="clearfix"></div>';

--- a/roadmap_page.php
+++ b/roadmap_page.php
@@ -359,7 +359,7 @@ foreach( $t_project_ids as $t_project_id ) {
 
 			echo '<div class="space-4"></div>';
 			echo '<div class="col-md-7 col-xs-12 no-padding">';
-			echo '<div class="progress progress-striped" data-percent="' . $t_progress . '%" >';
+			echo '<div class="progress progress-large progress-striped active" data-percent="' . $t_progress . '%" >';
 			echo '<div style="width:' . $t_progress . '%;" class="progress-bar progress-bar-success"></div>';
 			echo '</div></div>';
 			echo '<div class="clearfix"></div>';


### PR DESCRIPTION
Fixes #22142

Changes include:
- Enlarge the bar & fonts
- Adjust background color 
- Enable animation

Before:
<img width="1006" alt="Screen Shot 2019-12-07 at 8 21 47 PM" src="https://user-images.githubusercontent.com/1354889/70384189-ca839600-192f-11ea-9ab9-72a794e61285.png">
<img width="1021" alt="Screen Shot 2019-12-07 at 8 22 09 PM" src="https://user-images.githubusercontent.com/1354889/70384190-ca839600-192f-11ea-828c-8b954ba1051c.png">
<img width="389" alt="Screen Shot 2019-12-07 at 8 22 32 PM" src="https://user-images.githubusercontent.com/1354889/70384191-ca839600-192f-11ea-81df-cff9b9f35cb8.png">

After:
<img width="1018" alt="Screen Shot 2019-12-07 at 8 20 02 PM" src="https://user-images.githubusercontent.com/1354889/70384196-e129ed00-192f-11ea-994b-0437a39e5ec1.png">
<img width="1012" alt="Screen Shot 2019-12-07 at 8 20 37 PM" src="https://user-images.githubusercontent.com/1354889/70384197-e129ed00-192f-11ea-9a2b-b165cbc23368.png">
<img width="381" alt="Screen Shot 2019-12-07 at 8 23 08 PM" src="https://user-images.githubusercontent.com/1354889/70384198-e1c28380-192f-11ea-81a8-2eb36159314d.png">
