### PR TITLE
Allow setting rel=noopener/noreferrer for URL links

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2042,15 +2042,25 @@ $g_file_download_xsendfile_header_name = 'X-Sendfile';
 
 /**
  * Convert URLs and e-mail addresses to html links.
- * This flag controls whether www URLs and email addresses are automatically
- * converted to clickable links as well as where the www links open when
- * clicked. Valid options are:
+ *
+ * This flag controls whether URLs and email addresses are automatically
+ * converted to clickable links. Additionally, for URL links, it determines
+ * where they open when clicked (*target* attribute) and their type.
+ *
+ * The options below can be combined using bitwise operators (not all
+ * possible combinations make sense):
  * - OFF                Do not convert URLs or emails
  * - LINKS_SAME_WINDOW  Convert to links that open in the current window (DEFAULT)
- * - LINKS_NEW_WINDOW   Convert to links that open in a new window
+ * - LINKS_NEW_WINDOW   Convert to links that open in a new window (overrides LINKS_SAME_WINDOW)
+ * - LINKS_NOOPENER     Links have the `noopener` type (DEFAULT)
+ *                      {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener}
+ * - LINKS_NOREFERRER   Links have the `noreferrer` type, i.e. they omit the *Referer*
+ *                      header (implies LINKS_NOOPENER)
+ *                      {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noreferrer}
+ *
  * @global integer $g_html_make_links
  */
-$g_html_make_links = LINKS_SAME_WINDOW;
+$g_html_make_links = LINKS_SAME_WINDOW | LINKS_NOOPENER;
 
 /**
  * These are the valid html tags for multi-line fields (e.g. description)

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -633,6 +633,8 @@ define( 'SECONDS_PER_DAY', 86400 );
 # Auto-generated link targets
 define( 'LINKS_SAME_WINDOW', 1 );
 define( 'LINKS_NEW_WINDOW', 2 );
+define( 'LINKS_NOOPENER', 4 );
+define( 'LINKS_NOREFERRER', 8 );
 
 # Auth Related Constants
 define( 'API_TOKEN_LENGTH', 32 );

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -842,3 +842,50 @@ function helper_parse_id( $p_id, $p_field_name ) {
 function helper_parse_issue_id( $p_issue_id, $p_field_name = 'issue_id' ) {
 	return helper_parse_id( $p_issue_id, $p_field_name );
 }
+
+/**
+ * Return a link's attributes based on Mantis Config.
+ *
+ * Depending on $p_return_array parameter, return value will either be
+ * - an associative array with attribute => value pairs
+ *   e.g. ['rel'=>'noopener', target=>'_blank'], or
+ * - a string ready to be added to an html <a> tag,
+ *   e.g. ' rel="noopener" target="_blank"'
+ *
+ * @param bool $p_return_array true to return an array (default), false for string
+ * @return array|string
+ *
+ * @see $g_html_make_links
+ */
+function helper_get_link_attributes( $p_return_array = true ) {
+	$t_html_make_links = config_get( 'html_make_links' );
+
+	$t_attributes = array();
+	if( $t_html_make_links ) {
+		# Link target
+		if( $t_html_make_links & LINKS_NEW_WINDOW ) {
+			$t_attributes['target'] = '_blank';
+		}
+
+		# Link relation type
+		if( $t_html_make_links & ( LINKS_NOOPENER | LINKS_NOREFERRER ) ) {
+			if( $t_html_make_links & LINKS_NOREFERRER ) {
+				$t_attributes['rel'] = 'noreferrer';
+				# noreferrer implies noopener, so no need to set the latter
+			}
+			elseif( $t_html_make_links & LINKS_NOOPENER ) {
+				$t_attributes['rel'] = 'noopener';
+			}
+		}
+	}
+
+	if( $p_return_array ) {
+		return $t_attributes;
+	}
+
+	$t_string = '';
+	foreach( $t_attributes as $t_attr => $t_value ) {
+		$t_string .= " $t_attr=\"$t_value\"";
+	}
+	return $t_string;
+}

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -476,7 +476,8 @@ function string_insert_hrefs( $p_string ) {
 	static $s_url_regex = null;
 	static $s_email_regex = null;
 
-	if( !config_get( 'html_make_links' ) ) {
+	$t_html_make_links = config_get( 'html_make_links' );
+	if( !$t_html_make_links ) {
 		return $p_string;
 	}
 
@@ -506,17 +507,27 @@ function string_insert_hrefs( $p_string ) {
 		$s_email_regex = substr_replace( email_regex_simple(), '(?:mailto:)?', 1, 0 );
 	}
 
+	# Set the link's target and type according to configuration
+	$t_link_attributes = '';
+	if( $t_html_make_links & ( LINKS_NOOPENER | LINKS_NOREFERRER ) ) {
+		if( $t_html_make_links & LINKS_NOREFERRER ) {
+			$t_link_attributes .= 'noreferrer';
+			# noreferrer implies noopener, so no need to set the latter
+		} elseif( $t_html_make_links & LINKS_NOOPENER ) {
+			$t_link_attributes .= 'noopener';
+		}
+		$t_link_attributes = ' rel="' . $t_link_attributes . '"';
+	}
+	if( $t_html_make_links & LINKS_NEW_WINDOW ) {
+		$t_link_attributes .= ' target="_blank"';
+	}
+
 	# Find any URL in a string and replace it with a clickable link
 	$p_string = preg_replace_callback(
 		$s_url_regex,
-		function ( $p_match ) {
+		function ( $p_match ) use ( $t_link_attributes ) {
 			$t_url_href = 'href="' . rtrim( $p_match[1], '.' ) . '"';
-			if( config_get( 'html_make_links' ) == LINKS_NEW_WINDOW ) {
-				$t_url_target = ' target="_blank"';
-			} else {
-				$t_url_target = '';
-			}
-			return "<a ${t_url_href}${t_url_target}>${p_match[1]}</a>";
+			return "<a ${t_url_href}${t_link_attributes}>${p_match[1]}</a>";
 		},
 		$p_string
 	);

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -508,19 +508,7 @@ function string_insert_hrefs( $p_string ) {
 	}
 
 	# Set the link's target and type according to configuration
-	$t_link_attributes = '';
-	if( $t_html_make_links & ( LINKS_NOOPENER | LINKS_NOREFERRER ) ) {
-		if( $t_html_make_links & LINKS_NOREFERRER ) {
-			$t_link_attributes .= 'noreferrer';
-			# noreferrer implies noopener, so no need to set the latter
-		} elseif( $t_html_make_links & LINKS_NOOPENER ) {
-			$t_link_attributes .= 'noopener';
-		}
-		$t_link_attributes = ' rel="' . $t_link_attributes . '"';
-	}
-	if( $t_html_make_links & LINKS_NEW_WINDOW ) {
-		$t_link_attributes .= ' target="_blank"';
-	}
+	$t_link_attributes = helper_get_link_attributes( false );
 
 	# Find any URL in a string and replace it with a clickable link
 	$p_string = preg_replace_callback(

--- a/docbook/Admin_Guide/en-US/config/html.xml
+++ b/docbook/Admin_Guide/en-US/config/html.xml
@@ -9,29 +9,49 @@
 		<varlistentry>
 			<term>$g_html_make_links</term>
 			<listitem>
-				<para>This flag controls whether www URLs and email addresses are
-					automatically converted into clickable links as well as where
-					the www links open when clicked. The options are:
-					<itemizedlist>
-						<listitem>
-							<para><emphasis>OFF</emphasis> - do not convert URLs or emails
-							</para>
-						</listitem>
-						<listitem>
-							<para><emphasis>LINKS_SAME_WINDOW</emphasis> -
-								convert to links that open in current tab/window.
-								NOTE: for backwards-compatibility, this is
-								equivalent to <emphasis>ON</emphasis>.
-							</para>
-						</listitem>
-						<listitem>
-							<para><emphasis>LINKS_NEW_WINDOW</emphasis> -
-								convert to links that open in a new tab/window
-							</para>
-						</listitem>
-					</itemizedlist>
-					Default is <emphasis>LINKS_SAME_WINDOW</emphasis>.
+				<para>This flag controls whether URLs and email addresses are automatically
+					converted to clickable links. Additionally, for URL links, it determines
+					where they open when clicked (<emphasis>target</emphasis> attribute)
+					and their type.
 				</para>
+				<para>The options below can be combined using bitwise operators,
+					though not all possible combinations make sense.
+					The default is <emphasis>LINKS_SAME_WINDOW | LINKS_NOOPENER</emphasis>.
+				</para>
+				<itemizedlist>
+					<listitem>
+						<para><emphasis>OFF</emphasis> - do not convert URLs or emails
+						</para>
+					</listitem>
+					<listitem>
+						<para><emphasis>LINKS_SAME_WINDOW</emphasis> -
+							convert to links that open in current tab/window.
+							NOTE: for backwards-compatibility, this is
+							equivalent to <emphasis>ON</emphasis>.
+						</para>
+					</listitem>
+					<listitem>
+						<para><emphasis>LINKS_NEW_WINDOW</emphasis> -
+							convert to links that open in a new tab/window.
+							Overrides <emphasis>LINKS_SAME_WINDOW</emphasis>.
+						</para>
+					</listitem>
+					<listitem>
+						<para><emphasis>LINKS_NOOPENER</emphasis> -
+							Links have the
+							<ulink url="https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener">noopener</ulink>
+							type.
+						</para>
+					</listitem>
+					<listitem>
+						<para><emphasis>LINKS_NOREFERRER</emphasis> -
+							Links have the
+							<ulink url="https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noreferrer">noreferrer</ulink>
+							type, i.e. they omit the <emphasis>Referer</emphasis> header.
+							Implies <emphasis>LINKS_NOOPENER</emphasis>.
+						</para>
+					</listitem>
+				</itemizedlist>
 			</listitem>
 		</varlistentry>
 		<varlistentry>

--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -42,7 +42,7 @@
 class MantisMarkdown extends Parsedown
 {
 	/**
-	 * MantisMarkdown singleton instance for MantisMarkdown class.
+	 * @var MantisMarkdown singleton instance for MantisMarkdown class.
 	 */
 	private static $mantis_markdown = null;
 
@@ -69,6 +69,13 @@ class MantisMarkdown extends Parsedown
 
 		# XSS protection
 		$this->setSafeMode( true );
+
+		# Only turn URLs into links if config says so
+		plugin_push_current( 'MantisCoreFormatting' );
+		if( !plugin_config_get( 'process_urls' ) ) {
+			$this->setUrlsLinked( false );
+		}
+		plugin_pop_current();
 	}
 
 	/**

--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -255,20 +255,28 @@ class MantisMarkdown extends Parsedown
 	/**
 	 * Customize the inlineLink method
 	 *
-	 * @param array $block A block-level element
+	 * @param array $Excerpt A block-level element
 	 * @access protected
-	 * @return string html representation generated from markdown.
+	 * @return array html representation generated from markdown.
 	 */
-	protected function inlineLink( $block ) {
-
-		$block = parent::inlineLink( $block );
-
-		if( isset( $block['element']['attributes']['href'] )) {
-			$this->processAmpersand( $block['element']['attributes']['href'] );
-		}
-
-		return $block;
+	protected function inlineLink( $Excerpt ) {
+		return $this->processUrl( parent::inlineLink( $Excerpt ) );
 	}
+
+	protected function inlineUrl( $Excerpt ) {
+		return $this->processUrl( parent::inlineUrl( $Excerpt ) );
+	}
+
+	protected function inlineUrlTag( $Excerpt ) {
+		# @FIXME
+		# This function is supposed to process links like `<http://example.com>`
+		# on single-line texts, but it does not actually work: the function is
+		# never called (see Parsedown::line() 1077), because
+		# MantisCoreFormattingPlugin::formatted() applies html_specialchars()
+		# first, so the < > are converted to &lt;/&gt;.
+		return $this->processUrl( parent::inlineUrlTag( $Excerpt ) );
+	}
+
 
 	/**
 	 * Initialize the singleton static instance.
@@ -293,6 +301,30 @@ class MantisMarkdown extends Parsedown
 	 */
 	private function processAmpersand( &$p_text ) {
 		$p_text = str_replace( '&amp;', '&', $p_text );
+	}
+
+	/**
+	 * Set a link's target and rel attributes as appropriate.
+	 *
+	 * @param array|null $Excerpt
+	 * @return array|null
+	 *
+	 * @see helper_get_link_attributes()
+	 */
+	private function processUrl( $Excerpt ) {
+		if( isset( $Excerpt['element']['attributes']['href'] ) ) {
+			$this->processAmpersand( $Excerpt['element']['attributes']['href'] );
+		}
+
+		if( isset( $Excerpt['element']['attributes'] ) ) {
+			# Set the link's attributes according to configuration
+			$Excerpt['element']['attributes'] = array_replace(
+				$Excerpt['element']['attributes'],
+				helper_get_link_attributes()
+			);
+		}
+
+		return $Excerpt;
 	}
 
 }


### PR DESCRIPTION
$g_html_make_links now accepts 2 new contants, LINKS_NOOPENER and
LINKS_NOREFERRER, allowing the admin to set the corresponding type for
the URL links that are generated when the MantisCoreFormatting plugin's
URL Processing is ON.

The default value for $g_html_make_links has been changed from
`LINKS_SAME_WINDOW` to `LINKS_SAME_WINDOW | LINKS_NOOPENER`, for
security reasons.

Fixes [#30791](https://mantisbt.org/bugs/view.php?id=30791)
