### PR TITLE
Allow copy of categories excluding inherited ones

### DIFF
--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -114,6 +114,7 @@ $s_unassigned_projects_label = 'Unassigned Projects';
 $s_copy_users = 'Copy Users';
 $s_copy_categories_from = 'Copy Categories From';
 $s_copy_categories_to = 'Copy Categories To';
+$s_copy_categories_exclude_inherited = 'Exclude inherited categories';
 $s_copy_versions_from = 'Copy Versions From';
 $s_copy_versions_to = 'Copy Versions To';
 $s_copy_users_from = 'Copy Users From';

--- a/manage_proj_cat_copy.php
+++ b/manage_proj_cat_copy.php
@@ -51,6 +51,7 @@ $f_project_id		= gpc_get_int( 'project_id' );
 $f_other_project_id	= gpc_get_int( 'other_project_id' );
 $f_copy_from		= gpc_get_bool( 'copy_from' );
 $f_copy_to			= gpc_get_bool( 'copy_to' );
+$f_exclude_inherited = gpc_get_bool( 'exclude_inherited' );
 
 access_ensure_project_level( config_get( 'manage_project_threshold' ), $f_project_id );
 access_ensure_project_level( config_get( 'manage_project_threshold' ), $f_other_project_id );
@@ -65,7 +66,7 @@ if( $f_copy_from ) {
 	trigger_error( ERROR_NO_COPY_ACTION, ERROR );
 }
 
-$t_rows = category_get_all_rows( $t_src_project_id );
+$t_rows = category_get_all_rows( $t_src_project_id, !$f_exclude_inherited );
 
 foreach ( $t_rows as $t_row ) {
 	$t_name = $t_row['name'];

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -442,6 +442,12 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 			<button name="copy_to" class="btn btn-sm btn-primary btn-white btn-round" value="1">
 				<?php echo lang_get( 'copy_categories_to' ) ?>
 			</button>
+			<div class="padding-left-8 inline">
+			<input type="checkbox" class="ace" id="exclude_inherited" name="exclude_inherited">
+			<label for="exclude_inherited" class="lbl">
+				<?php echo lang_get( 'copy_categories_exclude_inherited' ); ?>
+			</label>
+			</div>
 		</fieldset>
 	</form>
 	</div>


### PR DESCRIPTION
This is an alternative, possibly better approach to fixing [#30812](https://mantisbt.org/bugs/view.php?id=30812), than the initial PR #1839.

Add a new checkbox next to the Copy to/from buttons on Manage Project
Page, allowing user to decide whether the copy operation should be
restricted to the source project's "local" categories, excluding the
global ones as well as those inherited from the parent project(s).

Note: this is targeted at _master_ because this is more of an enhancement than a bugfix.
