### PR TITLE
REST API to fetch project users

### DIFF
--- a/api/rest/restcore/projects_rest.php
+++ b/api/rest/restcore/projects_rest.php
@@ -86,8 +86,6 @@ function rest_project_users(\Slim\Http\Request $p_request, \Slim\Http\Response $
 			'id'        => $t_project_id,
 			'page_size' => $t_page_size,
 			'page'      => $t_page,
-		),
-		'options' => array(
 			'access_level' => $t_access_level,
 			'include_access_levels' => $t_include_access_levels
 		)
@@ -126,8 +124,6 @@ function rest_project_handlers(\Slim\Http\Request $p_request, \Slim\Http\Respons
 			'id'        => $t_project_id,
 			'page_size' => $t_page_size,
 			'page'      => $t_page,
-		),
-		'options' => array(
 			'access_level' => $t_access_level,
 			'include_access_levels' => $t_include_access_levels
 		)

--- a/api/rest/restcore/projects_rest.php
+++ b/api/rest/restcore/projects_rest.php
@@ -61,25 +61,26 @@ $g_app->group('/projects', function() use ( $g_app ) {
 });
 
 /**
- * A method to get list of users with the specified access level in the specified project.
+ * A helper function to get project users with the specified access level or above.
+ * The function will extract the parameters from the request and args.
  *
  * @param \Slim\Http\Request $p_request   The request.
  * @param \Slim\Http\Response $p_response The response.
  * @param array $p_args Arguments
+ * @param int $p_access_level access level to use or null to extract from request.
  * @return \Slim\Http\Response The augmented response.
  */
-function rest_project_users(\Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
-	$t_project_id = $p_args['id'];
-	if( is_blank( $t_project_id ) ) {
-		$t_message = "Project id is missing.";
-		return $p_response->withStatus( HTTP_STATUS_BAD_REQUEST, $t_message );
-	}
-
-	$t_project_id = (int)$t_project_id;
+function project_users( \Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args, $p_access_level = null ) {
+	$t_project_id = (int)$p_args['id'];
 	$t_page_size = $p_request->getParam( 'page_size' );
 	$t_page = $p_request->getParam( 'page' );
-	$t_access_level = $p_request->getParam( 'access_level' );
 	$t_include_access_levels = $p_request->getParam( 'include_access_levels' );
+
+	if( is_null( $p_access_level ) ) {
+		$t_access_level = (int)$p_request->getParam( 'access_level' );
+	} else {
+		$t_access_level = (int)$p_access_level;
+	}
 
 	$t_data = array(
 		'query' => array(
@@ -98,6 +99,18 @@ function rest_project_users(\Slim\Http\Request $p_request, \Slim\Http\Response $
 }
 
 /**
+ * A method to get list of users with the specified access level in the specified project.
+ *
+ * @param \Slim\Http\Request $p_request   The request.
+ * @param \Slim\Http\Response $p_response The response.
+ * @param array $p_args Arguments
+ * @return \Slim\Http\Response The augmented response.
+ */
+function rest_project_users( \Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
+	return project_users( $p_request, $p_response, $p_args );
+}
+
+/**
  * A method to get list of users with the handler access level in the specified project.
  *
  * @param \Slim\Http\Request $p_request   The request.
@@ -106,33 +119,9 @@ function rest_project_users(\Slim\Http\Request $p_request, \Slim\Http\Response $
  * @return \Slim\Http\Response The augmented response.
  */
 function rest_project_handlers(\Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
-	$t_project_id = $p_args['id'];
-	if( is_blank( $t_project_id ) ) {
-		$t_message = "Project id is missing.";
-		return $p_response->withStatus( HTTP_STATUS_BAD_REQUEST, $t_message );
-	}
-
-	$t_project_id = (int)$t_project_id;
-	$t_page_size = $p_request->getParam( 'page_size' );
-	$t_page = $p_request->getParam( 'page' );
-	$t_include_access_levels = $p_request->getParam( 'include_access_levels' );
-
+	$t_project_id = (int)$p_args['id'];
 	$t_access_level = config_get( 'handle_bug_threshold', null, null, $t_project_id );
-
-	$t_data = array(
-		'query' => array(
-			'id'        => $t_project_id,
-			'page_size' => $t_page_size,
-			'page'      => $t_page,
-			'access_level' => $t_access_level,
-			'include_access_levels' => $t_include_access_levels
-		)
-	);
-
-	$t_command = new ProjectUsersGetCommand( $t_data );
-	$t_result = $t_command->execute();
-
-	return $p_response->withStatus( HTTP_STATUS_SUCCESS )->withJson( $t_result );
+	return project_users( $p_request, $p_response, $p_args, $t_access_level );
 }
 
 /**

--- a/api/rest/restcore/projects_rest.php
+++ b/api/rest/restcore/projects_rest.php
@@ -66,14 +66,17 @@ $g_app->group('/projects', function() use ( $g_app ) {
  * @return \Slim\Http\Response The augmented response.
  */
 function rest_project_handlers(\Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
-	$t_project_id = isset( $p_args['id'] ) ? $p_args['id'] : $p_request->getParam( 'id' );
+	$t_project_id = $p_args['id'];
 	if( is_blank( $t_project_id ) ) {
 		$t_message = "Project id is missing.";
 		return $p_response->withStatus( HTTP_STATUS_BAD_REQUEST, $t_message );
 	}
 
-	$t_page_size = isset( $p_args['page_size'] ) ? $p_args['page_size'] : $p_request->getParam( 'page_size' );
-	$t_page = isset( $p_args['page'] ) ? $p_args['page'] : $p_request->getParam( 'page' );
+	$t_project_id = (int)$t_project_id;
+	$t_page_size = $p_request->getParam( 'page_size' );
+	$t_page = $p_request->getParam( 'page' );
+	$t_include_access_levels = $p_request->getParam( 'include_access_levels' );
+
 	$t_access_level = config_get( 'handle_bug_threshold', null, null, $t_project_id );
 
 	$t_data = array(
@@ -83,7 +86,8 @@ function rest_project_handlers(\Slim\Http\Request $p_request, \Slim\Http\Respons
 			'page'      => $t_page,
 		),
 		'options' => array(
-			'access_level' => $t_access_level
+			'access_level' => $t_access_level,
+			'include_access_levels' => $t_include_access_levels
 		)
 	);
 

--- a/api/rest/restcore/projects_rest.php
+++ b/api/rest/restcore/projects_rest.php
@@ -55,10 +55,52 @@ $g_app->group('/projects', function() use ( $g_app ) {
 
 	# Project Users that can handle issues
 	$g_app->get( '/{id}/handlers', 'rest_project_handlers' );
+
+	# Project Users
+	$g_app->get( '/{id}/users', 'rest_project_users' );
 });
 
 /**
- * A method to get list of users with the specific access level in the specified project.
+ * A method to get list of users with the specified access level in the specified project.
+ *
+ * @param \Slim\Http\Request $p_request   The request.
+ * @param \Slim\Http\Response $p_response The response.
+ * @param array $p_args Arguments
+ * @return \Slim\Http\Response The augmented response.
+ */
+function rest_project_users(\Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
+	$t_project_id = $p_args['id'];
+	if( is_blank( $t_project_id ) ) {
+		$t_message = "Project id is missing.";
+		return $p_response->withStatus( HTTP_STATUS_BAD_REQUEST, $t_message );
+	}
+
+	$t_project_id = (int)$t_project_id;
+	$t_page_size = $p_request->getParam( 'page_size' );
+	$t_page = $p_request->getParam( 'page' );
+	$t_access_level = $p_request->getParam( 'access_level' );
+	$t_include_access_levels = $p_request->getParam( 'include_access_levels' );
+
+	$t_data = array(
+		'query' => array(
+			'id'        => $t_project_id,
+			'page_size' => $t_page_size,
+			'page'      => $t_page,
+		),
+		'options' => array(
+			'access_level' => $t_access_level,
+			'include_access_levels' => $t_include_access_levels
+		)
+	);
+
+	$t_command = new ProjectUsersGetCommand( $t_data );
+	$t_result = $t_command->execute();
+
+	return $p_response->withStatus( HTTP_STATUS_SUCCESS )->withJson( $t_result );
+}
+
+/**
+ * A method to get list of users with the handler access level in the specified project.
  *
  * @param \Slim\Http\Request $p_request   The request.
  * @param \Slim\Http\Response $p_response The response.

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -1305,8 +1305,8 @@ function mc_project_get_users( $p_username, $p_password, $p_project_id, $p_acces
 		)
 	);
 
-	$cmd = new ProjectUsersGetCommand( $t_data );
-	$t_result = $cmd->execute();
+	$t_command = new ProjectUsersGetCommand( $t_data );
+	$t_result = $t_command->execute();
 	$t_result = $t_result['users'];
 
 	return $t_result;

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -1295,29 +1295,17 @@ function mc_project_get_users( $p_username, $p_password, $p_project_id, $p_acces
 		return mci_fault_login_failed();
 	}
 
-	$g_project_override = $p_project_id;
+	$t_data = array(
+		'query' => array(
+			'project_id' => $p_project_id
+		),
+		'options' => array(
+			'access_level' => $p_access
+		)
+	);
 
-	$t_users = project_get_all_user_rows( $p_project_id, $p_access ); # handles ALL_PROJECTS case
+	$cmd = new ProjectUsersGetCommand( $t_data );
+	$t_result = $cmd->execute();
 
-	$t_display = array();
-	$t_sort = array();
-
-	foreach( $t_users as $t_user ) {
-		$t_user_name = user_get_name_from_row( $t_user );
-		$t_display[] = string_attribute( $t_user_name );
-		$t_sort[] = user_get_name_for_sorting_from_row( $t_user );
-	}
-
-	array_multisort( $t_sort, SORT_ASC, SORT_STRING, $t_users, $t_display );
-
-	$t_result = array();
-	for( $i = 0;$i < count( $t_sort );$i++ ) {
-		$t_row = $t_users[$i];
-
-		# This is not very performant - But we have to assure that the data returned is exactly
-		# the same as the data that comes with an issue (test for equality - $t_row[] does not
-		# contain email fields).
-		$t_result[] = mci_account_get_array_by_id( $t_row['id'] );
-	}
 	return $t_result;
 }

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -1297,15 +1297,17 @@ function mc_project_get_users( $p_username, $p_password, $p_project_id, $p_acces
 
 	$t_data = array(
 		'query' => array(
-			'project_id' => $p_project_id
-		),
-		'options' => array(
-			'access_level' => $p_access
+			'id' => $p_project_id,
+			'page' => 1,
+			'page_size' => 0,
+			'access_level' => $p_access,
+			'include_access_levels' => 0
 		)
 	);
 
 	$cmd = new ProjectUsersGetCommand( $t_data );
 	$t_result = $cmd->execute();
+	$t_result = $t_result['users'];
 
 	return $t_result;
 }

--- a/core/commands/ProjectUsersGetCommand.php
+++ b/core/commands/ProjectUsersGetCommand.php
@@ -66,10 +66,10 @@ class ProjectUsersGetCommand extends Command {
 	 */
 	function validate() {
 		$this->project_id = (int)$this->query( 'id' );
-		$this->access_level = (int)$this->option( 'access_level' );
+		$this->access_level = (int)$this->query( 'access_level' );
 		$this->page = (int)$this->query( 'page', 1 );
 		$this->page_size = (int)$this->query( 'page_size', 50 );
-		$this->include_access_levels = (int)$this->option( 'include_access_levels', true );
+		$this->include_access_levels = (int)$this->query( 'include_access_levels', true );
 
 		if( $this->project_id <= ALL_PROJECTS ) {
 			throw new ClientException(

--- a/core/commands/ProjectUsersGetCommand.php
+++ b/core/commands/ProjectUsersGetCommand.php
@@ -1,0 +1,126 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+use Mantis\Exceptions\ClientException;
+
+/**
+ * A command to get the users within a project with the specified access level.
+ */
+class ProjectUsersGetCommand extends Command {
+	/**
+	 * The project id
+	 */
+	private $project_id;
+
+	/**
+	 * The minimum access level, users with access level greater or equal to this access level
+	 * will be returned.
+	 */
+	private $access_level;
+
+	/**
+	 * The page number (starts with 1)
+	 */
+	private $page;
+
+	/**
+	 * The number of users to return per page.
+	 */
+	private $page_size;
+
+	/**
+	 * Constructor
+	 *
+	 * @param array $p_data The command data.
+	 */
+	function __construct( array $p_data ) {
+		parent::__construct( $p_data );
+	}
+
+	/**
+	 * Validate the data.
+	 */
+	function validate() {
+		$this->project_id = $this->query( 'id' );
+		$this->access_level = $this->option( 'access_level' );
+		$this->page = $this->query( 'page', 1 );
+		$this->page_size = $this->query( 'page_size', 50 );
+
+		if( $this->project_id <= ALL_PROJECTS ) {
+			throw new ClientException(
+				sprintf( "Must specify a specific project id.", $this->project_id ),
+				ERROR_PROJECT_NOT_FOUND,
+				array( $this->project_id ) );
+		}
+
+		if( !project_exists( $this->project_id ) ) {
+			throw new ClientException(
+				sprintf( "Project '%d' not found", $this->project_id ),
+				ERROR_PROJECT_NOT_FOUND,
+				array( $this->project_id ) );
+		}
+
+		if( $this->page < 1 ) {
+			$this->page = 1;
+		}
+	}
+
+	/**
+	 * Process the command.
+	 *
+	 * @returns array Command response
+	 */
+	protected function process() {
+		global $g_project_override;
+		$g_project_override = $this->project_id;
+
+		$t_users = project_get_all_user_rows(
+			$this->project_id,
+			$this->access_level,
+			/* include_global_users */ true );
+
+		$t_display = array();
+		$t_sort = array();
+
+		foreach( $t_users as $t_user ) {
+			$t_user_name = user_get_name_from_row( $t_user );
+			$t_display[] = string_attribute( $t_user_name );
+			$t_sort[] = user_get_name_for_sorting_from_row( $t_user );
+		}
+
+		array_multisort( $t_sort, SORT_ASC, SORT_STRING, $t_users, $t_display );
+
+		unset( $t_display );
+		unset( $t_sort );
+
+		$t_skip = ( $this->page - 1 ) * $this->page_size;
+		$t_taken = 0;
+		$t_result = array();
+		$t_user_ids = array();
+
+		for( $i = $t_skip; $i < count( $t_users ); $i++ ) {
+			$t_user_ids[] = (int)$t_users[$i]['id'];
+			$t_taken++;
+
+			if( $this->page_size != 0 && $t_taken == $this->page_size ) {
+				break;
+			}
+		}
+
+		$t_result = mci_account_get_array_by_ids( $t_user_ids );
+		return $t_result;
+	}
+}

--- a/core/commands/ProjectUsersGetCommand.php
+++ b/core/commands/ProjectUsersGetCommand.php
@@ -23,37 +23,63 @@ require_once( dirname( __FILE__ ) . '/../../api/soap/mc_account_api.php' );
 require_once( dirname( __FILE__ ) . '/../../api/soap/mc_enum_api.php' );
 
 /**
- * A command to get the users within a project with the specified access level.
+ * Sample:
+ * {
+ *   "query": {
+ *     'id'        => 1,
+ *     'page'      => 1,
+ *     'page_size' => 50,
+ *     'access_level' => 1,
+ *     'include_access_levels' => 1
+ *   }
+ * }
+ */
+
+/**
+ * A command to get the users within a project with the specified access level
+ * or higher.
  */
 class ProjectUsersGetCommand extends Command {
 	/**
 	 * The project id
+	 *
+	 * @var integer
 	 */
 	private $project_id;
 
 	/**
 	 * The minimum access level, users with access level greater or equal to this access level
 	 * will be returned.
+	 *
+	 * @var integer
 	 */
 	private $access_level;
 
 	/**
 	 * The page number (starts with 1)
+	 *
+	 * @var integer
 	 */
 	private $page;
 
 	/**
 	 * The number of users to return per page.
+	 *
+	 * @var integer
 	 */
 	private $page_size;
 
 	/**
 	 * Include effective access level of users on the project?
+	 *
+	 * @var integer
 	 */
 	private $include_access_levels;
 
 	/**
 	 * The authenticated user id
+	 *
+	 * @var integer
 	 */
 	private $user_id;
 

--- a/core/commands/ProjectUsersGetCommand.php
+++ b/core/commands/ProjectUsersGetCommand.php
@@ -103,13 +103,6 @@ class ProjectUsersGetCommand extends Command {
 		$this->page_size = (int)$this->query( 'page_size', 50 );
 		$this->include_access_levels = (int)$this->query( 'include_access_levels', true );
 
-		if( $this->project_id <= ALL_PROJECTS ) {
-			throw new ClientException(
-				sprintf( "Must specify a specific project id.", $this->project_id ),
-				ERROR_PROJECT_NOT_FOUND,
-				array( $this->project_id ) );
-		}
-
 		if( !project_exists( $this->project_id ) ) {
 			throw new ClientException(
 				sprintf( "Project '%d' not found", $this->project_id ),
@@ -162,7 +155,7 @@ class ProjectUsersGetCommand extends Command {
 		$t_taken = 0;
 		$t_users_result = array();
 
-		$t_lang = user_pref_get_pref( auth_get_current_user_id(), 'language' );
+		$t_lang = mci_get_user_lang( auth_get_current_user_id() );
 
 		for( $i = $t_skip; $i < count( $t_users ); $i++ ) {
 			$t_user_id = (int)$t_users[$i]['id'];

--- a/core/commands/ProjectUsersGetCommand.php
+++ b/core/commands/ProjectUsersGetCommand.php
@@ -53,6 +53,11 @@ class ProjectUsersGetCommand extends Command {
 	private $include_access_levels;
 
 	/**
+	 * The authenticated user id
+	 */
+	private $user_id;
+
+	/**
 	 * Constructor
 	 *
 	 * @param array $p_data The command data.
@@ -65,6 +70,7 @@ class ProjectUsersGetCommand extends Command {
 	 * Validate the data.
 	 */
 	function validate() {
+		$this->user_id = auth_get_current_user_id();
 		$this->project_id = (int)$this->query( 'id' );
 		$this->access_level = (int)$this->query( 'access_level' );
 		$this->page = (int)$this->query( 'page', 1 );
@@ -85,6 +91,14 @@ class ProjectUsersGetCommand extends Command {
 				array( $this->project_id ) );
 		}
 
+		# If user doesn't have access to project, return project doesn't exist
+		if( !access_has_project_level( VIEWER, $this->project_id, $this->user_id ) ) {
+			throw new ClientException(
+				sprintf( "Project '%d' not found", $this->project_id ),
+				ERROR_PROJECT_NOT_FOUND,
+				array( $this->project_id ) );
+		}
+		
 		if( $this->page < 1 ) {
 			$this->page = 1;
 		}


### PR DESCRIPTION
- `/api/rest/projects/:id/users` to get all users or all users with a specified access level or above. This functionality is available in SOAP API.
- `/api/rest/projects/:id/handlers` to get all users that can be assigned issues in the project.

The user calling the API must have viewer access to the project. This was not enforced in SOAP API, but now it is.

Will submit a separate PR for Postman collection update, since there is a bunch of unrelated changes that accumulated over time.

Fixes #22791, #30907