### PR TITLE
Fix REST API errors when providing invalid custom field data

### DIFF
--- a/api/soap/mc_custom_field_api.php
+++ b/api/soap/mc_custom_field_api.php
@@ -38,7 +38,7 @@ function mci_get_custom_field_id_from_objectref( stdClass $p_object_ref ) {
 	if( isset( $p_object_ref['id'] ) && (int) $p_object_ref['id'] != 0 ) {
 		$t_id = (int)$p_object_ref['id'];
 	} else {
-		if( !is_blank( $p_object_ref['name'] ) ) {
+		if( isset( $p_object_ref['name'] ) && !is_blank( $p_object_ref['name'] ) ) {
 			$t_id = custom_field_get_id_from_name( $p_object_ref['name'] );
 		} else {
 			$t_id = 0;

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -637,16 +637,6 @@ function mci_project_custom_fields_validate( $p_project_id, &$p_custom_fields ) 
 		$t_custom_field_defs[$t_custom_field_id] = $t_def;
 	}
 
-	$fn_normalize_name = function( $p_name, $p_custom_field_defs ) {
-		foreach( $p_custom_field_defs as $t_custom_field_def ) {
-			if( strcasecmp( $t_custom_field_def['name'], $p_name ) == 0 ) {
-				return $t_custom_field_def['name'];
-			}
-		}
-
-		return $p_name;
-	};
-
 	$t_custom_field_values = array();
 	if( isset( $p_custom_fields ) ) {
 		if( !is_array( $p_custom_fields ) ) {
@@ -674,25 +664,25 @@ function mci_project_custom_fields_validate( $p_project_id, &$p_custom_fields ) 
 				);
 			}
 
-			$t_custom_field['field'] = ApiObjectFactory::objectToArray( $t_custom_field['field'] );
-
-			if( isset( $t_custom_field['field']['id'] ) ) {
-				$t_def = $t_custom_field_defs[(int)$t_custom_field['field']['id']];
+			$t_custom_field_id = mci_get_custom_field_id_from_objectref( (object)$t_custom_field['field'] );
+			if( $t_custom_field_id == 0 ) {
+				throw new ClientException(
+					'Invalid Custom Field '
+					# Output JSON stripped of quotes to help caller identify offending field
+					. str_replace( '"', '', json_encode( $t_custom_field['field'] ) ),
+					ERROR_CUSTOM_FIELD_NOT_FOUND
+				);
+			} else {
+				# Make sure the custom field is linked to the current project
+				if( !isset( $t_custom_field_defs[$t_custom_field_id] ) ) {
+					throw new ClientException(
+						"Custom Field Id '$t_custom_field_id' not found in Project '$p_project_id'.",
+						ERROR_CUSTOM_FIELD_NOT_FOUND
+					);
+				}
+				$t_def = $t_custom_field_defs[$t_custom_field_id];
 				$t_custom_field_values[$t_def['name']] = $t_custom_field['value'];
-				continue;
 			}
-
-			if( isset( $t_custom_field['field']['name'] ) ) {
-				$t_name = $fn_normalize_name( $t_custom_field['field']['name'], $t_custom_field_defs );
-				$t_custom_field_values[$t_name] = $t_custom_field['value'];
-				continue;
-			}
-
-			throw new ClientException(
-				'Custom field with no specified id or name.',
-				ERROR_EMPTY_FIELD,
-				"custom_field['field']['id']"
-			);
 		}
 	}
 

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -625,9 +625,11 @@ function mc_project_get_custom_fields( $p_username, $p_password, $p_project_id )
  * @param integer $p_project_id The project id.
  * @param array   $p_custom_fields The custom fields, may be not set.
  * @return bool|SoapFault|RestFault true or error.
+ *
+ * @throws ClientException
  */
 function mci_project_custom_fields_validate( $p_project_id, &$p_custom_fields ) {
-	# Load custom field definitions
+	# Load custom field definitions for the specified project
 	$t_related_custom_field_ids = custom_field_get_linked_ids( $p_project_id );
 	$t_custom_field_defs = array();
 	foreach( $t_related_custom_field_ids as $t_custom_field_id ) {

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -660,7 +660,7 @@ function mci_project_custom_fields_validate( $p_project_id, &$p_custom_fields ) 
 				throw new ClientException(
 					'Custom field has no value specified.',
 					ERROR_EMPTY_FIELD,
-					"custom_field['value']"
+					array( "custom_field['value']" )
 				);
 			}
 
@@ -668,7 +668,7 @@ function mci_project_custom_fields_validate( $p_project_id, &$p_custom_fields ) 
 				throw new ClientException(
 					'Custom field with no specified id or name.',
 					ERROR_EMPTY_FIELD,
-					"custom_field['field']"
+					array( "custom_field['field']" )
 				);
 			}
 

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -647,6 +647,12 @@ function mci_project_custom_fields_validate( $p_project_id, &$p_custom_fields ) 
 
 	$t_custom_field_values = array();
 	if( isset( $p_custom_fields ) ) {
+		if( !is_array( $p_custom_fields ) ) {
+			throw new ClientException(
+				"Invalid Custom Field '$p_custom_fields'",
+				ERROR_CUSTOM_FIELD_NOT_FOUND
+			);
+		}
 		foreach( $p_custom_fields as $t_custom_field ) {
 			$t_custom_field = ApiObjectFactory::objectToArray( $t_custom_field );
 


### PR DESCRIPTION
Fixes the following issues:

- [0026540](https://mantisbt.org/bugs/view.php?id=26540) | Passing unsanitized data to type hinted function causes program crash
- [0026541](https://mantisbt.org/bugs/view.php?id=26541) | Passing invalid id to rest api custom field update causes program crash
- [0026542](https://mantisbt.org/bugs/view.php?id=26542) | Passing out of range custom field id causes multiple PHP warnings / incorrect response

