### PR TITLE
Add new config $g_ldap_email_field

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2224,7 +2224,15 @@ $g_ldap_bind_passwd = '';
 $g_ldap_uid_field = 'uid';
 
 /**
+ * The LDAP field for the user's e-mail address.
+ * @see $g_use_ldap_email
+ * @global string $g_ldap_email_field
+ */
+$g_ldap_email_field = 'mail';
+
+/**
  * The LDAP field for the user's real name (i.e. common name).
+ * @see $g_use_ldap_realname
  * @global string $g_ldap_realname_field
  */
 $g_ldap_realname_field = 'cn';
@@ -2234,6 +2242,7 @@ $g_ldap_realname_field = 'cn';
  * database (OFF).
  * Note that MantisBT will update the database with the data retrieved
  * from LDAP when ON.
+ * @see $g_ldap_realname_field
  * @global integer $g_use_ldap_realname
  */
 $g_use_ldap_realname = OFF;
@@ -2243,6 +2252,7 @@ $g_use_ldap_realname = OFF;
  * in the database (OFF).
  * Note that MantisBT will update the database with the data retrieved
  * from LDAP when ON.
+ * @see $g_ldap_email_field
  * @global integer $g_use_ldap_email
  */
 $g_use_ldap_email = OFF;
@@ -4476,6 +4486,7 @@ $g_global_settings = array(
 	'language_path',
 	'ldap_bind_dn',
 	'ldap_bind_passwd',
+	'ldap_email_field',
 	'ldap_follow_referrals',
 	'ldap_network_timeout',
 	'ldap_organization',

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -176,7 +176,10 @@ function ldap_email_from_username( $p_username ) {
 	if( ldap_simulation_is_enabled() ) {
 		$t_email = ldap_simulation_email_from_username( $p_username );
 	} else {
-		$t_email = (string)ldap_get_field_from_username( $p_username, 'mail' );
+		$t_email = (string)ldap_get_field_from_username(
+			$p_username,
+			config_get_global( 'ldap_email_field' )
+		);
 	}
 	return $t_email;
 }
@@ -225,7 +228,7 @@ function ldap_escape_string( $p_string ) {
  * Retrieves user data from LDAP and stores it in cache.
  *
  * Uses a single LDAP query to retrieve the following fields:
- * - email (mail)
+ * - email {@see $g_ldap_email_field}
  * - realname {@see $g_ldap_realname_field}
  *
  * @param string $p_username The username.
@@ -259,7 +262,7 @@ function ldap_cache_user_data( $p_username ) {
 	$t_search_filter = '(&' . $t_ldap_organization
 		. '(' . $t_ldap_uid_field . '=' . ldap_escape_string( $p_username ) . '))';
 	$t_search_attrs = array(
-		'mail',
+		config_get_global( 'ldap_email_field' ),
 		config_get_global( 'ldap_realname_field' )
 	);
 

--- a/docbook/Admin_Guide/en-US/config/auth.xml
+++ b/docbook/Admin_Guide/en-US/config/auth.xml
@@ -304,6 +304,16 @@ ldaps://ldap.example.com:3269/
 			</varlistentry>
 
 			<varlistentry>
+				<term>$g_ldap_email_field</term>
+
+				<listitem>
+					<para>The LDAP field for e-mail address.
+						Defaults to <literal>mail</literal>.
+					</para>
+				</listitem>
+			</varlistentry>
+
+			<varlistentry>
 				<term>$g_ldap_realname_field</term>
 
 				<listitem>


### PR DESCRIPTION
Allows customizing the LDAP field used to store the user's e-mail
address, when $g_use_ldap_email = ON.

Fixes [#29230](https://mantisbt.org/bugs/view.php?id=29230)