### PR TITLE
Fix "Category 0 not found" when reporting new issue

### DIFF
--- a/core/category_api.php
+++ b/core/category_api.php
@@ -85,6 +85,11 @@ function category_ensure_exists( $p_category_id ) {
  * @return bool True if the category exists, false otherwise.
  */
 function category_exists_in_project( $p_category_id, $p_project_id ) {
+	if( $p_category_id == 0
+		&& config_get( 'allow_no_category', null, null, $p_project_id )
+	) {
+		return true;
+	}
 	$t_categories = array_column( category_get_all_rows( $p_project_id ), 'id' );
 	return in_array( $p_category_id, $t_categories );
 }


### PR DESCRIPTION
By definition, category "0" (no category) does not exist in any project,
but when empty category is allowed ($g_allow_no_category = ON),
category_exists_in_project() should return true.

Regression introduced by a4c4865b2102c2c0bfc53692499514db0b744dc9 in
issue #27361.

Fixes [#27826](https://mantisbt.org/bugs/view.php?id=27826)