### PR TITLE
Project Add/Update/Delete commands for REST, SOAP, and Web UI

### DIFF
--- a/api/rest/restcore/issues_rest.php
+++ b/api/rest/restcore/issues_rest.php
@@ -104,25 +104,31 @@ function rest_issue_get( \Slim\Http\Request $p_request, \Slim\Http\Response $p_r
 
 		# Get a set of issues
 		$t_project_id = (int)$p_request->getParam( 'project_id', ALL_PROJECTS );
-		if( $t_project_id != ALL_PROJECTS && !project_exists( $t_project_id ) ) {
-			$t_result = null;
+		if( $t_project_id != ALL_PROJECTS ) {
 			$t_message = "Project '$t_project_id' doesn't exist";
-			$p_response = $p_response->withStatus( HTTP_STATUS_NOT_FOUND, $t_message );
-		} else {
-			$t_filter_id = trim( $p_request->getParam( 'filter_id', '' ) );
-			# set the current project to correctly account for user permissions
-			helper_set_current_project( $t_project_id );
-
-			if( !empty( $t_filter_id ) ) {
-				$t_issues = mc_filter_get_issues(
-					'', '', $t_project_id, $t_filter_id, $t_page_number, $t_page_size );
-			} else {
-				$t_issues = mc_filter_get_issues(
-					'', '', $t_project_id, FILTER_STANDARD_ANY, $t_page_number, $t_page_size );
+			if (!project_exists( $t_project_id ) ) {
+				return $p_response->withStatus( HTTP_STATUS_NOT_FOUND, $t_message );
 			}
 
-			$t_result = array( 'issues' => $t_issues );
+			$t_user_id = auth_get_current_user_id();
+			if( !access_has_project_level( VIEWER, $t_project_id, $t_user_id ) ) {
+				return $p_response->withStatus( HTTP_STATUS_NOT_FOUND, $t_message );
+			}
 		}
+
+		$t_filter_id = trim( $p_request->getParam( 'filter_id', '' ) );
+		# set the current project to correctly account for user permissions
+		helper_set_current_project( $t_project_id );
+
+		if( !empty( $t_filter_id ) ) {
+			$t_issues = mc_filter_get_issues(
+				'', '', $t_project_id, $t_filter_id, $t_page_number, $t_page_size );
+		} else {
+			$t_issues = mc_filter_get_issues(
+				'', '', $t_project_id, FILTER_STANDARD_ANY, $t_page_number, $t_page_size );
+		}
+
+		$t_result = array( 'issues' => $t_issues );
 	}
 
 	$t_etag = mc_issue_hash( $t_issue_id, $t_result );

--- a/api/rest/restcore/projects_rest.php
+++ b/api/rest/restcore/projects_rest.php
@@ -269,7 +269,7 @@ function rest_project_add( \Slim\Http\Request $p_request, \Slim\Http\Response $p
 		'payload' => $t_payload,
 		'options' => array(
 			'return_project' => true
-		),
+		)
 	);
 
 	$t_command = new ProjectAddCommand( $t_data );
@@ -311,7 +311,7 @@ function rest_project_update( \Slim\Http\Request $p_request, \Slim\Http\Response
 		'payload' => $t_payload,
 		'options' => array(
 			'return_project' => true
-		),
+		)
 	);
 
 	$t_command = new ProjectUpdateCommand( $t_data );

--- a/api/rest/restcore/projects_rest.php
+++ b/api/rest/restcore/projects_rest.php
@@ -252,15 +252,19 @@ function rest_project_add( \Slim\Http\Request $p_request, \Slim\Http\Response $p
 		return $p_response->withStatus( HTTP_STATUS_BAD_REQUEST, "Invalid request body or format");
 	}
 
-	$t_project_id = mc_project_add( /* username */ '', /* password */ '', (object) $t_payload );
-	ApiObjectFactory::throwIfFault( $t_project_id );
+	$t_data = array(
+		'payload' => $t_payload,
+		'options' => array(
+			'return_project' => true
+		),
+	);
 
-	$t_user_id = auth_get_current_user_id();
-	$t_lang = mci_get_user_lang( $t_user_id );
-	$t_project = mci_project_get( $t_project_id, $t_lang, /* detail */ true );
+	$t_command = new ProjectAddCommand( $t_data );
+	$t_result = $t_command->execute();
+	$t_project_id = $t_result['project']['id'];
 
 	return $p_response->withStatus( HTTP_STATUS_CREATED, "Project created with id $t_project_id" )->
-		withJson( array( 'project' => $t_project ) );
+		withJson( $t_result );
 }
 
 /**

--- a/api/rest/restcore/projects_rest.php
+++ b/api/rest/restcore/projects_rest.php
@@ -264,7 +264,7 @@ function rest_project_add( \Slim\Http\Request $p_request, \Slim\Http\Response $p
 	$t_project_id = $t_result['project']['id'];
 
 	return $p_response->withStatus( HTTP_STATUS_CREATED, "Project created with id $t_project_id" )->
-		withJson( $t_result );
+		withJson( array( 'project' => $t_result['project'] ) );
 }
 
 /**

--- a/api/rest/restcore/projects_rest.php
+++ b/api/rest/restcore/projects_rest.php
@@ -71,6 +71,19 @@ function rest_projects_get( \Slim\Http\Request $p_request, \Slim\Http\Response $
 	}
 
 	$t_user_id = auth_get_current_user_id();
+
+	if( $t_project_id != ALL_PROJECTS ) {
+		$t_message = "Project '$t_project_id' doesn't exist";
+
+		if (!project_exists( $t_project_id ) ) {
+			return $p_response->withStatus( HTTP_STATUS_NOT_FOUND, $t_message );
+		}
+
+		if( !access_has_project_level( VIEWER, $t_project_id, $t_user_id ) ) {
+			return $p_response->withStatus( HTTP_STATUS_NOT_FOUND, $t_message );
+		}
+	}
+
 	$t_lang = mci_get_user_lang( $t_user_id );
 
 	$t_project_ids = user_get_all_accessible_projects( $t_user_id, $t_project_id );

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -474,6 +474,10 @@ function mci_project_get( $p_project_id, $p_lang, $p_detail ) {
 		$t_project['enabled'] = (int)$t_row['enabled'] != 0;
 		$t_project['view_state'] = mci_enum_get_array_by_id( (int)$t_row['view_state'], 'view_state', $p_lang );
 
+		if( !ApiObjectFactory::$soap ) {
+			$t_project['inherit_global'] = $t_row['inherit_global'] != 0;
+		}
+
 		# access_min field is not used
 		# $t_project['access_min'] = mci_enum_get_array_by_id( (int)$t_row['access_min'], 'access_levels', $p_lang );
 

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -1205,17 +1205,16 @@ function mc_project_delete( $p_username, $p_password, $p_project_id ) {
 		return mci_fault_login_failed();
 	}
 
-	if( !project_exists( $p_project_id ) ) {
-		return ApiObjectFactory::faultNotFound( 'Project \'' . $p_project_id . '\' does not exist.' );
-	}
+	$t_data = array(
+		'query' => array(
+			'id' => (int)$p_project_id,
+		),
+	);
 
-	$g_project_override = $p_project_id;
+	$t_command = new ProjectDeleteCommand( $t_data );
+	$t_command->execute();
 
-	if( !mci_has_administrator_access( $t_user_id, $p_project_id ) ) {
-		return mci_fault_access_denied( $t_user_id );
-	}
-
-	return project_delete( $p_project_id );
+	return true;
 }
 
 /**

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -1063,58 +1063,44 @@ function mc_project_add( $p_username, $p_password, stdClass $p_project ) {
 
 	$p_project = ApiObjectFactory::objectToArray( $p_project );
 
-	if( !isset( $p_project['name'] ) ) {
-		return ApiObjectFactory::faultBadRequest( 'Required field "name" is missing' );
-	} else {
-		$t_name = $p_project['name'];
+	$t_project_data = array();
+
+	if( isset( $p_project['name'] ) ) {
+		$t_project_data['name'] = $p_project['name'];
 	}
 
 	if( isset( $p_project['status'] ) ) {
-		$t_status = $p_project['status'];
-	} else {
-		$t_status = array( 'name' => 'development' ); # development
+		$t_project_data['status'] = array( 'id' => $p_project['status'] );
 	}
 
 	if( isset( $p_project['view_state'] ) ) {
-		$t_view_state = $p_project['view_state'];
-	} else {
-		$t_view_state = array( 'id' => VS_PUBLIC );
+		$t_project_data['view_state'] = array( 'id' => $p_project['view_state'] );
 	}
 
 	if( isset( $p_project['enabled'] ) ) {
-		$t_enabled = $p_project['enabled'];
-	} else {
-		$t_enabled = true;
+		$t_project_data['enabled'] = $p_project['enabled'];
 	}
 
 	if( isset( $p_project['description'] ) ) {
-		$t_description = $p_project['description'];
-	} else {
-		$t_description = '';
+		$t_project_data['description'] = $p_project['description'];
 	}
 
 	if( isset( $p_project['file_path'] ) ) {
-		$t_file_path = $p_project['file_path'];
-	} else {
-		$t_file_path = '';
+		$t_project_data['file_path'] = $p_project['file_path'];
 	}
 
 	if( isset( $p_project['inherit_global'] ) ) {
-		$t_inherit_global = $p_project['inherit_global'];
-	} else {
-		$t_inherit_global = true;
+		$t_project_data['inherit_global'] = $p_project['inherit_global'];
 	}
 
-	# check to make sure project doesn't already exist
-	if( !project_is_name_unique( $t_name ) ) {
-		return ApiObjectFactory::faultConflict( 'Project name already exists' );
-	}
+	$t_data = array( 'payload' => $t_project_data );
 
-	$t_project_status = mci_get_project_status_id( $t_status );
-	$t_project_view_state = mci_get_project_view_state_id( $t_view_state );
+	$t_command = new ProjectAddCommand( $t_data );
+	$t_result = $t_command->execute();
+	$t_project_id = $t_result['id'];
 
 	# project_create returns the new project's id, spit that out to web service caller
-	return project_create( $t_name, $t_description, $t_project_status, $t_project_view_state, $t_file_path, $t_enabled, $t_inherit_global );
+	return $t_project_id;
 }
 
 /**

--- a/api/soap/mc_project_api.php
+++ b/api/soap/mc_project_api.php
@@ -1070,11 +1070,11 @@ function mc_project_add( $p_username, $p_password, stdClass $p_project ) {
 	}
 
 	if( isset( $p_project['status'] ) ) {
-		$t_project_data['status'] = array( 'id' => $p_project['status'] );
+		$t_project_data['status'] = $p_project['status'];
 	}
 
 	if( isset( $p_project['view_state'] ) ) {
-		$t_project_data['view_state'] = array( 'id' => $p_project['view_state'] );
+		$t_project_data['view_state'] = $p_project['view_state'];
 	}
 
 	if( isset( $p_project['enabled'] ) ) {
@@ -1127,15 +1127,15 @@ function mc_project_update( $p_username, $p_password, $p_project_id, stdClass $p
 	}
 
 	if( isset( $p_project['description'] ) ) {
-		$t_project_data['description'] = $project['description'];
+		$t_project_data['description'] = $p_project['description'];
 	}
 
 	if( isset( $p_project['status'] ) ) {
-		$t_project_data['status'] = array( 'id' => $p_project['status'] );
+		$t_project_data['status'] = $p_project['status'];
 	}
 
 	if( isset( $p_project['view_state'] ) ) {
-		$t_project_data['view_state'] = array( 'id' => $p_project['view_state'] );
+		$t_project_data['view_state'] = $p_project['view_state'];
 	}
 
 	if( isset( $p_project['file_path'] ) ) {
@@ -1172,8 +1172,6 @@ function mc_project_update( $p_username, $p_password, $p_project_id, stdClass $p
  * @return boolean returns true or false depending on the success of the delete action
  */
 function mc_project_delete( $p_username, $p_password, $p_project_id ) {
-	global $g_project_override;
-
 	$t_user_id = mci_check_login( $p_username, $p_password );
 	if( $t_user_id === false ) {
 		return mci_fault_login_failed();

--- a/core/commands/ProjectAddCommand.php
+++ b/core/commands/ProjectAddCommand.php
@@ -16,6 +16,9 @@
 
 require_api( 'project_api.php' );
 
+require_once( dirname( __FILE__ ) . '/../../api/soap/mc_api.php' );
+require_once( dirname( __FILE__ ) . '/../../api/soap/mc_enum_api.php' );
+
 use Mantis\Exceptions\ClientException;
 
 /**
@@ -141,7 +144,7 @@ class ProjectAddCommand extends Command {
 	/**
 	 * Process the command.
 	 *
-	 * @return void
+	 * @return array the command result
 	 */
 	function process() {
 		$t_project_id = project_create(
@@ -174,5 +177,7 @@ class ProjectAddCommand extends Command {
 		} else {
 			$t_result['id'] = $t_project_id;
 		}
+
+		return $t_result;
 	}
 }

--- a/core/commands/ProjectAddCommand.php
+++ b/core/commands/ProjectAddCommand.php
@@ -1,0 +1,178 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+require_api( 'project_api.php' );
+
+use Mantis\Exceptions\ClientException;
+
+/**
+ * A command that adds a project.
+ */
+class ProjectAddCommand extends Command {
+	/**
+	 * Project Name
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * Project Description
+	 * @var string
+	 */
+	private $description;
+
+	/**
+	 * Project View State
+	 * @var int
+	 */
+	private $view_state;
+
+	/**
+	 * Project Inherit Global Categories
+	 * @var int
+	 */
+	private $inherit_global;
+
+	/**
+	 * Project Status
+	 * @var int
+	 */
+	private $status;
+
+	/**
+	 * Project Enabled
+	 * @var int
+	 */
+	private $enabled;
+
+	/**
+	 * Project File Path
+	 * @var string
+	 */
+	private $file_path;
+
+	/**
+	 * Constructor
+	 *
+	 * @param array $p_data The command data.
+	 */
+	function __construct( array $p_data ) {
+		parent::__construct( $p_data );
+	}
+
+	/**
+	 * Validate the inputs and user access level.
+	 *
+	 * @return void
+	 */
+	function validate() {
+		if( !access_has_global_level( config_get( 'create_project_threshold' ) ) ) {
+			throw new ClientException(
+				'Access denied to create projects',
+				ERROR_ACCESS_DENIED
+			);
+		}
+
+		if( is_blank( $this->payload( 'name' ) ) ) {
+			throw new ClientException(
+				'Project name cannot be empty',
+				ERROR_EMPTY_FIELD,
+				array( 'name' )
+			);
+		}
+
+		$t_project = $this->data['payload'];
+
+		$this->name = $this->payload( 'name' );
+		$this->description = $this->payload( 'description', '' );
+		$this->inherit_global = $this->payload( 'inherit_global', true );
+		$this->file_path = $this->payload( 'file_path', '' );
+		$this->view_state = isset( $t_project['view_state'] ) ?  mci_get_project_view_state_id( $t_project['view_state'] ) : config_get( 'default_project_view_status' );
+		$this->status = isset( $t_project['status'] ) ? mci_get_project_status_id( $t_project['status'] ) : 10 /* development */;
+		$this->enabled = $this->payload( 'enabled', true );
+
+		if( !project_is_name_unique( $this->name ) ) {
+			throw new ClientException(
+				'Project name is not unique',
+				ERROR_PROJECT_NAME_NOT_UNIQUE,
+				array( 'name' )
+			);
+		}
+
+		$t_enum_values = MantisEnum::getValues( config_get( 'project_status_enum_string' ) );
+		if( !in_array( $this->status, $t_enum_values ) ) {
+			throw new ClientException(
+				'Invalid project status',
+				ERROR_INVALID_FIELD_VALUE,
+				array( 'status' )
+			);
+		}
+
+		if( !is_bool( $this->inherit_global ) ) {
+			throw new ClientException(
+				'Invalid project inherit global',
+				ERROR_INVALID_FIELD_VALUE,
+				array( 'inherit_global' )
+			);
+		}
+
+		if( !is_bool( $this->enabled ) ) {
+			throw new ClientException(
+				'Invalid project enabled',
+				ERROR_INVALID_FIELD_VALUE,
+				array( 'enabled' )
+			);
+		}
+	}
+
+	/**
+	 * Process the command.
+	 *
+	 * @return void
+	 */
+	function process() {
+		$t_project_id = project_create(
+			$this->name,
+			$this->description,
+			$this->status,
+			$this->view_state,
+			$this->file_path,
+			$this->enabled,
+			$this->inherit_global
+		);
+
+		# If user doesn't have management access to project, then user is not an ADMINISTRATOR.
+		# grant user the higher of their global access level and the access level required to manage the project.
+		$t_user_id = auth_get_current_user_id();
+		$t_manage_project_access_level = config_get( 'manage_project_threshold', null, $t_user_id, $t_project_id );
+		if( !access_has_project_level( $t_manage_project_access_level, $t_project_id, $t_user_id ) ) {
+			$t_access_level = access_get_global_level( $t_user_id );
+			if( $t_access_level < $t_manage_project_access_level ) {
+				$t_access_level = $t_manage_project_access_level;
+			}
+
+			project_add_user( $t_project_id, $t_user_id, $t_access_level );
+		}
+
+		$t_result = array();
+		if( $this->option('return_project', false ) ) {
+			$t_lang = mci_get_user_lang( $t_user_id );
+			$t_result['project'] = mci_project_get( $t_project_id, $t_lang, /* detail */ true );
+		} else {
+			$t_result['id'] = $t_project_id;
+		}
+	}
+}

--- a/core/commands/ProjectAddCommand.php
+++ b/core/commands/ProjectAddCommand.php
@@ -170,6 +170,8 @@ class ProjectAddCommand extends Command {
 			project_add_user( $t_project_id, $t_user_id, $t_access_level );
 		}
 
+		event_signal( 'EVENT_MANAGE_PROJECT_CREATE', array( $t_project_id ) );
+
 		$t_result = array();
 		if( $this->option('return_project', false ) ) {
 			$t_lang = mci_get_user_lang( $t_user_id );

--- a/core/commands/ProjectAddCommand.php
+++ b/core/commands/ProjectAddCommand.php
@@ -170,6 +170,9 @@ class ProjectAddCommand extends Command {
 			project_add_user( $t_project_id, $t_user_id, $t_access_level );
 		}
 
+		global $g_project_override;
+		$g_project_override = $t_project_id;
+
 		event_signal( 'EVENT_MANAGE_PROJECT_CREATE', array( $t_project_id ) );
 
 		$t_result = array();

--- a/core/commands/ProjectDeleteCommand.php
+++ b/core/commands/ProjectDeleteCommand.php
@@ -67,6 +67,8 @@ class ProjectDeleteCommand extends Command {
 	 * @return void
 	 */
 	protected function process() {
+		event_signal( 'EVENT_MANAGE_PROJECT_DELETE', array( $this->id ) );
+
 		project_delete( $this->id );
 	}
 }

--- a/core/commands/ProjectDeleteCommand.php
+++ b/core/commands/ProjectDeleteCommand.php
@@ -1,0 +1,72 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+require_api( 'project_api.php' );
+
+use Mantis\Exceptions\ClientException;
+
+/**
+ * A command that deletes a project.
+ */
+class ProjectDeleteCommand extends Command {
+	/**
+	 * @var integer id of project to delete
+	 */
+	private $id;
+
+	/**
+	 * Constructor
+	 *
+	 * $p_data['query'] is expected to contain:
+	 * - id (integer)
+	 *
+	 * @param array $p_data The command data.
+	 */
+	function __construct( array $p_data ) {
+		parent::__construct( $p_data );
+	}
+
+	/**
+	 * Validate the inputs and user access level.
+	 *
+	 * @return void
+	 */
+	function validate() {
+		$t_user_id = auth_get_current_user_id();
+		if( !access_has_project_level( config_get( 'delete_project_threshold', null, $t_user_id, $this->id ) ) ) {
+			throw new ClientException(
+				'Access denied to delete project',
+				ERROR_ACCESS_DENIED );
+		}
+
+		$this->id = helper_parse_id( $this->query( 'id' ), 'project_id' );
+		if( !project_exists( $this->id ) ) {
+			throw new ClientException(
+				"Project '$this->id' not found",
+				ERROR_PROJECT_NOT_FOUND,
+				array( $this->id ) );
+		}
+	}
+
+	/**
+	 * Process the command.
+	 *
+	 * @return void
+	 */
+	protected function process() {
+		project_delete( $this->id );
+	}
+}

--- a/core/commands/ProjectDeleteCommand.php
+++ b/core/commands/ProjectDeleteCommand.php
@@ -67,6 +67,9 @@ class ProjectDeleteCommand extends Command {
 	 * @return void
 	 */
 	protected function process() {
+		global $g_project_override;
+		$g_project_override = $this->id;
+
 		event_signal( 'EVENT_MANAGE_PROJECT_DELETE', array( $this->id ) );
 
 		project_delete( $this->id );

--- a/core/commands/ProjectUpdateCommand.php
+++ b/core/commands/ProjectUpdateCommand.php
@@ -1,0 +1,195 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+require_api( 'project_api.php' );
+
+require_once( dirname( __FILE__ ) . '/../../api/soap/mc_api.php' );
+require_once( dirname( __FILE__ ) . '/../../api/soap/mc_enum_api.php' );
+
+use Mantis\Exceptions\ClientException;
+
+/**
+ * A command that updates a project.
+ */
+class ProjectUpdateCommand extends Command {
+	/**
+	 * Project Id
+	 * @var integer
+	 */
+	private $id;
+
+	/**
+	 * Project Name
+	 * @var string
+	 */
+	 */
+	private $name;
+
+	/**
+	 * Project Description
+	 * 
+	 * @var string
+	 */
+	private $description;
+
+	/**
+	 * Project View State
+	 * 
+	 * @var int
+	 */
+	private $view_state;
+
+	/*
+	 * Project Inherit Global Categories
+	 * 
+	 * @var int
+	 */
+	private $inherit_global;
+
+	/**
+	 * Project Status
+	 * 
+	 * @var int
+	 */
+	private $status;
+
+	/**
+	 * Project Enabled
+	 * 
+	 * @var int
+	 */
+	private $enabled;
+
+	/**
+	 * Project File Path
+	 * 
+	 * @var string
+	 */
+	private $file_path;
+
+	/**
+	 * Constructor
+	 *
+	 * $p_data['query'] is expected to contain:
+	 * - id (integer)
+	 *
+	 * $p_data['payload'] is expected to a subset of the following fields:
+	 * - id (integer)
+	 * - name (string)
+	 * - description (string)
+	 * - view_state (int)
+	 * - inherit_global (int)
+	 * - status (int)
+	 * - enabled (int)
+	 * - file_path (string)
+	 *
+	 * @param array $p_data The command data.
+	 */
+	function __construct( array $p_data ) {
+		parent::__construct( $p_data );
+	}
+
+	/**
+	 * Validate the inputs and access level.
+	 */
+	protected function validate() {
+		$this->id = $this->query( 'id' );
+		$t_project = $this->data['payload'];
+		if( isset( $t_project['id'] ) && (int)$t_project['id'] != (int)$this->id ) {
+			throw new ClientException(
+				'Project id in payload does not match id in query',
+				ERROR_INVALID_FIELD_VALUE,
+				array( 'id' ) );
+		}
+
+		// ensure that the project exists
+		if( !project_exists( $this->id ) ) {
+			throw new ClientException(
+				'Project not found',
+				ERROR_PROJECT_NOT_FOUND,
+				array( $this->id ) );
+		}
+
+		global $g_project_override;
+		$g_project_override = $this->id;
+
+		$t_user_id = auth_get_current_user_id();
+		if( !access_has_project_level( config_get( 'manage_project_threshold', null, $t_user_id, $this->id ) ) ) {
+			throw new ClientException(
+				'Access denied to update project',
+				ERROR_ACCESS_DENIED );
+		}
+
+		$this->name = $this->payload( 'name', project_get_field( $this->id, 'name' ) );
+		if( is_blank( $this->name ) ) {
+			throw new ClientException(
+				'Project name cannot be blank',
+				ERROR_EMPTY_FIELD,
+				array( 'name' ) );
+		}
+
+		$this->description = $this->payload( 'description', project_get_field( $this->id, 'description' ) );
+		$this->inherit_global = (int)$this->payload( 'inherit_global', project_get_field( $this->id, 'inherit_global' ) );
+		$this->enabled = (int)$this->payload( 'enabled', project_get_field( $this->id, 'enabled' ) );
+		$this->file_path = $this->payload( 'file_path', project_get_field( $this->id, 'file_path' ) );
+
+		$this->view_state = $this->payload( 'view_state', array( 'id' => project_get_field( $this->id, 'view_state' ) ) );
+		$this->view_state = mci_get_project_view_state_id( $this->view_state );
+
+		$this->status = $this->payload( 'status', array( 'id' => project_get_field( $this->id, 'status' ) ) );
+		$this->status = mci_get_project_status_id( $this->status );
+
+		# check to make sure a modified project doesn't already exist
+		if( $this->name != project_get_name( $this->id ) ) {
+			if( !project_is_name_unique( $this->name ) ) {
+				throw new ClientException(
+					'Project name already exists',
+					ERROR_PROJECT_NAME_NOT_UNIQUE,
+					array( $this->name ) );
+			}
+		}
+	}
+
+	/**
+	 * Process the command.
+	 *
+	 * @return void
+	 */
+	protected function process() {
+		project_update(
+			$this->id,
+			$this->name,
+			$this->description,
+			$this->status,
+			$this->view_state,
+			$this->file_path,
+			$this->enabled,
+			$this->inherit_global
+		);
+
+		event_signal( 'EVENT_MANAGE_PROJECT_UPDATE', array( $this->id ) );
+
+		$t_result = array();
+		if( $this->option('return_project', false ) ) {
+			$t_user_id = auth_get_current_user_id();
+
+			$t_lang = mci_get_user_lang( $t_user_id );
+			$t_result['project'] = mci_project_get( $this->id, $t_lang, /* detail */ true );
+		} else {
+			$t_result['id'] = $this->id;
+		}
+	}
+}

--- a/core/commands/ProjectUpdateCommand.php
+++ b/core/commands/ProjectUpdateCommand.php
@@ -35,7 +35,6 @@ class ProjectUpdateCommand extends Command {
 	 * Project Name
 	 * @var string
 	 */
-	 */
 	private $name;
 
 	/**
@@ -106,7 +105,14 @@ class ProjectUpdateCommand extends Command {
 	 * Validate the inputs and access level.
 	 */
 	protected function validate() {
-		$this->id = $this->query( 'id' );
+		$this->id = (int)$this->query( 'id' );
+		if( $this->id == ALL_PROJECTS || $this->id < 1 ) {
+			throw new ClientException(
+				'Project id is invalid',
+				ERROR_INVALID_FIELD_VALUE,
+				array( 'id' ) );
+		}
+
 		$t_project = $this->data['payload'];
 		if( isset( $t_project['id'] ) && (int)$t_project['id'] != (int)$this->id ) {
 			throw new ClientException(
@@ -115,7 +121,6 @@ class ProjectUpdateCommand extends Command {
 				array( 'id' ) );
 		}
 
-		// ensure that the project exists
 		if( !project_exists( $this->id ) ) {
 			throw new ClientException(
 				'Project not found',
@@ -180,6 +185,8 @@ class ProjectUpdateCommand extends Command {
 			$this->inherit_global
 		);
 
+		project_clear_cache( $this->id );
+
 		event_signal( 'EVENT_MANAGE_PROJECT_UPDATE', array( $this->id ) );
 
 		$t_result = array();
@@ -191,5 +198,7 @@ class ProjectUpdateCommand extends Command {
 		} else {
 			$t_result['id'] = $this->id;
 		}
+
+		return $t_result;
 	}
 }

--- a/core/project_api.php
+++ b/core/project_api.php
@@ -376,8 +376,6 @@ function project_create( $p_name, $p_description, $p_status, $p_view_state = VS_
  * @return void
  */
 function project_delete( $p_project_id ) {
-	event_signal( 'EVENT_MANAGE_PROJECT_DELETE', array( $p_project_id ) );
-
 	$t_email_notifications = config_get( 'enable_email_notification' );
 
 	# temporarily disable all notifications

--- a/manage_proj_create.php
+++ b/manage_proj_create.php
@@ -106,8 +106,6 @@ if( 0 != $f_parent_id ) {
 	$t_redirect_url = 'manage_proj_page.php';
 }
 
-event_signal( 'EVENT_MANAGE_PROJECT_CREATE', array( $t_project_id ) );
-
 form_security_purge( 'manage_proj_create' );
 
 layout_page_header( null, $t_redirect_url );

--- a/manage_proj_create.php
+++ b/manage_proj_create.php
@@ -54,7 +54,6 @@ require_api( 'project_api.php' );
 form_security_validate( 'manage_proj_create' );
 
 auth_reauthenticate();
-access_ensure_global_level( config_get( 'create_project_threshold' ) );
 
 $f_name 		= gpc_get_string( 'name' );
 $f_description 	= gpc_get_string( 'description' );
@@ -62,17 +61,28 @@ $f_view_state	= gpc_get_int( 'view_state' );
 $f_status		= gpc_get_int( 'status' );
 $f_file_path	= gpc_get_string( 'file_path', '' );
 $f_inherit_global = gpc_get_bool( 'inherit_global', 0 );
-$f_inherit_parent = gpc_get_bool( 'inherit_parent', 0 );
+
+$t_data = array(
+	'payload' => array(
+		'name' => $f_name,
+		'description' => $f_description,
+		'file_path' => $f_file_path,
+		'inherit_global' => $f_inherit_global,
+		'view_state' => array( 'id' => $f_view_state ),
+		'status' => array( 'id' => $f_status ),
+	),
+	'options' => array(
+		'return_project' => false,
+	)
+);
+
+$t_command = new ProjectAddCommand( $t_data );
+$t_result = $t_command->execute();
+
+$t_project_id = $t_result['id'];
 
 $f_parent_id	= gpc_get_int( 'parent_id', 0 );
-
-$t_project_id = project_create( strip_tags( $f_name ), $f_description, $f_status, $f_view_state, $f_file_path, true, $f_inherit_global );
-
-if( ( $f_view_state == VS_PRIVATE ) && ( false === current_user_is_administrator() ) ) {
-	$t_access_level = access_get_global_level();
-	$t_current_user_id = auth_get_current_user_id();
-	project_add_user( $t_project_id, $t_current_user_id, $t_access_level );
-}
+$f_inherit_parent = gpc_get_bool( 'inherit_parent', 0 );
 
 # If parent project id != 0 then we're creating a subproject
 if( 0 != $f_parent_id ) {

--- a/manage_proj_create.php
+++ b/manage_proj_create.php
@@ -69,10 +69,10 @@ $t_data = array(
 		'file_path' => $f_file_path,
 		'inherit_global' => $f_inherit_global,
 		'view_state' => array( 'id' => $f_view_state ),
-		'status' => array( 'id' => $f_status ),
+		'status' => array( 'id' => $f_status )
 	),
 	'options' => array(
-		'return_project' => false,
+		'return_project' => false
 	)
 );
 

--- a/manage_proj_delete.php
+++ b/manage_proj_delete.php
@@ -53,7 +53,14 @@ auth_reauthenticate();
 
 $f_project_id = gpc_get_int( 'project_id' );
 
-access_ensure_project_level( config_get( 'delete_project_threshold' ), $f_project_id );
+$t_data = array(
+	'query' => array(
+		'id' => $f_project_id,
+	),
+);
+
+$t_command = new ProjectDeleteCommand( $t_data );
+$t_command->validate();
 
 $t_message = sprintf( lang_get( 'project_delete_msg' ),
 	string_attribute( project_get_name( $f_project_id ) ),
@@ -61,7 +68,7 @@ $t_message = sprintf( lang_get( 'project_delete_msg' ),
 );
 helper_ensure_confirmed( $t_message, lang_get( 'project_delete_button' ) );
 
-project_delete( $f_project_id );
+$t_command->execute();
 
 form_security_purge( 'manage_proj_update' );
 

--- a/manage_proj_delete.php
+++ b/manage_proj_delete.php
@@ -55,8 +55,8 @@ $f_project_id = gpc_get_int( 'project_id' );
 
 $t_data = array(
 	'query' => array(
-		'id' => $f_project_id,
-	),
+		'id' => $f_project_id
+	)
 );
 
 $t_command = new ProjectDeleteCommand( $t_data );
@@ -66,6 +66,7 @@ $t_message = sprintf( lang_get( 'project_delete_msg' ),
 	string_attribute( project_get_name( $f_project_id ) ),
 	project_get_bug_count( $f_project_id )
 );
+
 helper_ensure_confirmed( $t_message, lang_get( 'project_delete_button' ) );
 
 $t_command->execute();

--- a/manage_proj_update.php
+++ b/manage_proj_update.php
@@ -48,7 +48,7 @@ $f_inherit_global = gpc_get_bool( 'inherit_global', 0 );
 
 $t_data = array(
 	'query' => array(
-		'id' => $f_project_id,
+		'id' => $f_project_id
 	),
 	'payload' => array(
 		'name' => $f_name,
@@ -57,7 +57,7 @@ $t_data = array(
 		'view_state' => array( 'id' => $f_view_state ),
 		'file_path' => $f_file_path,
 		'enabled' => $f_enabled,
-		'inherit_global' => $f_inherit_global,
+		'inherit_global' => $f_inherit_global
 	)
 );
 

--- a/manage_proj_update.php
+++ b/manage_proj_update.php
@@ -23,25 +23,15 @@
  * @link http://www.mantisbt.org
  *
  * @uses core.php
- * @uses access_api.php
  * @uses authentication_api.php
- * @uses config_api.php
- * @uses event_api.php
  * @uses form_api.php
  * @uses gpc_api.php
- * @uses print_api.php
- * @uses project_api.php
  */
 
 require_once( 'core.php' );
-require_api( 'access_api.php' );
 require_api( 'authentication_api.php' );
-require_api( 'config_api.php' );
-require_api( 'event_api.php' );
 require_api( 'form_api.php' );
 require_api( 'gpc_api.php' );
-require_api( 'print_api.php' );
-require_api( 'project_api.php' );
 
 form_security_validate( 'manage_proj_update' );
 
@@ -56,10 +46,23 @@ $f_file_path 	= gpc_get_string( 'file_path', '' );
 $f_enabled	 	= gpc_get_bool( 'enabled' );
 $f_inherit_global = gpc_get_bool( 'inherit_global', 0 );
 
-access_ensure_project_level( config_get( 'manage_project_threshold' ), $f_project_id );
+$t_data = array(
+	'query' => array(
+		'id' => $f_project_id,
+	),
+	'payload' => array(
+		'name' => $f_name,
+		'description' => $f_description,
+		'status' => array( 'id' => $f_status ),
+		'view_state' => array( 'id' => $f_view_state ),
+		'file_path' => $f_file_path,
+		'enabled' => $f_enabled,
+		'inherit_global' => $f_inherit_global,
+	)
+);
 
-project_update( $f_project_id, $f_name, $f_description, $f_status, $f_view_state, $f_file_path, $f_enabled, $f_inherit_global );
-event_signal( 'EVENT_MANAGE_PROJECT_UPDATE', array( $f_project_id ) );
+$t_command = new ProjectUpdateCommand( $t_data );
+$t_command->execute();
 
 form_security_purge( 'manage_proj_update' );
 


### PR DESCRIPTION
This PR fixes the following issues:

- [32231](https://www.mantisbt.org/bugs/view.php?id=32231): Create ProjectAddCommand
- [32238](https://www.mantisbt.org/bugs/view.php?id=32238): Create ProjectUpdateCommand
- [32232](https://www.mantisbt.org/bugs/view.php?id=32232): Create ProjectDeleteCommand
- [32237](https://www.mantisbt.org/bugs/view.php?id=32237): REST API Create Project API requires administrator rather than create_project_threshold
- [32236](https://www.mantisbt.org/bugs/view.php?id=32236): REST API Create Project doesn't trigger EVENT_MANAGE_PROJECT_CREATE plugin event
- [32235](https://www.mantisbt.org/bugs/view.php?id=32235): SOAP API Create Project doesn't trigger EVENT_MANAGE_PROJECT_CREATE plugin event
- [32234](https://www.mantisbt.org/bugs/view.php?id=32234): SOAP API Create Project API requires administrator rather than create_project_threshold
- [32248](https://www.mantisbt.org/bugs/view.php?id=32248): Get Project REST API returns html if user doesn't have access
- [32249](https://www.mantisbt.org/bugs/view.php?id=32249): Get Project Issues returns html if user doesn't have access to project