### PR TITLE
Simple Screen

### DIFF
--- a/admin/check/check_config_inc.php
+++ b/admin/check/check_config_inc.php
@@ -96,6 +96,7 @@ check_print_test_row( 'Default move category must exists ("default_category_for_
 );
 
 $t_field_options = array(
+	'simple_bug_report_page_fields',
 	'bug_report_page_fields',
 	'bug_view_page_fields',
 	'bug_update_page_fields'

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -193,7 +193,12 @@ $f_report_stay			= gpc_get_bool( 'report_stay', false );
 $f_copy_notes_from_parent         = gpc_get_bool( 'copy_notes_from_parent', false );
 $f_copy_attachments_from_parent   = gpc_get_bool( 'copy_attachments_from_parent', false );
 
-$t_fields = config_get( 'bug_report_page_fields' );
+if( access_has_project_level( config_get( 'extended_report_levels' ), $t_project_id ) ) {
+	$t_fields = config_get( 'bug_report_page_fields' );
+} else {
+	$t_fields = config_get( 'simple_bug_report_page_fields' );	
+}
+
 $t_fields = columns_filter_disabled( $t_fields );
 
 $t_show_category = in_array( 'category_id', $t_fields );

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2592,6 +2592,24 @@ $g_bug_report_page_fields = array(
 );
 
 /**
+ * An array of access levels or a threshold to identify who should be presented the extended  report form.
+ * Setting it to an array, one can cherry-pick the access levels that should get the extended report screen.
+ * sample: $g_extended_reporter_levels = array( DEVELOPER, ADMINISTRATOR );
+ * Now only the Developers & Administrators will get the extended report form, all others will get the simplified report form.
+ *
+ * @global array $g_extended_report_levels
+ */
+$g_extended_report_levels = REPORTER;
+
+/**
+ *
+ * @see $g_bug_report_page_fields  
+ * 
+ */
+$g_simple_bug_report_page_fields = '%bug_report_page_fields%' ;
+
+
+/**
  * An array of optional fields to show on the bug view page.
  *
  * The following optional fields are allowed:
@@ -4775,6 +4793,7 @@ $g_public_config_names = array(
 	'eta_enum_string',
 	'excel_columns',
 	'export_issues_threshold',
+	'extended_report_levels',
 	'fallback_language',
 	'favicon_image',
 	'file_download_content_type_overrides',
@@ -4917,6 +4936,7 @@ $g_public_config_names = array(
 	'show_version_dates_threshold',
 	'show_version',
 	'signup_use_captcha',
+	'simple_bug_report_page_fields',
 	'sort_by_last_name',
 	'sort_icon_arr',
 	'sponsor_threshold',

--- a/docbook/Admin_Guide/en-US/config/fields.xml
+++ b/docbook/Admin_Guide/en-US/config/fields.xml
@@ -85,6 +85,62 @@
 				</para>
 			</listitem>
 		</varlistentry>
+				<varlistentry>
+			<term>$g_simple_bug_report_page_fields</term>
+			<listitem>
+				<para>
+					An array of optional fields to show on the simplified bug report page for users with a certain level (See: <emphasis>extended_report_levels</emphasis>).
+				</para>
+				<para>
+					The following optional fields are allowed:
+					additional_info,
+					attachments,
+					category_id,
+					due_date,
+					eta,
+					handler,
+					monitors,
+					os,
+					os_build,
+					platform,
+					priority,
+					product_build,
+					product_version,
+					reproducibility,
+					resolution,
+					severity,
+					status,
+					steps_to_reproduce,
+					tags,
+					target_version,
+					view_state.
+				</para>
+				<para>
+					The summary and description fields are always shown
+					and do not need to be listed in this option. Fields
+					not listed above cannot be shown on the bug report
+					page. Visibility of custom fields is handled via the
+					Manage =&gt; Custom Fields administrator page.
+					This setting is used to provide a simplified reporting form for users with a specific access level as defined in <emphasis>simple_report_level</emphasis>.
+				</para>
+				<para>Note that <emphasis>monitors</emphasis> is not an actual
+					field; adding it to the list will let authorized reporters
+					(see <emphasis>monitor_add_others_bug_threshold</emphasis>
+					in <xref linkend="admin.config.misc" />)
+					select users to add to the issue's monitoring list.
+					Monitors will only be notified of the submission if both
+					their e-mail preferencess and the <emphasis>notify_flags</emphasis>
+					configuration (see <xref linkend="admin.config.email" />)
+					allows it, i.e.
+					<programlisting>$g_notify_flags['new']['monitor'] = ON;</programlisting>
+				</para>
+				<para>
+					This setting can be set on a per-project basis by
+					using the Manage =&gt; Configuration
+					administrator page.
+				</para>
+			</listitem>
+		</varlistentry>
 		<varlistentry>
 			<term>$g_bug_view_page_fields</term>
 			<listitem>

--- a/docbook/Admin_Guide/en-US/config/misc.xml
+++ b/docbook/Admin_Guide/en-US/config/misc.xml
@@ -105,6 +105,12 @@
 			</listitem>
 		</varlistentry>
 		<varlistentry>
+			<term>$g_extended_report_levels</term>
+			<listitem>
+				<para>Access levels for which users are provided with the extended report form.</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
 			<term>$g_allow_account_delete</term>
 			<listitem>
 				<para>Allow users to delete their own accounts.</para>


### PR DESCRIPTION
Fixes #30737
Allow users to report an issue with a very simple screen based upon their authorization level (Mantis-wide or by project).

This is a replacement for #1829