### PR TITLE
Further improvements to admin/test_langs.php

### DIFF
--- a/admin/test_langs.php
+++ b/admin/test_langs.php
@@ -254,12 +254,14 @@ class LangCheckFile {
 						break;
 					case '[':
 						if( $t_last_token != T_VARIABLE ) {
+							$this->logFail( "Unexpected opening square bracket '['", $t_line);
 							$t_pass = false;
 						}
 						$t_variable_array = true;
 						break;
 					case ']':
 						if( !$t_expect_end_array ) {
+							$this->logFail( "Unexpected closing square bracket ']'", $t_line);
 							$t_pass = false;
 						}
 						$t_expect_end_array = false;
@@ -276,7 +278,7 @@ class LangCheckFile {
 						if( $t_last_token == T_CONSTANT_ENCAPSED_STRING ) {
 							$t_two_part_string = true;
 						} else {
-							$this->logFail( "string concatenation found at unexpected location", $t_line );
+							$this->logFail( "String concatenation found at unexpected location", $t_line );
 							$t_pass = false;
 						}
 						break;

--- a/admin/test_langs.php
+++ b/admin/test_langs.php
@@ -162,7 +162,7 @@ class LangCheckFile {
 
 		/** @noinspection PhpUndefinedVariableInspection */
 		printf( '<td class="%s">%s</td>', $t_class, $t_messages );
-		echo '</tr>';
+		echo '</tr>' . PHP_EOL;
 	}
 
 	/**
@@ -478,12 +478,13 @@ function checkplugins() {
 		print_info( count( $t_plugins ) . " Plugins found" );
 	} catch( UnexpectedValueException $e ) {
 		print_fail( $e->getMessage() );
-		echo '</tr>';
+		echo '</tr>' . PHP_EOL;
 		return;
 	}
-	echo '</tr>';
+	echo '</tr>' . PHP_EOL;
 
 	foreach( $t_plugins as $t_plugin => $t_path ) {
+		echo PHP_EOL;
 		echo '<tr><th colspan="2">';
 		echo "Checking language files for plugin <strong>$t_plugin</strong>";
 		echo '</th></tr>';
@@ -556,13 +557,13 @@ function get_lang_files( $p_path ) {
  */
 function checklangdir( $p_path ) {
 	$t_path = rtrim( $p_path, DIRECTORY_SEPARATOR ) . '/lang/';
-	echo '<tr><td>';
+	echo PHP_EOL . '<tr><td>';
 	echo "Retrieving language files from '$t_path'";
 	echo '</td>';
 
 	if( !is_dir( $t_path ) ) {
 		print_info( "Directory does not exist" );
-		echo '</tr>';
+		echo '</tr>' . PHP_EOL;
 		return;
 	} else {
 		try {
@@ -570,12 +571,12 @@ function checklangdir( $p_path ) {
 			print_info( count( $t_lang_files ) . " files found" );
 		} catch( UnexpectedValueException $e ) {
 			print_fail( $e->getMessage() );
-			echo '</tr>';
+			echo '</tr>' . PHP_EOL;
 			return;
 		}
 	}
 
-	echo '</tr>';
+	echo '</tr>' . PHP_EOL;
 
 	# Check reference English language file
 	$t_key = array_search( LangCheckFile::BASE, $t_lang_files );

--- a/admin/test_langs.php
+++ b/admin/test_langs.php
@@ -420,12 +420,19 @@ print_admin_menu_bar( 'test_langs.php' );
 	<div class="space-10"></div>
 
 	<!-- CORE LANGUAGE FILES -->
-	<div class="widget-box widget-color-blue2">
+	<div id="core" class="widget-box widget-color-blue2">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<?php print_icon( 'fa-text-width', 'ace-icon' ); ?>
 				Testing Core Language Files
 			</h4>
+			<div class="widget-toolbar no-border hidden-xs">
+				<div class="widget-menu">
+					<a href="#plugins" class="btn btn-primary btn-white btn-round btn-sm">
+						Scroll down to Plugins
+					</a>
+				</div>
+			</div>
 		</div>
 
 		<div class="widget-body">
@@ -442,12 +449,19 @@ checklangdir( $t_mantis_dir );
 	<div class="space-10"></div>
 
 	<!-- PLUGINS -->
-	<div class="widget-box widget-color-blue2">
+	<div id="plugins" class="widget-box widget-color-blue2">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<?php print_icon( 'fa-text-width', 'ace-icon' ); ?>
 				Testing Plugins Language Files
 			</h4>
+			<div class="widget-toolbar no-border hidden-xs">
+				<div class="widget-menu">
+					<a href="#" class="btn btn-primary btn-white btn-round btn-sm">
+						Scroll back to top
+					</a>
+				</div>
+			</div>
 		</div>
 
 		<div class="widget-body">

--- a/admin/test_langs.php
+++ b/admin/test_langs.php
@@ -477,7 +477,12 @@ function checkplugins() {
 
 	try {
 		$t_plugins = get_plugins( $t_path );
-		print_info( count( $t_plugins ) . " Plugins found" );
+		$t_toc = '<ol class="plugins-toc">';
+		foreach( $t_plugins as $t_plugin => $t_path ) {
+			$t_toc .= '<li><a href="#plugin-' . $t_plugin . '">' . $t_plugin . '</a></li>';
+		}
+		$t_toc .= '</ol>';
+		print_info( count( $t_plugins ) . " Plugins found" . $t_toc );
 	} catch( UnexpectedValueException $e ) {
 		print_fail( $e->getMessage() );
 		echo '</tr>' . PHP_EOL;
@@ -488,7 +493,8 @@ function checkplugins() {
 	foreach( $t_plugins as $t_plugin => $t_path ) {
 		echo PHP_EOL;
 		echo '<tr><th colspan="2">';
-		echo "Checking language files for plugin <strong>$t_plugin</strong>";
+		echo '<a id="plugin-' . $t_plugin . '"></a>';
+		echo "Checking language files for plugin <em>$t_plugin</em>";
 		echo '</th></tr>';
 		checklangdir( $t_path );
 	}
@@ -601,7 +607,7 @@ function checklangdir( $p_path ) {
 }
 
 function print_info( $p_message ) {
-	echo '<td class="alert-info">', string_attribute( $p_message ), '</td>';
+	echo '<td class="alert-info">', ( $p_message ), '</td>';
 }
 
 function print_fail( $p_message ) {

--- a/admin/test_langs.php
+++ b/admin/test_langs.php
@@ -430,7 +430,7 @@ print_admin_menu_bar( 'test_langs.php' );
 
 		<div class="widget-body">
 			<div class="widget-main no-padding table-responsive">
-				<table class="table table-bordered table-condensed ">
+				<table class="table table-bordered table-condensed test-langs">
 <?php
 checklangdir( $t_mantis_dir );
 ?>
@@ -452,7 +452,7 @@ checklangdir( $t_mantis_dir );
 
 		<div class="widget-body">
 			<div class="widget-main no-padding table-responsive">
-				<table class="table table-bordered table-condensed ">
+				<table class="table table-bordered table-condensed test-langs">
 <?php
 checkplugins();
 ?>

--- a/admin/test_langs.php
+++ b/admin/test_langs.php
@@ -29,9 +29,6 @@ $t_mantis_dir = dirname( dirname( __FILE__ ) ) . '/';
 
 require_once( $t_mantis_dir . 'core.php' );
 
-# Load schema version needed to render admin menu bar
-require_once( 'schema.php' );
-
 /**
  * Class CheckLangFile.
  *

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "adodb/adodb-php": "^5.20.21",
         "phpmailer/phpmailer": "~6.0",
         "erusev/parsedown": "^1.7.0, <=1.7.3",
+        "ezyang/htmlpurifier": "^4.14",
         "dapphp/securimage": "dev-mantis"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d33dac6c110c053b6da13ae32c6ae4b",
+    "content-hash": "0ce17d41e53323852e7374dca40a494e",
     "packages": [
         {
             "name": "adodb/adodb-php",
@@ -168,6 +168,57 @@
                 "source": "https://github.com/erusev/parsedown/tree/1.7.3"
             },
             "time": "2019-03-17T18:48:37+00:00"
+        },
+        {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "12ab42bd6e742c70c0a52f7b82477fcd44e64b75"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/12ab42bd6e742c70c0a52f7b82477fcd44e64b75",
+                "reference": "12ab42bd6e742c70c0a52f7b82477fcd44e64b75",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ],
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "exclude-from-classmap": [
+                    "/library/HTMLPurifier/Language/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "support": {
+                "issues": "https://github.com/ezyang/htmlpurifier/issues",
+                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.14.0"
+            },
+            "time": "2021-12-25T01:21:49+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/css/default.css
+++ b/css/default.css
@@ -166,3 +166,10 @@ table.filters td.category {
 .listjs-table .sort:hover {
 	text-decoration: underline;
 }
+
+.test-langs ol.plugins-toc {
+    column-count: auto;
+    column-width: 130px;
+    column-gap: 60px;
+    margin: 10px 15px 10px 30px;
+}

--- a/css/default.css
+++ b/css/default.css
@@ -31,7 +31,9 @@ tr.spacer			{ background-color: #ffffff !important; color: #000000; height: 5px;
 #buglist .cftype-textarea
 	{ text-align: left; }
 
-.sticky-separator { background-color: lightgrey;}
+.sticky-separator,
+.test-langs th
+	{ background-color: lightgrey; }
 
 /* manage_plugin_page.php */
 span.dependency_dated		{ color: maroon; }


### PR DESCRIPTION
This is a follow-up on PR #1772.

It includes a bit of code cleanup, and brings a few additional UI enhancements (related to [#27383](https://mantisbt.org/bugs/view.php?id=27383)):
- add missing error messages
- improved visibility for plugin headers in table
- add a TOC for tested plugins, allowing user to scroll straight to a specific one
- add buttons to navigate between the core and plugin sections

It also implements 2 extra checks for language strings:
- basic syntax check (invalid tags, unexpected end tags, open/end tag mismatch, etc), fixing [#30447](https://mantisbt.org/bugs/view.php?id=30447)
- Use [HTMLPurifier](http://htmlpurifier.org/) to detect if any unauthorized tags are present, which is a partial fix for [#12242](https://mantisbt.org/bugs/view.php?id=12242)

