### PR TITLE
Hide "move" functionality if user has access to just a single project

### DIFF
--- a/core/bug_group_action_api.php
+++ b/core/bug_group_action_api.php
@@ -222,6 +222,7 @@ function bug_group_action_get_commands( array $p_project_ids = null ) {
 		$t_update_bug_status_allowed = access_has_project_level( config_get( 'update_bug_status_threshold', null, $t_user_id, $t_project_id ), $t_project_id );
 
 		if( !isset( $t_commands['MOVE'] ) &&
+			user_has_more_than_one_project( $t_user_id ) &&
 			access_has_project_level( config_get( 'move_bug_threshold', null, $t_user_id, $t_project_id ), $t_project_id ) ) {
 			$t_commands['MOVE'] = lang_get( 'actiongroup_menu_move' );
 		}

--- a/core/commands/IssueViewPageCommand.php
+++ b/core/commands/IssueViewPageCommand.php
@@ -251,7 +251,8 @@ class IssueViewPageCommand extends Command {
 		$t_flags['can_close'] = !$t_issue_readonly &&
 			access_can_close_bug( $t_issue_data ) && bug_check_workflow( $t_issue_data->status, $t_closed_status );
 
-		$t_flags['can_move'] = !$t_issue_readonly && access_has_bug_level( config_get( 'move_bug_threshold' ), $t_issue_id );
+		$t_flags['can_move'] = !$t_issue_readonly && user_has_more_than_one_project( $t_user_id ) &&
+			access_has_bug_level( config_get( 'move_bug_threshold' ), $t_issue_id );
 		$t_flags['can_delete'] = !$t_issue_readonly && access_has_bug_level( config_get( 'delete_bug_threshold' ), $t_issue_id );
 
 		if( $t_force_readonly ) {


### PR DESCRIPTION
Fixes #26861