### PR TITLE
Improve timezone setting logic

### DIFF
--- a/admin/install.php
+++ b/admin/install.php
@@ -1249,7 +1249,10 @@ if( 5 == $t_install_state ) {
 	$t_write_failed = true;
 
 	if( !$t_config_exists ) {
-		if( $t_fd = @fopen( $t_config_filename, 'w' ) ) {
+		# Try to create the config file
+		if( is_writable( $g_config_path )
+			&& $t_fd = fopen( $t_config_filename, 'w' )
+		) {
 			fwrite( $t_fd, $t_config );
 			fclose( $t_fd );
 		}

--- a/admin/install.php
+++ b/admin/install.php
@@ -163,6 +163,7 @@ if( 0 == $t_install_state || 2 == $t_install_state ) {
 <?php
 }
 
+global $g_config_path;
 $t_config_filename = $g_config_path . 'config_inc.php';
 $t_config_exists = file_exists( $t_config_filename );
 
@@ -179,6 +180,11 @@ foreach( $t_prefix_defaults['oci8'] as $t_key => $t_value ) {
 	$t_prefix_defaults['other'][$t_key] = config_get( $t_key, '' );
 }
 
+/**
+ * @var string $f_db_table_prefix'
+ * @var string $f_db_table_plugin_prefix
+ * @var string $f_db_table_suffix
+ */
 if( $t_config_exists && $t_install_state <= 1 ) {
 	# config already exists - probably an upgrade
 	$f_dsn                    = config_get( 'dsn', '' );
@@ -362,6 +368,7 @@ if( 2 == $t_install_state ) {
 	print_test( 'Checking PHP support for database type', db_check_database_support( $f_db_type ), true, 'database is not supported by PHP. Check that it has been compiled into your server.' );
 
 	# ADOdb library version check
+	global $ADODB_vers;
 	$t_adodb_version = substr( $ADODB_vers, 1, strpos( $ADODB_vers, ' ' ) - 1 );
 	print_test( 'Checking ADOdb Library version is at least ' . DB_MIN_VERSION_ADODB,
 		version_compare( $t_adodb_version, DB_MIN_VERSION_ADODB, '>=' ),
@@ -557,7 +564,7 @@ if( !$g_database_upgrade ) {
 <!-- Database type selection list -->
 <tr>
 	<td>
-		Type of Database
+		<label for="db_type">Type of Database</label>
 	</td>
 	<td>
 		<!-- Default values for table prefix/suffix -->
@@ -586,7 +593,7 @@ if( !$g_database_upgrade ) {
 			);
 
 			foreach( $t_db_list as $t_db => $t_db_descr ) {
-				echo '<option value="' . $t_db . '"' .
+				echo '<option value="' . $t_db . '" ' .
 					( $t_db == $f_db_type ? ' selected="selected"' : '' ) . '>' .
 					$t_db_descr . "</option>\n";
 			}
@@ -598,29 +605,29 @@ if( !$g_database_upgrade ) {
 <!-- Database server hostname -->
 <tr>
 	<td>
-		Hostname (for Database Server)
+		<label for="hostname">Hostname (for Database Server)</label>
 	</td>
 	<td>
-		<input name="hostname" type="text" value="<?php echo string_attribute( $f_hostname ) ?>">
+		<input id="hostname" name="hostname" type="text" value="<?php echo string_attribute( $f_hostname ) ?>">
 	</td>
 </tr>
 
 <!-- Database username and password -->
 <tr>
 	<td>
-		Username (for Database)
+		<label for="db_username">Username (for Database)</label>
 	</td>
 	<td>
-		<input name="db_username" type="text" value="<?php echo string_attribute( $f_db_username ) ?>">
+		<input id="db_username" name="db_username" type="text" value="<?php echo string_attribute( $f_db_username ) ?>">
 	</td>
 </tr>
 
 <tr>
 	<td>
-		Password (for Database)
+		<label for="db_password">Password (for Database)</label>
 	</td>
 	<td>
-		<input name="db_password" type="password" value="<?php
+		<input id="db_password" name="db_password" type="password" value="<?php
 			echo !is_blank( $f_db_password ) && $t_config_exists
 				? CONFIGURED_PASSWORD
 				: $f_db_password;
@@ -631,10 +638,10 @@ if( !$g_database_upgrade ) {
 <!-- Database name -->
 <tr>
 	<td>
-		Database name (for Database)
+		<label for="database_name">Database name (for Database)</label>
 	</td>
 	<td>
-		<input name="database_name" type="text" value="<?php echo string_attribute( $f_database_name ) ?>">
+		<input id="database_name" name="database_name" type="text" value="<?php echo string_attribute( $f_database_name ) ?>">
 	</td>
 </tr>
 <?php
@@ -644,19 +651,27 @@ if( !$g_database_upgrade ) {
 <!-- Admin user and password -->
 <tr>
 	<td>
-		Admin Username (to <?php echo( !$g_database_upgrade ) ? 'create Database' : 'update Database'?> if required)
+		<label for="admin_username">
+			Admin Username (to
+			<?php echo( !$g_database_upgrade ) ? 'create Database' : 'update Database'?>
+			if required)
+		</label>
 	</td>
 	<td>
-		<input name="admin_username" type="text" value="<?php echo string_attribute( $f_admin_username ) ?>">
+		<input id="admin_username" name="admin_username" type="text" value="<?php echo string_attribute( $f_admin_username ) ?>">
 	</td>
 </tr>
 
 <tr>
 	<td>
-		Admin Password (to <?php echo( !$g_database_upgrade ) ? 'create Database' : 'update Database'?> if required)
+		<label for="admin_password">
+			Admin Password (to
+			<?php echo( !$g_database_upgrade ) ? 'create Database' : 'update Database'?>
+			if required)
+		</label>
 	</td>
 	<td>
-		<input name="admin_password" type="password" value="<?php
+		<input id="admin_password" name="admin_password" type="password" value="<?php
 			echo !is_blank( $f_admin_password ) && $f_admin_password == $f_db_password
 				? CONFIGURED_PASSWORD
 				: string_attribute( $f_admin_password );
@@ -708,7 +723,7 @@ if( !$g_database_upgrade ) {
 <!-- Timezone -->
 <tr>
 	<td>
-		Default Time Zone
+		<label for="timezone">Default Time Zone</label>
 	</td>
 	<td>
 		<select id="timezone" name="timezone">
@@ -723,10 +738,10 @@ if( !$g_database_upgrade ) {
 <!-- Printing SQL queries -->
 <tr>
 	<td>
-		Print SQL Queries instead of Writing to the Database
+		<label for="log_queries">Print SQL Queries instead of Writing to the Database</label>
 	</td>
 	<td>
-		<input name="log_queries" type="checkbox" class="ace" value="1" <?php echo( $f_log_queries ? 'checked="checked"' : '' )?>>
+		<input id="log_queries" name="log_queries" type="checkbox" class="ace" value="1" <?php echo( $f_log_queries ? 'checked="checked"' : '' )?>>
 		<span class="lbl"></span>
 	</td>
 </tr>
@@ -776,6 +791,7 @@ if( 3 == $t_install_state ) {
 		Create database if it does not exist
 	</td>
 	<?php
+		global $g_db;
 		$t_result = @$g_db->Connect( $f_hostname, $f_admin_username, $f_admin_password, $f_database_name );
 
 		$t_db_open = false;
@@ -944,6 +960,7 @@ if( 3 == $t_install_state ) {
 							true,
 							print_r( $t_sqlarray, true )
 						);
+						/** @noinspection PhpExpressionAlwaysConstantInspection Set by print_test() */
 						if( $g_failed ) {
 							# Error occurred, bail out
 							break;

--- a/core.php
+++ b/core.php
@@ -269,9 +269,12 @@ require_api( 'config_api.php' );
 # Set the default timezone
 # To reduce overhead, we assume that the timezone configuration is valid,
 # i.e. it exists in timezone_identifiers_list(). If not, a PHP NOTICE will
-# be raised. Use admin checks to validate configuration.
-@date_default_timezone_set( config_get_global( 'default_timezone' ) );
-$t_tz = @date_default_timezone_get();
+# be raised and we fall back to the system's default timezone.
+# Use admin checks to validate configuration.
+$t_tz = config_get_global( 'default_timezone' );
+if( empty( $t_tz ) || !date_default_timezone_set( $t_tz )) {
+	$t_tz = date_default_timezone_get();
+}
 config_set_global( 'default_timezone', $t_tz, true );
 
 if( !defined( 'MANTIS_MAINTENANCE_MODE' ) ) {

--- a/core.php
+++ b/core.php
@@ -45,6 +45,8 @@
  * @uses php_api.php
  * @uses user_pref_api.php
  * @uses wiki_api.php
+ *
+ * @noinspection PhpIncludeInspection
  */
 
 /**
@@ -94,6 +96,7 @@ require_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'vendor/autoload.php' 
 require_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'config_defaults_inc.php' );
 
 # Load user-defined constants (if required)
+global $g_config_path;
 if( file_exists( $g_config_path . 'custom_constants_inc.php' ) ) {
 	require_once( $g_config_path . 'custom_constants_inc.php' );
 }
@@ -275,9 +278,10 @@ $t_tz = config_get_global( 'default_timezone' );
 if( empty( $t_tz ) || !date_default_timezone_set( $t_tz )) {
 	$t_tz = date_default_timezone_get();
 }
-config_set_global( 'default_timezone', $t_tz, true );
+config_set_global( 'default_timezone', $t_tz );
 
 if( !defined( 'MANTIS_MAINTENANCE_MODE' ) ) {
+	global $g_use_persistent_connections, $g_hostname, $g_db_username, $g_db_password, $g_database_name;
 	if( OFF == $g_use_persistent_connections ) {
 		db_connect( config_get_global( 'dsn', false ), $g_hostname, $g_db_username, $g_db_password, $g_database_name );
 	} else {

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -142,7 +142,7 @@ function error_handler( $p_type, $p_error, $p_file, $p_line ) {
 	global $g_error_send_page_header;
 
 	# check if errors were disabled with @ somewhere in this call chain
-	if( 0 == error_reporting() ) {
+	if( !( error_reporting() & $p_type ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Previously, core.php tried to set the default timezone to the value
stored in global configuration, with error suppression. Due to [[1]],
this does not actually prevent the notice from appearing with PHP 8.

Refactored the code to get the system's default time zone if it is not
defined in configuration. A PHP notice is still thrown if the specified
timezone is not valid, as documented in the code.

Also, since PHP 5.4, date_default_timezone_get() no longer throws a
warning so the '@' operator is not needed anymore.

Fixes [#27796](https://mantisbt.org/bugs/view.php?id=27796)

[1]: https://bugs.php.net/bug.php?id=80548