### PR TITLE
Correct CSS class names for custom fields

### DIFF
--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -1433,6 +1433,21 @@ function print_custom_field_input( array $p_field_def, $p_bug_id = null, $p_requ
 	}
 }
 
+/*
+ * Returns a valid CSS identifier for the given custom field.
+ *
+ * The string is built based on the custom field's name, replacing any potentially
+ * unsupported character(s) by dashes `-` to ensure its validity. The resulting
+ * identifier can be used as part of a custom CSS class.
+ *
+ * @param string $p_custom_field_name The custom field's name
+ *
+ * @return string The CSS identifier
+ */
+function custom_field_css_name( $p_custom_field_name ) {
+    return 'custom-' . preg_replace( '/[^a-zA-Z0-9_-]+/', '-', $p_custom_field_name );
+}
+
 /**
  * Constructs the name of a field used as a flag to indicate that a custom field is present on the form
  * @param integer $p_custom_field_id  The custom field id to create the field name for.

--- a/core/custom_function_api.php
+++ b/core/custom_function_api.php
@@ -343,7 +343,7 @@ function custom_function_default_print_column_title( $p_column, $p_columns_targe
 	$t_custom_field = column_get_custom_field_name( $p_column );
 	if( $t_custom_field !== null ) {
 		if( COLUMNS_TARGET_CSV_PAGE != $p_columns_target ) {
-			echo '<th class="column-custom-' . $t_custom_field . '">';
+			echo '<th class="column-' . custom_field_css_name( $t_custom_field ) . '">';
 		}
 
 		$t_field_id = custom_field_get_id_from_name( $t_custom_field );
@@ -408,7 +408,7 @@ function custom_function_default_print_column_value( $p_column, BugData $p_bug, 
 
 	$t_custom_field = column_get_custom_field_name( $p_column );
 	if( $t_custom_field !== null ) {
-		printf( $t_column_start, 'custom-' . $t_custom_field );
+		printf( $t_column_start, custom_field_css_name( $t_custom_field ) );
 
 		$t_field_id = custom_field_get_id_from_name( $t_custom_field );
 		if( $t_field_id === false ) {


### PR DESCRIPTION
Not all characters are allowed to be used in CSS class names.
Replace any potentially unsupported character(s) by dashes `-`.

Fixes #26473