### PR TITLE
Fix usage of reporter_summary_limit on summary page

### DIFF
--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -504,7 +504,7 @@ function summary_print_by_reporter( array $p_filter = null ) {
 		$t_reporters[] = (int)$t_row['reporter_id'];
 		$t_bugs_total_count += $t_row['num'];
 		$t_reporters_count++;
-		if( $t_reporter_summary_limit > 0 && $t_reporters_count > $t_reporter_summary_limit ) {
+		if( $t_reporters_count == $t_reporter_summary_limit ) {
 			break;
 		}
 	}


### PR DESCRIPTION
"Reporter Stats" section on summary page displayed one more row than set
in option reporter_summary_limit.

Fixes #26555