### PR TITLE
Set overflow-wrap to 'anywhere' for tbody only (#1690)

### DIFF
--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -171,6 +171,10 @@ table {
     background-color: #ffffff !important;
 }
 
+table tbody {
+	overflow-wrap: anywhere;
+}
+
 /* Disable printing of link urls */
 a:link:after, a:visited:after {
     content: normal !important;

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -171,8 +171,12 @@ table {
     background-color: #ffffff !important;
 }
 
-table tbody {
-	overflow-wrap: anywhere;
+td {
+    overflow-wrap: anywhere;
+}
+
+td a {
+    overflow-wrap: normal;
 }
 
 /* Disable printing of link urls */

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -171,12 +171,8 @@ table {
     background-color: #ffffff !important;
 }
 
-td {
-    overflow-wrap: anywhere;
-}
-
-td a {
-    overflow-wrap: normal;
+[class*="description"] {
+	overflow-wrap: anywhere;
 }
 
 /* Disable printing of link urls */

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -171,8 +171,21 @@ table {
     background-color: #ffffff !important;
 }
 
-[class*="description"] {
-	overflow-wrap: anywhere;
+/* Breaking lines when needed */
+[class*="description"],
+[class*="steps-to-reproduce"],
+[class*="additional-information"],
+[class*="bugnote"],
+[class*="custom-field"] {
+    overflow-wrap: anywhere;
+}
+
+pre {
+    white-space: pre-wrap;       /* Since CSS 2.1 */
+    white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+    white-space: -pre-wrap;      /* Opera 4-6 */
+    white-space: -o-pre-wrap;    /* Opera 7 */
+    word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
 
 /* Disable printing of link urls */


### PR DESCRIPTION
This new css rule applies the solution proposed by @syncguru in a more selective way.
The main problem with the proposed solution in #1690 was its application to the whole table.
As css tables are divided in two main parts (header -thead-, and body -tbody-), applying the rule only to tbody does not change the header behavior.