### PR TITLE
Improved filter : none and not empty are available on custom fields a…

### DIFF
--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -470,6 +470,7 @@ define( 'CUSTOM_FIELD_TYPE_TEXTAREA', 10 );
 define( 'META_FILTER_MYSELF', -1 );
 define( 'META_FILTER_NONE', - 2 );
 define( 'META_FILTER_CURRENT', - 3 );
+define( 'META_FILTER_NOT_EMPTY', - 4 );
 define( 'META_FILTER_ANY', 0 );
 
 # Filter view types

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -465,6 +465,32 @@ function filter_field_is_none( $p_field_value ) {
 }
 
 /**
+ * Checks the supplied value to see if it is a NOT_EMPTY value.
+ * @param string $p_field_value The value to check.
+ * @return boolean true for "NOT_EMPTY" values and false for others.
+ * @todo is a check for these necessary?  if( ( $t_filter_value === 'none' ) || ( $t_filter_value === '[none]' ) )
+ */
+function filter_field_is_not_empty( $p_field_value ) {
+	if( is_array( $p_field_value ) ) {
+		foreach( $p_field_value as $t_value ) {
+			if( ( META_FILTER_NOT_EMPTY == $t_value ) && ( is_numeric( $t_value ) ) ) {
+				return true;
+			}
+		}
+	} else {
+		if( is_string( $p_field_value ) && is_blank( $p_field_value ) ) {
+			return false;
+		}
+
+		if( ( META_FILTER_NOT_EMPTY == $p_field_value ) && ( is_numeric( $p_field_value ) ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
  *  Checks the supplied value to see if it is a MYSELF value.
  * @param string $p_field_value The value to check.
  * @return boolean true for "MYSELF" values and false for others.
@@ -672,6 +698,9 @@ function filter_ensure_valid_filter( array $p_filter_arr ) {
 		}
 		if( ( $t_value === 'none' ) || ( $t_value === '[none]' ) ) {
 			$t_value = META_FILTER_NONE;
+		}
+		if( ( $t_value === 'not empty' ) || ( $t_value === '[not empty]' ) ) {
+			$t_value = META_FILTER_EMPTY;
 		}
 		# Ensure the filter property has the right type - see #20087
 		switch( $p_type ) {

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -206,6 +206,7 @@ function helper_check_variables_equal( $p_var1, $p_var2, $p_strict ) {
 		#   META_FILTER_MYSELF = -1
 		#   META_FILTER_NONE = -2
 		#   META_FILTER_CURRENT = -3
+		#   META_FILTER_NOT_EMPTY = -4
 		#   META_FILTER_ANY = 0
 		#
 		# For these reasons, a === comparison is required.

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1226,6 +1226,7 @@ $s_filter_match_any = 'Any Condition';
 
 # view_all_inc.php
 $s_none = 'none';
+$s_not_empty = 'not empty';
 $s_current = 'current';
 $s_search = 'Search';
 $s_view_prev_link = 'View Prev';

--- a/lang/strings_french.txt
+++ b/lang/strings_french.txt
@@ -1458,3 +1458,4 @@ $s_persist = 'Rendre persitant';
 $s_load = 'Charger';
 $s_apply_changes = 'Appliquer les modifications';
 $s_undo = 'Annuler';
+$s_not_empty = 'non vide';


### PR DESCRIPTION
…nd user fields

This pull request aims to provide a patch for these issues. It adds a new option [not empty] to user field filters and custom filters (except for text area).

0004864: Unable to filter on empty custom field value 
0008149: New filter option: [Someone] for Assigned to and other filter fields 
0012798: Add a filter option [Something] as opposite of [None] i.e. field not null 
(and other closed/duplicate issues that are attached)

I have tried to make the smallest possible changes to the existing code except for one function in core/filter_form_api.php which has been factorized. More improvements could have been made to this class but i didn't want to risk having unwanted behaviours.

I hope the patch will be accepted into the official code and i'm expecting your remarks if additional code improvements are needed.
 