### PR TITLE
Fix gpc_set_cookie ignoring HttpOnly parameter

### DIFF
--- a/core/gpc_api.php
+++ b/core/gpc_api.php
@@ -384,7 +384,7 @@ function gpc_set_cookie( $p_name, $p_value, $p_expire = false, $p_path = null, $
 		$p_domain = config_get_global( 'cookie_domain' );
 	}
 
-	return setcookie( $p_name, $p_value, $p_expire, $p_path, $p_domain, $g_cookie_secure_flag_enabled, true );
+	return setcookie( $p_name, $p_value, $p_expire, $p_path, $p_domain, $g_cookie_secure_flag_enabled, $p_httponly );
 }
 
 /**


### PR DESCRIPTION
Function `gpc_set_cookie` ignores parameter `$p_httponly` and sets all cookies to be HttpOnly, which prevents legitimate use cases where Javascript code would need to change the cookie value.