### PR TITLE
Remove deprecated parameter from error handlers

### DIFF
--- a/admin/check/check_api.php
+++ b/admin/check/check_api.php
@@ -47,17 +47,15 @@ function check_init_error_handler() {
  * @param string  $p_error   Error number.
  * @param string  $p_file    File error occurred in.
  * @param integer $p_line    Line number.
- * @param string  $p_context Context.
  * @return void
  */
-function check_error_handler( $p_type, $p_error, $p_file, $p_line, $p_context ) {
+function check_error_handler( $p_type, $p_error, $p_file, $p_line ) {
 	global $g_errors_raised;
 	$g_errors_raised[] = array(
 		'type' => $p_type,
 		'error' => $p_error,
 		'file' => $p_file,
-		'line' => $p_line,
-		'context' => $p_context
+		'line' => $p_line
 	);
 }
 

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -1121,10 +1121,9 @@ EOL;
  * @param string  $p_error   Contains the error message, as a string.
  * @param string  $p_file    Contains the filename that the error was raised in, as a string.
  * @param integer $p_line    Contains the line number the error was raised at, as an integer.
- * @param array   $p_context To the active symbol table at the point the error occurred (optional).
  * @return void
  */
-function mc_error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) {
+function mc_error_handler( $p_type, $p_error, $p_file, $p_line ) {
 	# check if errors were disabled with @ somewhere in this call chain
 	# also suppress php 5 strict warnings
 	if( 0 == error_reporting() || 2048 == $p_type ) {

--- a/core/json_api.php
+++ b/core/json_api.php
@@ -60,10 +60,9 @@ function json_url( $p_url, $p_member = null ) {
  * @param string  $p_error   Contains the error message, as a string.
  * @param string  $p_file    Contains the filename that the error was raised in, as a string.
  * @param integer $p_line    Contains the line number the error was raised at, as an integer.
- * @param array   $p_context The active symbol table at the point the error occurred (optional).
  * @return void
  */
-function json_error_handler( $p_type, $p_error, $p_file, $p_line, array $p_context ) {
+function json_error_handler( $p_type, $p_error, $p_file, $p_line ) {
 	# flush any language overrides to return to user's natural default
 	if( function_exists( 'db_is_connected' ) ) {
 		if( db_is_connected() ) {


### PR DESCRIPTION
errcontext parameter for error handlers has been deprecated as of PHP 7.2.0 [1]

[1] https://www.php.net/manual/en/function.set-error-handler.php

Fixes #27703