### PR TITLE
Fix status colors on Relationship Graph page

### DIFF
--- a/bug_relationship_graph.php
+++ b/bug_relationship_graph.php
@@ -50,6 +50,8 @@ require_api( 'lang_api.php' );
 require_api( 'print_api.php' );
 require_api( 'relationship_graph_api.php' );
 
+require_css( 'status_config.php' );
+
 # If relationship graphs were made disabled, we disallow any access to
 # this script.
 


### PR DESCRIPTION
Status color boxes were shown in black on the page, due to missing include of status_config.php CSS.

Fixes [#31829](https://mantisbt.org/bugs/view.php?id=31829)