### PR TITLE
Create a Cronjob script and plugin event

### DIFF
--- a/core/events_inc.php
+++ b/core/events_inc.php
@@ -152,4 +152,6 @@ event_declare_many( array(
 
 	# Authentication Events
 	'EVENT_AUTH_USER_FLAGS' => EVENT_TYPE_FIRST,
+
+	'EVENT_CRONJOB' => EVENT_TYPE_EXECUTE
 ) );

--- a/docbook/Developers_Guide/en-US/Events_Reference.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference.xml
@@ -175,6 +175,18 @@
 					for more details.
 				</para>
 			</blockquote>
+
+			<blockquote id="dev.eventref.cronjob">
+				<title>EVENT_CRONJOB (Execute)</title>
+
+				<blockquote>
+					<para>
+						This is an event that is triggered by the scripts/cronjob.php on
+						some recurring schedule (once an hour is recommended). Plugins
+						handle this event to execute recurring tasks.
+					</para>
+				</blockquote>
+			</blockquote>
 		</blockquote>
 	</section>
 

--- a/scripts/cronjob.php
+++ b/scripts/cronjob.php
@@ -17,7 +17,11 @@
 # See the README and LICENSE files for details
 
 /**
- * Cron Script to trigger cronjob work for plugins
+ * Cron script to allow scheduled execution of plugin tasks.
+ *
+ * @package scripts
+ * @copyright Copyright 2021  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link https://mantisbt.org
  */
 
 /**
@@ -30,7 +34,7 @@ require_once( dirname( dirname( __FILE__ ) ) . '/core.php' );
 
 # Make sure this script doesn't run via the webserver
 if( php_sapi_name() != 'cli' ) {
-	echo "cronjob.php is not allowed to run through the webserver.\n";
+	echo basename( __FILE__ ) . " is not allowed to run through the webserver.\n";
 	exit( 1 );
 }
 

--- a/scripts/cronjob.php
+++ b/scripts/cronjob.php
@@ -1,0 +1,38 @@
+#!/usr/bin/php -q
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+# See the README and LICENSE files for details
+
+/**
+ * Cron Script to trigger cronjob work for plugins
+ */
+
+/**
+ * Global Bypass http headers
+ */
+global $g_bypass_headers;
+$g_bypass_headers = 1;
+
+require_once( dirname( dirname( __FILE__ ) ) . '/core.php' );
+
+# Make sure this script doesn't run via the webserver
+if( php_sapi_name() != 'cli' ) {
+	echo "cronjob.php is not allowed to run through the webserver.\n";
+	exit( 1 );
+}
+
+event_signal( 'EVENT_CRONJOB' );
+exit( 0 );


### PR DESCRIPTION
This way there is one cronjob script to execute which triggers an event, then all plugins can hook into it.

Fixes #27882