### PR TITLE
Various improvements to installer when generating SQL script

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -873,6 +873,16 @@ if( 3 == $t_install_state ) {
 		if( $f_log_queries ) {
 			echo '<tr><td><span class="bigger-120">Database Creation Suppressed, SQL Queries follow</span>';
 
+			echo '<div class="space-6"></div>';
+			echo '<div class="alert alert-warning">';
+			echo "Please note that executing the generated script below <strong>may not result in a fully functional "
+				. "database</strong>, particularly in upgrade scenarios. This is due to the fact that some upgrade "
+				. "steps require the execution of PHP code; these <em>Upgrade Functions</em> are defined in "
+				. '<a href="https://github.com/mantisbt/mantisbt/blob/master/core/install_helper_functions_api.php">install_helper_functions_api.php</a>'
+				. " and cannot be translated to SQL statements. Use at your own risk.";
+			echo '</div>';
+
+			echo '<pre>';
 			echo "-- MantisBT " . MANTIS_VERSION . " Database creation script". PHP_EOL;
 			echo "-- " . date("c") . PHP_EOL . PHP_EOL;
 		}

--- a/admin/install.php
+++ b/admin/install.php
@@ -1078,7 +1078,17 @@ if( 3 == $t_install_state ) {
 		}
 		if( $f_log_queries ) {
 			# add a query to set the database version
-			echo 'INSERT INTO ' . db_get_table( 'config' ) . ' ( value, type, access_reqd, config_id, project_id, user_id ) VALUES (\'' . $t_last_id . '\', 1, 90, \'database_version\', 0, 0 );' . PHP_EOL;
+			if( $t_last_update == -1 ) {
+				echo "INSERT INTO " . db_get_table( 'config' )
+					. " ( value, type, access_reqd, config_id, project_id, user_id )"
+					. " VALUES ($t_last_id, 1, 90, 'database_version', 0, 0 );"
+					. PHP_EOL;
+			} else {
+				echo "UPDATE " . db_get_table( 'config' )
+					. " SET value = $t_last_id"
+					. " WHERE config_id = 'database_version' AND project_id = 0 AND user_id = 0;"
+					. PHP_EOL;
+			}
 			echo '</pre><br /><p style="color:red">Your database has not been created yet. Please create the database, then install the tables and data using the information above before proceeding.</p></td></tr>';
 		}
 	}

--- a/admin/install.php
+++ b/admin/install.php
@@ -1461,12 +1461,17 @@ if( 7 == $t_install_state ) {
 <tr>
 	<td>
 		<span class="bigger-130">
+<?php if( $f_log_queries ) { ?>
+		SQL script generated successfully.
+		Use it to manually create or upgrade your database.
+<?php } else { ?>
 		MantisBT was installed successfully.
-<?php if( $f_db_exists ) {?>
+<?php if( $f_db_exists ) { ?>
 		<a href="../login_page.php">Continue</a> to log in.
 <?php } else { ?>
 		Please log in as the administrator and <a href="../login_page.php">create</a> your first project.
 		</span>
+<?php } ?>
 <?php } ?>
 	</td>
 	<?php print_test_result( GOOD ); ?>

--- a/admin/install.php
+++ b/admin/install.php
@@ -1126,7 +1126,14 @@ if( 3 == $t_install_state ) {
 					. " WHERE config_id = 'database_version' AND project_id = 0 AND user_id = 0;"
 					. PHP_EOL;
 			}
-			echo '</pre><br /><p style="color:red">Your database has not been created yet. Please create the database, then install the tables and data using the information above before proceeding.</p></td></tr>';
+			echo '</pre>';
+
+			echo '<div class="space-6"></div>';
+			echo '<div class="alert alert-danger">';
+			echo "<strong>Your database is not ready yet !</strong> "
+				. "Please create it, then install the tables and data using the above script before proceeding.";
+			echo '</div>';
+			echo '</td></tr>';
 		}
 	}
 	if( false == $g_failed ) {


### PR DESCRIPTION
Resolves the following issues:

- [0026568](https://mantisbt.org/bugs/view.php?id=26568): Use appropriate statement to update DB schema when generating SQL
- [0026661](https://mantisbt.org/bugs/view.php?id=26661): Add informational comments to SQL script generated by installer
- [0026662](https://mantisbt.org/bugs/view.php?id=26662): Final statement to set database version not logged in SQL script
- [0026663](https://mantisbt.org/bugs/view.php?id=26663): improve installer messages when generating SQL script
