### PR TITLE
Fixed parameters borked as soon as code was going through another sql(?)

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -669,6 +669,7 @@ class BugData {
 		#  as unix timestamps which could confuse the history log and they
 		#  shouldn't get updated like this anyway.  If you really need to change
 		#  them use bug_set_field()
+		$targetversionupdate = access_has_project_level( config_get( 'roadmap_update_threshold' ) );
 		db_param_push();
 		$t_query = 'UPDATE {bug}
 					SET project_id=' . db_param() . ', reporter_id=' . db_param() . ',
@@ -693,7 +694,7 @@ class BugData {
 			$this->build, $this->fixed_in_version,
 		);
 		$t_roadmap_updated = false;
-		if( access_has_project_level( config_get( 'roadmap_update_threshold' ) ) ) {
+		if ( $targetversionupdate ) {
 			$t_query .= '
 						target_version=' . db_param() . ',';
 			$t_fields[] = $this->target_version;


### PR DESCRIPTION
Hi!

See this error message when having target versions & trying to resolve an issue via plugins/Source. 

If you like to see, the parameter numbering goes up to 18, then another db action interrupts(uh, thats what I think, at least), and the parameter numbering starts from $1 again (at target_version).

I simply store the condition in a local variable and therefore have no need to restart db_param()

I am not sure if this is a good fix acording to your overall coding. Maybe I can also store db_param() somewhere, do another DB operation and pop it afterwards.

It would be good to have this fixed, it was at least disturbing plugins/Source.

Thank you,
Frank

LINE 11:       target_version=$1,<br />
                              ^<br />
DETAIL:  integer gegen character varying for the query: UPDATE mantis_bug_table<br />
					SET project_id=$1, reporter_id=$2,<br />
						handler_id=$3, duplicate_id=$4,<br />
						priority=$5, severity=$6,<br />
						reproducibility=$7, status=$8,<br />
						resolution=$9, projection=$10,<br />
						category_id=$11, eta=$12,<br />
						os=$13, os_build=$14,<br />
						platform=$15, version=$16,<br />
						build=$17, fixed_in_version=$18,<br />
						target_version=$1,<br />
						view_state=$2,<br />
						summary=$3,<br />
						sponsorship_total=$4,<br />
						sticky=$5,<br />
						due_date=$6<br />
					WHERE id=$7.</p>