### PR TITLE
Prevent sending reminders to unauthorized users

### DIFF
--- a/bug_reminder.php
+++ b/bug_reminder.php
@@ -74,7 +74,16 @@ if( bug_is_readonly( $f_bug_id ) ) {
 	trigger_error( ERROR_BUG_READ_ONLY_ACTION_DENIED, ERROR );
 }
 
+# Abort if user is not authorized to send reminders
 access_ensure_bug_level( config_get( 'bug_reminder_threshold' ), $f_bug_id );
+
+# Ensure target users are allowed to receive reminders
+$t_receive_reminder = config_get( 'reminder_receive_threshold' );
+foreach( $f_to as $t_recipient ) {
+	if( !access_has_bug_level( $t_receive_reminder, $f_bug_id, $t_recipient ) ) {
+		trigger_error( ERROR_USER_DOES_NOT_HAVE_REQ_ACCESS, ERROR );
+	}
+}
 
 # Automatically add recipients to monitor list if they are above the monitor
 # threshold, option is enabled, and not reporter or handler.
@@ -82,7 +91,7 @@ $t_reminder_recipients_monitor_bug = config_get( 'reminder_recipients_monitor_bu
 $t_monitor_bug_threshold = config_get( 'monitor_bug_threshold' );
 $t_handler = bug_get_field( $f_bug_id, 'handler_id' );
 $t_reporter = bug_get_field( $f_bug_id, 'reporter_id' );
-foreach ( $f_to as $t_recipient ) {
+foreach( $f_to as $t_recipient ) {
 	if( ON == $t_reminder_recipients_monitor_bug
 		&& access_has_bug_level( $t_monitor_bug_threshold, $f_bug_id )
 		&& $t_recipient != $t_handler
@@ -118,7 +127,6 @@ if( ON == config_get( 'store_reminders' ) ) {
 form_security_purge( 'bug_reminder' );
 
 layout_page_header( null, string_get_bug_view_url( $f_bug_id ) );
-
 layout_page_begin();
 
 $t_redirect = string_get_bug_view_url( $f_bug_id );

--- a/core/category_api.php
+++ b/core/category_api.php
@@ -173,6 +173,20 @@ function category_update( $p_category_id, $p_name, $p_assigned_to ) {
 	}
 
 	$t_old_category = category_get_row( $p_category_id );
+	$t_project_id = (int)$t_old_category['project_id'];
+
+	# Ensure target user exists and is allowed to handle bugs
+	if( $p_assigned_to != NO_USER ) {
+		if( user_exists( $p_assigned_to ) ) {
+			$t_handle_bugs = config_get( 'handle_bug_threshold' );
+			if( !access_has_project_level( $t_handle_bugs, $t_project_id, $p_assigned_to ) ) {
+				trigger_error( ERROR_USER_DOES_NOT_HAVE_REQ_ACCESS, ERROR );
+			}
+		} else {
+			error_parameters( $p_assigned_to );
+			trigger_error( ERROR_USER_BY_ID_NOT_FOUND, ERROR );
+		}
+	}
 
 	db_param_push();
 	$t_query = 'UPDATE {category} SET name=' . db_param() . ', user_id=' . db_param() . '

--- a/core/category_api.php
+++ b/core/category_api.php
@@ -303,7 +303,7 @@ function category_remove_all( $p_project_id, $p_new_category_id = 0 ) {
  * Return the definition row for the category
  * @param integer $p_category_id Category identifier.
  * @param boolean $p_error_if_not_exists true: error if not exists, otherwise return false.
- * @return array An array containing category details.
+ * @return array|false An array containing category details.
  * @access public
  */
 function category_get_row( $p_category_id, $p_error_if_not_exists = true ) {
@@ -404,7 +404,6 @@ function category_cache_array_rows_by_project( array $p_project_id_array ) {
 	foreach( $t_rows as $t_project_id => $t_row ) {
 		$g_cache_category_project[(int)$t_project_id] = $t_row;
 	}
-	return;
 }
 
 /**
@@ -463,6 +462,7 @@ function category_get_all_rows( $p_project_id, $p_inherit = null, $p_sort_by_pro
 	global $g_category_cache, $g_cache_category_project;
 
 	if( isset( $g_cache_category_project[(int)$p_project_id] ) ) {
+		$t_categories = array();
 		if( !empty( $g_cache_category_project[(int)$p_project_id]) ) {
 			foreach( $g_cache_category_project[(int)$p_project_id] as $t_id ) {
 				$t_categories[] = category_get_row( $t_id );
@@ -473,10 +473,8 @@ function category_get_all_rows( $p_project_id, $p_inherit = null, $p_sort_by_pro
 				usort( $t_categories, 'category_sort_rows_by_project' );
 				category_sort_rows_by_project( null );
 			}
-			return $t_categories;
-		} else {
-			return array();
 		}
+		return $t_categories;
 	}
 
 	$c_project_id = (int)$p_project_id;
@@ -547,7 +545,6 @@ function category_cache_array_rows( array $p_cat_id_array ) {
 	while( $t_row = db_fetch_array( $t_result ) ) {
 		$g_category_cache[(int)$t_row['id']] = $t_row;
 	}
-	return;
 }
 
 /**

--- a/core/cfdefs/cfdef_standard.php
+++ b/core/cfdefs/cfdef_standard.php
@@ -467,7 +467,7 @@ function cfdef_input_textbox( array $p_field_def, $p_custom_field_value, $p_requ
 		if( substr( $t_cf_regex, -1 ) != '$' ) {
 			$t_cf_regex .= '.*';
 		}
-		echo ' pattern="' . $t_cf_regex . '"';
+		echo ' pattern="' . string_attribute( $t_cf_regex ) . '"';
 	}
 	echo ' value="' . string_attribute( $p_custom_field_value ) .'" />';
 }

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -233,6 +233,10 @@ define( 'CONFIRMATION_TYPE_SUCCESS', 0 );
 define( 'CONFIRMATION_TYPE_WARNING', 1 );
 define( 'CONFIRMATION_TYPE_FAILURE', 2 );
 
+# Plugin management
+define( 'PLUGIN_PRIORITY_LOW', 1 );
+define( 'PLUGIN_PRIORITY_HIGH', 5 );
+
 # error messages
 define( 'ERROR_PHP', -1 );
 define( 'ERROR_GENERIC', 0 );

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -218,12 +218,13 @@ function file_bug_has_attachments( $p_bug_id ) {
  * @param string   $p_action            'view' or 'download'
  * @param int      $p_bug_id            A bug identifier
  * @param int      $p_uploader_user_id  The user who uploaded the attachment
+ * @param int|null $p_bugnote_id        If specified, will check at bugnote level
  *
  * @return bool
  *
  * @internal Should not be used outside of File API.
  */
-function file_can_view_or_download( $p_action, $p_bug_id, $p_uploader_user_id ) {
+function file_can_view_or_download( $p_action, $p_bug_id, $p_uploader_user_id, $p_bugnote_id = null ) {
 	switch( $p_action ) {
 		case 'view':
 			$t_threshold_global = 'view_attachments_threshold';
@@ -240,7 +241,11 @@ function file_can_view_or_download( $p_action, $p_bug_id, $p_uploader_user_id ) 
 	$t_project_id = bug_get_field( $p_bug_id, 'project_id' );
 	$t_access_global = config_get( $t_threshold_global,null, null, $t_project_id );
 
-	$t_can_access = access_has_bug_level( $t_access_global, $p_bug_id );
+	if( $p_bugnote_id === null ) {
+		$t_can_access = access_has_bug_level( $t_access_global, $p_bug_id );
+	} else {
+		$t_can_access = access_has_bugnote_level( $t_access_global, $p_bugnote_id );
+	}
 	if( $t_can_access ) {
 		return true;
 	}
@@ -263,6 +268,22 @@ function file_can_view_bug_attachments( $p_bug_id, $p_uploader_user_id = null ) 
 }
 
 /**
+ * Check if the current user can view attachments for the specified bug note.
+ *
+ * @param integer $p_bugnote_id       A bugnote identifier.
+ * @param integer $p_uploader_user_id The user who uploaded the attachment.
+ *
+ * @return boolean
+ */
+function file_can_view_bugnote_attachments( $p_bugnote_id, $p_uploader_user_id = null ) {
+	if( $p_bugnote_id == 0 ) {
+		return true;
+	}
+	$t_bug_id = bugnote_get_field( $p_bugnote_id, 'bug_id' );
+	return file_can_view_or_download( 'view', $t_bug_id, $p_uploader_user_id );
+}
+
+/**
  * Check if the current user can download attachments for the specified bug.
  *
  * @param integer $p_bug_id           A bug identifier.
@@ -272,6 +293,22 @@ function file_can_view_bug_attachments( $p_bug_id, $p_uploader_user_id = null ) 
  */
 function file_can_download_bug_attachments( $p_bug_id, $p_uploader_user_id = null ) {
 	return file_can_view_or_download( 'download', $p_bug_id, $p_uploader_user_id );
+}
+
+/**
+ * Check if the current user can download attachments for the specified bug note.
+ *
+ * @param integer $p_bugnote_id       A bugnote identifier.
+ * @param integer $p_uploader_user_id The user who uploaded the attachment.
+ *
+ * @return boolean
+ */
+function file_can_download_bugnote_attachments( $p_bugnote_id, $p_uploader_user_id = null ) {
+	if( $p_bugnote_id == 0 ) {
+		return true;
+	}
+	$t_bug_id = bugnote_get_field( $p_bugnote_id, 'bug_id' );
+	return file_can_view_or_download( 'download', $t_bug_id, $p_uploader_user_id, $p_bugnote_id );
 }
 
 /**

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -422,19 +422,21 @@ function file_normalize_attachment_path( $p_diskfile, $p_project_id ) {
 
 /**
  * Gets an array of attachments that are visible to the currently logged in user.
+ *
  * Each element of the array contains the following:
- * display_name - The attachment display name (i.e. file name dot extension)
- * size - The attachment size in bytes.
- * date_added - The date where the attachment was added.
- * can_download - true: logged in user has access to download the attachment, false: otherwise.
- * diskfile - The name of the file on disk.  Typically this is a hash without an extension.
- * download_url - The download URL for the attachment (only set if can_download is true).
- * exists - Applicable for DISK attachments.  true: file exists, otherwise false.
- * can_delete - The logged in user can delete the attachments.
- * preview - true: the attachment should be previewable, otherwise false.
- * type - Can be "image", "text" or empty for other types.
- * alt - The alternate text to be associated with the icon.
- * icon - array with icon information, contains 'url' and 'alt' elements.
+ * - display_name - The attachment display name (i.e. file name dot extension)
+ * - size - The attachment size in bytes.
+ * - date_added - The date where the attachment was added.
+ * - can_download - true: logged in user has access to download the attachment, false: otherwise.
+ * - diskfile - The name of the file on disk.  Typically this is a hash without an extension.
+ * - download_url - The download URL for the attachment (only set if can_download is true).
+ * - exists - Applicable for DISK attachments.  true: file exists, otherwise false.
+ * - can_delete - The logged in user can delete the attachments.
+ * - preview - true: the attachment should be previewable, otherwise false.
+ * - type - Can be "image", "text" or empty for other types.
+ * - alt - The alternate text to be associated with the icon.
+ * - icon - array with icon information, contains 'url' and 'alt' elements.
+ *
  * @param integer $p_bug_id A bug identifier.
  * @return array
  */

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -95,8 +95,8 @@ function plugin_pop_current() {
 function plugin_get_force_installed() {
 	$t_forced_plugins = config_get_global( 'plugins_force_installed' );
 
-	# MantisCore pseudo-plugin is force-installed by definition, with priority 3
-	$t_forced_plugins['MantisCore'] = 3;
+	# MantisCore pseudo-plugin is force-installed by definition
+	$t_forced_plugins['MantisCore'] = PLUGIN_PRIORITY_HIGH;
 
 	return $t_forced_plugins;
 }

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1262,12 +1262,14 @@ function print_custom_field_projects_list( $p_field_id ) {
  * @return void
  */
 function print_plugin_priority_list( $p_priority ) {
-	if( $p_priority < 1 || $p_priority > 5 ) {
+	if( $p_priority < PLUGIN_PRIORITY_LOW || $p_priority > PLUGIN_PRIORITY_HIGH ) {
 		echo '<option value="', $p_priority, '" selected="selected">', $p_priority, '</option>';
 	}
 
-	for( $i = 5;$i >= 1;$i-- ) {
-		echo '<option value="', $i, '" ', check_selected( $p_priority, $i ), ' >', $i, '</option>';
+	for( $i = PLUGIN_PRIORITY_HIGH; $i >= PLUGIN_PRIORITY_LOW; $i-- ) {
+		echo '<option value="', $i, '"';
+		check_selected( $p_priority, $i );
+		echo '>', $i, '</option>';
 	}
 }
 

--- a/file_download.php
+++ b/file_download.php
@@ -110,7 +110,9 @@ if( $f_type == 'bug' ) {
 # Check access rights
 switch( $f_type ) {
 	case 'bug':
-		if( !file_can_download_bug_attachments( $v_bug_id, (int)$v_user_id ) ) {
+		if( !file_can_download_bug_attachments( $v_bug_id, $v_user_id )
+		|| !file_can_download_bugnote_attachments( $v_bugnote_id, $v_user_id )
+		) {
 			access_denied();
 		}
 		break;

--- a/file_download.php
+++ b/file_download.php
@@ -99,6 +99,18 @@ if( false === $t_row ) {
 	error_parameters( $c_file_id );
 	trigger_error( ERROR_FILE_NOT_FOUND, ERROR );
 }
+/**
+ * @var int    $v_bug_id
+ * @var int    $v_project_id
+ * @var string $v_diskfile
+ * @var string $v_filename
+ * @var int    $v_filesize
+ * @var string $v_file_type
+ * @var string $v_content
+ * @var int    $v_date_added
+ * @var int    $v_user_id
+ * @var int    $v_bugnote_id
+ */
 extract( $t_row, EXTR_PREFIX_ALL, 'v' );
 
 if( $f_type == 'bug' ) {

--- a/manage_plugin_update.php
+++ b/manage_plugin_update.php
@@ -48,14 +48,17 @@ form_security_validate( 'manage_plugin_update' );
 auth_reauthenticate();
 access_ensure_global_level( config_get( 'manage_plugin_threshold' ) );
 
-$t_query = 'SELECT basename FROM {plugin}';
-$t_result = db_query( $t_query );
+$t_update_query = new DbQuery( 'UPDATE {plugin}
+	SET priority=:priority, protected=:protected
+	WHERE basename=:basename'
+);
 
-while( $t_row = db_fetch_array( $t_result ) ) {
+$t_query = new DbQuery( 'SELECT basename FROM {plugin}' );
+
+foreach( $t_query->fetch_all() as $t_row ) {
 	$t_basename = $t_row['basename'];
 
 	$f_change = gpc_get_bool( 'change_'.$t_basename, 0 );
-
 	if( !$f_change ) {
 		continue;
 	}
@@ -63,10 +66,10 @@ while( $t_row = db_fetch_array( $t_result ) ) {
 	$f_priority = gpc_get_int( 'priority_'.$t_basename, 3 );
 	$f_protected = gpc_get_bool( 'protected_'.$t_basename, 0 );
 
-	$t_query = 'UPDATE {plugin} SET priority=' . db_param() . ', protected=' . db_param() .
-		' WHERE basename=' . db_param();
-
-	db_query( $t_query, array( $f_priority, $f_protected, $t_basename ) );
+	$t_update_query->bind( 'basename', $t_basename );
+	$t_update_query->bind( 'priority', $f_priority );
+	$t_update_query->bind( 'protected', $f_protected );
+	$t_update_query->execute();
 }
 
 form_security_purge( 'manage_plugin_update' );

--- a/manage_plugin_update.php
+++ b/manage_plugin_update.php
@@ -64,6 +64,11 @@ foreach( $t_query->fetch_all() as $t_row ) {
 	}
 
 	$f_priority = gpc_get_int( 'priority_'.$t_basename, 3 );
+	if( $f_priority < 1 || $f_priority > 5 ) {
+		error_parameters( 'priority_' . $t_basename );
+		trigger_error( ERROR_INVALID_FIELD_VALUE, ERROR );
+	}
+
 	$f_protected = gpc_get_bool( 'protected_'.$t_basename, 0 );
 
 	$t_update_query->bind( 'basename', $t_basename );

--- a/manage_plugin_update.php
+++ b/manage_plugin_update.php
@@ -64,7 +64,7 @@ foreach( $t_query->fetch_all() as $t_row ) {
 	}
 
 	$f_priority = gpc_get_int( 'priority_'.$t_basename, 3 );
-	if( $f_priority < 1 || $f_priority > 5 ) {
+	if( $f_priority < PLUGIN_PRIORITY_LOW || $f_priority > PLUGIN_PRIORITY_HIGH ) {
 		error_parameters( 'priority_' . $t_basename );
 		trigger_error( ERROR_INVALID_FIELD_VALUE, ERROR );
 	}

--- a/manage_proj_cat_delete.php
+++ b/manage_proj_cat_delete.php
@@ -57,7 +57,6 @@ form_security_validate( 'manage_proj_cat_delete' );
 auth_reauthenticate();
 
 $f_category_id = gpc_get_int( 'id' );
-$f_project_id = gpc_get_int( 'project_id' );
 
 $t_row = category_get_row( $f_category_id );
 $t_name = category_full_name( $f_category_id );
@@ -79,16 +78,13 @@ category_remove( $f_category_id );
 
 form_security_purge( 'manage_proj_cat_delete' );
 
-if( $f_project_id == ALL_PROJECTS ) {
+if( $t_project_id == ALL_PROJECTS ) {
 	$t_redirect_url = 'manage_proj_page.php';
 } else {
-	$t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id;
+	$t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $t_project_id;
 }
 
 layout_page_header( null, $t_redirect_url );
-
 layout_page_begin( 'manage_overview_page.php' );
-
 html_operation_successful( $t_redirect_url );
-
 layout_page_end();

--- a/manage_proj_cat_edit_page.php
+++ b/manage_proj_cat_edit_page.php
@@ -85,7 +85,6 @@ print_manage_menu( 'manage_proj_cat_edit_page.php' );
 		<table class="table table-bordered table-condensed table-striped">
 		<fieldset>
 			<?php echo form_security_field( 'manage_proj_cat_update' ) ?>
-			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>"/>
 			<input type="hidden" name="category_id" value="<?php echo string_attribute( $f_category_id ) ?>" />
 			<tr>
 				<td class="category">
@@ -124,7 +123,6 @@ print_manage_menu( 'manage_proj_cat_edit_page.php' );
 		<fieldset>
 			<?php echo form_security_field( 'manage_proj_cat_delete' ) ?>
 			<input type="hidden" name="id" value="<?php echo string_attribute( $f_category_id ) ?>" />
-			<input type="hidden" name="project_id" value="<?php echo string_attribute( $f_project_id ) ?>" />
 			<input type="submit" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'delete_category_button' ) ?>" />
 		</fieldset>
 	</form>

--- a/manage_proj_cat_update.php
+++ b/manage_proj_cat_update.php
@@ -61,6 +61,7 @@ $f_assigned_to		= gpc_get_int( 'assigned_to', 0 );
 access_ensure_project_level( config_get( 'manage_project_threshold' ), $f_project_id );
 
 if( is_blank( $f_name ) ) {
+	error_parameters( 'name' );
 	trigger_error( ERROR_EMPTY_FIELD, ERROR );
 }
 

--- a/manage_proj_cat_update.php
+++ b/manage_proj_cat_update.php
@@ -84,9 +84,6 @@ if( $f_project_id == ALL_PROJECTS ) {
 }
 
 layout_page_header( null, $t_redirect_url );
-
 layout_page_begin( 'manage_overview_page.php' );
-
 html_operation_successful( $t_redirect_url );
-
 layout_page_end();

--- a/manage_proj_cat_update.php
+++ b/manage_proj_cat_update.php
@@ -54,11 +54,8 @@ form_security_validate( 'manage_proj_cat_update' );
 auth_reauthenticate();
 
 $f_category_id		= gpc_get_int( 'category_id' );
-$f_project_id		= gpc_get_int( 'project_id', ALL_PROJECTS );
 $f_name				= trim( gpc_get_string( 'name' ) );
 $f_assigned_to		= gpc_get_int( 'assigned_to', 0 );
-
-access_ensure_project_level( config_get( 'manage_project_threshold' ), $f_project_id );
 
 if( is_blank( $f_name ) ) {
 	error_parameters( 'name' );
@@ -69,6 +66,8 @@ $t_row = category_get_row( $f_category_id );
 $t_old_name = $t_row['name'];
 $t_project_id = $t_row['project_id'];
 
+access_ensure_project_level( config_get( 'manage_project_threshold' ), $t_project_id );
+
 # check for duplicate
 if( mb_strtolower( $f_name ) != mb_strtolower( $t_old_name ) ) {
 	category_ensure_unique( $t_project_id, $f_name );
@@ -78,10 +77,10 @@ category_update( $f_category_id, $f_name, $f_assigned_to );
 
 form_security_purge( 'manage_proj_cat_update' );
 
-if( $f_project_id == ALL_PROJECTS ) {
+if( $t_project_id == ALL_PROJECTS ) {
 	$t_redirect_url = 'manage_proj_page.php';
 } else {
-	$t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id;
+	$t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $t_project_id;
 }
 
 layout_page_header( null, $t_redirect_url );


### PR DESCRIPTION
Adds a check in bug_reminder.php to ensure that all the recipients have
the required access level to receive them (reminder_receive_threshold).

Fixes [#27276](https://mantisbt.org/bugs/view.php?id=27276)