### PR TITLE
Trim username on login

### DIFF
--- a/login_password_page.php
+++ b/login_password_page.php
@@ -58,7 +58,7 @@ require_css( 'login.css' );
 $f_error                 = gpc_get_bool( 'error' );
 $f_cookie_error          = gpc_get_bool( 'cookie_error' );
 $f_return                = string_sanitize_url( gpc_get_string( 'return', '' ) );
-$f_username              = gpc_get_string( 'username', '' );
+$f_username              = trim( gpc_get_string( 'username', '' ) );
 $f_reauthenticate        = gpc_get_bool( 'reauthenticate', false );
 $f_perm_login            = gpc_get_bool( 'perm_login', false );
 $f_secure_session        = gpc_get_bool( 'secure_session', false );


### PR DESCRIPTION
When an LDAP user adds spaces before or after their username when
logging in, they will be authenticated successfully and logged in, but
Mantis will create a new entry in the user table including the spaces.

Fixes [#25097](https://mantisbt.org/bugs/view.php?id=25097)