### PR TITLE
New configs to restrict access to Export and Print issues

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2783,7 +2783,7 @@ $g_monitor_add_others_bug_threshold = DEVELOPER;
 $g_monitor_delete_others_bug_threshold = DEVELOPER;
 
 /**
- * Access level needed to export filtered bugs
+ * Access level required to export issues
  * Look in the constant_inc.php file if you want to set a different value.
  * @global integer $g_export_issues_threshold
  */

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2751,7 +2751,6 @@ $g_view_bug_threshold = VIEWER;
 
 /**
  * Access level needed to monitor bugs.
- * Look in the constant_inc.php file if you want to set a different value.
  * @global integer $g_monitor_bug_threshold
  */
 $g_monitor_bug_threshold = REPORTER;
@@ -2765,7 +2764,6 @@ $g_show_monitor_list_threshold = DEVELOPER;
 /**
  * Access level needed to add other users to the list of users monitoring
  * a bug.
- * Look in the constant_inc.php file if you want to set a different value.
  * This setting should not be lower than $g_show_monitor_list_threshold.
  * @see $g_show_monitor_list_threshold
  * @global integer $g_monitor_add_others_bug_threshold
@@ -2775,7 +2773,6 @@ $g_monitor_add_others_bug_threshold = DEVELOPER;
 /**
  * Access level needed to delete other users from the list of users
  * monitoring a bug.
- * Look in the constant_inc.php file if you want to set a different value.
  * This setting should not be lower than $g_show_monitor_list_threshold.
  * @see $g_show_monitor_list_threshold
  * @global integer $g_monitor_delete_others_bug_threshold
@@ -2784,14 +2781,12 @@ $g_monitor_delete_others_bug_threshold = DEVELOPER;
 
 /**
  * Access level required to export issues
- * Look in the constant_inc.php file if you want to set a different value.
  * @global integer $g_export_issues_threshold
  */
 $g_export_issues_threshold = VIEWER;
 
 /**
  * access level needed to view private bugs
- * Look in the constant_inc.php file if you want to set a different value
  * @global integer $g_private_bug_threshold
  */
 $g_private_bug_threshold = DEVELOPER;
@@ -2813,7 +2808,6 @@ $g_update_bug_assign_threshold = '%handle_bug_threshold%';
 
 /**
  * access level needed to view private bugnotes
- * Look in the constant_inc.php file if you want to set a different value
  * @global integer $g_private_bugnote_threshold
  */
 $g_private_bugnote_threshold = DEVELOPER;

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2780,6 +2780,12 @@ $g_monitor_add_others_bug_threshold = DEVELOPER;
 $g_monitor_delete_others_bug_threshold = DEVELOPER;
 
 /**
+ * Access level required to print issues
+ * @global integer $g_print_reports_threshold
+ */
+$g_print_reports_threshold = VIEWER;
+
+/**
  * Access level required to export issues
  * @global integer $g_export_issues_threshold
  */
@@ -4826,6 +4832,7 @@ $g_public_config_names = array(
 	'preview_max_width',
 	'preview_text_extensions',
 	'print_issues_page_columns',
+	'print_reports_threshold',
 	'priority_enum_string',
 	'priority_significant_threshold',
 	'private_bug_threshold',

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2783,6 +2783,13 @@ $g_monitor_add_others_bug_threshold = DEVELOPER;
 $g_monitor_delete_others_bug_threshold = DEVELOPER;
 
 /**
+ * Access level needed to export filtered bugs
+ * Look in the constant_inc.php file if you want to set a different value.
+ * @global integer $g_export_issues_threshold
+ */
+$g_export_issues_threshold = VIEWER;
+
+/**
  * access level needed to view private bugs
  * Look in the constant_inc.php file if you want to set a different value
  * @global integer $g_private_bug_threshold

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -4749,6 +4749,7 @@ $g_public_config_names = array(
 	'enable_sponsorship',
 	'eta_enum_string',
 	'excel_columns',
+	'export_issues_threshold',
 	'fallback_language',
 	'favicon_image',
 	'file_download_content_type_overrides',

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2787,7 +2787,7 @@ $g_monitor_delete_others_bug_threshold = DEVELOPER;
  *
  * @global integer $g_print_reports_threshold
  */
-$g_print_reports_threshold = VIEWER;
+$g_print_reports_threshold = UPDATER;
 
 /**
  * Access level required to export issues.

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2780,13 +2780,20 @@ $g_monitor_add_others_bug_threshold = DEVELOPER;
 $g_monitor_delete_others_bug_threshold = DEVELOPER;
 
 /**
- * Access level required to print issues
+ * Access level required to print issue reports.
+ *
+ * Grants users access to the Print Reports functionality (Word/HTML) from the
+ * View Issues page (print_all_bug_page.php and print_all_bug_page_word.php).
+ *
  * @global integer $g_print_reports_threshold
  */
 $g_print_reports_threshold = VIEWER;
 
 /**
- * Access level required to export issues
+ * Access level required to export issues.
+ *
+ * Lets user export issues to CSV and Excel from the View Issues page.
+ *
  * @global integer $g_export_issues_threshold
  */
 $g_export_issues_threshold = VIEWER;

--- a/css/default.css
+++ b/css/default.css
@@ -29,6 +29,8 @@ tr.spacer			{ background-color: #ffffff !important; color: #000000; height: 5px;
 #buglist .column-additional-information
 	{ text-align: left; }
 
+.sticky-separator { background-color: lightgrey;}
+
 /* manage_plugin_page.php */
 span.dependency_dated		{ color: maroon; }
 span.dependency_met			{ color: green; }

--- a/csv_export.php
+++ b/csv_export.php
@@ -45,6 +45,11 @@ require_api( 'filter_api.php' );
 require_api( 'helper_api.php' );
 require_api( 'print_api.php' );
 
+if( !access_has_project_level( config_get( 'export_issues_threshold' ) ) ) {
+	# current user is not allowed to export content => redirection (compliant with bug_count = 0)
+	print_header_redirect( 'view_all_set.php?type=0' );
+}
+
 auth_ensure_user_authenticated();
 
 helper_begin_long_process();

--- a/csv_export.php
+++ b/csv_export.php
@@ -45,12 +45,12 @@ require_api( 'filter_api.php' );
 require_api( 'helper_api.php' );
 require_api( 'print_api.php' );
 
+auth_ensure_user_authenticated();
+
 if( !access_has_project_level( config_get( 'export_issues_threshold' ) ) ) {
 	# current user is not allowed to export content => redirection (compliant with bug_count = 0)
 	print_header_redirect( 'view_all_set.php?type=0' );
 }
-
-auth_ensure_user_authenticated();
 
 helper_begin_long_process();
 

--- a/csv_export.php
+++ b/csv_export.php
@@ -47,10 +47,7 @@ require_api( 'print_api.php' );
 
 auth_ensure_user_authenticated();
 
-if( !access_has_project_level( config_get( 'export_issues_threshold' ) ) ) {
-	# current user is not allowed to export content => redirection (compliant with bug_count = 0)
-	print_header_redirect( 'view_all_set.php?type=0' );
-}
+access_ensure_project_level( config_get( 'export_issues_threshold' ) );
 
 helper_begin_long_process();
 

--- a/docbook/Admin_Guide/en-US/config/misc.xml
+++ b/docbook/Admin_Guide/en-US/config/misc.xml
@@ -65,6 +65,15 @@
 			</listitem>
 		</varlistentry>
 		<varlistentry>
+			<term>$g_export_issues_threshold</term>
+			<listitem>
+				<para>Access level needed to export issues with Mantis
+					embedded functions. 
+					The default value is VIEWER.
+				</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
 			<term>$g_allow_reporter_close</term>
 			<listitem>
 				<para>Allow reporters to close the bugs they reported.</para>

--- a/docbook/Admin_Guide/en-US/config/misc.xml
+++ b/docbook/Admin_Guide/en-US/config/misc.xml
@@ -67,8 +67,8 @@
 		<varlistentry>
 			<term>$g_print_reports_threshold</term>
 			<listitem>
-				<para>Access level required to print reports from 
-					MantisBT (HTML and Word). 
+				<para>Grants users access to the Print Reports functionality
+					(Word/HTML) from the View Issues page.
 					The default value is VIEWER.
 				</para>
 			</listitem>
@@ -76,8 +76,8 @@
 		<varlistentry>
 			<term>$g_export_issues_threshold</term>
 			<listitem>
-				<para>Access level required to export issues from 
-					MantisBT to formats like CSV and Excel. 
+				<para>Access level required to export issues to CSV and Excel
+					formats from the View Issues page.
 					The default value is VIEWER.
 				</para>
 			</listitem>

--- a/docbook/Admin_Guide/en-US/config/misc.xml
+++ b/docbook/Admin_Guide/en-US/config/misc.xml
@@ -65,6 +65,15 @@
 			</listitem>
 		</varlistentry>
 		<varlistentry>
+			<term>$g_print_reports_threshold</term>
+			<listitem>
+				<para>Access level required to print reports from 
+					MantisBT (HTML and Word). 
+					The default value is VIEWER.
+				</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
 			<term>$g_export_issues_threshold</term>
 			<listitem>
 				<para>Access level required to export issues from 

--- a/docbook/Admin_Guide/en-US/config/misc.xml
+++ b/docbook/Admin_Guide/en-US/config/misc.xml
@@ -69,7 +69,7 @@
 			<listitem>
 				<para>Grants users access to the Print Reports functionality
 					(Word/HTML) from the View Issues page.
-					The default value is VIEWER.
+					The default value is UPDATER.
 				</para>
 			</listitem>
 		</varlistentry>

--- a/docbook/Admin_Guide/en-US/config/misc.xml
+++ b/docbook/Admin_Guide/en-US/config/misc.xml
@@ -67,8 +67,8 @@
 		<varlistentry>
 			<term>$g_export_issues_threshold</term>
 			<listitem>
-				<para>Access level needed to export issues with Mantis
-					embedded functions. 
+				<para>Access level required to export issues from 
+					MantisBT to formats like CSV and Excel. 
 					The default value is VIEWER.
 				</para>
 			</listitem>

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -52,12 +52,12 @@ require_api( 'helper_api.php' );
 require_api( 'print_api.php' );
 require_api( 'utility_api.php' );
 
+auth_ensure_user_authenticated();
+
 if( !access_has_project_level( config_get( 'export_issues_threshold' ) ) ) {
 	# current user is not allowed to export content => redirection to print page (compliant with bug_count = 0)
 	print_header_redirect( 'view_all_set.php?type=0&print=1' );
 }
-
-auth_ensure_user_authenticated();
 
 $f_export = gpc_get_string( 'export', '' );
 

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -52,6 +52,11 @@ require_api( 'helper_api.php' );
 require_api( 'print_api.php' );
 require_api( 'utility_api.php' );
 
+if( !access_has_project_level( config_get( 'export_issues_threshold' ) ) ) {
+	# current user is not allowed to export content => redirection to print page (compliant with bug_count = 0)
+	print_header_redirect( 'view_all_set.php?type=0&print=1' );
+}
+
 auth_ensure_user_authenticated();
 
 $f_export = gpc_get_string( 'export', '' );

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -54,10 +54,7 @@ require_api( 'utility_api.php' );
 
 auth_ensure_user_authenticated();
 
-if( !access_has_project_level( config_get( 'export_issues_threshold' ) ) ) {
-	# current user is not allowed to export content => redirection to print page (compliant with bug_count = 0)
-	print_header_redirect( 'view_all_set.php?type=0&print=1' );
-}
+access_ensure_project_level( config_get( 'export_issues_threshold' ) );
 
 $f_export = gpc_get_string( 'export', '' );
 

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -789,6 +789,7 @@ $s_readonly_status = 'Status where an issue becomes read only';
 $s_reopen_status = 'Status to which a reopened issue is set';
 $s_reopen_resolution = 'Resolution to which a reopened issue is set';
 $s_limit_view_unless_threshold_option = 'View other users\' issues (if not set, access will be limited to issues reported, handled, or monitored by the user)';
+$s_export_issues = 'Export issues';
 
 # manage_config_revert_page
 $s_config_delete_sure = 'Are you sure you want to delete the settings for %1$s in project %2$s?';

--- a/manage_config_work_threshold_page.php
+++ b/manage_config_work_threshold_page.php
@@ -406,6 +406,8 @@ if( ON == config_get( 'limit_reporters', null, ALL_USERS, ALL_PROJECTS ) ) {
 } else {
 	get_capability_row( lang_get( 'limit_view_unless_threshold_option' ), 'limit_view_unless_threshold' );
 }
+get_capability_row( lang_get( 'print_all_bug_page_link' ), 'print_reports_threshold' );
+get_capability_row( lang_get( 'export_issues' ), 'export_issues_threshold' );
 get_section_end();
 
 # Notes

--- a/manage_config_work_threshold_set.php
+++ b/manage_config_work_threshold_set.php
@@ -204,6 +204,8 @@ if( capability_exists( 'limit_reporters' ) ) {
 if( capability_exists( 'limit_view_unless_threshold' ) ) {
 	set_capability_row( 'limit_view_unless_threshold' );
 }
+set_capability_row( 'print_reports_threshold' );
+set_capability_row( 'export_issues_threshold' );
 
 # Notes
 set_capability_row( 'add_bugnote_threshold' );

--- a/print_all_bug_page.php
+++ b/print_all_bug_page.php
@@ -59,6 +59,8 @@ require_api( 'utility_api.php' );
 
 auth_ensure_user_authenticated();
 
+access_ensure_project_level( config_get( 'print_reports_threshold' ) );
+
 $f_search		= gpc_get_string( FILTER_PROPERTY_SEARCH, false ); # @todo need a better default
 $f_offset		= gpc_get_int( 'offset', 0 );
 

--- a/print_all_bug_page_word.php
+++ b/print_all_bug_page_word.php
@@ -72,6 +72,7 @@ require_api( 'project_api.php' );
 require_api( 'string_api.php' );
 
 auth_ensure_user_authenticated();
+access_ensure_project_level( config_get( 'print_reports_threshold' ) );
 
 $f_type_page	= gpc_get_string( 'type_page', 'word' );
 $f_search		= gpc_get_string( 'search', false ); # @todo need a better default

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -120,8 +120,10 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 			}
 
 			# -- Print link --
-			print_small_button( 'print_all_bug_page.php' . $t_filter_param, lang_get( 'print_all_bug_page_link' ) );
-			
+			if( access_has_project_level( config_get( 'print_reports_threshold' ) ) ) {
+				print_small_button( 'print_all_bug_page.php' . $t_filter_param, lang_get( 'print_all_bug_page_link' ) );
+			}
+
 			# -- Export links --
 			if( access_has_project_level( config_get( 'export_issues_threshold' ) ) ) {
 				print_small_button( 'csv_export.php' . $t_filter_param, lang_get( 'csv_export' ) );

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -209,46 +209,6 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 </thead><tbody>
 
 <?php
-/**
- * Output Bug Rows
- *
- * @param array $p_rows An array of bug objects.
- * @return void
- */
-function write_bug_rows( array $p_rows ) {
-	global $g_columns, $g_filter;
-
-	$t_in_stickies = ( $g_filter && ( 'on' == $g_filter[FILTER_PROPERTY_STICKY] ) );
-
-	# -- Loop over bug rows --
-
-	$t_rows = count( $p_rows );
-	for( $i=0; $i < $t_rows; $i++ ) {
-		$t_row = $p_rows[$i];
-
-		if( ( 0 == $t_row->sticky ) && ( 0 == $i ) ) {
-			$t_in_stickies = false;
-		}
-		if( ( 0 == $t_row->sticky ) && $t_in_stickies ) {	# demarcate stickies, if any have been shown
-?>
-		   <tr>
-				   <td colspan="<?php echo count( $g_columns ); ?>" bgcolor="#d3d3d3"></td>
-		   </tr>
-<?php
-			$t_in_stickies = false;
-		}
-
-		echo '<tr>';
-
-		$t_column_value_function = 'print_column_value';
-		foreach( $g_columns as $t_column ) {
-			helper_call_custom_function( $t_column_value_function, array( $t_column, $t_row ) );
-		}
-		echo '</tr>';
-	}
-}
-
-
 write_bug_rows( $t_rows );
 # -- ====================== end of BUG LIST ========================= --
 ?>
@@ -299,3 +259,36 @@ if( ( $t_filter_position & FILTER_POSITION_BOTTOM ) == FILTER_POSITION_BOTTOM ) 
 	filter_draw_selection_area();
 }
 # -- ====================== end of FILTER FORM ================== --
+
+/**
+ * Output Bug Rows
+ *
+ * @param array $p_rows An array of bug objects.
+ * @return void
+ */
+function write_bug_rows( array $p_rows ) {
+	global $g_columns, $g_filter;
+
+	$t_in_stickies = ( $g_filter && ( 'on' == $g_filter[FILTER_PROPERTY_STICKY] ) );
+
+	# Loop over bug rows
+	$t_rows = count( $p_rows );
+	for( $i = 0; $i < $t_rows; $i++ ) {
+		$t_row = $p_rows[$i];
+
+		if( ( 0 == $t_row->sticky ) && ( 0 == $i ) ) {
+			$t_in_stickies = false;
+		}
+		if( ( 0 == $t_row->sticky ) && $t_in_stickies ) {
+			# demarcate stickies, if any have been shown
+			echo '<tr><td colspan="' . count( $g_columns ) . '" bgcolor="#d3d3d3"></td></tr>';
+			$t_in_stickies = false;
+		}
+
+		echo '<tr>';
+		foreach( $g_columns as $t_column ) {
+			helper_call_custom_function( 'print_column_value', array( $t_column, $t_row ) );
+		}
+		echo '</tr>';
+	}
+}

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -118,10 +118,17 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 				$t_filter_param = '?' . $t_filter_param;
 				$t_summary_link = 'summary_page.php' . $t_filter_param;
 			}
-			# -- Print and Export links --
+
+			# -- Print link --
 			print_small_button( 'print_all_bug_page.php' . $t_filter_param, lang_get( 'print_all_bug_page_link' ) );
-			print_small_button( 'csv_export.php' . $t_filter_param, lang_get( 'csv_export' ) );
-			print_small_button( 'excel_xml_export.php' . $t_filter_param, lang_get( 'excel_export' ) );
+			
+			# -- Export links --
+			$t_export_issues_threshold = config_get( 'export_issues_threshold' );
+			if( access_has_project_level( $t_export_issues_threshold ) ) {
+				print_small_button( 'csv_export.php' . $t_filter_param, lang_get( 'csv_export' ) );
+				print_small_button( 'excel_xml_export.php' . $t_filter_param, lang_get( 'excel_export' ) );
+			}
+
 			if( access_has_project_level( config_get( 'view_summary_threshold' ), $t_current_project ) ) {
 				print_small_button( $t_summary_link, lang_get( 'summary_link' ) );
 			}

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -301,7 +301,7 @@ function write_bug_rows( array $p_rows ) {
 		}
 		if( ( 0 == $t_row->sticky ) && $t_in_stickies ) {
 			# demarcate stickies, if any have been shown
-			echo '<tr><td colspan="' . count( $g_columns ) . '" bgcolor="#d3d3d3"></td></tr>';
+			echo '<tr class="sticky-separator"><td colspan="' . count( $g_columns ) . '"></td></tr>';
 			$t_in_stickies = false;
 		}
 

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -123,8 +123,7 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 			print_small_button( 'print_all_bug_page.php' . $t_filter_param, lang_get( 'print_all_bug_page_link' ) );
 			
 			# -- Export links --
-			$t_export_issues_threshold = config_get( 'export_issues_threshold' );
-			if( access_has_project_level( $t_export_issues_threshold ) ) {
+			if( access_has_project_level( config_get( 'export_issues_threshold' ) ) ) {
 				print_small_button( 'csv_export.php' . $t_filter_param, lang_get( 'csv_export' ) );
 				print_small_button( 'excel_xml_export.php' . $t_filter_param, lang_get( 'excel_export' ) );
 			}

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -93,28 +93,31 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 
 ?>
 <div class="col-md-12 col-xs-12">
-<div class="space-10"></div>
-<form id="bug_action" method="post" action="bug_actiongroup_page.php">
-<?php # CSRF protection not required here - form does not result in modifications ?>
-<div class="widget-box widget-color-blue2">
-	<div class="widget-header widget-header-small">
-	<h4 class="widget-title lighter">
-		<?php print_icon( 'fa-columns', 'ace-icon' ); ?>
-		<?php echo lang_get( 'viewing_bugs_title' ) ?>
-		<?php
-			# -- Viewing range info --
-			$v_start = 0;
-			$v_end = 0;
-			if (count($t_rows) > 0) {
-				$v_start = $g_filter['per_page'] * ($f_page_number - 1) + 1;
-				$v_end = $v_start + count($t_rows) - 1;
-			}
-			echo '<span class="badge"> ' . $v_start . ' - ' . $v_end . ' / ' . $t_bug_count . '</span>' ;
-		?>
-	</h4>
-	</div>
+	<div class="space-10"></div>
+	<form id="bug_action" method="post" action="bug_actiongroup_page.php">
+		<?php # CSRF protection not required here - form does not result in modifications ?>
+		<div class="widget-box widget-color-blue2">
+			<div class="widget-header widget-header-small">
+				<h4 class="widget-title lighter">
+<?php
+	print_icon( 'fa-columns', 'ace-icon' );
+	echo lang_get( 'viewing_bugs_title' );
+
+	# Viewing range info
+	$v_start = 0;
+	$v_end = 0;
+	if (count($t_rows) > 0) {
+		$v_start = $g_filter['per_page'] * ($f_page_number - 1) + 1;
+		$v_end = $v_start + count($t_rows) - 1;
+	}
+	echo '<span class="badge"> ' . $v_start . ' - ' . $v_end . ' / ' . $t_bug_count . '</span>' ;
+?>
+				</h4>
+			</div>
 
 <?php
+	# -- ====================== TOP TOOLBAR ============================ --
+
 	$t_filter_param = filter_get_temporary_key_param( $t_filter );
 	if( empty( $t_filter_param ) ) {
 		$t_summary_link = 'view_all_set.php?summary=1&temporary=y';
@@ -162,10 +165,10 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 		|| $t_page_number_links
 	) {
 ?>
-	<div class="widget-body">
-		<div class="widget-toolbox padding-8 clearfix">
-			<div class="btn-toolbar">
-				<div class="btn-group pull-left">
+			<div class="widget-body">
+				<div class="widget-toolbox padding-8 clearfix">
+					<div class="btn-toolbar">
+						<div class="btn-group pull-left">
 <?php
 		if( $t_can_print_reports ) {
 			print_small_button(
@@ -183,29 +186,31 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 
 		echo $t_plugin_menu_items;
 ?>
-				</div>
+						</div>
 <?php
 		if( $t_page_number_links ) {
 ?>
-				<div class="btn-group pull-right">
-					<?php echo $t_page_number_links ?>
-				</div>
+						<div class="btn-group pull-right">
+							<?php echo $t_page_number_links ?>
+						</div>
 <?php
 		}
 ?>
+					</div>
+				</div>
 			</div>
-		</div>
-	</div>
 <?php
 	}
+
+	# -- ====================== end of TOP TOOLBAR ============================ --
 ?>
 
-<div class="widget-main no-padding">
-	<div class="table-responsive checkbox-range-selection">
-	<table id="buglist" class="table table-bordered table-condensed table-hover table-striped">
-	<thead>
+			<div class="widget-main no-padding">
+				<div class="table-responsive checkbox-range-selection">
+					<table id="buglist" class="table table-bordered table-condensed table-hover table-striped">
+						<thead>
 <?php # -- Bug list column header row -- ?>
-<tr class="buglist-headers">
+							<tr class="buglist-headers">
 <?php
 	$t_title_function = 'print_column_title';
 	$t_sort_properties = filter_get_visible_sort_properties_array( $t_filter, COLUMNS_TARGET_VIEW_PAGE );
@@ -213,25 +218,26 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 		helper_call_custom_function( $t_title_function, array( $t_column, COLUMNS_TARGET_VIEW_PAGE, $t_sort_properties ) );
 	}
 ?>
-</tr>
+							</tr>
+						</thead>
 
-</thead><tbody>
+						<tbody>
 
 <?php
-write_bug_rows( $t_rows );
-# -- ====================== end of BUG LIST ========================= --
+	write_bug_rows( $t_rows );
+	# -- ====================== end of BUG LIST ========================= --
 ?>
 
-</tbody>
-</table>
-</div>
+						</tbody>
+					</table>
+				</div>
 
-<div class="widget-toolbox padding-8 clearfix">
+				<div class="widget-toolbox padding-8 clearfix">
 <?php
 # -- ====================== MASS BUG MANIPULATION =================== --
 # @@@ ideally buglist-footer would be in <tfoot>, but that's not possible due to global g_checkboxes_exist set via write_bug_rows()
 ?>
-	<div class="form-inline pull-left">
+					<div class="form-inline pull-left">
 <?php
 		/**
 		 * Global $g_checkboxes_exist is set in write_bug_rows() via the
@@ -254,16 +260,17 @@ write_bug_rows( $t_rows );
 			echo '&#160;';
 		}
 ?>
-			</div>
-			<div class="btn-group pull-right">
-				<?php echo $t_page_number_links ?>
-			</div>
-<?php # -- ====================== end of MASS BUG MANIPULATION ========================= -- ?>
-</div>
+					</div>
 
-</div>
-</div>
-</form>
+					<div class="btn-group pull-right">
+						<?php echo $t_page_number_links ?>
+					</div>
+<?php # -- ====================== end of MASS BUG MANIPULATION ========================= -- ?>
+				</div>
+
+			</div>
+		</div>
+	</form>
 </div>
 <?php
 

--- a/view_all_inc.php
+++ b/view_all_inc.php
@@ -53,6 +53,15 @@ require_api( 'html_api.php' );
 require_api( 'lang_api.php' );
 require_api( 'print_api.php' );
 
+/**
+ * Variables defined in parent script.
+ * @var array $g_filter
+ * @var array $t_rows
+ * @var array $t_unique_project_ids
+ * @var int $f_page_number
+ * @var int $t_page_count
+ * @var int $t_bug_count
+ */
 $t_filter = current_user_get_bug_filter();
 filter_init( $t_filter );
 
@@ -140,7 +149,7 @@ if( ( $t_filter_position & FILTER_POSITION_TOP ) == FILTER_POSITION_TOP ) {
 	ob_start();
 	print_page_links(
 		'view_all_bug_page.php',
-		1, $t_page_count, (int)$f_page_number,
+		1, $t_page_count, $f_page_number,
 		filter_get_temporary_key( $t_filter )
 	);
 	$t_page_number_links = ob_get_clean();
@@ -224,14 +233,18 @@ write_bug_rows( $t_rows );
 ?>
 	<div class="form-inline pull-left">
 <?php
+		/**
+		 * Global $g_checkboxes_exist is set in write_bug_rows() via the
+		 * print_column_value custom function.
+		 * @noinspection PhpConditionAlreadyCheckedInspection
+		 */
 		if( $g_checkboxes_exist ) {
 			echo '<label class="inline">';
 			echo '<input class="ace check_all input-sm" type="checkbox" id="bug_arr_all" name="bug_arr_all" value="all" />';
 			echo '<span class="lbl padding-6">' . lang_get( 'select_all' ) . ' </span > ';
 			echo '</label>';
-		}
-		if( $g_checkboxes_exist ) {
 ?>
+			<!--suppress HtmlFormInputWithoutLabel -->
 			<select name="action" class="input-sm">
 				<?php print_all_bug_action_option_list($t_unique_project_ids) ?>
 			</select>


### PR DESCRIPTION
Add 2 new config options, *$g_print_reports_threshold* and *$g_export_issues_threshold* (both defaulting to `VIEWER`), to restrict access to the mass export functions on view_all_bugs_page.php:

- CSV and Excel export
- Print reports

Fixes [#22224](https://mantisbt.org/bugs/view.php?id=22224), [#25492](https://mantisbt.org/bugs/view.php?id=25492)

This replaces PR #1021, which I finally got around to reviewing. The code looks good and tested OK with just a minor correction: adding a missing access check in print_all_bug_page_word.php.

Many thanks @MrBricodage for the initial submission and your work on this, with our apologies for taking so long to handle it.
