### PR TITLE
html_javascript_link function skip default directory if path specified

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -129,7 +129,14 @@ function html_rss_link() {
  * @return void
  */
 function html_javascript_link( $p_filename ) {
-	echo "\t", '<script type="text/javascript" src="', helper_mantis_url( 'js/' . $p_filename ), '"></script>', "\n";
+	$t_filename = $p_filename;
+
+	# If no path is specified, look for JavaScript files in default directory
+	if( $t_filename == basename( $t_filename ) ) {
+		$t_filename = 'js/' . $t_filename;
+	}
+	
+	echo "\t", '<script type="text/javascript" src="', string_sanitize_url( helper_mantis_url( $t_filename ), true ), '"></script>', "\n";
 }
 
 /**


### PR DESCRIPTION
html_javascript_link function now checks if path is specified and does not append js directory to JavaScript file path, Fixes [#32227](https://mantisbt.org/bugs/view.php?id=32227)