### PR TITLE
Fix timeouts and perf for viewing large issues

### DIFF
--- a/core/file_api.php
+++ b/core/file_api.php
@@ -272,14 +272,21 @@ function file_can_view_bug_attachments( $p_bug_id, $p_uploader_user_id = null ) 
  *
  * @param integer $p_bugnote_id       A bugnote identifier.
  * @param integer $p_uploader_user_id The user who uploaded the attachment.
+ * @param integer $p_bug_id           The bug id, if null, will be retrieved from bugnote record.
  *
  * @return boolean
  */
-function file_can_view_bugnote_attachments( $p_bugnote_id, $p_uploader_user_id = null ) {
+function file_can_view_bugnote_attachments( $p_bugnote_id, $p_uploader_user_id = null, $p_bug_id = null ) {
 	if( $p_bugnote_id == 0 ) {
 		return true;
 	}
-	$t_bug_id = bugnote_get_field( $p_bugnote_id, 'bug_id' );
+
+	if( $p_bug_id === null ) {
+		$t_bug_id = bugnote_get_field( $p_bugnote_id, 'bug_id' );
+	} else {
+		$t_bug_id = (int)$p_bug_id;
+	}
+
 	return file_can_view_or_download( 'view', $t_bug_id, $p_uploader_user_id );
 }
 
@@ -462,7 +469,7 @@ function file_get_visible_attachments( $p_bug_id ) {
 		$t_attachment_note_id = (int)$t_row['bugnote_id'];
 
 		if( !file_can_view_bug_attachments( $p_bug_id, $t_user_id )
-		|| !file_can_view_bugnote_attachments( $t_attachment_note_id, $t_user_id )
+		|| !file_can_view_bugnote_attachments( $t_attachment_note_id, $t_user_id, $p_bug_id )
 		) {
 			continue;
 		}


### PR DESCRIPTION
Fixes [32244](https://www.mantisbt.org/bugs/view.php?id=32244)

Before change:

- Unique queries executed: 55
- Total queries executed: 177
- Total query execution time: 0.08 seconds

After optimization for caching bug attachments:

- Unique queries executed: 55
- Total queries executed: 60
- Total query execution time: 0.0242 seconds

After optimization for removing unnecessary mapping from bugnote_id to bug_id:

- DB Unique queries executed: 46
- DB Total queries executed: 51
- DB Total query execution time: 0.0235 seconds

This yields 70%+ improvement in performance for issue view page.