### PR TITLE
Fix bugnote_clear_cache()

### DIFF
--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -808,9 +808,12 @@ function bugnote_clear_cache( $p_bugnote_id = null ) {
 		$g_cache_bugnotes_by_id = array();
 		$g_cache_bugnotes_by_bug_id = array();
 	} else {
-		if( isset( $g_cache_bugnotes_by_id[(int)$p_bugnote_id] ) ) {
-			$t_note_obj = $g_cache_bugnotes_by_id[(int)$p_bugnote_id];
-			# current note id will be unset in the following call
+		$p_bugnote_id = (int)$p_bugnote_id;
+		if( isset( $g_cache_bugnotes_by_id[$p_bugnote_id] ) ) {
+			$t_note_obj = $g_cache_bugnotes_by_id[$p_bugnote_id];
+			unset($g_cache_bugnotes_by_id[$p_bugnote_id]);
+
+			# Clear the bug-level cache for the bugnote's parent bug
 			bugnote_clear_bug_cache( $t_note_obj->bug_id );
 		}
 	}


### PR DESCRIPTION
bugnote_clear_cache() only removed the note from $g_cache_bugnotes_by_id
if it has also been stored in $g_cache_bugnotes_by_bug_id, but failed in
the scenario where the bug-level cache has not been populated.

Adding a specific unset() call to ensure the bugnote is actually removed
from both caches.

Fixes [#27217](https://www.mantisbt.org/bugs/view.php?id=27217)