### PR TITLE
Fixes #26811: Increase number of char in DNS extension (username)

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -3079,7 +3079,7 @@ $g_bug_count_hyperlink_prefix = 'view_all_set.php?type=' . FILTER_ACTION_PARSE_N
  * http://rubular.com/.
  * @global string $g_user_login_valid_regex
  */
-$g_user_login_valid_regex = '/^([a-z\d\-.+_ ]+(@[a-z\d\-.]+\.[a-z]{2,4})?)$/i';
+$g_user_login_valid_regex = '/^([a-z\d\-.+_ ]+(@[a-z\d\-.]+\.[a-z]{2,18})?)$/i';
 
 /**
  * Default tag prefix used to filter the list of tags in


### PR DESCRIPTION
The regex used to validate username limits the extension dns name to 4 chars.
However, lot of domains exceed this rule.
The following python code give the longest dns suffix:


```
import urllib2

def is_ascii(s):
    return all(ord(c) < 128 for c in s)

data = urllib2.urlopen("https://publicsuffix.org/list/public_suffix_list.dat")
nb_char = 0
longest_domain = None
for line in data:
    if not line.startswith('//') and '.' not in line and is_ascii(line):
        d = line.strip()
        if len(d) > nb_char:
            nb_char = len(d)
            longest_domain = d

print("Longest domain {} with {} chars".format(longest_domain, nb_char))
```

The longest dns name is 18 chars