### PR TITLE
FIX: rest api: call to undefined methods when handling RestFault

### DIFF
--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -58,6 +58,24 @@ class RestFault {
 		$this->status_code = $p_status_code;
 		$this->fault_string = $p_fault_string === null ? '' : $p_fault_string;
 	}
+
+    /**
+     * Error description getter
+     *
+     * @return string The error description
+     */
+	function getMessage() {
+		return $this->fault_string;
+	}
+
+    /**
+     * Http status code getter
+     *
+     * @return integer The http status code
+     */
+	function getCode() {
+		return $this->status_code;
+	}
 }
 
 /**


### PR DESCRIPTION
When calling `ApiObjectFactory::throwIfFault()` to check whether an API call returned a fault (`RestFault` or `SoapFault` depending of the API type), if that is indeed the case, a `LegacyApiFaultException` is created by getting the message and code from the fault object.

This is done by calling `getCode()` and `getMessage()` on the fault. Yet, `RestFault` implements none of those methods (contrary to `SoapFault`, which extends PHP's standard `Exception` class).

This causes a `Slim Application Error` page in HTML instead of the exected JSON error response.