### PR TITLE
Use $g_logo_image for RSS feeds

### DIFF
--- a/issues_rss.php
+++ b/issues_rss.php
@@ -102,7 +102,7 @@ $t_path = config_get_global( 'path' );
 $t_encoding = 'utf-8';
 $t_about = $t_path;
 $t_title = config_get( 'window_title' );
-$t_image_link = $t_path . 'images/mantis_logo_button.gif';
+$t_image_link = $t_path . config_get( 'logo_image' );
 
 # only rss 2.0
 $t_category = project_get_name( $f_project_id );

--- a/news_rss.php
+++ b/news_rss.php
@@ -89,7 +89,7 @@ if( $f_username !== null ) {
 }
 
 $t_description = $t_title;
-$t_image_link = config_get_global( 'path' ) . 'images/mantis_logo_button.gif';
+$t_image_link = config_get_global( 'path' ) . config_get( 'logo_image' );;
 
 # only rss 2.0
 $t_category = string_rss_links( project_get_name( $f_project_id ) );


### PR DESCRIPTION
The code was using an hardcoded image name (mantis_logo_button.gif),
obsolete since the introduction of the new MantisBT logo, back in
2012 / 1.2.9 (!)

Fixes [#21133](https://mantisbt.org/bugs/view.php?id=21133)