### PR TITLE
#0029583: Support for sending emails with CC and/or BCC

### DIFF
--- a/core/email_api.php
+++ b/core/email_api.php
@@ -1369,12 +1369,16 @@ function email_send( EmailData $p_email_data ) {
 	$t_mail->AddCustomHeader( 'Auto-Submitted:auto-generated' );
 	$t_mail->AddCustomHeader( 'X-Auto-Response-Suppress: All' );
 
-	if( isset($t_email_data->metadata['cc']) && $t_email_data->metadata['cc'] )
-		foreach( $t_email_data->metadata['cc'] as $cc )
-			$t_mail->addCC(trim($cc));
-	if( isset($t_email_data->metadata['bcc']) && $t_email_data->metadata['bcc'] )
-		foreach( $t_email_data->metadata['bcc'] as $bcc )
-			$t_mail->addBCC(trim($bcc));
+	if( isset( $t_email_data->metadata['cc'] ) && $t_email_data->metadata['cc'] ) {
+		foreach( $t_email_data->metadata['cc'] as $cc ) {
+			$t_mail->addCC( trim( $cc ) );
+		}
+	}
+	if( isset( $t_email_data->metadata['bcc'] ) && $t_email_data->metadata['bcc'] ) {
+		foreach( $t_email_data->metadata['bcc'] as $bcc ) {
+			$t_mail->addBCC( trim( $bcc ) );
+		}
+	}
 
 	$t_mail->Encoding   = 'quoted-printable';
 

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -1157,9 +1157,11 @@ function email_bug_deleted( $p_bug_id ) {
  * @param array   $p_headers   Array of additional headers to send with the email.
  * @param boolean $p_force     True to force sending of emails in shutdown function,
  *                             even when using cronjob
+ * @param array   $p_cc        Array of cc recipients.
+ * @param array   $p_bcc       Array of bcc recipients.
  * @return integer|null
  */
-function email_store( $p_recipient, $p_subject, $p_message, array $p_headers = null, $p_force = false ) {
+function email_store( $p_recipient, $p_subject, $p_message, array $p_headers = null, $p_force = false, $p_cc = [], $p_bcc = []) {
 	global $g_email_shutdown_processing;
 
 	$t_recipient = trim( $p_recipient );
@@ -1179,6 +1181,8 @@ function email_store( $p_recipient, $p_subject, $p_message, array $p_headers = n
 	$t_email_data->body = $t_message;
 	$t_email_data->metadata = array();
 	$t_email_data->metadata['headers'] = $p_headers === null ? array() : $p_headers;
+	$t_email_data->metadata['cc'] = $p_cc;
+	$t_email_data->metadata['bcc'] = $p_bcc;
 
 	# Urgent = 1, Not Urgent = 5, Disable = 0
 	$t_email_data->metadata['charset'] = 'utf-8';
@@ -1364,6 +1368,13 @@ function email_send( EmailData $p_email_data ) {
 	$t_mail->FromName = config_get( 'from_name' );
 	$t_mail->AddCustomHeader( 'Auto-Submitted:auto-generated' );
 	$t_mail->AddCustomHeader( 'X-Auto-Response-Suppress: All' );
+
+	if( isset($t_email_data->metadata['cc']) && $t_email_data->metadata['cc'] )
+		foreach( $t_email_data->metadata['cc'] as $cc )
+			$t_mail->addCC(trim($cc));
+	if( isset($t_email_data->metadata['bcc']) && $t_email_data->metadata['bcc'] )
+		foreach( $t_email_data->metadata['bcc'] as $bcc )
+			$t_mail->addBCC(trim($bcc));
 
 	$t_mail->Encoding   = 'quoted-printable';
 

--- a/core/email_queue_api.php
+++ b/core/email_queue_api.php
@@ -60,6 +60,8 @@ class EmailData {
 	 */
 	public $metadata = array(
 		'headers' => array(),
+		'cc' => array(),
+		'bcc' => array(),
 	);
 
 	/**


### PR DESCRIPTION
ATM the only way to specify CC and BCC fields when sending a mail from a plugin via Mantis is by setting the relevant headers via addCustomHeader(), but this implies they will be encoded by PHPMailer.
The pull request adds two optional parameters to email_store() function, containing the CC and BCC arrays of email addresses.
For more info, please see https://mantisbt.org/bugs/view.php?id=29583
Thank you