### PR TITLE
Process bugnote stats in chunks for MSSQL

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1648,12 +1648,7 @@ function bug_get_bugnote_stats_array( array $p_bugs_id, $p_user_id = null ) {
 		$t_id_array[$t_id] = (int)$t_id;
 	}
 
-	if ( null === $p_user_id ) {
-		$t_user_id = auth_get_current_user_id();
-	}
-	else {
-		$t_user_id = $p_user_id;
-	}
+	$t_user_id = $p_user_id ?? auth_get_current_user_id();
 
 	db_param_push();
 	$t_params = array();

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1639,12 +1639,13 @@ function bug_get_newest_bugnote_timestamp( $p_bug_id ) {
  * @uses database_api.php
  */
 function bug_get_bugnote_stats_array( array $p_bugs_id, $p_user_id = null ) {
+	if( empty( $p_bugs_id ) ) {
+		return array();
+	}
+
 	$t_id_array = array();
 	foreach( $p_bugs_id as $t_id ) {
 		$t_id_array[$t_id] = (int)$t_id;
-	}
-	if( empty( $t_id_array ) ) {
-		return array();
 	}
 
 	if ( null === $p_user_id ) {

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1670,6 +1670,12 @@ function bug_get_bugnote_stats_array( array $p_bugs_id, $p_user_id = null ) {
 	$t_current_project_id = null;
 	$t_current_bug_id = null;
 	while( $t_query_row = db_fetch_array( $t_result ) ) {
+		/**
+		 * Variables defined in the loop's first iteration
+		 * @var bool $t_private_bugnote_visible
+		 * @var int  $t_note_count
+		 * @var int  $t_last_submit_date
+		 */
 		$c_bug_id = (int)$t_query_row['bug_id'];
 		if( 0 == $t_counter || $t_current_project_id !== $t_query_row['project_id'] ) {
 			# evaluating a new project from the rowset


### PR DESCRIPTION
This PR 
- refactors bug_get_bugnote_stats_array() to use a DbQuery object (+ some minor code cleanup and optimization).
- implements @obmsch's [suggested approach](https://mantisbt.org/bugs/view.php?id=24393#c66522) to process the bug Id's in chunks of 2100 to work around SQL Server's limitation.

This hopefully fixes [#24393](https://mantisbt.org/bugs/view.php?id=24393) - feedback from MSSQL users welcome.