### PR TITLE
Improve Project delete confirmation message

### DIFF
--- a/core/project_api.php
+++ b/core/project_api.php
@@ -1016,3 +1016,19 @@ function project_link_for_menu( $p_project_id, $p_active = false, $p_class = '',
 
 	return sprintf('<a class="%s" href="%s">%s</a>', $p_class, $t_url, $t_label );
 }
+
+/**
+ * Returns the number of issues associated with the given Project.
+ *
+ * @param int $p_project_id A project identifier.
+ *
+ * @return int
+ */
+function project_get_bug_count( $p_project_id ) {
+	$t_query = new DbQuery();
+	$t_query->sql( 'SELECT COUNT(*) FROM {bug} WHERE project_id='
+		. $t_query->param( $p_project_id )
+	);
+	$t_query->execute();
+	return $t_query->value();
+}

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -859,7 +859,7 @@ $s_add_subproject_title = 'Add Subproject';
 $s_project_deleted_msg = 'Project successfully removed...';
 
 # manage_proj_delete_page.php
-$s_project_delete_msg = 'Are you sure you want to delete this project and all attached issue reports?';
+$s_project_delete_msg = 'Are you sure you want to delete project "%1$s" ?<br>This will also delete %2$s attached issue reports.';
 $s_project_delete_button = 'Delete Project';
 
 # manage_proj_edit_page.php

--- a/manage_proj_delete.php
+++ b/manage_proj_delete.php
@@ -55,11 +55,11 @@ $f_project_id = gpc_get_int( 'project_id' );
 
 access_ensure_project_level( config_get( 'delete_project_threshold' ), $f_project_id );
 
-$t_project_name = project_get_name( $f_project_id );
-
-helper_ensure_confirmed( lang_get( 'project_delete_msg' ) .
-		'<br />' . lang_get( 'project_name_label' ) . lang_get( 'word_separator' ) . $t_project_name,
-		lang_get( 'project_delete_button' ) );
+$t_message = sprintf( lang_get( 'project_delete_msg' ),
+	string_attribute( project_get_name( $f_project_id ) ),
+	project_get_bug_count( $f_project_id )
+);
+helper_ensure_confirmed( $t_message, lang_get( 'project_delete_button' ) );
 
 project_delete( $f_project_id );
 


### PR DESCRIPTION
The 'project_delete_msg' string now includes the bug count in addition
to the Project's name.

New Project API function project_get_bug_count() returns the number
of issues associated to the given project.

Fixes [#27768](https://mantisbt.org/bugs/view.php?id=27768)