### PR TITLE
Version field is now required

### DIFF
--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -559,7 +559,7 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 		<fieldset>
 			<?php echo form_security_field( 'manage_proj_ver_add' ) ?>
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
-			<input type="text" class="input-sm" name="version" size="32" maxlength="64" />
+			<input type="text" class="input-sm" required name="version" size="32" maxlength="64" />
 			<input type="submit" name="add_version" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_version_button' ) ?>" />
 			<input type="submit" name="add_and_edit_version" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_and_edit_version_button' ) ?>" />
 		</fieldset>

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -115,7 +115,10 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
 			<tr>
 				<td class="category">
-					<span class="required">*</span> <?php echo lang_get( 'project_name' ) ?>
+					<label for="project-name">
+						<span class="required">*</span>
+						<?php echo lang_get( 'project_name' ) ?>
+					</label>
 				</td>
 				<td>
 					<input type="text" id="project-name" name="name" class="input-sm" size="60" maxlength="128" value="<?php echo string_attribute( $t_row['name'] ) ?>" required />
@@ -123,7 +126,9 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 			</tr>
 			<tr>
 				<td class="category">
-					<?php echo lang_get( 'status' ) ?>
+					<label for="project-status">
+						<?php echo lang_get( 'status' ) ?>
+					</label>
 				</td>
 				<td>
 					<select id="project-status" name="status" class="input-sm">
@@ -133,30 +138,30 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 			</tr>
 			<tr>
 				<td class="category">
-					<?php echo lang_get( 'enabled' ) ?>
+					<label for="project-enabled">
+						<?php echo lang_get( 'enabled' ) ?>
+					</label>
 				</td>
 				<td>
-					<label>
-						<input type="checkbox" class="ace" id="project-enabled" name="enabled" <?php check_checked( (int)$t_row['enabled'], ON ); ?> />
-						<span class="lbl"></span>
-					</label>
+					<input type="checkbox" class="ace" id="project-enabled" name="enabled" <?php check_checked( (int)$t_row['enabled'], ON ); ?> />
 				</td>
 			</tr>
 			<tr>
 				<td class="category">
-					<?php echo lang_get( 'inherit_global' ) ?>
+					<label for="project-inherit-global">
+						<?php echo lang_get( 'inherit_global' ) ?>
+					</label>
 				</td>
 				<td>
-					<label>
-						<input type="checkbox" class="ace" id="project-inherit-global" name="inherit_global" <?php check_checked( (int)$t_row['inherit_global'], ON ); ?> />
-						<span class="lbl"></span>
-					</label>
+					<input type="checkbox" class="ace" id="project-inherit-global" name="inherit_global" <?php check_checked( (int)$t_row['inherit_global'], ON ); ?> />
 				</td>
 			</tr>
 
 			<tr>
 				<td class="category">
-					<?php echo lang_get( 'view_status' ) ?>
+					<label for="project-view-state">
+						<?php echo lang_get( 'view_status' ) ?>
+					</label>
 				</td>
 				<td>
 					<select id="project-view-state" name="view_state" class="input-sm">
@@ -175,7 +180,9 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 				?>
 				<tr>
 					<td class="category">
-						<?php echo lang_get( 'upload_file_path' ) ?>
+						<label for="project-file-path">
+							<?php echo lang_get( 'upload_file_path' ) ?>
+						</label>
 					</td>
 					<td>
 						<input type="text" id="project-file-path" name="file_path" class="input-sm" size="60" maxlength="250" value="<?php echo string_attribute( $t_file_path ) ?>" />
@@ -184,7 +191,9 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 			} ?>
 			<tr>
 				<td class="category">
-					<?php echo lang_get( 'description' ) ?>
+					<label for="project-description">
+						<?php echo lang_get( 'description' ) ?>
+					</label>
 				</td>
 				<td>
 					<?php # Newline after opening textarea tag is intentional, see #25839 ?>
@@ -254,13 +263,14 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 			<fieldset>
 				<?php echo form_security_field( 'manage_proj_subproj_add' ) ?>
 				<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
+				<!--suppress HtmlFormInputWithoutLabel -->
 				<select name="subproject_id" class="input-sm" required>
 				<option selected disabled value=""><?php echo '[', lang_get( 'select_project_button' ), ']' ?></option><?php
 				$t_all_subprojects = project_hierarchy_get_subprojects( $f_project_id, true );
 				$t_all_subprojects[] = $f_project_id;
 				$t_manage_access = config_get( 'manage_project_threshold' );
 				$t_projects = project_get_all_rows();
-				$t_projects = multi_sort( $t_projects, 'name', ASCENDING );
+				$t_projects = multi_sort( $t_projects, 'name' );
 				foreach ( $t_projects as $t_project ) {
 					if( in_array( $t_project['id'], $t_all_subprojects ) ||
 						in_array( $f_project_id, project_hierarchy_get_all_subprojects( $t_project['id'] ) ) ||
@@ -394,6 +404,7 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 		<fieldset>
 			<?php echo form_security_field( 'manage_proj_cat_copy' ) ?>
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
+			<!--suppress HtmlFormInputWithoutLabel -->
 			<select name="other_project_id" class="input-sm" required>
 				<option selected disabled value=""><?php echo '[', lang_get( 'select_project_button' ), ']' ?></option>
 				<?php print_project_option_list( null, false, $f_project_id ); ?>
@@ -458,6 +469,7 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 		<fieldset>
 			<?php echo form_security_field( 'manage_proj_cat_add' ) ?>
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
+			<!--suppress HtmlFormInputWithoutLabel -->
 			<input type="text" name="name" required size="32" maxlength="128" class="input-sm" />
 			<input type="submit" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_category_button' ) ?>" />
 			<input type="submit" name="add_and_edit_category" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_and_edit_category_button' ) ?>" />
@@ -484,6 +496,7 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 		<fieldset>
 			<?php echo form_security_field( 'manage_proj_ver_copy' ) ?>
 			<input type="hidden" class="form-control input-sm" name="project_id" value="<?php echo $f_project_id ?>" />
+			<!--suppress HtmlFormInputWithoutLabel -->
 			<select name="other_project_id" class="input-sm" required>
 				<option selected disabled value=""><?php echo '[', lang_get( 'select_project_button' ), ']' ?></option>
 				<?php print_project_option_list( null, false, $f_project_id ); ?>
@@ -559,6 +572,7 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 		<fieldset>
 			<?php echo form_security_field( 'manage_proj_ver_add' ) ?>
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
+			<!--suppress HtmlFormInputWithoutLabel -->
 			<input type="text" class="input-sm" required name="version" size="32" maxlength="64" />
 			<input type="submit" name="add_version" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_version_button' ) ?>" />
 			<input type="submit" name="add_and_edit_version" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_and_edit_version_button' ) ?>" />
@@ -591,6 +605,7 @@ if( access_has_project_level( config_get( 'custom_field_link_threshold' ), $f_pr
 		<fieldset>
 			<?php echo form_security_field( 'manage_proj_custom_field_copy' ) ?>
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
+			<!--suppress HtmlFormInputWithoutLabel -->
 			<select name="other_project_id" class="input-sm" required>
 				<option selected disabled value=""><?php echo '[', lang_get( 'select_project_button' ), ']' ?></option>
 				<?php print_project_option_list( null, false, $f_project_id ); ?>
@@ -628,6 +643,7 @@ if( access_has_project_level( config_get( 'custom_field_link_threshold' ), $f_pr
 							<?php echo form_security_field( 'manage_proj_custom_field_update' ) ?>
 							<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
 							<input type="hidden" name="field_id" value="<?php echo $t_field_id ?>" />
+							<!--suppress HtmlFormInputWithoutLabel -->
 							<input type="text" class="input-sm" name="sequence" value="<?php echo custom_field_get_sequence( $t_field_id, $f_project_id ) ?>" size="2" />
 							<input type="submit" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'update' ) ?>" />
 						</fieldset>
@@ -654,6 +670,7 @@ if( access_has_project_level( config_get( 'custom_field_link_threshold' ), $f_pr
 		<fieldset>
 			<?php echo form_security_field( 'manage_proj_custom_field_add_existing' ) ?>
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
+			<!--suppress HtmlFormInputWithoutLabel -->
 			<select name="field_id" class="input-sm">
 				<?php
 					$t_cf_defs = array();
@@ -716,6 +733,7 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 						<fieldset>
 							<?php echo form_security_field( 'manage_proj_user_copy' ) ?>
 							<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
+							<!--suppress HtmlFormInputWithoutLabel -->
 							<select name="other_project_id" class="input-sm" required>
 								<option selected disabled value=""><?php echo '[', lang_get( 'select_project_button' ), ']' ?></option>
 								<?php print_project_option_list( null, false, $f_project_id ); ?>
@@ -749,15 +767,15 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 				<div id="manage-project-users-form-toolbox" class="hidden widget-toolbox padding-8 clearfix">
 					<div class="btn-toolbar">
 						<div class="widget-toolbar no-border pull-left">
+							<!--suppress HtmlFormInputWithoutLabel -->
 							<input type="text" class="search input-sm" placeholder="<?php echo lang_get( 'filter_button' ) ?>" />
 						</div>
 						<div class="widget-toolbar pull-left">
-							<label><?php echo lang_get( 'show' ) ?>
-							<input id="input-per-page" type="text" min="5" size="2" class="input-sm" value="<?php echo config_get( 'default_limit_view' ) ?>"/>
-							</label>
 							<label>
-								&nbsp;(<?php echo lang_get( 'total' ), ': ', $t_users_count, ' ', lang_get( 'users_link' ) ?>)
+								<?php echo lang_get( 'show' ) ?>
+								<input id="input-per-page" type="text" min="5" size="2" class="input-sm" value="<?php echo config_get( 'default_limit_view' ) ?>"/>
 							</label>
+							<?php echo '(', lang_get( 'total' ), ': ', $t_users_count, ' ', lang_get( 'users_link' ), ')' ?>
 						</div>
 						<div class="btn-group pull-right">
 							<ul class="pagination small no-margin"></ul>
@@ -915,7 +933,10 @@ if( count( $t_users ) > 0 ) { ?>
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
 			<tr>
 				<td class="category">
-				   <span class="required">*</span> <?php echo lang_get( 'username' ) ?>
+					<label for="project-add-users-username">
+						<span class="required">*</span>
+						<?php echo lang_get( 'username' ) ?>
+					</label>
 				</td>
 				<td>
 					<select id="project-add-users-username" name="user_id[]" class="input-sm" multiple="multiple" size="10" required><?php
@@ -927,7 +948,9 @@ if( count( $t_users ) > 0 ) { ?>
 			</tr>
 			<tr>
 				<td class="category">
-					<?php echo lang_get( 'access_level' ) ?>
+					<label for="project-add-users-access-level">
+						<?php echo lang_get( 'access_level' ) ?>
+					</label>
 				</td>
 				<td>
 					<select id="project-add-users-access-level" name="access_level" class="input-sm"><?php

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -458,7 +458,7 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 		<fieldset>
 			<?php echo form_security_field( 'manage_proj_cat_add' ) ?>
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
-			<input type="text" name="name" size="32" maxlength="128" class="input-sm" />
+			<input type="text" name="name" required size="32" maxlength="128" class="input-sm" />
 			<input type="submit" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_category_button' ) ?>" />
 			<input type="submit" name="add_and_edit_category" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_and_edit_category_button' ) ?>" />
 		</fieldset>

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -121,7 +121,10 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 					</label>
 				</td>
 				<td>
-					<input type="text" id="project-name" name="name" class="input-sm" size="60" maxlength="128" value="<?php echo string_attribute( $t_row['name'] ) ?>" required />
+					<input type="text" id="project-name" name="name" required
+						   class="input-sm" size="60" maxlength="128"
+						   value="<?php echo string_attribute( $t_row['name'] ) ?>"
+					/>
 				</td>
 			</tr>
 			<tr>
@@ -143,7 +146,9 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 					</label>
 				</td>
 				<td>
-					<input type="checkbox" class="ace" id="project-enabled" name="enabled" <?php check_checked( (int)$t_row['enabled'], ON ); ?> />
+					<input type="checkbox" id="project-enabled" name="enabled" class="ace"
+						<?php check_checked( (int)$t_row['enabled'], ON ); ?>
+					/>
 				</td>
 			</tr>
 			<tr>
@@ -153,7 +158,9 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 					</label>
 				</td>
 				<td>
-					<input type="checkbox" class="ace" id="project-inherit-global" name="inherit_global" <?php check_checked( (int)$t_row['inherit_global'], ON ); ?> />
+					<input type="checkbox" id="project-inherit-global" name="inherit_global" class="ace"
+						<?php check_checked( (int)$t_row['inherit_global'], ON ); ?>
+					/>
 				</td>
 			</tr>
 
@@ -185,7 +192,10 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 						</label>
 					</td>
 					<td>
-						<input type="text" id="project-file-path" name="file_path" class="input-sm" size="60" maxlength="250" value="<?php echo string_attribute( $t_file_path ) ?>" />
+						<input type="text" id="project-file-path" name="file_path"
+							   class="input-sm" size="60" maxlength="250"
+							   value="<?php echo string_attribute( $t_file_path ) ?>"
+						/>
 					</td>
 				</tr><?php
 			} ?>
@@ -211,7 +221,9 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 		</div>
 		<div class="widget-toolbox padding-8 clearfix">
 			<span class="required pull-right"> * <?php echo lang_get( 'required' ) ?></span>
-			<input type="submit" class="btn btn-primary btn-white btn-round" value="<?php echo lang_get( 'update_project_button' ) ?>" />
+			<input type="submit" class="btn btn-primary btn-white btn-round"
+				   value="<?php echo lang_get( 'update_project_button' ) ?>"
+			/>
 		</div>
 	</div>
 	</form>
@@ -228,7 +240,9 @@ if( access_has_global_level ( config_get( 'delete_project_threshold' ) ) ) { ?>
 		<fieldset>
 			<?php echo form_security_field( 'manage_proj_delete' ) ?>
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
-			<input type="submit" class="btn btn-primary btn-sm btn-white btn-round"" value="<?php echo lang_get( 'delete_project_button' ) ?>" />
+			<input type="submit" class="btn btn-primary btn-sm btn-white btn-round"
+				   value="<?php echo lang_get( 'delete_project_button' ) ?>"
+			/>
 		</fieldset>
 	</form>
 </div>
@@ -253,8 +267,13 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 		<?php
 		# Check the user's global access level before allowing project creation
 		if( access_has_global_level ( config_get( 'create_project_threshold' ) ) ) {
-			print_form_button( 'manage_proj_create_page.php?parent_id=' . $f_project_id, lang_get( 'create_new_subproject_link' ),
-				null, null, 'btn btn-sm btn-primary btn-white btn-round' );
+			print_form_button(
+				'manage_proj_create_page.php?parent_id=' . $f_project_id,
+				lang_get( 'create_new_subproject_link' ),
+				null,
+				null,
+				'btn btn-sm btn-primary btn-white btn-round'
+			);
 		} ?>
 	</div>
 		<form id="manage-project-subproject-add-form" method="post" action="manage_proj_subproj_add.php" class="form-inline">
@@ -265,22 +284,33 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 				<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
 				<!--suppress HtmlFormInputWithoutLabel -->
 				<select name="subproject_id" class="input-sm" required>
-				<option selected disabled value=""><?php echo '[', lang_get( 'select_project_button' ), ']' ?></option><?php
-				$t_all_subprojects = project_hierarchy_get_subprojects( $f_project_id, true );
-				$t_all_subprojects[] = $f_project_id;
-				$t_manage_access = config_get( 'manage_project_threshold' );
-				$t_projects = project_get_all_rows();
-				$t_projects = multi_sort( $t_projects, 'name' );
-				foreach ( $t_projects as $t_project ) {
-					if( in_array( $t_project['id'], $t_all_subprojects ) ||
-						in_array( $f_project_id, project_hierarchy_get_all_subprojects( $t_project['id'] ) ) ||
-						!access_has_project_level( $t_manage_access, $t_project['id'] ) ) {
-						continue;
-					} ?>
-					<option value="<?php echo $t_project['id'] ?>"><?php echo string_attribute( $t_project['name'] ) ?></option><?php
-				} # End looping over projects ?>
+					<option selected disabled value="">
+						<?php echo '[', lang_get( 'select_project_button' ), ']' ?>
+					</option>
+<?php
+	$t_all_subprojects = project_hierarchy_get_subprojects( $f_project_id, true );
+	$t_all_subprojects[] = $f_project_id;
+	$t_manage_access = config_get( 'manage_project_threshold' );
+	$t_projects = project_get_all_rows();
+	$t_projects = multi_sort( $t_projects, 'name' );
+	foreach ( $t_projects as $t_project ) {
+		if( in_array( $t_project['id'], $t_all_subprojects ) ||
+			in_array( $f_project_id, project_hierarchy_get_all_subprojects( $t_project['id'] ) ) ||
+			!access_has_project_level( $t_manage_access, $t_project['id'] )
+		) {
+			continue;
+		}
+?>
+					<option value="<?php echo $t_project['id'] ?>">
+						<?php echo string_attribute( $t_project['name'] ) ?>
+					</option>
+<?php
+	} # End looping over projects
+?>
 				</select>
-				<input type="submit" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_subproject' ); ?>" />
+				<input type="submit" class="btn btn-sm btn-primary btn-white btn-round"
+					   value="<?php echo lang_get( 'add_subproject' ); ?>"
+				/>
 			</fieldset>
 			</div>
 			</div>
@@ -352,14 +382,18 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 						</td>
 						<td class="center">
 							<div class="inline">
-							<?php print_link_button(
-								'manage_proj_edit_page.php?project_id=' . $t_subproject['id'],
-								lang_get( 'edit' ), 'btn-xs' );
-							?>
-							<?php print_link_button(
-								"manage_proj_subproj_delete.php?project_id=$f_project_id&subproject_id=" . $t_subproject['id'] . form_security_param( 'manage_proj_subproj_delete' ),
-								lang_get( 'unlink_link' ), 'btn-xs' );
-							?>
+<?php
+	print_link_button(
+		'manage_proj_edit_page.php?project_id=' . $t_subproject['id'],
+		lang_get( 'edit' ), 'btn-xs'
+	);
+	print_link_button(
+		"manage_proj_subproj_delete.php?project_id=$f_project_id&subproject_id="
+		. $t_subproject['id']
+		. form_security_param( 'manage_proj_subproj_delete' ),
+		lang_get( 'unlink_link' ), 'btn-xs'
+	);
+?>
 							</div>
 						</td>
 					</tr>
@@ -373,7 +407,9 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 		</div>
 		</div>
 			<div class="widget-toolbox padding-8 clearfix">
-				<input type="submit" class="btn btn-primary btn-white btn-round" value="<?php echo lang_get( 'update_subproject_inheritance' ) ?>" />
+				<input type="submit" class="btn btn-primary btn-white btn-round"
+					   value="<?php echo lang_get( 'update_subproject_inheritance' ) ?>"
+				/>
 			</div>
 		</div>
 	</form>
@@ -406,11 +442,17 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
 			<!--suppress HtmlFormInputWithoutLabel -->
 			<select name="other_project_id" class="input-sm" required>
-				<option selected disabled value=""><?php echo '[', lang_get( 'select_project_button' ), ']' ?></option>
+				<option selected disabled value="">
+					<?php echo '[', lang_get( 'select_project_button' ), ']' ?>
+				</option>
 				<?php print_project_option_list( null, false, $f_project_id ); ?>
 			</select>
-			<input type="submit" name="copy_from" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'copy_categories_from' ) ?>" />
-			<input type="submit" name="copy_to" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'copy_categories_to' ) ?>" />
+			<input type="submit" name="copy_from" class="btn btn-sm btn-primary btn-white btn-round"
+				   value="<?php echo lang_get( 'copy_categories_from' ) ?>"
+			/>
+			<input type="submit" name="copy_to" class="btn btn-sm btn-primary btn-white btn-round"
+				   value="<?php echo lang_get( 'copy_categories_to' ) ?>"
+			/>
 		</fieldset>
 	</form>
 	</div>
@@ -418,7 +460,8 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 			<div class="widget-main no-padding">
 <?php
 	$t_categories = category_get_all_rows( $f_project_id );
-	if( count( $t_categories ) > 0 ) { ?>
+	if( count( $t_categories ) > 0 ) {
+?>
 	<div class="table-responsive">
 	<table class="table table-striped table-bordered table-condensed">
 		<thead>
@@ -439,20 +482,32 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 				<td><?php echo prepare_user_name( $t_category['user_id'] ) ?></td>
 				<td class="center">
 					<div class="inline">
-					<?php if( !$t_inherited ) {
-						$t_id = urlencode( $t_id );
-						$t_project_id = urlencode( $f_project_id );
-						echo '<div class="pull-left">';
-						print_form_button( 'manage_proj_cat_edit_page.php?id=' . $t_id . '&project_id=' . $t_project_id, lang_get( 'edit' ),
-							null, null, 'btn btn-xs btn-primary btn-white btn-round' );
-						echo '</div>';
-					} ?>
-					<?php if( !$t_inherited ) {
-						echo '<div class="pull-left">';
-						print_form_button( 'manage_proj_cat_delete.php?id=' . $t_id . '&project_id=' . $t_project_id, lang_get( 'delete' ),
-							null, null, 'btn btn-xs btn-primary btn-white btn-round' );
-						echo '</div>';
-					} ?>
+<?php
+			if( !$t_inherited ) {
+				$t_id = urlencode( $t_id );
+				$t_project_id = urlencode( $f_project_id );
+				echo '<div class="pull-left">';
+				print_form_button(
+					'manage_proj_cat_edit_page.php?id=' . $t_id . '&project_id=' . $t_project_id,
+					lang_get( 'edit' ),
+					null,
+					null,
+					'btn btn-xs btn-primary btn-white btn-round'
+				);
+				echo '</div>';
+			}
+			if( !$t_inherited ) {
+				echo '<div class="pull-left">';
+				print_form_button(
+					'manage_proj_cat_delete.php?id=' . $t_id . '&project_id=' . $t_project_id,
+					lang_get( 'delete' ),
+					null,
+					null,
+					'btn btn-xs btn-primary btn-white btn-round'
+				);
+				echo '</div>';
+			}
+?>
 					</div>
 				</td>
 			</tr>
@@ -460,8 +515,11 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 		} # end for loop
 ?>
 		</tbody>
-	</table></div><?php
-	} ?>
+	</table>
+	</div>
+<?php
+	}
+?>
 </div>
 </div>
 <div class="widget-toolbox padding-8 clearfix">
@@ -471,8 +529,13 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
 			<!--suppress HtmlFormInputWithoutLabel -->
 			<input type="text" name="name" required size="32" maxlength="128" class="input-sm" />
-			<input type="submit" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_category_button' ) ?>" />
-			<input type="submit" name="add_and_edit_category" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_and_edit_category_button' ) ?>" />
+			<input type="submit" class="btn btn-sm btn-primary btn-white btn-round"
+				   value="<?php echo lang_get( 'add_category_button' ) ?>"
+			/>
+			<input type="submit" name="add_and_edit_category"
+				   class="btn btn-sm btn-primary btn-white btn-round"
+				   value="<?php echo lang_get( 'add_and_edit_category_button' ) ?>"
+			/>
 		</fieldset>
 	</form>
 </div>
@@ -501,8 +564,12 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 				<option selected disabled value=""><?php echo '[', lang_get( 'select_project_button' ), ']' ?></option>
 				<?php print_project_option_list( null, false, $f_project_id ); ?>
 			</select>
-			<input type="submit" name="copy_from" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'copy_versions_from' ) ?>" />
-			<input type="submit" name="copy_to" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'copy_versions_to' ) ?>" />
+			<input type="submit" name="copy_from" class="btn btn-sm btn-primary btn-white btn-round"
+				   value="<?php echo lang_get( 'copy_versions_from' ) ?>"
+			/>
+			<input type="submit" name="copy_to" class="btn btn-sm btn-primary btn-white btn-round"
+				   value="<?php echo lang_get( 'copy_versions_to' ) ?>"
+			/>
 		</fieldset>
 	</form>
 	</div>
@@ -546,11 +613,17 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 					$t_version_id = version_get_id( $t_name, $f_project_id );
 					if( !$t_inherited ) {
 						echo '<div class="pull-left">';
-						print_form_button( 'manage_proj_ver_edit_page.php?version_id=' . $t_version_id, lang_get( 'edit' ) );
+						print_form_button(
+							'manage_proj_ver_edit_page.php?version_id=' . $t_version_id,
+							lang_get( 'edit' )
+						);
 						echo '</div>';
 
 						echo '<div class="pull-left">';
-						print_form_button( 'manage_proj_ver_delete.php?version_id=' . $t_version_id, lang_get( 'delete' ) );
+						print_form_button(
+							'manage_proj_ver_delete.php?version_id=' . $t_version_id,
+							lang_get( 'delete' )
+						);
 						echo '</div>';
 					} ?>
 					</div>
@@ -574,8 +647,12 @@ if ( config_get_global( 'subprojects_enabled') == ON ) {
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
 			<!--suppress HtmlFormInputWithoutLabel -->
 			<input type="text" class="input-sm" required name="version" size="32" maxlength="64" />
-			<input type="submit" name="add_version" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_version_button' ) ?>" />
-			<input type="submit" name="add_and_edit_version" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_and_edit_version_button' ) ?>" />
+			<input type="submit" name="add_version" class="btn btn-sm btn-primary btn-white btn-round"
+				   value="<?php echo lang_get( 'add_version_button' ) ?>"
+			/>
+			<input type="submit" name="add_and_edit_version" class="btn btn-sm btn-primary btn-white btn-round"
+				   value="<?php echo lang_get( 'add_and_edit_version_button' ) ?>"
+			/>
 		</fieldset>
 	</form>
 	</div>
@@ -610,8 +687,12 @@ if( access_has_project_level( config_get( 'custom_field_link_threshold' ), $f_pr
 				<option selected disabled value=""><?php echo '[', lang_get( 'select_project_button' ), ']' ?></option>
 				<?php print_project_option_list( null, false, $f_project_id ); ?>
 			</select>
-			<input type="submit" name="copy_from" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'copy_from' ) ?>" />
-			<input type="submit" name="copy_to" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'copy_to' ) ?>" />
+			<input type="submit" name="copy_from" class="btn btn-sm btn-primary btn-white btn-round"
+				   value="<?php echo lang_get( 'copy_from' ) ?>"
+			/>
+			<input type="submit" name="copy_to" class="btn btn-sm btn-primary btn-white btn-round"
+				   value="<?php echo lang_get( 'copy_to' ) ?>"
+			/>
 		</fieldset>
 	</form>
 	</div>
@@ -644,14 +725,21 @@ if( access_has_project_level( config_get( 'custom_field_link_threshold' ), $f_pr
 							<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
 							<input type="hidden" name="field_id" value="<?php echo $t_field_id ?>" />
 							<!--suppress HtmlFormInputWithoutLabel -->
-							<input type="text" class="input-sm" name="sequence" value="<?php echo custom_field_get_sequence( $t_field_id, $f_project_id ) ?>" size="2" />
-							<input type="submit" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'update' ) ?>" />
+							<input type="text" class="input-sm" name="sequence" size="2"
+								   value="<?php echo custom_field_get_sequence( $t_field_id, $f_project_id ) ?>"
+							/>
+							<input type="submit" class="btn btn-sm btn-primary btn-white btn-round"
+								   value="<?php echo lang_get( 'update' ) ?>"
+							/>
 						</fieldset>
 					</form>
 				</td>
 				<td class="center"><?php
 					# You need global permissions to edit custom field defs
-					print_form_button( "manage_proj_custom_field_remove.php?field_id=$t_field_id&project_id=$f_project_id", lang_get( 'remove_link' ) ); ?>
+					print_form_button(
+						"manage_proj_custom_field_remove.php?field_id=$t_field_id&project_id=$f_project_id",
+						lang_get( 'remove_link' )
+					); ?>
 				</td>
 			</tr>
 <?php
@@ -682,12 +770,16 @@ if( access_has_project_level( config_get( 'custom_field_link_threshold' ), $f_pr
 					foreach( $t_custom_fields as $t_field )
 					{
 						if( !custom_field_is_linked( $t_field['id'], $f_project_id ) ) {
-							echo '<option value="', $t_field['id'], '">', string_attribute( lang_get_defaulted( $t_field['name'] ) ), '</option>' ;
+							echo '<option value="', $t_field['id'], '">',
+								string_attribute( lang_get_defaulted( $t_field['name'] ) ),
+								'</option>' ;
 						}
 					}
 				?>
 			</select>
-			<input type="submit" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_existing_custom_field' ) ?>" />
+			<input type="submit" class="btn btn-sm btn-primary btn-white btn-round"
+				   value="<?php echo lang_get( 'add_existing_custom_field' ) ?>"
+			/>
 		</fieldset>
 	</form>
 </div><?php
@@ -735,12 +827,18 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 							<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
 							<!--suppress HtmlFormInputWithoutLabel -->
 							<select name="other_project_id" class="input-sm" required>
-								<option selected disabled value=""><?php echo '[', lang_get( 'select_project_button' ), ']' ?></option>
+								<option selected disabled value="">
+									<?php echo '[', lang_get( 'select_project_button' ), ']' ?>
+								</option>
 								<?php print_project_option_list( null, false, $f_project_id ); ?>
 							</select>
 							<span class=form-inline">
-								<input type="submit" name="copy_from" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'copy_users_from' ) ?>" />
-								<input type="submit" name="copy_to" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'copy_users_to' ) ?>" />
+								<input type="submit" name="copy_from" class="btn btn-sm btn-primary btn-white btn-round"
+									   value="<?php echo lang_get( 'copy_users_from' ) ?>"
+								/>
+								<input type="submit" name="copy_to" class="btn btn-sm btn-primary btn-white btn-round"
+									   value="<?php echo lang_get( 'copy_users_to' ) ?>"
+								/>
 							</span>
 						</fieldset>
 					</form>
@@ -773,9 +871,13 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 						<div class="widget-toolbar pull-left">
 							<label>
 								<?php echo lang_get( 'show' ) ?>
-								<input id="input-per-page" type="text" min="5" size="2" class="input-sm" value="<?php echo config_get( 'default_limit_view' ) ?>"/>
+								<input id="input-per-page" type="text" min="5" size="2" class="input-sm"
+									   value="<?php echo config_get( 'default_limit_view' ) ?>"
+								/>
 							</label>
-							<?php echo '(', lang_get( 'total' ), ': ', $t_users_count, ' ', lang_get( 'users_link' ), ')' ?>
+							<?php echo '(', lang_get( 'total' ), ': ',
+								$t_users_count, ' ', lang_get( 'users_link' ), ')'
+							?>
 						</div>
 						<div class="btn-group pull-right">
 							<ul class="pagination small no-margin"></ul>
@@ -791,14 +893,28 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 							<table class="table table-striped table-bordered table-condensed">
 								<thead>
 									<tr>
-										<th><div class="sort" role="button" data-sort="key-name"><?php echo lang_get( 'username' ) ?></div></th>
-										<th><div class="sort" role="button" data-sort="key-email"><?php echo lang_get( 'email' ) ?></div></th>
-										<th class="col-md-4"><div class="sort" role="button" data-sort="key-access"><?php echo lang_get( 'access_level' ) ?></div></th>
-										<th><?php echo lang_get( 'remove_link' ) ?></th>
+										<th>
+											<div class="sort" role="button" data-sort="key-name">
+												<?php echo lang_get( 'username' ) ?>
+											</div>
+										</th>
+										<th>
+											<div class="sort" role="button" data-sort="key-email">
+												<?php echo lang_get( 'email' ) ?>
+											</div>
+										</th>
+										<th class="col-md-4">
+											<div class="sort" role="button" data-sort="key-access">
+												<?php echo lang_get( 'access_level' ) ?>
+											</div>
+										</th>
+										<th>
+											<?php echo lang_get( 'remove_link' ) ?>
+										</th>
 									</tr>
 								</thead>
 								<tbody class="list">
-		<?php
+<?php
 		# If including global users, fetch here all local user to later distinguish them
 		$t_local_users = array();
 		if( $f_show_global_users ) {
@@ -810,7 +926,7 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 			$t_can_manage_this_user = $t_can_manage_users
 					&& access_has_project_level( $t_user['access_level'], $f_project_id )
 					&& ( !$f_show_global_users || isset( $t_local_users[$t_user['id']]) );
-		?>
+?>
 		<tr>
 			<td class="key-name" data-sortvalue="<?php echo $t_username ?>">
 				<a href="manage_user_edit_page.php?user_id=<?php echo $t_user['id'] ?>">
@@ -856,7 +972,10 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 					?>
 					<div class="checkbox no-padding no-margin editable_user_delete">
 						<label>
-							<input type="checkbox" name="user_access_delete[]" value="<?php echo $t_user['id'] ?>" class="ace user_access_delete" />
+							<input type="checkbox" name="user_access_delete[]"
+								   class="ace user_access_delete"
+								   value="<?php echo $t_user['id'] ?>"
+							/>
 							<span class="lbl"></span>
 						</label>
 					</div>
@@ -874,34 +993,51 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 
 						<div class="widget-toolbox padding-8 clearfix">
 							<div class="form-inline pull-left">
-								<input type="submit" name="submit-apply" class="btn btn-primary btn-white btn-round" value="<?php echo lang_get( 'apply_changes' ) ?>" />
+								<input type="submit" name="submit-apply"
+									   class="btn btn-primary btn-white btn-round"
+									   value="<?php echo lang_get( 'apply_changes' ) ?>"
+								/>
 							</div>
 							<div class="form-inline pull-right">
 								<?php echo form_security_field( 'manage_proj_user_remove' ) ?>
-								<input type="submit" name="btn-remove-all" class="btn btn-primary btn-white btn-round btn-xs"
-									formaction="manage_proj_user_remove.php" value="<?php echo lang_get( 'remove_all_link' ) ?>">
+								<input type="submit" name="btn-remove-all"
+									   class="btn btn-primary btn-white btn-round btn-xs"
+									   formaction="manage_proj_user_remove.php"
+									   value="<?php echo lang_get( 'remove_all_link' ) ?>"
+								/>
 								<button name="btn-undo-remove-all" class="hidden btn btn-primary btn-white btn-round btn-xs">
-									<?php echo lang_get( 'undo' ). ': ', lang_get( 'remove_all_link' ) ?></button>
+									<?php echo lang_get( 'undo' ). ': ', lang_get( 'remove_all_link' ) ?>
+								</button>
 							</div>
 						</div>
 					</form>
 				</div>
-	<?php
+<?php
 	} // end if user count > 0
-	?>
+?>
 			</div>
 			<div class="widget-toolbox padding-8 clearfix">
-	<?php
+<?php
 	# You need global or project-specific permissions to remove users
 	#  from this project
 	if( !$f_show_global_users ) {
-		print_form_button( "manage_proj_edit_page.php?project_id=$f_project_id&show_global_users=true", lang_get( 'show_global_users' ),
-			null, OFF, 'btn btn-sm btn-primary btn-white btn-round' );
+		print_form_button(
+			"manage_proj_edit_page.php?project_id=$f_project_id&show_global_users=true",
+			lang_get( 'show_global_users' ),
+			null,
+			OFF,
+			'btn btn-sm btn-primary btn-white btn-round'
+		);
 	} else {
-		print_form_button( "manage_proj_edit_page.php?project_id=$f_project_id", lang_get( 'hide_global_users' ),
-			null, OFF, 'btn btn-sm btn-primary btn-white btn-round' );
+		print_form_button(
+			"manage_proj_edit_page.php?project_id=$f_project_id",
+			lang_get( 'hide_global_users' ),
+			null,
+			OFF,
+			'btn btn-sm btn-primary btn-white btn-round'
+		);
 	}
-	?>
+?>
 			</div>
 		</div>
 	</div>
@@ -939,10 +1075,13 @@ if( count( $t_users ) > 0 ) { ?>
 					</label>
 				</td>
 				<td>
-					<select id="project-add-users-username" name="user_id[]" class="input-sm" multiple="multiple" size="10" required><?php
+					<select id="project-add-users-username" name="user_id[]"
+							class="input-sm" multiple="multiple" size="10" required>
+<?php
 						foreach( $t_users AS $t_user_id=>$t_display_name ) {
 							echo '<option value="', $t_user_id, '">', string_attribute( $t_display_name ), '</option>';
-						} ?>
+						}
+?>
 					</select>
 				</td>
 			</tr>
@@ -953,9 +1092,14 @@ if( count( $t_users ) > 0 ) { ?>
 					</label>
 				</td>
 				<td>
-					<select id="project-add-users-access-level" name="access_level" class="input-sm"><?php
+					<select id="project-add-users-access-level" name="access_level" class="input-sm">
+<?php
 						# only access levels that are less than or equal current user access level for current project
-						print_project_access_levels_option_list( config_get( 'default_new_account_access_level' ), $f_project_id ); ?>
+						print_project_access_levels_option_list(
+							config_get( 'default_new_account_access_level' ),
+							$f_project_id
+						);
+?>
 					</select>
 				</td>
 			</tr>
@@ -966,7 +1110,9 @@ if( count( $t_users ) > 0 ) { ?>
 		</div>
 			<div class="widget-toolbox padding-8 clearfix">
 				<span class="required pull-right"> * <?php echo lang_get( 'required' ) ?></span>
-				<input type="submit" class="btn btn-primary btn-white btn-round" value="<?php echo lang_get( 'add_user_button' ) ?>" />
+				<input type="submit" class="btn btn-primary btn-white btn-round"
+					   value="<?php echo lang_get( 'add_user_button' ) ?>"
+				/>
 			</div>
 		</div>
 	</form>

--- a/manage_proj_ver_add.php
+++ b/manage_proj_ver_add.php
@@ -91,14 +91,18 @@ foreach ( $t_versions as $t_version ) {
 
 form_security_purge( 'manage_proj_ver_add' );
 
-if( $f_add_and_edit && $t_version_id != 0 ) {
+if( $t_version_id == 0 ) {
+	error_parameters( lang_get( 'version' ) );
+	trigger_error( ERROR_EMPTY_FIELD, ERROR );
+}
+
+if( $f_add_and_edit ) {
 	$t_redirect_url = 'manage_proj_ver_edit_page.php?version_id=' . $t_version_id;
 } else {
 	$t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id;
 }
 
 layout_page_header( null, $t_redirect_url );
-
 layout_page_begin( 'manage_overview_page.php' );
 
 html_operation_successful( $t_redirect_url );


### PR DESCRIPTION
When adding a new version from manage_proj_edit_page.php via the
'Add Version' or 'Add and Edit Version', it should not be allowed to
submit an empty field.

The HTML required attribute has been added to the 'version' input, and
the manage_proj_ver_add.php page displays an error message if no version
was created.

Fixes [#27994](https://mantisbt.org/bugs/view.php?id=27994)