### PR TITLE
Add configuration option to make the cookie MANTIS_collapse_settings not persistent

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -1282,6 +1282,12 @@ $g_cookie_time_length = 60 * 60 * 24 * 365;
 $g_allow_permanent_cookie = ON;
 
 /**
+ * Makes the MANTIS_collapse_settings cookie a session cookie
+ * @global integer $g_collapse_settings_session_cookie
+ */
+$g_collapse_settings_session_cookie = OFF;
+
+/**
  * The time (in seconds) to allow for page execution during long processes
  *  such as upgrading your database.
  * The default value of 0 indicates that the page should be allowed to

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -340,6 +340,9 @@ function html_head_javascript() {
 		html_javascript_link( 'dropzone-' . DROPZONE_VERSION . '.min.js' );
 	}
 
+	if (config_get_global('collapse_settings_session_cookie') == ON){
+		html_javascript_link('collapse_settings_session_cookie.js');
+        }
 	html_javascript_link( 'common.js' );
 	foreach ( $g_scripts_included as $t_script_path ) {
 		html_javascript_link( $t_script_path );

--- a/js/collapse_settings_session_cookie.js
+++ b/js/collapse_settings_session_cookie.js
@@ -1,0 +1,21 @@
+/*
+# Mantis - a php based bugtracking system
+
+# Copyright 2000 - 2002  Kenzaburo Ito - kenito@300baud.org
+# Copyright 2002 MantisBT Team   - mantisbt-dev@lists.sourceforge.net
+
+# Mantis is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Mantis is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Mantis.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var g_collapse_settings_session_cookie = 1;

--- a/js/common.js
+++ b/js/common.js
@@ -697,7 +697,12 @@ function SetCookie( p_cookie, p_value ) {
 
 	t_expires.setTime( t_expires.getTime() + (365 * 24 * 60 * 60 * 1000));
 
-	document.cookie = t_cookie_name + "=" + p_value + "; expires=" + t_expires.toUTCString() + ";";
+	if (typeof g_collapse_settings_session_cookie !== "undefined"){
+		document.cookie = t_cookie_name + "=" + p_value ;
+	} else {
+		document.cookie = t_cookie_name + "=" + p_value + "; expires=" +
+		t_expires.toUTCString() + ";";
+	}
 }
 
 function ToggleDiv( p_div ) {


### PR DESCRIPTION
Note:  When using the chrome browser this cookie will still persist unless the option - "On startup | Continue where you left off" is disabled in the browser settings. If this option setting is enabled in the browser, the MANTIS g_collapse_settings_session_cookie setting has no effect.