### PR TITLE
Fix form should be a POST not a GET

### DIFF
--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -723,7 +723,7 @@ if( $t_flags['monitor_show'] ) {
 			if( $t_flags['monitor_can_add'] ) {
 	?>
 			<br /><br />
-			<form method="get" action="bug_monitor_add.php" class="form-inline noprint">
+			<form method="post" action="bug_monitor_add.php" class="form-inline noprint">
 			<?php echo form_security_field( 'bug_monitor_add' ) ?>
 				<input type="hidden" name="bug_id" value="<?php echo (integer)$f_issue_id; ?>" />
 				<!--suppress HtmlFormInputWithoutLabel -->


### PR DESCRIPTION
Browsers/extensions may pre-load any GET URL, including from forms. GET is specified as read-only. A user of mine was having all bugs they viewed auto-monitored.

I have confirmed this fix works. Mantis allows GET or POST for every/most inputs.