### PR TITLE
Add resolved percentage on Roadmap section title

### DIFF
--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -1107,7 +1107,7 @@ function auth_is_cookie_valid( $p_cookie_string ) {
  * @return integer user id
  * @access public
  *
- * @throws ClientException
+ * @noinspection PhpDocMissingThrowsInspection
  */
 function auth_get_current_user_id() {
 	global $g_cache_current_user_id;
@@ -1125,6 +1125,7 @@ function auth_get_current_user_id() {
 	}
 
 	# @todo error with an error saying they aren't logged in? Or redirect to the login page maybe?
+	/** @noinspection PhpUnhandledExceptionInspection */
 	$t_user_id = user_get_id_by_cookie( $t_cookie_string );
 
 	# The cookie was invalid. Clear the cookie (to allow people to log in again)

--- a/core/version_api.php
+++ b/core/version_api.php
@@ -591,6 +591,8 @@ function version_get_id( $p_version, $p_project_id = null, $p_inherit = null ) {
  * @param integer $p_version_id A valid version identifier.
  * @param string  $p_field_name A valid field name to lookup.
  * @return string
+ *
+ * @throws ClientException
  */
 function version_get_field( $p_version_id, $p_field_name ) {
 	$t_row = version_cache_row( $p_version_id );

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1345,7 +1345,7 @@ $s_changelog_empty_manager = 'No Change Log information available.  Issues are i
 
 # Roadmap
 $s_roadmap = 'Roadmap';
-$s_resolved_progress = '%1$d of %2$d issue(s) resolved. Progress (%3$d%%).';
+$s_resolved_progress = '%1$d of %2$d issue(s) resolved';
 $s_roadmap_empty = 'No Roadmap information available';
 $s_roadmap_empty_manager = 'No Roadmap information available.  Issues are included once projects have versions and issues have "target version" set.';
 

--- a/roadmap_page.php
+++ b/roadmap_page.php
@@ -221,10 +221,13 @@ function print_version_header( array $p_version_row, $p_progress ) {
  *
  * @param array $p_version_row array contain project version data
  * @param RoadmapProgress $p_progress
+ *
+ * @noinspection PhpDocMissingThrowsInspection
  */
 function print_version_footer( $p_version_row, $p_progress ) {
 	$t_project_id   = $p_version_row['project_id'];
 	$t_version_id   = $p_version_row['id'];
+	/** @noinspection PhpUnhandledExceptionInspection */
 	$t_version_name = version_get_field( $t_version_id, 'version' );
 
 	echo '</div>';
@@ -285,6 +288,7 @@ if( is_blank( $f_version ) ) {
 			$t_project_id = $f_project_id;
 		}
 	} else {
+		/** @noinspection PhpUnhandledExceptionInspection */
 		$t_project_id = version_get_field( $f_version_id, 'project_id' );
 	}
 } else {
@@ -459,6 +463,7 @@ foreach( $t_project_ids as $t_project_id ) {
 			if( $t_cycle || !in_array( $t_issue_parent, $t_issue_ids ) ) {
 				$l = array_search( $t_issue_parent, $t_issue_set_ids );
 				if( $l !== false ) {
+					/** @noinspection PhpStatementHasEmptyBodyInspection */
 					for( $m = $l+1; $m < count( $t_issue_set_ids ) && $t_issue_set_levels[$m] > $t_issue_set_levels[$l]; $m++ ) {
 						#do nothing
 					}


### PR DESCRIPTION
On the Roadmap page, a version's progress is now displayed on the right
of the section's title, with a tooltip showing the number of issues
resolved vs planned.

The resolved_progress language string has been modified to remove the
3rd placeholder (percentage) which is redundant.

Script has been refactored to use a new internal RoadmapProgress class,
simplifying code and removing some duplication.

Fixes [#28182](https://mantisbt.org/bugs/view.php?id=28182)
