### PR TITLE
Added config option for Username recall

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -392,6 +392,13 @@ $g_lost_password_feature = ON;
  */
 $g_max_lost_password_in_progress_count = 3;
 
+/**
+ * Remember username after failed login, username will be pass to login page
+ * after failed loging attempt
+ * @global integer $g_remember_username
+ */
+$g_remember_username = ON;
+
 #############
 # Anti-Spam #
 #############

--- a/login.php
+++ b/login.php
@@ -74,9 +74,12 @@ if( auth_attempt_login( $f_username, $f_password, $f_perm_login ) ) {
 } else {
 	$t_query_args = array(
 		'error' => 1,
-		'username' => $f_username,
 		'return' => $t_return,
 	);
+
+	if (config_get_global('remember_username') == ON){
+		$t_query_args['username'] = $f_username;
+	}
 
 	if( $f_reauthenticate ) {
 		$t_query_args['reauthenticate'] = 1;


### PR DESCRIPTION
Added configuration option to not pass username back to login prompt after a failed login.
Option name: g_remember_username, ON=username is remembered OFF=username is not remembered

Please refer to:
Project: mantisbt
ID: [0026399](https://mantisbt.org/bugs/view.php?id=26399)
Summary: Username shown in URL if password rejected.
