### PR TITLE
Update MantisMarkdown.php

### DIFF
--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -83,6 +83,8 @@ class MantisMarkdown extends Parsedown
 		# Text processing converts special character to entity name
 		# Make sure to restore "&gt;" entity name to its characted result ">"
 		$p_text = str_replace( "&gt;", ">", $p_text );
+		$p_text = str_replace( "&lt;", "<", $p_text );
+		$p_text = str_replace( "&quot;", '"', $p_text );
 
 		return self::$mantis_markdown->text( $p_text );
 	}


### PR DESCRIPTION
When < and " are output, the HTML entities are output up to now. This change corrects this.