### PR TITLE
Wrap long text strings in tables

### DIFF
--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -169,6 +169,7 @@
 
 table {
     background-color: #ffffff !important;
+    overflow-wrap: anywhere;
 }
 
 /* Disable printing of link urls */


### PR DESCRIPTION
Fixes #27114

Before:

<img width="1292" alt="Screen Shot 2020-08-07 at 3 39 00 PM" src="https://user-images.githubusercontent.com/1354889/89683024-b8466700-d8c5-11ea-9ec1-0c493665a26a.png">


After:

<img width="824" alt="Screen Shot 2020-08-07 at 3 35 44 PM" src="https://user-images.githubusercontent.com/1354889/89683080-dad88000-d8c5-11ea-85b8-2e46fcbebbe7.png">

