### PR TITLE
Markdown. Add external css file, remove inline styles from quotes.

### DIFF
--- a/plugins/MantisCoreFormatting/MantisCoreFormatting.php
+++ b/plugins/MantisCoreFormatting/MantisCoreFormatting.php
@@ -54,7 +54,15 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 			'EVENT_DISPLAY_FORMATTED'	=> 'formatted',		# Formatted String Display
 			'EVENT_DISPLAY_RSS'			=> 'rss',			# RSS String Display
 			'EVENT_DISPLAY_EMAIL'		=> 'email',			# Email String Display
+			'EVENT_LAYOUT_RESOURCES'	=> 'resources'		# Load stylesheet
 		);
+	}
+
+	/**
+	 * @return void
+	 */
+	function resources() {
+		echo '<link rel="stylesheet" href="' . plugin_file( 'markdown.css' ) . '" />';
 	}
 
 	/**

--- a/plugins/MantisCoreFormatting/MantisCoreFormatting.php
+++ b/plugins/MantisCoreFormatting/MantisCoreFormatting.php
@@ -62,7 +62,9 @@ class MantisCoreFormattingPlugin extends MantisFormattingPlugin {
 	 * @return void
 	 */
 	function resources() {
-		echo '<link rel="stylesheet" href="' . plugin_file( 'markdown.css' ) . '" />';
+		if ( ON == plugin_config_get( 'process_markdown' )) {
+			echo '<link rel="stylesheet" href="' . plugin_file( 'markdown.css' ) . '" />';
+		}
 	}
 
 	/**

--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -157,48 +157,6 @@ class MantisMarkdown extends Parsedown
 	}
 
 	/**
-	 * Add an inline style on a blockquote markdown elements
-	 *
-	 * @param string $line The Markdown syntax to parse
-	 * @param array $block A block-level element
-	 * @param string $fn the function name to call (blockQuote or blockQuoteContinue)
-	 * @access private
-	 * @return string html representation generated from markdown.
-	 */
-	private function __quote( $line, $block, $fn ) {
-
-		if( $block = call_user_func( 'parent::' . $fn, $line, $block ) ) {
-			# TODO: To open another issue to track css style sheet issue vs. inline style.
-			$block['element']['attributes']['style'] = 'padding:0.13em 1em;color:rgb(119,119,119);border-left:0.25em solid #C0C0C0;font-size:13px;';
-		}
-
-		return $block;
-	}
-
-	/**
-	 * Customize the blockQuote method by adding a style attribute
-	 *
-	 * @param string $line The Markdown syntax to parse
-	 * @access protected
-	 * @return string html representation generated from markdown.
-	 */
-	protected function blockQuote( $line ){
-		return $this->__quote( $line, array(), __FUNCTION__ );
-	}
-
-	/**
-	 * Customize the blockQuoteContinue method by adding a style attribute
-	 *
-	 * @param string $line The Markdown syntax to parse
-	 * @param array $block A block-level element
-	 * @access protected
-	 * @return string html representation generated from markdown.
-	 */
-	protected function blockQuoteContinue( $line, array $block ){
-		return $this->__quote( $line, $block, __FUNCTION__ );
-	}
-
-	/**
 	 * Customize the inlineCode method
 	 *
 	 * @param array $block A block-level element

--- a/plugins/MantisCoreFormatting/files/markdown.css
+++ b/plugins/MantisCoreFormatting/files/markdown.css
@@ -6,5 +6,5 @@
     padding: 0.13em 1em;
     color: rgb(119,119,119);
     border-left: 0.25em solid #C0C0C0;
-    font-size: 13px;
+    font-size: inherit;
 }

--- a/plugins/MantisCoreFormatting/files/markdown.css
+++ b/plugins/MantisCoreFormatting/files/markdown.css
@@ -1,0 +1,10 @@
+/* quotes */
+.bug-description blockquote,
+.bug-steps-to-reproduce blockquote,
+.bug-additional-information blockquote,
+.bugnote-note blockquote {
+    padding: 0.13em 1em;
+    color: rgb(119,119,119);
+    border-left: 0.25em solid #C0C0C0;
+    font-size: 13px;
+}

--- a/plugins/MantisCoreFormatting/files/markdown.css
+++ b/plugins/MantisCoreFormatting/files/markdown.css
@@ -1,8 +1,5 @@
 /* quotes */
-.bug-description blockquote,
-.bug-steps-to-reproduce blockquote,
-.bug-additional-information blockquote,
-.bugnote-note blockquote {
+blockquote {
     padding: 0.13em 1em;
     color: rgb(119,119,119);
     border-left: 0.25em solid #C0C0C0;

--- a/plugins/MantisCoreFormatting/tests/MarkdownTest.php
+++ b/plugins/MantisCoreFormatting/tests/MarkdownTest.php
@@ -134,15 +134,15 @@ no space after `>`:
 EOD;
 
 		$markdown_quote_output = <<<EOD
-<blockquote style="border-color:#847d7d">
+<blockquote>
 <p>quote</p>
 </blockquote>
 <p>indented:</p>
-<blockquote style="border-color:#847d7d">
+<blockquote>
 <p>quote</p>
 </blockquote>
 <p>no space after <code>&gt;</code>:</p>
-<blockquote style="border-color:#847d7d">
+<blockquote>
 <p>quote</p>
 </blockquote>
 EOD;

--- a/plugins/MantisCoreFormatting/tests/MarkdownTest.php
+++ b/plugins/MantisCoreFormatting/tests/MarkdownTest.php
@@ -117,37 +117,4 @@ EOD;
 
 		$this->assertEquals( $markdown_table_output, MantisMarkdown::convert_text( $markdown_table ) );
 	}
-
-	/**
-	 * Test the quote markdown if style attribute is defined
-	 * @return void
-	 */
-	public function testQuoteStyleAttribute() {
-		$markdown_quote = <<<EOD
-> quote
-
-indented:
-	> quote
-
-no space after `>`:
->quote
-EOD;
-
-		$markdown_quote_output = <<<EOD
-<blockquote>
-<p>quote</p>
-</blockquote>
-<p>indented:</p>
-<blockquote>
-<p>quote</p>
-</blockquote>
-<p>no space after <code>&gt;</code>:</p>
-<blockquote>
-<p>quote</p>
-</blockquote>
-EOD;
-
-		$this->assertEquals( $markdown_quote_output, MantisMarkdown::convert_text( $markdown_quote ) );
-	}
-
 }


### PR DESCRIPTION
This is an attempt to finish PR #1004 with fewer code changes. This is the first merge request of a small series addressing some Markdown issues.

### Add external css file, clean up quotes

- Reduce lines of codes in MantisMarkdown.php ("decomplexing")
- Fixing https://mantisbt.org/bugs/view.php?id=22190
- tiny change, no impact to core files.
- Remove test. It does not pass and after removing the inline styles, it is just a copy of [parsedown's own test](https://parsedown.org/tests/simple_blockquote).
- Having an external css file in place makes it easy to address styling issues like [this](https://mantisbt.org/bugs/view.php?id=22181) or [this](https://mantisbt.org/bugs/view.php?id=22485) and others in the future.


| before | after |
|---        |---      |
|![mantis-quotings-before](https://user-images.githubusercontent.com/67791701/183534505-b617c575-ca9b-430a-a16b-7b5d4b7431f5.png) | ![mantis-quotings-after](https://user-images.githubusercontent.com/67791701/183534488-82ff0d13-7c69-4a7c-bf72-3e92f5b1f548.png)      |




If this patch is accepted, i think the [origin PR](https://github.com/mantisbt/mantisbt/pull/1004)  can closed and i will commit a follow up merge request to clean up the "table stuff". [reduce LOC](https://github.com/mantisbt/mantisbt/compare/master...grummbeer:mantisbt:markdown-cleanup-02-tables) and [reduce test](https://github.com/mantisbt/mantisbt/compare/master...grummbeer:mantisbt:markdown-cleanup-03-table-test).

[This note](https://github.com/mantisbt/mantisbt/pull/1004#issuecomment-287067147) is about emails and inline styles. Does Mantis send HTML mail at all or does it no longer send HTML mail? Text mails with the generally accepted `>` are well formatted by the clients, HTML-blockquote should also have a client dependent default styleing that is not quite so terrible. But if this is still relevant, a following pull request should solve this issue. Source code for website is something other than the HTML part of an email. 