### PR TITLE
Use query parameters in install helper function

### DIFF
--- a/core/install_helper_functions_api.php
+++ b/core/install_helper_functions_api.php
@@ -409,10 +409,11 @@ function install_correct_multiselect_custom_fields_db_format() {
 		$c_bug_id = (int)$t_row['bug_id'];
 		$c_value = '|' . rtrim( ltrim( $t_row['value'], '|' ), '|' ) . '|';
 		$t_update_query = 'UPDATE {custom_field_string}
-			SET value = \'' . $c_value . '\'
-			WHERE field_id = ' . $c_field_id . '
-				AND bug_id = ' . $c_bug_id;
-		db_query( $t_update_query );
+			SET value = ' . db_param() . '
+			WHERE field_id = ' . db_param() . '
+				AND bug_id = ' . db_param();
+		$t_param = array( $c_value, $c_field_id, $c_bug_id );
+		db_query( $t_update_query, $t_param );
 	}
 
 	# Remove vertical pipe | prefix and suffix from radio custom field values.
@@ -429,10 +430,11 @@ function install_correct_multiselect_custom_fields_db_format() {
 		$c_bug_id = (int)$t_row['bug_id'];
 		$c_value = rtrim( ltrim( $t_row['value'], '|' ), '|' );
 		$t_update_query = 'UPDATE {custom_field_string}
-			SET value = \'' . $c_value . '\'
-			WHERE field_id = ' . $c_field_id . '
-				AND bug_id = ' . $c_bug_id;
-		db_query( $t_update_query );
+			SET value = ' . db_param() . '
+			WHERE field_id = ' . db_param() . '
+		 ]		AND bug_id = ' . db_param();
+		$t_param = array( $c_value, $c_field_id, $c_bug_id );
+		db_query( $t_update_query, $t_param );
 	}
 
 	# Re-enable query logging if we disabled it


### PR DESCRIPTION
install_correct_multiselect_custom_fields_db_format() injected actual
field values in the update SQL queries, which is a potential source for
SQL injection, and causes the upgrade from MantisBT < 1.2.0 to fail when
custom_field_table contains an apostrophe.

Fixes [#26636](https://mantisbt.org/bugs/view.php?id=26636)