### PR TITLE
UserResetPassword Command fixes

### DIFF
--- a/api/rest/restcore/users_rest.php
+++ b/api/rest/restcore/users_rest.php
@@ -109,7 +109,5 @@ function rest_user_reset_password( \Slim\Http\Request $p_request, \Slim\Http\Res
 	$t_command = new UserResetPasswordCommand( $t_data );
 	$t_result = $t_command->execute();
 
-	return $p_response
-		->withStatus( HTTP_STATUS_SUCCESS )
-		->withJson( $t_result );
+	return $p_response->withStatus( HTTP_STATUS_NO_CONTENT );
 }

--- a/api/rest/restcore/users_rest.php
+++ b/api/rest/restcore/users_rest.php
@@ -107,7 +107,13 @@ function rest_user_reset_password( \Slim\Http\Request $p_request, \Slim\Http\Res
 	);
 
 	$t_command = new UserResetPasswordCommand( $t_data );
-	$t_command->execute();
+	$t_result = $t_command->execute();
+
+	if( $t_result['result'] == UserResetPasswordCommand::RESULT_FAILURE ) {
+		return $p_response
+			->withStatus( HTTP_STATUS_FORBIDDEN )
+			->withJson( array( 'message' => "Cannot reset a protected user's password") );
+	}
 
 	return $p_response->withStatus( HTTP_STATUS_NO_CONTENT );
 }

--- a/api/rest/restcore/users_rest.php
+++ b/api/rest/restcore/users_rest.php
@@ -109,11 +109,7 @@ function rest_user_reset_password( \Slim\Http\Request $p_request, \Slim\Http\Res
 	$t_command = new UserResetPasswordCommand( $t_data );
 	$t_result = $t_command->execute();
 
-	if( $t_result['result'] == UserResetPasswordCommand::RESULT_FAILURE ) {
-		return $p_response
-			->withStatus( HTTP_STATUS_FORBIDDEN )
-			->withJson( array( 'message' => "Cannot reset a protected user's password") );
-	}
-
-	return $p_response->withStatus( HTTP_STATUS_NO_CONTENT );
+	return $p_response
+		->withStatus( HTTP_STATUS_SUCCESS )
+		->withJson( $t_result );
 }

--- a/core/commands/UserResetPasswordCommand.php
+++ b/core/commands/UserResetPasswordCommand.php
@@ -59,7 +59,10 @@ class UserResetPasswordCommand extends Command {
 	 */
 	function validate() {
 		$this->user_id_reset = (int)$this->query( 'id', null );
-		if( $this->user_id_reset <= 0 || !user_exists( $this->user_id_reset ) ) {
+
+		# Make sure the account exists
+		$t_user = user_get_row( $this->user_id_reset );
+		if( $t_user === false ) {
 			throw new ClientException( 'Invalid user id', ERROR_INVALID_FIELD_VALUE, array( 'id' ) );
 		}
 
@@ -78,12 +81,6 @@ class UserResetPasswordCommand extends Command {
 				'Password reset not allowed for protected accounts',
 				ERROR_PROTECTED_ACCOUNT
 			);
-		}
-
-		# @TODO this seems redundant with the check at beginning of function
-		$t_user = user_get_row( $this->user_id_reset );
-		if( $t_user === false ) { // cannot be
-			throw new ClientException( 'Invalid user id', ERROR_INVALID_FIELD_VALUE, array( 'id' ) );
 		}
 
 		# Ensure that the account to be reset is of equal or lower access than

--- a/core/commands/UserResetPasswordCommand.php
+++ b/core/commands/UserResetPasswordCommand.php
@@ -36,9 +36,8 @@ class UserResetPasswordCommand extends Command {
 	/**
 	 * Constants for execute() method's return value.
 	 */
-	const RESULT_FAILURE = 0;
-	const RESULT_RESET = 1;
-	const RESULT_UNLOCK = 2;
+	const RESULT_RESET = 'reset';
+	const RESULT_UNLOCK = 'unlock';
 
 	/**
 	 * @var integer The id of the user to delete.
@@ -56,6 +55,7 @@ class UserResetPasswordCommand extends Command {
 
 	/**
 	 * Validate the data.
+	 * @throws ClientException
 	 */
 	function validate() {
 		$this->user_id_reset = (int)$this->query( 'id', null );
@@ -68,18 +68,31 @@ class UserResetPasswordCommand extends Command {
 			throw new ClientException( 'Access denied to reset user password', ERROR_ACCESS_DENIED );
 		}
 
+		# Mantis can't reset protected accounts' passwords, but if the
+		# account is locked, we allow the operation as Unlock
+		if( auth_can_set_password( $this->user_id_reset )
+			&& user_is_protected( $this->user_id_reset )
+			&& user_is_login_request_allowed( $this->user_id_reset )
+		) {
+			throw new ClientException(
+				'Password reset not allowed for protected accounts',
+				ERROR_PROTECTED_ACCOUNT
+			);
+		}
+
+		# @TODO this seems redundant with the check at beginning of function
 		$t_user = user_get_row( $this->user_id_reset );
 		if( $t_user === false ) { // cannot be
 			throw new ClientException( 'Invalid user id', ERROR_INVALID_FIELD_VALUE, array( 'id' ) );
 		}
 
-		# Ensure that the account to be reset is of equal or lower access to the
-		# current user.
+		# Ensure that the account to be reset is of equal or lower access than
+		# the current user.
 		if( !access_has_global_level( $t_user['access_level'] ) ) {
 			throw new ClientException( 'Access denied to reset user password with higher access level', ERROR_ACCESS_DENIED );
 		}
 
-		# Check that we are not reseting the last administrator account
+		# Check that we are not resetting the last administrator account
 		$t_admin_threshold = config_get_global( 'admin_site_threshold' );
 		if( user_is_administrator( $this->user_id_reset ) &&
 			user_count_level( $t_admin_threshold, /* enabled */ true ) <= 1 ) {
@@ -93,19 +106,19 @@ class UserResetPasswordCommand extends Command {
 	 * Process the command.
 	 *
 	 * @returns array Command response
+	 * @throws ClientException
 	 */
 	protected function process() {
-		# If the password can be changed, we reset it, otherwise we unlock
-		# the account (i.e. reset failed login count)
-		if( auth_can_set_password( $this->user_id_reset ) ) {
-			$t_result = user_reset_password( $this->user_id_reset )
-				? self::RESULT_RESET
-				: self::RESULT_FAILURE; # Shouldn't we throw an exception in this case ?
-		} else {
-			user_reset_failed_login_count_to_zero( $this->user_id_reset );
-			$t_result = self::RESULT_UNLOCK;
+		# If the password can be changed, reset it
+		if( auth_can_set_password( $this->user_id_reset )
+			&& user_reset_password( $this->user_id_reset )
+		) {
+			return array( 'action' => self::RESULT_RESET );
 		}
 
-		return array( 'result' =>  $t_result );
+		# Password can't be changed, unlock the account
+		# the account (i.e. reset failed login count)
+		user_reset_failed_login_count_to_zero( $this->user_id_reset );
+		return array( 'action' =>  self::RESULT_UNLOCK );
 	}
 }

--- a/core/commands/UserResetPasswordCommand.php
+++ b/core/commands/UserResetPasswordCommand.php
@@ -58,17 +58,17 @@ class UserResetPasswordCommand extends Command {
 	 * @throws ClientException
 	 */
 	function validate() {
+		# Ensure user has the required access level to reset passwords
+		if( !access_has_global_level( config_get_global( 'manage_user_threshold' ) ) ) {
+			throw new ClientException( 'Access denied to reset user password', ERROR_ACCESS_DENIED );
+		}
+
 		$this->user_id_reset = (int)$this->query( 'id', null );
 
 		# Make sure the account exists
 		$t_user = user_get_row( $this->user_id_reset );
 		if( $t_user === false ) {
 			throw new ClientException( 'Invalid user id', ERROR_INVALID_FIELD_VALUE, array( 'id' ) );
-		}
-
-		# Ensure user has access level to delete users
-		if( !access_has_global_level( config_get_global( 'manage_user_threshold' ) ) ) {
-			throw new ClientException( 'Access denied to reset user password', ERROR_ACCESS_DENIED );
 		}
 
 		# Mantis can't reset protected accounts' passwords, but if the

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1725,6 +1725,7 @@ function user_set_name( $p_user_id, $p_username ) {
  * @param integer $p_user_id    A valid user identifier.
  * @param boolean $p_send_email Whether to send confirmation email.
  * @return boolean
+ * @throws ClientException
  */
 function user_reset_password( $p_user_id, $p_send_email = true ) {
 	$t_protected = user_get_field( $p_user_id, 'protected' );
@@ -1743,6 +1744,11 @@ function user_reset_password( $p_user_id, $p_send_email = true ) {
 		$t_email = user_get_field( $p_user_id, 'email' );
 		if( is_blank( $t_email ) ) {
 			trigger_error( ERROR_LOST_PASSWORD_NO_EMAIL_SPECIFIED, ERROR );
+			throw new ClientException(
+				sprintf( "User id '%d' does not have an e-mail address.", (int)$p_user_id ),
+				ERROR_LOST_PASSWORD_NO_EMAIL_SPECIFIED,
+				array( (int)$p_user_id )
+			);
 		}
 
 		# Create random password

--- a/manage_user_reset.php
+++ b/manage_user_reset.php
@@ -52,20 +52,18 @@ $t_data = array(
 );
 
 $t_command = new UserResetPasswordCommand( $t_data );
+# The case of trying to reset a protected account now causes the Command to
+# trigger an exception, so we do not need any special handling here.
 $t_result = $t_command->execute();
-$t_result = $t_result['result'];
 
 $t_redirect_url = 'manage_user_page.php';
 
 form_security_purge( 'manage_user_reset' );
 
-layout_page_header(
-	null,
-	$t_result != UserResetPasswordCommand::RESULT_FAILURE ? $t_redirect_url : null
-);
+layout_page_header( null, $t_redirect_url );
 layout_page_begin( 'manage_overview_page.php' );
 
-switch( $t_result ) {
+switch( $t_result['action'] ) {
 	case UserResetPasswordCommand::RESULT_RESET:
 		if(    ( ON == config_get( 'send_reset_password' ) )
 			&& ( ON == config_get( 'enable_email_notification' ) )
@@ -80,9 +78,6 @@ switch( $t_result ) {
 	case UserResetPasswordCommand::RESULT_UNLOCK:
 		html_operation_successful( $t_redirect_url, lang_get( 'account_unlock_msg' ) );
 		break;
-	case UserResetPasswordCommand::RESULT_FAILURE:
-		# Protected account
-		html_operation_failure( $t_redirect_url, lang_get( 'account_reset_protected_msg' ) );
 }
 
 layout_page_end();


### PR DESCRIPTION
This is a follow-up on PR #1599

- [0026880](https://mantisbt.org/bugs/view.php?id=26880): Impossible to reset user's password
  => Fixes a regression issue
- [0026885](https://mantisbt.org/bugs/view.php?id=26885): Resetting password for protected user via REST API should fail
  => Improves the *users/:id/reset* endpoint 

