### PR TITLE
Remove 'firebug' as logging destination

### DIFF
--- a/admin/check/check_config_inc.php
+++ b/admin/check/check_config_inc.php
@@ -76,8 +76,8 @@ check_print_test_warn_row( 'Check whether diagnostic logging is enabled',
 );
 
 check_print_test_warn_row( 'Check whether log output is sent to end user',
-	!($g_log_destination == 'firebug' || $g_log_destination == 'page'),
-	array( false => 'Diagnostic output destination is currently sent to end users browser' )
+	$g_log_destination !== 'page',
+	array( false => "Diagnostics output destination is currently set to end-user's browser" )
 );
 
 check_print_test_warn_row( 'Detailed errors should be OFF',

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -4316,9 +4316,6 @@ $g_log_level = LOG_NONE;
  * - 'file':    Log to a specific file, specified as an absolute path, e.g.
  *              'file:/var/log/mantis.log' (Unix) or
  *              'file:c:/temp/mantisbt.log' (Windows)
- * - 'firebug': make use of Firefox {@link http://getfirebug.com/ Firebug Add-on}.
- *              If user is not running firefox, this options falls back to
- *              the default php error log settings.
  * - 'page':    Display log output at bottom of the page. See also
  *              {@link $g_show_log_threshold} to restrict who can see log data.
  *

--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -132,22 +132,6 @@ function log_event( $p_level, $p_msg ) {
 			global $g_log_events;
 			$g_log_events[] = array( time(), $p_level, $t_event, $t_caller);
 			break;
-		case 'firebug':
-			if( !class_exists( 'FirePHP' ) ) {
-				if( file_exists( config_get_global( 'library_path' ) . 'FirePHPCore/FirePHP.class.php' ) ) {
-					require_lib( 'FirePHPCore/FirePHP.class.php' );
-				}
-			}
-			if( class_exists( 'FirePHP' ) ) {
-				static $s_firephp;
-				if( $s_firephp === null ) {
-					$s_firephp = FirePHP::getInstance( true );
-				}
-				# Don't use $t_msg, let FirePHP format the message
-				$s_firephp->log( $p_msg, $t_now . ' ' . $t_level );
-				return;
-			}
-			# if firebug is not available, fall through
 		default:
 			# use default PHP error log settings
 			error_log( $t_php_event . PHP_EOL );

--- a/docbook/Admin_Guide/en-US/config/logging.xml
+++ b/docbook/Admin_Guide/en-US/config/logging.xml
@@ -319,17 +319,6 @@ or
 						</listitem>
 					</varlistentry>
 					<varlistentry>
-						<term>'firebug'</term>
-						<listitem>
-							<para>make use of Firefox
-								<ulink url="http://getfirebug.com/">
-									Firebug Add-on</ulink>.
-								If user is not running firefox, this options
-								falls back to the default php error log settings.
-							</para>
-						</listitem>
-					</varlistentry>
-					<varlistentry>
 						<term>'page'</term>
 						<listitem>
 							<para>Display log output at bottom of the page.


### PR DESCRIPTION
Firebug development stopped in 2017 with the launch of Firefox 57 [1].

Fixes #26572

[1]: https://getfirebug.com/