### PR TITLE
Fix PHP Notice in admin/test_langs.php

### DIFF
--- a/admin/test_langs.php
+++ b/admin/test_langs.php
@@ -424,11 +424,10 @@ function checktoken( $p_file, $p_base = false ) {
  * @param string  $p_error   Error code.
  * @param string  $p_file    File error occurred in.
  * @param integer $p_line    Line number error occurred on.
- * @param string  $p_context Context of error.
  * @return void
  */
-function lang_error_handler( $p_type, $p_error, $p_file, $p_line, $p_context ) {
-	print_error( 'error handler thrown: ' . $p_type . '<br />' . $p_error . '<br />' . $p_file . '<br />' . $p_line . '<br />' . $p_context );
+function lang_error_handler( $p_type, $p_error, $p_file, $p_line ) {
+	print_error( 'error handler thrown: ' . $p_type . '<br />' . $p_error . '<br />' . $p_file . '<br />' . $p_line );
 }
 
 /**


### PR DESCRIPTION
Did not fix the issue (deal with the errcontext array),
but removed the errcontext parameter as it has been deprecated as of PHP 7.2.0 [1]

[1] https://www.php.net/manual/en/function.set-error-handler.php

Fixes #27701