### PR TITLE
Markdown. Simplify table processing.

### DIFF
--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -79,6 +79,20 @@ class MantisMarkdown extends Parsedown
 	}
 
 	/**
+	 * @param array $Element Properties of a marked element.
+	 * @return string HTML markup of the element.
+	 */
+	protected function element( $Element )
+	{
+		# Adding CSS classes to tables.
+		if( $Element['name'] === 'table' ) {
+			$Element['attributes']['class'] = $this->table_class;
+		}
+
+		return parent::element( $Element );
+	}
+
+	/**
 	 * Convert a field that supports multiple lines form markdown to html.
 	 * @param string $p_text The text to convert.
 	 * @return string  The html text.
@@ -120,47 +134,6 @@ class MantisMarkdown extends Parsedown
 		if ( preg_match( '/^ {0,3}#{1,6}(?: |$)/', $line['text'] ) ) {
 			return parent::blockHeader($line);
 		}
-	}
-
-	/**
-	 * Add a class attribute on a table markdown elements
-	 *
-	 * @param string $line The Markdown syntax to parse
-	 * @param array $block A block-level element
-	 * @param string $fn the function name to call (blockTable or blockTableContinue)
-	 * @access private
-	 * @return string html representation generated from markdown.
-	 */
-	private function __doTable( $line, $block, $fn ) {
-		if( $block = call_user_func( 'parent::' . $fn, $line, $block ) ) {
-			$block['element']['attributes']['class'] = $this->table_class;
-		}
-
-		return $block;
-	}
-
-	/**
-	 * Customize the logic on blockTable method by adding a class attribute
-	 *
-	 * @param string $line The Markdown syntax to parse
-	 * @param array $block A block-level element
-	 * @access protected
-	 * @return string html representation generated from markdown.
-	 */
-	protected function blockTable( $line, array $block = null ) {
-		return $this->__doTable( $line, $block, __FUNCTION__ );
-	}
-
-	/**
-	 * Customize the logic on blockTableContinue method by adding a class attribute
-	 *
-	 * @param string $line The Markdown syntax to parse
-	 * @param array $block A block-level element
-	 * @access protected
-	 * @return string html representation generated from markdown.
-	 */
-	protected function blockTableContinue( $line, array $block ) {
-		return $this->__doTable( $line, $block, __FUNCTION__ );
 	}
 
 	/**

--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -82,7 +82,7 @@ class MantisMarkdown extends Parsedown
 	 * @param array $Element Properties of a marked element.
 	 * @return string HTML markup of the element.
 	 */
-	protected function element( $Element )
+	protected function element( array $Element )
 	{
 		# Adding CSS classes to tables.
 		if( $Element['name'] === 'table' ) {

--- a/plugins/MantisCoreFormatting/tests/MarkdownTest.php
+++ b/plugins/MantisCoreFormatting/tests/MarkdownTest.php
@@ -78,43 +78,15 @@ class MantisMarkdownTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
-	* Test if table class attribute is defined
+	 * Test if table class attribute is defined
 	 * @return void
 	 */
 	public function testTableClassDefined() {
 		$markdown_table = <<<EOD
-| _header_ 1   | header 2     |
-| ------------ | ------------ |
-| _cell_ 1.1   | ~~cell~~ 1.2 |
-| `|` 2.1      | \| 2.2       |
-| `\|` 2.1     | [link](/)    |
+| header |
+| ---    |
+| cell   |
 EOD;
-
-		$markdown_table_output = <<<EOD
-<table class="table table-nonfluid">
-<thead>
-<tr>
-<th><em>header</em> 1</th>
-<th>header 2</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><em>cell</em> 1.1</td>
-<td><del>cell</del> 1.2</td>
-</tr>
-<tr>
-<td><code>|</code> 2.1</td>
-<td>| 2.2</td>
-</tr>
-<tr>
-<td><code>\|</code> 2.1</td>
-<td><a href="/">link</a></td>
-</tr>
-</tbody>
-</table>
-EOD;
-
-		$this->assertEquals( $markdown_table_output, MantisMarkdown::convert_text( $markdown_table ) );
+		$this->assertTrue( false !== strpos( MantisMarkdown::convert_text( $markdown_table ), 'class="table table-nonfluid"' ));
 	}
 }


### PR DESCRIPTION
After reducing some lines of code in the [first step](https://github.com/mantisbt/mantisbt/pull/1841), this is the second patch of a small series addressing some markdown issues. 

Fix: https://mantisbt.org/bugs/view.php?id=30919 (step 2. and 3.)

### Simplify `<table>` processing

Parsedown provides the method `element` which gives access to all marked elements and makes it easy to change the  properties/attributes of an element just before converted into HTML markup. 

- Reduce lines of codes in MantisMarkdown.php ("decomplexing").
- Reduce the test to its intended purpose.
    - Asserting the existence of the `class` attribute with the value `table table-nonfluid` and not the processing of inline formatting. 
    - The `[link](/)` part made the test unnecessarily dependent on the `process_urls` option.
    - No need to copy an already existing test (https://parsedown.org/tests/table_inline_markdown).

 
| before (master) | after |
|---                       |---     |
| ![table-before-master](https://user-images.githubusercontent.com/67791701/188292629-e386f5aa-c8eb-4dcf-943d-52af3d6f4889.png) | ![table-after](https://user-images.githubusercontent.com/67791701/188292632-617d3abe-7a69-41f7-bb31-08c7a18eee31.png)  |