### PR TITLE
When copying categories, only process "local" ones

### DIFF
--- a/manage_proj_cat_copy.php
+++ b/manage_proj_cat_copy.php
@@ -65,7 +65,7 @@ if( $f_copy_from ) {
 	trigger_error( ERROR_CATEGORY_NO_ACTION, ERROR );
 }
 
-$t_rows = category_get_all_rows( $t_src_project_id );
+$t_rows = category_get_all_rows( $t_src_project_id, false );
 
 foreach ( $t_rows as $t_row ) {
 	$t_name = $t_row['name'];


### PR DESCRIPTION
It does not make sense to copy the global categories, if they are wanted
in the target project, it should inherit them.

Fixes [#30812](https://mantisbt.org/bugs/view.php?id=30812)