### PR TITLE
Include cache key when including unversioned css

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -208,11 +208,16 @@ function require_css( $p_stylesheet_path ) {
  */
 function html_css() {
 	global $g_stylesheets_included;
-	html_css_link( config_get_global( 'css_include_file' ) );
+
+	$t_cache_key = helper_generate_cache_key();
+
+	html_css_link( config_get_global( 'css_include_file' ) . '?cache_key=' . $t_cache_key );
+
 	# Add right-to-left css if needed
 	if( lang_get( 'directionality' ) == 'rtl' ) {
-		html_css_link( config_get_global( 'css_rtl_include_file' ) );
+		html_css_link( config_get_global( 'css_rtl_include_file' ) . '?cache_key=' . $t_cache_key );
 	}
+
 	foreach( $g_stylesheets_included as $t_stylesheet_path ) {
 		# status_config.php is a special css file, dynamically generated.
 		# Add a hash to the query string to differentiate content based on its
@@ -224,7 +229,8 @@ function html_css() {
 				'cache_key=' . helper_generate_cache_key( array( 'user' ) )
 			);
 		}
-		html_css_link( $t_stylesheet_path );
+
+		html_css_link( $t_stylesheet_path . $t_version );
 	}
 
 	# dropzone css

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -251,6 +251,8 @@ function layout_head_meta() {
  * @return void
  */
 function layout_head_css() {
+	$t_cache_key = helper_generate_cache_key();
+
 	# bootstrap & fontawesome
 	if ( config_get_global( 'cdn_enabled' ) == ON ) {
 		html_css_cdn_link( 'https://stackpath.bootstrapcdn.com/bootstrap/' . BOOTSTRAP_VERSION . '/css/bootstrap.min.css',BOOTSTRAP_HASH_CSS );
@@ -267,7 +269,7 @@ function layout_head_css() {
 		html_css_link( 'font-awesome-' . FONT_AWESOME_VERSION . '.min.css' );
 
 		# theme text fonts
-		html_css_link( 'fonts.css' );
+		html_css_link( 'fonts.css?cache_key=' . $t_cache_key );
 
 		# datetimepicker
 		html_css_link( 'bootstrap-datetimepicker-' . DATETIME_PICKER_VERSION . '.min.css' );
@@ -276,12 +278,12 @@ function layout_head_css() {
 	# page specific plugin styles
 
 	# theme styles
-	html_css_link( 'ace.min.css' );
-	html_css_link( 'ace-mantis.css' );
-	html_css_link( 'ace-skins.min.css' );
+	html_css_link( 'ace.min.css?cache_key=' . $t_cache_key );
+	html_css_link( 'ace-mantis.css?cache_key=' . $t_cache_key );
+	html_css_link( 'ace-skins.min.css?cache_key=' . $t_cache_key );
 
 	if( layout_is_rtl() ) {
-		html_css_link( 'ace-rtl.min.css' );
+		html_css_link( 'ace-rtl.min.css?cache_key=' . $t_cache_key );
 	}
 
 	echo "\n";


### PR DESCRIPTION
When including our css files that don't have a version in the name,
include cache key based on Mantis version.

Fixes #26148