### PR TITLE
Improve LDAP API performance through caching

### DIFF
--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -214,7 +214,7 @@ function ldap_cache_user_data( $p_username ) {
 	# Bind
 	$t_ds = @ldap_connect_bind();
 	if( $t_ds === false ) {
-		ldap_log_error( $t_ds );
+		log_event( LOG_LDAP, "ERROR: could not bind to LDAP server" );
 		return false;
 	}
 
@@ -337,10 +337,6 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
 
 		# Bind
 		$t_ds = ldap_connect_bind();
-		if( $t_ds === false ) {
-			ldap_log_error( $t_ds );
-			trigger_error( ERROR_LDAP_AUTH_FAILED, ERROR );
-		}
 
 		# Search for the user id
 		log_event( LOG_LDAP, 'Searching for ' . $t_search_filter );

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -212,7 +212,6 @@ function ldap_cache_user_data( $p_username ) {
 	log_event( LOG_LDAP, "Retrieving data for '$p_username' from LDAP server" );
 
 	# Bind
-	log_event( LOG_LDAP, 'Binding to LDAP server' );
 	$t_ds = @ldap_connect_bind();
 	if( $t_ds === false ) {
 		ldap_log_error( $t_ds );
@@ -337,7 +336,6 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
 		);
 
 		# Bind
-		log_event( LOG_LDAP, 'Binding to LDAP server' );
 		$t_ds = ldap_connect_bind();
 		if( $t_ds === false ) {
 			ldap_log_error( $t_ds );

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -140,18 +140,11 @@ function ldap_email( $p_user_id ) {
  * @return string
  */
 function ldap_email_from_username( $p_username ) {
-	global $g_cache_ldap_data;
-	if( isset( $g_cache_ldap_data[$p_username]['mail'] ) ) {
-		return $g_cache_ldap_data[$p_username]['mail'];
-	}
-
 	if( ldap_simulation_is_enabled() ) {
 		$t_email = ldap_simulation_email_from_username( $p_username );
 	} else {
 		$t_email = (string)ldap_get_field_from_username( $p_username, 'mail' );
 	}
-
-	$g_cache_ldap_data[$p_username]['mail'] = $t_email;
 	return $t_email;
 }
 
@@ -167,24 +160,16 @@ function ldap_realname( $p_user_id ) {
 
 /**
  * Gets a user real name given their user name.
- *
  * @param string $p_username The user's name.
  * @return string The user's real name.
  */
 function ldap_realname_from_username( $p_username ) {
-	global $g_cache_ldap_data;
-	if( isset( $g_cache_ldap_data[$p_username]['realname'] ) ) {
-		return $g_cache_ldap_data[$p_username]['realname'];
-	}
-
 	if( ldap_simulation_is_enabled() ) {
 		$t_realname = ldap_simulatiom_realname_from_username( $p_username );
 	} else {
 		$t_ldap_realname_field = config_get( 'ldap_realname_field' );
 		$t_realname = (string)ldap_get_field_from_username( $p_username, $t_ldap_realname_field );
 	}
-
-	$g_cache_ldap_data[$p_username]['realname'] = $t_realname;
 	return $t_realname;
 }
 
@@ -215,6 +200,14 @@ function ldap_escape_string( $p_string ) {
  * @return string The field value or null if not found.
  */
 function ldap_get_field_from_username( $p_username, $p_field ) {
+	global $g_cache_ldap_data;
+
+	# Returned cached data if available
+	if( isset( $g_cache_ldap_data[$p_username][$p_field] ) ) {
+		log_event(LOG_LDAP, "Retrieving field '$p_field' for '$p_username' from cache");
+		return $g_cache_ldap_data[$p_username][$p_field];
+	}
+
 	$t_ldap_organization    = config_get( 'ldap_organization' );
 	$t_ldap_root_dn         = config_get( 'ldap_root_dn' );
 	$t_ldap_uid_field		= config_get( 'ldap_uid_field' );
@@ -273,6 +266,8 @@ function ldap_get_field_from_username( $p_username, $p_field ) {
 		return null;
 	}
 
+	# Cache the field's value
+	$g_cache_ldap_data[$p_username][$p_field] = $t_value;
 	return $t_value;
 }
 

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -281,7 +281,7 @@ function ldap_cache_user_data( $p_username ) {
  * @return string The field value or null if not found.
  */
 function ldap_get_field_from_username( $p_username, $p_field ) {
-	log_event(LOG_LDAP, "Retrieving field '$p_field' for '$p_username'");
+	log_event( LOG_LDAP, "Retrieving field '$p_field' for '$p_username'" );
 	$t_ldap_data = ldap_cache_user_data( $p_username );
 
 	# Make sure LDAP data is available and the requested field exists

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -129,17 +129,7 @@ $g_cache_ldap_email = array();
  * @return string
  */
 function ldap_email( $p_user_id ) {
-	global $g_cache_ldap_email;
-
-	if( isset( $g_cache_ldap_email[(int)$p_user_id] ) ) {
-		return $g_cache_ldap_email[(int)$p_user_id];
-	}
-
-	$t_username = user_get_username( $p_user_id );
-	$t_email = ldap_email_from_username( $t_username );
-
-	$g_cache_ldap_email[(int)$p_user_id] = $t_email;
-	return $t_email;
+	return ldap_email_from_username( user_get_username( $p_user_id ) );
 }
 
 /**
@@ -148,15 +138,18 @@ function ldap_email( $p_user_id ) {
  * @return string
  */
 function ldap_email_from_username( $p_username ) {
+	global $g_cache_ldap_email;
+	if( isset( $g_cache_ldap_email[$p_username]['mail'] ) ) {
+		return $g_cache_ldap_email[$p_username]['mail'];
+	}
+
 	if( ldap_simulation_is_enabled() ) {
-		return ldap_simulation_email_from_username( $p_username );
+		$t_email = ldap_simulation_email_from_username( $p_username );
+	} else {
+		$t_email = (string)ldap_get_field_from_username( $p_username, 'mail' );
 	}
 
-	$t_email = ldap_get_field_from_username( $p_username, 'mail' );
-	if( $t_email === null ) {
-		return '';
-	}
-
+	$g_cache_ldap_email[$p_username]['mail'] = $t_email;
 	return $t_email;
 }
 

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -260,10 +260,8 @@ function ldap_cache_user_data( $p_username ) {
 	# Store data in the cache
 	$g_cache_ldap_data[$p_username] = $t_data;
 
-	# Free results / unbind
-	# According to documentation, calling ldap_free_result() is not strictly necessary
+	# Unbind
 	log_event( LOG_LDAP, 'Unbinding from LDAP server' );
-	# ldap_free_result( $t_sr );
 	ldap_unbind( $t_ds );
 
 	return $t_data;
@@ -357,7 +355,6 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
 		$t_info = @ldap_get_entries( $t_ds, $t_sr );
 		if( $t_info === false ) {
 			ldap_log_error( $t_ds );
-			ldap_free_result( $t_sr );
 			ldap_unbind( $t_ds );
 			trigger_error( ERROR_LDAP_AUTH_FAILED, ERROR );
 		}
@@ -381,7 +378,6 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
 		}
 
 		log_event( LOG_LDAP, 'Unbinding from LDAP server' );
-		ldap_free_result( $t_sr );
 		ldap_unbind( $t_ds );
 	}
 

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -102,7 +102,7 @@ function ldap_connect_bind( $p_binddn = '', $p_password = '' ) {
 		}
 
 		if( !is_blank( $p_binddn ) && !is_blank( $p_password ) ) {
-			log_event( LOG_LDAP, 'Attempting bind to ldap server with username and password' );
+			log_event( LOG_LDAP, "Attempting bind to ldap server as '$p_binddn'" );
 			$t_br = @ldap_bind( $t_ds, $p_binddn, $p_password );
 		} else {
 			# Either the Bind DN or the Password are empty, so attempt an anonymous bind.

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -237,7 +237,7 @@ function ldap_cache_user_data( $p_username ) {
 	if( $t_sr === false ) {
 		ldap_log_error( $t_ds );
 		ldap_unbind( $t_ds );
-		log_event( LOG_LDAP, 'ldap search failed' );
+		log_event( LOG_LDAP, "Search '$t_search_filter' failed" );
 		return false;
 	}
 
@@ -348,7 +348,7 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
 		if( $t_sr === false ) {
 			ldap_log_error( $t_ds );
 			ldap_unbind( $t_ds );
-			log_event( LOG_LDAP, 'ldap search failed' );
+			log_event( LOG_LDAP, "Search '$t_search_filter' failed" );
 			trigger_error( ERROR_LDAP_AUTH_FAILED, ERROR );
 		}
 

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -211,7 +211,9 @@ function ldap_cache_user_data( $p_username ) {
 
 	log_event( LOG_LDAP, "Retrieving data for '$p_username' from LDAP server" );
 
-	# Bind
+	# Bind and connect.
+	# We suppress errors, because failing to connect is not blocking in this
+	# context, it just means we won't be able to retrieve user data from LDAP.
 	$t_ds = @ldap_connect_bind();
 	if( $t_ds === false ) {
 		log_event( LOG_LDAP, "ERROR: could not bind to LDAP server" );
@@ -335,7 +337,9 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
 			'dn',
 		);
 
-		# Bind
+		# Bind and connect.
+		# No need to check for failures, as ldap_connect_bind() throws errors.
+		log_event( LOG_LDAP, 'Binding to LDAP server' );
 		$t_ds = ldap_connect_bind();
 
 		# Search for the user id

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -396,7 +396,7 @@ function ldap_authenticate_by_username( $p_username, $p_password ) {
 			$t_fields_to_update = array('password' => md5( $p_password ));
 
 			if( ON == config_get( 'use_ldap_realname' ) ) {
-				$t_fields_to_update['realname'] = ldap_realname( $t_user_id );
+				$t_fields_to_update['realname'] = ldap_realname_from_username( $p_username );
 			}
 
 			if( ON == config_get( 'use_ldap_email' ) ) {

--- a/docbook/Admin_Guide/en-US/Installation.xml
+++ b/docbook/Admin_Guide/en-US/Installation.xml
@@ -194,6 +194,7 @@
 								<listitem><para><emphasis>GD</emphasis> -
 									required for the captcha feature
 								</para></listitem>
+
 								<listitem>
 									<para><emphasis>Fileinfo</emphasis> -
 										Required for file attachments and most of the plugins
@@ -203,7 +204,14 @@
 										as MantisBT won't be able to send
 										the Content-Type header to a browser
 										requesting an attachment.
-									</para></listitem>
+									</para>
+								</listitem>
+
+								<listitem><para><emphasis>LDAP</emphasis> -
+									required for LDAP or Active Directory authentication
+									(see <xref linkend="admin.auth.ldap" />).
+								</para></listitem>
+
 							</itemizedlist></listitem>
 						</varlistentry>
 


### PR DESCRIPTION
Note: this only affects actual LDAP server queries, LDAP simulation functions are not cached.

This fixes [#26622](https://mantisbt.org/bugs/view.php?id=26622) and should address [#26600](https://mantisbt.org/bugs/view.php?id=26600) too. 