### PR TITLE
Attachment to new tab

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2066,6 +2066,13 @@ $g_max_dropdown_length = 40;
  */
 $g_wrap_in_preformatted_text = ON;
 
+/**
+ * Controls whether attachment links redirect users t a new tab or not
+ * If turned off, a click on a link will not redirect to a new tab
+ * @global integer $g_attachment_to_new_tab
+ */
+$g_attachment_to_new_tab = OFF;
+
 #############################################
 # MantisBT Authentication and LDAP Settings #
 #############################################
@@ -4557,6 +4564,7 @@ $g_public_config_names = array(
 	'antispam_max_event_count',
 	'antispam_time_window_in_seconds',
 	'assign_sponsored_bugs_threshold',
+	'attachment_to_new_tab',
 	'auto_set_status_to_assigned',
 	'backward_year_count',
 	'bottom_include_page',

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1971,7 +1971,7 @@ function print_bug_attachment( array $p_attachment, $p_security_token ) {
 function print_bug_attachment_header( array $p_attachment, $p_security_token ) {
 	if( $p_attachment['exists'] ) {
 		if( $p_attachment['can_download'] ) {
-			echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '">';
+			echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '" target=_blank>';
 		}
 		print_file_icon( $p_attachment['display_name'] );
 		if( $p_attachment['can_download'] ) {
@@ -1979,7 +1979,7 @@ function print_bug_attachment_header( array $p_attachment, $p_security_token ) {
 		}
 		echo lang_get( 'word_separator' );
 		if( $p_attachment['can_download'] ) {
-			echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '">';
+			echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '" target=_blank>';
 		}
 		echo string_display_line( $p_attachment['display_name'] );
 		if( $p_attachment['can_download'] ) {
@@ -2055,7 +2055,7 @@ function print_bug_attachment_preview_image( array $p_attachment ) {
 	$t_image_url = $p_attachment['download_url'] . '&show_inline=1' . form_security_param( 'file_show_inline' );
 
 	echo "\n<div class=\"bug-attachment-preview-image\">";
-	echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '">';
+	echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '" target=_blank>';
 	echo '<img src="' . string_attribute( $t_image_url ) . '" alt="' . string_attribute( $t_title ) . '" loading="lazy" style="' . string_attribute( $t_preview_style ) . '" />';
 	echo '</a></div>';
 }

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1971,7 +1971,7 @@ function print_bug_attachment( array $p_attachment, $p_security_token ) {
 function print_bug_attachment_header( array $p_attachment, $p_security_token ) {
 	if( $p_attachment['exists'] ) {
 		if( $p_attachment['can_download'] ) {
-			echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '" target=_blank>';
+			echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '"' . get_attachment_link_target() . '>';
 		}
 		print_file_icon( $p_attachment['display_name'] );
 		if( $p_attachment['can_download'] ) {
@@ -1979,7 +1979,7 @@ function print_bug_attachment_header( array $p_attachment, $p_security_token ) {
 		}
 		echo lang_get( 'word_separator' );
 		if( $p_attachment['can_download'] ) {
-			echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '" target=_blank>';
+			echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '"' . get_attachment_link_target() . '>';
 		}
 		echo string_display_line( $p_attachment['display_name'] );
 		if( $p_attachment['can_download'] ) {
@@ -2055,7 +2055,7 @@ function print_bug_attachment_preview_image( array $p_attachment ) {
 	$t_image_url = $p_attachment['download_url'] . '&show_inline=1' . form_security_param( 'file_show_inline' );
 
 	echo "\n<div class=\"bug-attachment-preview-image\">";
-	echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '" target=_blank>';
+	echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '"' . get_attachment_link_target() . '>';
 	echo '<img src="' . string_attribute( $t_image_url ) . '" alt="' . string_attribute( $t_title ) . '" loading="lazy" style="' . string_attribute( $t_preview_style ) . '" />';
 	echo '</a></div>';
 }
@@ -2075,7 +2075,7 @@ function print_bug_attachment_preview_audio_video( array $p_attachment, $p_file_
 	$t_type = $p_attachment['type'];
 
 	echo "\n<div class=\"bug-attachment-preview-" . $t_type . "\">";
-	echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '" target=_blank>';
+	echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '"' . get_attachment_link_target() . '>';
 	echo '<' . $t_type . ' controls="controls"' . $t_preload . '>';
 	echo '<source src="' . string_attribute( $t_file_url ) . '" type="' . string_attribute( $p_file_type ) . '">';
   	echo lang_get( 'browser_does_not_support_' . $t_type );
@@ -2123,6 +2123,17 @@ function print_timezone_option_list( $p_timezone ) {
  */
 function get_filesize_info( $p_size, $p_unit ) {
 	return sprintf( lang_get( 'max_file_size_info' ), number_format( $p_size ), $p_unit );
+}
+
+/**
+ * Returns target tag to be added in attachment links
+ * @return string
+ */
+function get_attachment_link_target() {
+	if( config_get( 'attachment_to_new_tab' ) ) {
+		return ' target="_blank"';
+	}
+	return ' target="_self"';
 }
 
 /**

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -2075,7 +2075,7 @@ function print_bug_attachment_preview_audio_video( array $p_attachment, $p_file_
 	$t_type = $p_attachment['type'];
 
 	echo "\n<div class=\"bug-attachment-preview-" . $t_type . "\">";
-	echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '">';
+	echo '<a href="' . string_attribute( $p_attachment['download_url'] ) . '" target=_blank>';
 	echo '<' . $t_type . ' controls="controls"' . $t_preload . '>';
 	echo '<source src="' . string_attribute( $t_file_url ) . '" type="' . string_attribute( $p_file_type ) . '">';
   	echo lang_get( 'browser_does_not_support_' . $t_type );


### PR DESCRIPTION
I think the behavior when viewing attachment should change: when clicking on an image in a bugnote, it displays it in the same tab. I think it would be better to redirect this full display of the image to a new tab. That would allow you to go back and forth between seeing the image and seeing the bugnote text associated.

This new redirection would be effective for both clicking on the icon or on the name of the attachment (as shown below), and also when clicking on an image preview in a bugnote, or a preview of an audio / video.

![image](https://user-images.githubusercontent.com/9255251/128195047-1609dc70-61b5-4908-b763-3a5d41473cfd.png)