### PR TITLE
Display footer only when page navigation is needed

### DIFF
--- a/manage_tags_page.php
+++ b/manage_tags_page.php
@@ -176,12 +176,18 @@ print_manage_menu( 'manage_tags_page.php' );
 	</table>
 	</div>
 	</div>
+<?php
+	# Do not display the section's footer if we have only one page of users,
+	# otherwise it will be empty as the navigation controls won't be shown.
+	if( $t_total_tag_count > $t_per_page ) {
+?>
 	<div class="widget-toolbox padding-8 clearfix">
-	<div class="btn-toolbar pull-right"><?php
-		# @todo hack - pass in the hide inactive filter via cheating the actual filter value
-		print_page_links( 'manage_tags_page.php', 1, $t_page_count, (int)$f_page_number, $f_filter ); ?>
+		<div class="btn-toolbar pull-right"><?php
+			# @todo hack - pass in the hide inactive filter via cheating the actual filter value
+			print_page_links( 'manage_tags_page.php', 1, $t_page_count, (int)$f_page_number, $f_filter ); ?>
+		</div>
 	</div>
-</div>
+<?php } ?>
 </div>
 </div>
 

--- a/manage_user_page.php
+++ b/manage_user_page.php
@@ -406,17 +406,25 @@ $t_user_count = count( $t_users );
 </div>
 </div>
 
+<?php
+	# Do not display the section's footer if we have only one page of users,
+	# otherwise it will be empty as the navigation controls won't be shown.
+	if( $t_total_user_count > $p_per_page ) {
+?>
 <div class="widget-toolbox padding-8 clearfix">
 	<div class="btn-toolbar pull-right">
-		<?php
+<?php
 		# @todo hack - pass in the hide inactive filter via cheating the actual filter value
 		print_page_links( 'manage_user_page.php', 1, $t_page_count, (int)$f_page_number,
 			$f_filter . "&amp;search=$f_search" . $t_hide_inactive_filter . $t_show_disabled_filter . "&amp;sort=$c_sort&amp;dir=$c_dir");
-		?>
+?>
 	</div>
 </div>
+<?php } ?>
+
 </div>
 </div>
 </div>
+
 <?php
 layout_page_end();


### PR DESCRIPTION
- In manage user page, the navigation controls are only displayed in the
  section footer when there is more than one page. Issue #12677 moved
  the search form to the header, resulting in an empty footer div when
  there are 50 users or less.
- In manage tags page, the navigation controls are only displayed in the
  section footer when there is more than one page, resulting in an empty
  footer div when there are 20 tags or less.

The footer div in the above pages is now hidden when there is only one
page worth of data.

Fixes [#27387](https://mantisbt.org/bugs/view.php?id=27387)