### PR TITLE
Add Reset buttons to installer's pre/suffix fields

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -681,6 +681,11 @@ if( !$g_database_upgrade ) {
 			${'f_' . $t_key} // The actual value of the corresponding form variable
 		);
 		echo "\n&nbsp;";
+		printf( '<button id="%s" type="button" class="btn btn-sm btn-primary btn-white btn-round reset-prefix">%s</button>',
+			"btn_$t_key",
+			lang_get( 'reset' )
+		);
+		echo "\n&nbsp;";
 		if( $t_key != 'db_table_suffix' ) {
 			$t_id_sample = $t_key. '_sample';
 			echo '<label for="' . $t_id_sample . '">Sample table name:</label>';

--- a/js/install.js
+++ b/js/install.js
@@ -22,6 +22,65 @@ $(document).ready( function() {
 'use strict';
 
 /**
+ * PrefixInput object
+ * @param input
+ * @constructor
+ */
+function PrefixInput (inputId) {
+	this.input = $('#' + inputId);
+	this.button = $('#btn_' + inputId);
+
+	/** Corresponding reset button */
+	this.resetButton = function () { return this.button; };
+	this.enableButton = function () { this.button.removeAttr('disabled');};
+	this.disableButton = function () { this.button.attr('disabled', true);};
+
+	/** Default value (data attribute) */
+	this.getDefault = function () { return this.input.data('defval'); };
+	this.setDefault = function (value) {
+		this.input.data('defval', value);
+		if (this.isValueDefault()) {
+			this.disableButton();
+		}
+	};
+
+	this.getValue = function () { return this.input.val(); };
+	this.isValueDefault = function () { return this.getValue() === this.getDefault(); };
+
+	/**
+	 *
+	 * @param value
+	 */
+	this.setValue = function (value) {
+		this.input.val(value);
+		if (this.isValueDefault()) {
+			this.disableButton();
+		}
+	};
+
+	/**
+	 * Reset the input's value to default
+	 * Set focus to the input, select the whole text and disable the reset button.
+	 */
+	this.resetValue = function () {
+		this.input.val(this.getDefault());
+		this.input.focus()[0].setSelectionRange(0, this.getValue().length);
+		this.disableButton();
+	};
+}
+
+var reset_buttons = $('button.reset-prefix');
+
+/**
+ * Initialize all input's default values and disable the reset buttons
+ */
+var inputs = $('input.table-prefix').each(function () {
+	var input = new PrefixInput(this.id);
+	input.setDefault(input.getValue());
+	input.disableButton();
+});
+
+/**
  * On Change event for database type selection list
  * Preset prefix, plugin prefix and suffix fields when changing db type
  */
@@ -39,14 +98,13 @@ $('#db_type').change(
 		// Loop over the selected DB's default values for each pre/suffix
 		$('#default_' + db + ' span').each(
 			function () {
-				var target = $("#" + this.className);
-				var oldVal = target.data('defval');
+				var input = new PrefixInput(this.className);
+
 				// Only change the value if not changed from default
-				if (typeof oldVal === 'undefined' || oldVal === target.val()) {
-					target.val(this.textContent);
+				if (input.isValueDefault()) {
+					input.setValue(this.textContent);
 				}
-				// Store default value
-				target.data('defval', this.textContent);
+				input.setDefault(this.textContent);
 			}
 		);
 
@@ -55,12 +113,35 @@ $('#db_type').change(
 );
 
 /**
- * Populate sample table names based on given prefix/suffix
+ * Process changes to prefix/suffix inputs
  */
-$('input.table-prefix').on('input', update_sample_table_names);
+inputs.on('input', function () {
+	var input = new PrefixInput(this.id);
+
+	// Enable / disable the Reset button as appropriate
+	if(input.isValueDefault()) {
+		input.disableButton();
+	} else {
+		input.enableButton();
+	}
+
+	update_sample_table_names();
+});
+
+/**
+ * Buttons to reset the prefix/suffix to the current default value
+ */
+reset_buttons.click(function () {
+	var input = new PrefixInput($(this).prev('input.table-prefix')[0].id);
+	input.resetValue();
+	update_sample_table_names();
+});
 
 update_sample_table_names();
 
+/**
+ * Populate sample table names based on given prefix/suffix
+ */
 function update_sample_table_names() {
 	var prefix = $('#db_table_prefix').val().trim();
 	if(prefix && prefix.substr(-1) !== '_') {

--- a/js/install.js
+++ b/js/install.js
@@ -18,8 +18,8 @@
 # along with Mantis.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 $(document).ready( function() {
+'use strict';
 
 /**
  * On Change event for database type selection list
@@ -28,7 +28,7 @@ $(document).ready( function() {
 $('#db_type').change(
 	function () {
 		var db;
-		if ($(this).val() == 'oci8') {
+		if ($(this).val() === 'oci8') {
 			db = 'oci8';
 			$('#oracle_size_warning').show();
 		} else {
@@ -42,7 +42,7 @@ $('#db_type').change(
 				var target = $("#" + this.className);
 				var oldVal = target.data('defval');
 				// Only change the value if not changed from default
-				if (typeof oldVal === 'undefined' || oldVal == target.val()) {
+				if (typeof oldVal === 'undefined' || oldVal === target.val()) {
 					target.val(this.textContent);
 				}
 				// Store default value
@@ -52,7 +52,7 @@ $('#db_type').change(
 
 		update_sample_table_names();
 	}
-).change();
+);
 
 /**
  * Populate sample table names based on given prefix/suffix
@@ -60,22 +60,23 @@ $('#db_type').change(
 $('input.table-prefix').on('input', update_sample_table_names);
 
 update_sample_table_names();
-});
 
 function update_sample_table_names() {
 	var prefix = $('#db_table_prefix').val().trim();
-	if(prefix && prefix.substr(-1) != '_') {
+	if(prefix && prefix.substr(-1) !== '_') {
 		prefix += '_';
 	}
 	var suffix = $('#db_table_suffix').val().trim();
-	if(suffix && suffix.substr(0,1) != '_') {
+	if(suffix && suffix.substr(0,1) !== '_') {
 		suffix = '_' + suffix;
 	}
 	var plugin = $('#db_table_plugin_prefix').val().trim();
-	if(plugin && plugin.substr(-1) != '_') {
+	if(plugin && plugin.substr(-1) !== '_') {
 		plugin += '_';
 	}
 
 	$('#db_table_prefix_sample').val(prefix + '<CORE TABLE>' + suffix);
 	$('#db_table_plugin_prefix_sample').val(prefix + plugin + '<PLUGIN>_<TABLE>' + suffix);
 }
+
+});


### PR DESCRIPTION
Allows admins to reset their input to database-specific default values.

Fixes [#26664](https://mantisbt.org/bugs/view.php?id=26664)

