### PR TITLE
Fix deprecated conversion of false to array

### DIFF
--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -283,7 +283,7 @@ function ldap_cache_user_data( $p_username ) {
 		return false;
 	}
 
-	$t_data = false;
+	$t_data = array();
 	foreach( $t_search_attrs as $t_attr ) {
 		# Suppress error to avoid Warning in case an invalid attribute was specified
 		$t_value = @ldap_get_values( $t_ds, $t_entry, $t_attr );
@@ -292,6 +292,10 @@ function ldap_cache_user_data( $p_username ) {
 			continue;
 		}
 		$t_data[$t_attr] = $t_value[0];
+	}
+	
+	if (empty($t_data)) {
+		$t_data = false;
 	}
 
 	# Store data in the cache


### PR DESCRIPTION
Fixed the PHP 8.1 error

> Automatic conversion of false to array is deprecated

[#30790](https://mantisbt.org/bugs/view.php?id=30790)