### PR TITLE
Remove get_magic_quotes_* checks

### DIFF
--- a/admin/check/check_php_inc.php
+++ b/admin/check/check_php_inc.php
@@ -115,18 +115,6 @@ check_print_test_row(
 	array( false => 'The value of this directive is currently: ' . $t_variables_order )
 );
 
-check_print_test_row(
-	'magic_quotes_gpc php.ini directive is disabled',
-	!( function_exists( 'get_magic_quotes_gpc' ) && @get_magic_quotes_gpc() ),
-	array( false => 'PHP\'s magic quotes feature is <a href="http://www.php.net/manual/en/security.magicquotes.whynot.php">deprecated in PHP 5.3.0</a> and should not be used.' )
-);
-
-check_print_test_row(
-	'magic_quotes_runtime php.ini directive is disabled',
-	!( function_exists( 'get_magic_quotes_runtime' ) && @get_magic_quotes_runtime() ),
-	array( false => 'PHP\'s magic quotes feature is <a href="http://www.php.net/manual/en/security.magicquotes.whynot.php">deprecated in PHP 5.3.0</a> and should not be used.' )
-);
-
 check_print_test_warn_row(
 	'register_argc_argv php.ini directive is disabled',
 	!ini_get_bool( 'register_argc_argv' ),


### PR DESCRIPTION
Our minimum supported PHP version is 5.5.0.

Starting from PHP 5.4.0, get_magic_quotes_runtime and get_magic_quotes_gpc
always return FALSE, as the magic quotes feature was removed from PHP.
So the check is no longer needed.

Starting from 7.4.0 the functions have been deprecated.

Fixes #26964