### PR TITLE
Bugfixes on Category when reporting / updating issues

### DIFF
--- a/bug_actiongroup.php
+++ b/bug_actiongroup.php
@@ -228,7 +228,9 @@ foreach( $f_bug_arr as $t_bug_id ) {
 		case 'UP_CATEGORY':
 			$f_category_id = gpc_get_int( 'category' );
 			if( access_has_bug_level( config_get( 'update_bug_threshold' ), $t_bug_id ) ) {
-				if( category_exists( $f_category_id ) ) {
+				if( category_exists( $f_category_id )
+					|| $f_category_id == 0 && config_get( 'allow_no_category' )
+				) {
 					# @todo we need to issue a helper_call_custom_function( 'issue_update_validate', array( $t_bug_id, $t_bug_data, $f_bugnote_text ) );
 					bug_set_field( $t_bug_id, 'category_id', $f_category_id );
 					email_bug_updated( $t_bug_id );

--- a/bug_actiongroup_page.php
+++ b/bug_actiongroup_page.php
@@ -303,7 +303,7 @@ if( $t_multiple_projects ) {
 				'" value="' . $t_date_to_display . '" />';
 			echo '<i class="fa fa-calendar fa-xlg datetimepicker"></i>';
 		} else {
-			echo '<select name="' . $t_form . '" class="input-sm">';
+			echo '<select name="' . $t_form . '" class="input-sm" required>';
 
 			switch( $f_action ) {
 				case 'COPY':

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -260,11 +260,12 @@ if( $t_show_attachments ) {
 	event_signal( 'EVENT_REPORT_BUG_FORM_TOP', array( $t_project_id ) );
 
 	if( $t_show_category ) {
+		$t_allow_no_category = config_get( 'allow_no_category' );
 ?>
 	<tr>
 		<th class="category" width="30%">
 			<?php
-			echo config_get( 'allow_no_category' ) ? '' : '<span class="required">*</span> ';
+			echo $t_allow_no_category ? '' : '<span class="required">*</span> ';
 			echo '<label for="category_id">';
 			print_documentation_link( 'category' );
 			echo '</label>';
@@ -274,14 +275,18 @@ if( $t_show_attachments ) {
 			<?php if( $t_changed_project ) {
 				echo '[' . project_get_field( $t_bug->project_id, 'name' ) . '] ';
 			} ?>
-			<select <?php echo helper_get_tab_index() ?> id="category_id" name="category_id" class="autofocus input-sm">
+			<select id="category_id" name="category_id" class="autofocus input-sm" <?php
+				echo helper_get_tab_index();
+				echo $t_allow_no_category ? '' : ' required';
+			?>>
 				<?php
 					print_category_option_list( $f_category_id );
 				?>
 			</select>
 		</td>
 	</tr>
-<?php }
+<?php
+	}
 
 	if( $t_show_reproducibility ) {
 ?>

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -206,7 +206,13 @@ if( $t_show_id || $t_show_project || $t_show_category || $t_show_view_state || $
 	echo '<tr>';
 	echo '<td width="15%" class="category">', $t_show_id ? lang_get( 'id' ) : '', '</td>';
 	echo '<td width="20%" class="category">', $t_show_project ? lang_get( 'email_project' ) : '', '</td>';
-	echo '<td width="15%" class="category">', $t_show_category ? '<label for="category_id">' . lang_get( 'category' ) . '</label>' : '', '</td>';
+	echo '<td width="15%" class="category">';
+	if( $t_show_category ) {
+		$t_allow_no_category = config_get( 'allow_no_category' );
+		echo $t_allow_no_category ? '' : '<span class="required">*</span> ';
+		echo '<label for="category_id">' . lang_get( 'category' ) . '</label>';
+	}
+	echo '</td>';
 	echo '<td width="20%" class="category">', $t_show_view_state ? '<label for="view_state">' . lang_get( 'view_status' ) . '</label>' : '', '</td>';
 	echo '<td width="15%" class="category">', $t_show_date_submitted ? lang_get( 'date_submitted' ) : '', '</td>';
 	echo '<td width="15%" class="category">', $t_show_last_updated ? lang_get( 'last_update' ) : '', '</td>';
@@ -228,7 +234,9 @@ if( $t_show_id || $t_show_project || $t_show_category || $t_show_view_state || $
 	echo '<td>';
 
 	if( $t_show_category ) {
-		echo '<select ' . helper_get_tab_index() . ' id="category_id" name="category_id" class="input-sm">';
+		echo '<select ' . helper_get_tab_index()
+			. ( $t_allow_no_category ? '' : ' required' )
+			. ' id="category_id" name="category_id" class="input-sm">';
 		print_category_option_list( $t_bug->category_id, $t_bug->project_id );
 		echo '</select>';
 	}
@@ -629,17 +637,26 @@ echo '<tr class="hidden"></tr>';
 # Summary
 if( $t_show_summary ) {
 	echo '<tr>';
-	echo '<th class="category"><label for="summary">' . lang_get( 'summary' ) . '</label></th>';
-	echo '<td colspan="5">', '<input ', helper_get_tab_index(), ' type="text" id="summary" name="summary" size="105" maxlength="128" value="', $t_summary_attribute, '" />';
+	echo '<th class="category">';
+	echo '<span class="required">*</span> ';
+	echo '<label for="summary">' . lang_get( 'summary' ) . '</label>';
+	echo '</th>';
+	echo '<td colspan="5">';
+	echo '<input ', helper_get_tab_index(),
+		' type="text" required id="summary" name="summary" size="105" maxlength="128" value="',
+		$t_summary_attribute, '" />';
 	echo '</td></tr>';
 }
 
 # Description
 if( $t_show_description ) {
 	echo '<tr>';
-	echo '<th class="category"><label for="description">' . lang_get( 'description' ) . '</label></th>';
+	echo '<th class="category">';
+	echo '<span class="required">*</span> ';
+	echo '<label for="description">' . lang_get( 'description' ) . '</label>';
+	echo '</th>';
 	echo '<td colspan="5">';
-	echo '<textarea class="form-control" ', helper_get_tab_index(),
+	echo '<textarea class="form-control" required ', helper_get_tab_index(),
 		' cols="80" rows="10" id="description" name="description">', "\n",
 		$t_description_textarea, '</textarea>';
 	echo '</td></tr>';

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -759,25 +759,32 @@ function print_category_option_list( $p_category_id = 0, $p_project_id = null ) 
 		echo '<option value="0"';
 		check_selected( $p_category_id, 0 );
 		echo '>';
-		echo category_full_name( 0, false ), '</option>';
+		echo category_full_name( 0, false );
+		echo '</option>', PHP_EOL;
 	} else {
 		if( 0 == $p_category_id ) {
 			if( count( $t_cat_arr ) == 1 ) {
 				$p_category_id = (int) $t_cat_arr[0]['id'];
 			} else {
-				echo '<option value="0"';
-				echo check_selected( $p_category_id, 0 );
+				echo '<option value="0" disabled hidden';
+				check_selected( $p_category_id, 0 );
 				echo '>';
-				echo string_attribute( lang_get( 'select_option' ) ) . '</option>';
+				echo string_attribute( lang_get( 'select_option' ) );
+				echo '</option>', PHP_EOL;
 			}
 		}
 	}
 
 	foreach( $t_cat_arr as $t_category_row ) {
 		$t_category_id = (int)$t_category_row['id'];
+		$t_category_name = category_full_name(
+			$t_category_id,
+			$t_category_row['project_id'] != $t_project_id
+		);
 		echo '<option value="' . $t_category_id . '"';
 		check_selected( $p_category_id, $t_category_id );
-		echo '>' . string_attribute( category_full_name( $t_category_id, $t_category_row['project_id'] != $t_project_id ) ) . '</option>';
+		echo '>';
+		echo string_attribute( $t_category_name ), '</option>', PHP_EOL;
 	}
 }
 


### PR DESCRIPTION
Addresses the following issues:

- [#26686](https://mantisbt.org/bugs/view.php?id=26686): Make category on bug_report_page a required field when $g_allow_no_category = OFF;
- [#26687](https://mantisbt.org/bugs/view.php?id=26687): Required fields when reporting an issue, should also be when updating it
- [#26690](https://mantisbt.org/bugs/view.php?id=26690): Mass update does not allow setting an empty category

