### PR TITLE
Prevent recursion when signaling EVENT_LOG event

### DIFF
--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -83,9 +83,15 @@ function log_event( $p_level, $p_msg ) {
 	$t_now = date( config_get_global( 'complete_date_format' ) );
 	$t_level = $g_log_levels[$p_level];
 
-	$t_plugin_event = '[' . $t_level . '] ' . $t_msg;
-	if( function_exists( 'event_signal' ) ) {
+	# Prevent recursion from plugins hooked on EVENT_LOG
+	static $s_event_log_called = false;
+	# Checking existence of event_signal function is required, because Logging
+	# API is loaded before Event API.
+	if( !$s_event_log_called && function_exists( 'event_signal' ) ) {
+		$t_plugin_event = '[' . $t_level . '] ' . $t_msg;
+		$s_event_log_called = true;
 		event_signal( 'EVENT_LOG', array( $t_plugin_event ) );
+		$s_event_log_called = false;
 	}
 
 	$t_log_destination = config_get_global( 'log_destination' );


### PR DESCRIPTION
If a plugin hooked on EVENT_LOG calls log_event() directly or indirectly and the log level settings include the level for the event being logged, MantisBT enters in an endless recursion loop.

Using a static variable to prevent recursion if EVENT_LOG has already been signaled prevents this.

Fixes [#32243](https://mantisbt.org/bugs/view.php?id=32243)
Fixes https://github.com/mantisbt-plugins/EventLog/issues/3