### PR TITLE
Print changelog/roadmap items as unordered list 

### DIFF
--- a/changelog_page.php
+++ b/changelog_page.php
@@ -378,14 +378,18 @@ foreach( $t_project_ids as $t_project_id ) {
 			}
 		}
 
+		echo '<ul class="changelog">' . PHP_EOL;
 		for( $j = 0; $j < count( $t_issue_set_ids ); $j++ ) {
 			$t_issue_set_id = $t_issue_set_ids[$j];
 			$t_issue_set_level = $t_issue_set_levels[$j];
 
+			echo '<li>';
 			helper_call_custom_function( 'changelog_print_issue', array( $t_issue_set_id, $t_issue_set_level ) );
+			echo '</li>' . PHP_EOL;
 
 			$t_issues_found = true;
 		}
+		echo '</ul>' . PHP_EOL;
 
 	if( $t_version_header_printed ) {
 		print_version_footer( $t_version_id,  $t_issues_resolved);

--- a/changelog_page.php
+++ b/changelog_page.php
@@ -100,20 +100,24 @@ function print_version_header( $p_version_id ) {
 
 	echo '<div id="' . $t_block_id . '" class="widget-box widget-color-blue2 ' . $t_block_css . '">';
 	echo '<div class="widget-header widget-header-small">';
+	echo PHP_EOL;
 	echo '<h4 class="widget-title lighter">';
 	print_icon( 'fa-retweet', 'ace-icon' );
 	echo $t_release_title, lang_get( 'word_separator' );
 	echo '</h4>';
+	echo PHP_EOL;
 	echo '<div class="widget-toolbar">';
 	echo '<a data-action="collapse" href="#">';
 	print_icon( $t_block_icon, '1 ace-icon bigger-125' );
 	echo '</a>';
 	echo '</div>';
 	echo '</div>';
+	echo PHP_EOL;
 
 	echo '<div class="widget-body">';
 	echo '<div class="widget-toolbox padding-8 clearfix">';
 	echo '<div class="pull-left">' . icon_get( 'fa-calendar-o', 'fa-lg' ) . ' ' . $t_release_date . '</div>';
+	echo PHP_EOL;
 	echo '<div class="btn-toolbar pull-right">';
 	print_extra_small_button(
 		'view_all_set.php?type=' . FILTER_ACTION_PARSE_NEW
@@ -131,9 +135,12 @@ function print_version_header( $p_version_id ) {
 		string_display_line( $t_project_name )
 	);
 	echo '</div>';
+	echo PHP_EOL;
 
 	echo '</div>';
+	echo PHP_EOL;
 	echo '<div class="widget-main">';
+
 }
 
 /**
@@ -159,6 +166,7 @@ function print_version_footer( $p_version_id, $p_issues_resolved ) {
 	);
 	echo '</div></div></div>';
 	echo '<div class="space-10"></div>';
+	echo PHP_EOL;
 }
 
 /**
@@ -170,6 +178,7 @@ function print_project_header_changelog( $p_project_name ) {
 	echo '<div class="page-header">';
 	echo '<h1><strong>' . string_display_line( $p_project_name ), '</strong> - ', lang_get( 'changelog' ) . '</h1>';
 	echo '</div>';
+	echo PHP_EOL;
 }
 
 $t_issues_found = false;
@@ -322,6 +331,7 @@ foreach( $t_project_ids as $t_project_id ) {
 
 		if( $t_issues_resolved > 0 ) {
 			if( !$t_project_header_printed ) {
+				echo PHP_EOL;
 				print_project_header_changelog( $t_project_name );
 				$t_project_header_printed = true;
 			}

--- a/changelog_page.php
+++ b/changelog_page.php
@@ -115,14 +115,21 @@ function print_version_header( $p_version_id ) {
 	echo '<div class="widget-toolbox padding-8 clearfix">';
 	echo '<div class="pull-left">' . icon_get( 'fa-calendar-o', 'fa-lg' ) . ' ' . $t_release_date . '</div>';
 	echo '<div class="btn-toolbar pull-right">';
-	echo '<a class="btn btn-xs btn-primary btn-white btn-round" ';
-	echo 'href="view_all_set.php?type=' . FILTER_ACTION_PARSE_NEW . '&temporary=y&' . FILTER_PROPERTY_PROJECT_ID . '=' . $t_project_id .
-		 '&' . filter_encode_field_and_value( FILTER_PROPERTY_FIXED_IN_VERSION, $t_version_name ) .
-		 '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">';
-	echo lang_get( 'view_bugs_link' );
-	echo '<a class="btn btn-xs btn-primary btn-white btn-round" href="changelog_page.php?version_id=' . $p_version_id . '">' . string_display_line( $t_version_name ) . '</a>';
-	echo '<a class="btn btn-xs btn-primary btn-white btn-round" href="changelog_page.php?project_id=' . $t_project_id . '">' . string_display_line( $t_project_name ) . '</a>';
-	echo '</a>';
+	print_extra_small_button(
+		'view_all_set.php?type=' . FILTER_ACTION_PARSE_NEW
+		. '&temporary=y&' . FILTER_PROPERTY_PROJECT_ID . '=' . $t_project_id
+		. '&' . filter_encode_field_and_value( FILTER_PROPERTY_FIXED_IN_VERSION, $t_version_name )
+		. '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE,
+		lang_get( 'view_bugs_link' )
+	);
+	print_extra_small_button(
+		'changelog_page.php?version_id=' . $p_version_id,
+		string_display_line( $t_version_name )
+	);
+	print_extra_small_button(
+		'changelog_page.php?project_id=' . $t_project_id,
+		string_display_line( $t_project_name )
+	);
 	echo '</div>';
 
 	echo '</div>';
@@ -143,12 +150,13 @@ function print_version_footer( $p_version_id, $p_issues_resolved ) {
 	echo '</div>';
 	echo '<div class="widget-toolbox padding-8 clearfix">';
 	echo ' ' . $p_issues_resolved . ' ' . lang_get( $t_bug_string ) . ' ';
-	echo '<a class="btn btn-xs btn-primary btn-white btn-round" ';
-	echo 'href="view_all_set.php?type=' . FILTER_ACTION_PARSE_NEW . '&temporary=y&' . FILTER_PROPERTY_PROJECT_ID . '=' . $t_project_id .
-		 '&' . filter_encode_field_and_value( FILTER_PROPERTY_FIXED_IN_VERSION, $t_version_name ) .
-		 '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">';
-	echo lang_get( 'view_bugs_link' );
-	echo '</a>';
+	print_extra_small_button(
+		'view_all_set.php?type=' . FILTER_ACTION_PARSE_NEW
+		. '&temporary=y&' . FILTER_PROPERTY_PROJECT_ID . '=' . $t_project_id
+		. '&' . filter_encode_field_and_value( FILTER_PROPERTY_FIXED_IN_VERSION, $t_version_name )
+		. '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE,
+		 lang_get( 'view_bugs_link' )
+	);
 	echo '</div></div></div>';
 	echo '<div class="space-10"></div>';
 }

--- a/core/custom_function_api.php
+++ b/core/custom_function_api.php
@@ -114,7 +114,6 @@ function custom_function_default_changelog_print_issue( $p_issue_id, $p_issue_le
 			&& access_can_see_handler_for_bug( $t_bug ) ) {
 		echo ' (', prepare_user_name( $t_bug->handler_id ), ')';
 	}
-	echo '<div class="space-2"></div>';
 }
 
 /**
@@ -173,7 +172,6 @@ function custom_function_default_roadmap_print_issue( $p_issue_id, $p_issue_leve
 			&& access_can_see_handler_for_bug( $t_bug ) ) {
 		echo ' (', prepare_user_name( $t_bug->handler_id ), ')';
 	}
-	echo '<div class="space-2"></div>';
 }
 
 /**

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -588,6 +588,15 @@ hr {
     border-color: #393939;
 }
 
+/* Changelog and Roadmap items */
+ul.changelog, ul.roadmap {
+    list-style-type: none;
+    margin-left: 0;
+}
+ul.changelog > li, ul.roadmap > li {
+    margin-bottom: 4px;
+}
+
 /* Mantis 28826: Remove vertical lines for bordered tables. */
 .table-bordered > thead > tr > th,
 .table-bordered > tbody > tr > th,
@@ -732,4 +741,3 @@ hr {
     }
 
 }
-

--- a/roadmap_page.php
+++ b/roadmap_page.php
@@ -489,15 +489,19 @@ foreach( $t_project_ids as $t_project_id ) {
 			}
 		}
 
+		echo '<ul class="roadmap">' . PHP_EOL;
 		$t_count_ids = count( $t_issue_set_ids );
 		for( $j = 0; $j < $t_count_ids; $j++ ) {
 			$t_issue_set_id = $t_issue_set_ids[$j];
 			$t_issue_set_level = $t_issue_set_levels[$j];
 
+			echo '<li>';
 			helper_call_custom_function( 'roadmap_print_issue', array( $t_issue_set_id, $t_issue_set_level ) );
+			echo '</li>' . PHP_EOL;
 
 			$t_issues_found = true;
 		}
+		echo '</ul>' . PHP_EOL;
 
 		if( $t_version_header_printed ) {
 			print_version_footer( $t_version_row, $t_progress );

--- a/roadmap_page.php
+++ b/roadmap_page.php
@@ -182,10 +182,12 @@ function print_version_header( array $p_version_row, $p_progress ) {
 
 	echo '<div id="' . $t_block_id . '" class="widget-box widget-color-blue2 ' . $t_block_css . '">';
 	echo '<div class="widget-header widget-header-small">';
+	echo PHP_EOL;
 	echo '<h4 class="widget-title lighter">';
 	print_icon( 'fa-road', 'ace-icon' );
 	echo $t_release_title, lang_get( 'word_separator' );
 	echo '</h4>';
+	echo PHP_EOL;
 	echo '<div class="widget-toolbar">';
 	echo '<a data-action="collapse" href="#">';
 	print_icon( $t_block_icon, '1 ace-icon bigger-125' );
@@ -193,14 +195,17 @@ function print_version_header( array $p_version_row, $p_progress ) {
 	echo '</div>';
 	$p_progress->printHeader();
 	echo '</div>';
+	echo PHP_EOL;
 
 	echo '<div class="widget-body">';
 	echo '<div class="widget-toolbox padding-8 clearfix">';
 	if( $t_scheduled_release_date ) {
+		echo PHP_EOL;
 		echo '<div class="pull-left">';
 		print_icon( 'fa-calendar-o', 'fa-lg' );
 		echo ' ' . $t_scheduled_release_date . '</div>';
 	}
+	echo PHP_EOL;
 	echo '<div class="btn-toolbar pull-right">';
 	print_extra_small_button(
 		'view_all_set.php?type=' . FILTER_ACTION_PARSE_NEW
@@ -218,8 +223,10 @@ function print_version_header( array $p_version_row, $p_progress ) {
 		string_display_line( $t_project_name )
 	);
 	echo '</div>';
+	echo PHP_EOL;
 
 	echo '</div>';
+	echo PHP_EOL;
 	echo '<div class="widget-main">';
 }
 
@@ -255,6 +262,7 @@ function print_version_footer( $p_version_row, $p_progress ) {
 
 	echo '</div></div>';
 	echo '<div class="space-10"></div>';
+	echo PHP_EOL;
 }
 
 /**
@@ -266,6 +274,7 @@ function print_project_header_roadmap( $p_project_name ) {
 	echo '<div class="page-header">';
 	echo '<h1><strong>' . string_display_line( $p_project_name ), '</strong> - ', lang_get( 'roadmap' ) . '</h1>';
 	echo '</div>';
+	echo PHP_EOL;
 }
 
 $t_issues_found = false;
@@ -433,6 +442,7 @@ foreach( $t_project_ids as $t_project_id ) {
 
 		if( $t_progress->hasIssues() ) {
 			if( !$t_project_header_printed ) {
+				echo PHP_EOL;
 				print_project_header_roadmap( $t_project_name );
 				$t_project_header_printed = true;
 			}

--- a/roadmap_page.php
+++ b/roadmap_page.php
@@ -202,14 +202,21 @@ function print_version_header( array $p_version_row, $p_progress ) {
 		echo ' ' . $t_scheduled_release_date . '</div>';
 	}
 	echo '<div class="btn-toolbar pull-right">';
-	echo '<a class="btn btn-xs btn-primary btn-white btn-round" ';
-	echo 'href="view_all_set.php?type=' . FILTER_ACTION_PARSE_NEW . '&temporary=y&' . FILTER_PROPERTY_PROJECT_ID . '=' . $t_project_id .
-		 '&' . filter_encode_field_and_value( FILTER_PROPERTY_TARGET_VERSION, $t_version_name ) .
-		 '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">';
-	echo lang_get( 'view_bugs_link' );
-	echo '<a class="btn btn-xs btn-primary btn-white btn-round" href="roadmap_page.php?version_id=' . $t_version_id . '">' . string_display_line( $t_version_name ) . '</a>';
-	echo '<a class="btn btn-xs btn-primary btn-white btn-round" href="roadmap_page.php?project_id=' . $t_project_id . '">' . string_display_line( $t_project_name ) . '</a>';
-	echo '</a>';
+	print_extra_small_button(
+		'view_all_set.php?type=' . FILTER_ACTION_PARSE_NEW
+		. '&temporary=y&' . FILTER_PROPERTY_PROJECT_ID . '=' . $t_project_id
+		. '&' . filter_encode_field_and_value( FILTER_PROPERTY_TARGET_VERSION, $t_version_name )
+		. '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE,
+		lang_get( 'view_bugs_link' )
+	);
+	print_extra_small_button(
+		'roadmap_page.php?version_id=' . $t_version_id,
+		string_display_line( $t_version_name )
+	);
+	print_extra_small_button(
+		'roadmap_page.php?project_id=' . $t_project_id,
+		string_display_line( $t_project_name )
+	);
 	echo '</div>';
 
 	echo '</div>';
@@ -235,12 +242,14 @@ function print_version_footer( $p_version_row, $p_progress ) {
 	if( $p_progress->hasIssues() ) {
 		echo '<div class="widget-toolbox padding-8 clearfix">';
 		echo $p_progress->string();
-		echo ' <a class="btn btn-xs btn-primary btn-white btn-round" ';
-		echo 'href="view_all_set.php?type=' . FILTER_ACTION_PARSE_NEW . '&temporary=y&' . FILTER_PROPERTY_PROJECT_ID . '=' . $t_project_id .
-			 '&' . filter_encode_field_and_value( FILTER_PROPERTY_TARGET_VERSION, $t_version_name ) .
-			 '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE . '">';
-		echo lang_get( 'view_bugs_link' );
-		echo '</a>';
+		echo ' ';
+		print_extra_small_button(
+			'view_all_set.php?type=' . FILTER_ACTION_PARSE_NEW
+			. '&temporary=y&' . FILTER_PROPERTY_PROJECT_ID . '=' . $t_project_id
+			. '&' . filter_encode_field_and_value( FILTER_PROPERTY_TARGET_VERSION, $t_version_name )
+			. '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . META_FILTER_NONE,
+			lang_get( 'view_bugs_link' )
+		);
 		echo '</div>';
 	}
 


### PR DESCRIPTION
Rendered output is visually unchanged.

- Code cleanup: use print_extra_small_button() instead of manually building the buttons with <a> tags.
- Add newlines to make generated HTML easier to read

Fixes [#30192](https://mantisbt.org/bugs/view.php?id=30192)