### PR TITLE
Fix system notice in View Issues page on PHP 7.4

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1694,7 +1694,7 @@ function bug_get_bugnote_stats_array( array $p_bugs_id, $p_user_id = null ) {
  * associated with the bug was modified and the total bugnote
  * count in one db query
  * @param integer $p_bug_id Integer representing bug identifier.
- * @return object consisting of bugnote stats
+ * @return array|false Bugnote stats, false if no bugnotes
  * @access public
  * @uses database_api.php
  */

--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -1234,14 +1234,14 @@ function print_column_bugnotes_count( BugData $p_bug, $p_columns_target = COLUMN
 	$t_bugnote_stats = bug_get_bugnote_stats( $p_bug->id );
 	if( is_array( $t_bugnote_stats ) ) {
 		$t_bugnote_count = $t_bugnote_stats['count'];
-		$v_bugnote_updated = $t_bugnote_stats['last_modified'];
+		$t_bugnote_updated = $t_bugnote_stats['last_modified'];
 	} else {
 		$t_bugnote_count = 0;
 	}
 
 	echo '<td class="column-bugnotes-count">';
 	if( $t_bugnote_count > 0 ) {
-		$t_show_in_bold = $v_bugnote_updated > strtotime( '-' . $g_filter[FILTER_PROPERTY_HIGHLIGHT_CHANGED] . ' hours' );
+		$t_show_in_bold = $t_bugnote_updated > strtotime( '-' . $g_filter[FILTER_PROPERTY_HIGHLIGHT_CHANGED] . ' hours' );
 		if( $t_show_in_bold ) {
 			echo '<span class="bold">';
 		}

--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -1232,7 +1232,7 @@ function print_column_bugnotes_count( BugData $p_bug, $p_columns_target = COLUMN
 
 	# grab the bugnote count
 	$t_bugnote_stats = bug_get_bugnote_stats( $p_bug->id );
-	if( null !== $t_bugnote_stats ) {
+	if( is_array( $t_bugnote_stats ) ) {
 		$t_bugnote_count = $t_bugnote_stats['count'];
 		$v_bugnote_updated = $t_bugnote_stats['last_modified'];
 	} else {


### PR DESCRIPTION
In PHP 7.3 and earlier, dereferencing a non-array variable simply
returns NULL; starting with 7.4, a SYSTEM NOTICE is triggered.

Adjusting the code to make sure the stats have indeed been returned
(i.e. we got an array) instead of relying on a `!== null` check, which
in any case wrong since bug_get_bugnote_stats() returns false, not NULL.

Also update PHPDoc for bug_get_bugnote_stats() to reflect that.

Fixes [#26439](https://mantisbt.org/bugs/view.php?id=26439)