### PR TITLE
REST API for Users Improvements

### DIFF
--- a/api/rest/restcore/users_rest.php
+++ b/api/rest/restcore/users_rest.php
@@ -29,7 +29,7 @@
  */
 $g_app->group('/users', function() use ( $g_app ) {
 	$g_app->get( '/me', 'rest_user_get_me' );
-	$g_app->get( '/{user_id}', 'rest_user_get' );
+	$g_app->get( '/{ref}', 'rest_user_get' );
 
 	$g_app->post( '/', 'rest_user_create' );
 	$g_app->post( '', 'rest_user_create' );
@@ -106,7 +106,7 @@ function rest_user_get_me( \Slim\Http\Request $p_request, \Slim\Http\Response $p
  * @return \Slim\Http\Response The augmented response.
  */
 function rest_user_get( \Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
-	$t_user_id = $p_args['user_id'];
+	$t_user_ref = $p_args['ref'];
 
 	$t_select = $p_request->getParam( 'select', null );
 	if( is_null( $t_select ) ) {
@@ -126,7 +126,7 @@ function rest_user_get( \Slim\Http\Request $p_request, \Slim\Http\Response $p_re
 
 	$t_data = array(
 		'query' => array(
-			'id' => $t_user_id,
+			'ref' => $t_user_ref,
 			'select' => $t_select
 		),
 		'options' => array(

--- a/api/rest/restcore/users_rest.php
+++ b/api/rest/restcore/users_rest.php
@@ -62,9 +62,31 @@ $g_app->group('/users', function() use ( $g_app ) {
  * @noinspection PhpUnusedParameterInspection
  */
 function rest_user_get_me( \Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
+	$t_default_select = array(
+		'id',
+		'name',
+		'real_name',
+		'email',
+		'access_level',
+		'language',
+		'timezone',
+		'created_at',
+		'projects'
+	);
+
+	$t_select = $p_request->getParam( 'select', null );
+	if( $t_select == null ) {
+		$t_select = $t_default_select;
+	} else {
+		$t_select = explode( ',', $t_select );
+	}
+
 	$t_data = array(
+		'query' => array(
+			'select' => $t_select
+		),
 		'options' => array(
-			'include_in_user_element' => false
+			'return_as_users' => false
 		)
 	);
 
@@ -86,9 +108,29 @@ function rest_user_get_me( \Slim\Http\Request $p_request, \Slim\Http\Response $p
 function rest_user_get( \Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
 	$t_user_id = $p_args['user_id'];
 
+	$t_select = $p_request->getParam( 'select', null );
+	if( is_null( $t_select ) ) {
+		$t_select = array(
+			'id',
+			'name',
+			'real_name',
+			'email',
+			'access_level',
+			'language',
+			'timezone',
+			'created_at'
+		);
+	} else {
+		$t_select = explode( ',', $t_select );
+	}
+
 	$t_data = array(
 		'query' => array(
 			'id' => $t_user_id,
+			'select' => $t_select
+		),
+		'options' => array(
+			'return_as_users' => true
 		)
 	);
 

--- a/api/rest/restcore/users_rest.php
+++ b/api/rest/restcore/users_rest.php
@@ -62,7 +62,15 @@ $g_app->group('/users', function() use ( $g_app ) {
  * @noinspection PhpUnusedParameterInspection
  */
 function rest_user_get_me( \Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
-	$t_result = mci_user_get( auth_get_current_user_id() );
+	$t_data = array(
+		'options' => array(
+			'include_in_user_element' => false
+		)
+	);
+
+	$t_command = new UserGetCommand( $t_data );
+	$t_result = $t_command->execute();
+
 	return $p_response->withStatus( HTTP_STATUS_SUCCESS )->withJson( $t_result );
 }
 
@@ -77,19 +85,16 @@ function rest_user_get_me( \Slim\Http\Request $p_request, \Slim\Http\Response $p
  */
 function rest_user_get( \Slim\Http\Request $p_request, \Slim\Http\Response $p_response, array $p_args ) {
 	$t_user_id = $p_args['user_id'];
-	if( $t_user_id <= 0 ) {
-		return $p_response->withStatus( HTTP_STATUS_BAD_REQUEST, "Invalid user id $t_user_id" );
-	}
 
-	if( !access_has_global_level( config_get( 'manage_user_threshold' ) ) ) {
-		return $p_response->withStatus( HTTP_STATUS_FORBIDDEN, "Access denied" );
-	}
+	$t_data = array(
+		'query' => array(
+			'id' => $t_user_id,
+		)
+	);
 
-	if( !user_exists( $t_user_id ) ) {
-		return $p_response->withStatus( HTTP_STATUS_NOT_FOUND, "User $t_user_id not found" );
-	}
+	$t_command = new UserGetCommand( $t_data );
+	$t_result = $t_command->execute();
 
-	$t_result = mci_user_get( $t_user_id );
 	return $p_response->withStatus( HTTP_STATUS_SUCCESS )->withJson( $t_result );
 }
 

--- a/core/commands/UserGetCommand.php
+++ b/core/commands/UserGetCommand.php
@@ -1,0 +1,84 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+require_api( 'authentication_api.php' );
+require_api( 'config_api.php' );
+
+use Mantis\Exceptions\ClientException;
+
+/**
+ * A command that gets user information. If id is not specified, it will get the current user.
+ * To get other users' information, the user must have manage_user_threshold access level.
+ *
+ * Sample:
+ * {
+ *   "query": {
+ *      "id": 1234
+ *   },
+ *   "options": {
+ * 	    "include_in_user_element": true
+ *   }
+ * }
+ */
+class UserGetCommand extends Command {
+	/**
+	 * @var integer The id of the user to get.
+	 */
+	private $target_user_id;
+
+	/**
+	 * Constructor
+	 *
+	 * @param array $p_data The command data.
+	 */
+	function __construct( array $p_data ) {
+		parent::__construct( $p_data );
+	}
+
+	/**
+	 * Validate the data.
+	 */
+	function validate() {
+		$t_current_user_id = auth_get_current_user_id();
+		$this->target_user_id = (int)$this->query( 'id', $t_current_user_id );
+		if( $this->target_user_id <= 0 ) {
+			throw new ClientException( 'Invalid user id', ERROR_INVALID_FIELD_VALUE, array( 'id' ) );
+		}
+
+		$t_same_user = $t_current_user_id == $this->target_user_id;
+
+		# Ensure user has access level to retrieve user information
+		if( !$t_same_user && !access_has_global_level( config_get_global( 'manage_user_threshold' ) ) ) {
+			throw new ClientException( 'Access denied to get other users', ERROR_ACCESS_DENIED );
+		}
+	}
+
+	/**
+	 * Process the command.
+	 *
+	 * @return array Command response
+	 */
+	protected function process() {
+		$t_result = mci_user_get( $this->target_user_id );
+
+		if( $this->option( 'include_in_user_element', true ) ) {
+			$t_result = array( 'user' => $t_result );
+		}
+
+		return $t_result;
+	}
+}
+

--- a/tests/rest/RestBase.php
+++ b/tests/rest/RestBase.php
@@ -201,8 +201,17 @@ class RestBase extends PHPUnit\Framework\TestCase {
 
 		if( $t_response_code >= 200 && $t_response_code < 300 ) {
 			$t_body = json_decode( $p_response->getBody(), true );
-			$t_user = $t_body['user'];
-			$t_user_id = (int)$t_user['id'];
+
+			if( isset( $t_body['users'] ) ) {
+				$t_users = $t_body['users'];
+				$t_user_id = (int)$t_users[0]['id'];	
+			} if( isset( $t_body['user'] ) ) {
+				$t_user = $t_body['user'];
+				$t_user_id = (int)$t_user['id'];	
+			} else {
+				$t_user_id = (int)$t_body['id'];
+			}
+
 			$this->usersToDelete[] = $t_user_id;
 		}
 

--- a/tests/rest/RestUserTests.php
+++ b/tests/rest/RestUserTests.php
@@ -148,10 +148,10 @@ class RestUserTests extends RestBase {
 
 		$t_response = $this->builder()->post( '/users', $t_user_to_create )->send();
 		$this->deleteAfterRunUserIfCreated( $t_response );
-		$this->assertEquals( 201, $t_response->getStatusCode() );
+		$this->assertEquals( 201, $t_response->getStatusCode(), 'create_user' );
 
 		$t_response = $this->builder()->post( '/users', $t_user_to_create )->send();
-		$this->assertEquals( 400, $t_response->getStatusCode() );
+		$this->assertEquals( 400, $t_response->getStatusCode(), 'create_duplicate_user' );
 	}
 
 	/**
@@ -167,20 +167,72 @@ class RestUserTests extends RestBase {
 		$this->assertEquals( 201, $t_response->getStatusCode() );
 
 		$t_response = $this->builder()->get( '/users/' . $t_user_id )->send();
-		$this->assertEquals( 200, $t_response->getStatusCode() );
+		$this->assertEquals( 200, $t_response->getStatusCode(), 'get_user_by_id: ' . $t_user_id );
 
 		$t_body = json_decode( $t_response->getBody(), true );
-		$this->assertTrue( isset( $t_body['users'] ) );
-		$this->assertEquals( 1, count( $t_body['users'] ) );
+		$this->assertTrue( isset( $t_body['users'] ), 'users_element_exists' );
+		$this->assertEquals( 1, count( $t_body['users'] ), 'users_count' );
 
 		$t_user = $t_body['users'][0];
-		$this->assertTrue( isset( $t_user['id'] ) );
-		$this->assertTrue( is_numeric( $t_user['id'] ) );
-		$this->assertEquals( $t_user_to_create['name'], $t_user['name'] );
-		$this->assertEquals( 'english', $t_user['language'] );
-		$this->assertEquals( 25, $t_user['access_level']['id'] );
-		$this->assertEquals( "reporter", $t_user['access_level']['name'] );
-		$this->assertEquals( "reporter", $t_user['access_level']['label'] );
+		$this->assertTrue( isset( $t_user['id'] ), 'user id exists' );
+		$this->assertTrue( is_numeric( $t_user['id'] ), 'user id numeric' );
+		$this->assertEquals( $t_user_to_create['name'], $t_user['name'], 'username check' );
+		$this->assertEquals( 'english', $t_user['language'], 'language' );
+		$this->assertEquals( 25, $t_user['access_level']['id'], 'access level id' );
+		$this->assertEquals( "reporter", $t_user['access_level']['name'], 'access level name' );
+		$this->assertEquals( "reporter", $t_user['access_level']['label'], 'access level label' );
+	}
+
+	/**
+	 * Test getting an existing user by id.
+	 */
+	public function testGetUserByRef() {
+		$t_user_to_create = array(
+			'name' => Faker::username(),
+			'email' => Faker::email(),
+			'real_name' => Faker::realname(),
+		);
+
+		$t_response = $this->builder()->post( '/users', $t_user_to_create )->send();
+		$t_user_id = $this->deleteAfterRunUserIfCreated( $t_response );
+		$this->assertEquals( 201, $t_response->getStatusCode() );
+
+		# Get by Id
+		$t_response = $this->builder()->get( '/users/' . $t_user_id )->send();
+		$this->assertEquals( 200, $t_response->getStatusCode(), 'get_user_by_id' );
+
+		$t_body = json_decode( $t_response->getBody(), true );
+		$this->assertTrue( isset( $t_body['users'] ), 'users element exists by id' );
+		$this->assertEquals( 1, count( $t_body['users'] ), 'users count by id' );
+
+		# Get by Name
+		$t_response = $this->builder()->get( '/users/' . $t_user_to_create['name'] )->send();
+		$this->assertEquals( 200, $t_response->getStatusCode(), 'get_user_by_name' );
+
+		$t_body = json_decode( $t_response->getBody(), true );
+		$this->assertTrue( isset( $t_body['users'] ), 'users element exists by name' );
+		$this->assertEquals( 1, count( $t_body['users'] ), 'users count by name' );
+
+		# Get by Email
+		$t_response = $this->builder()->get( '/users/' . $t_user_to_create['email'] )->send();
+		$this->assertEquals( 200, $t_response->getStatusCode(), 'get_user_by_email' );
+
+		$t_body = json_decode( $t_response->getBody(), true );
+		$this->assertTrue( isset( $t_body['users'] ), 'users element exists by email' );
+		$this->assertEquals( 1, count( $t_body['users'] ), 'users count by email' );
+
+		# Get by Real Name
+		$t_response = $this->builder()->get( '/users/' . $t_user_to_create['real_name'] )->send();
+		$this->assertEquals( 200, $t_response->getStatusCode(), 'get_user_by_realname' );
+
+		$t_body = json_decode( $t_response->getBody(), true );
+		$this->assertTrue( isset( $t_body['users'] ), 'users element exists by realname' );
+		$this->assertEquals( 1, count( $t_body['users'] ), 'users count by realname' );
+
+		$t_user = $t_body['users'][0];
+		$this->assertTrue( isset( $t_user['id'] ), 'user id element exists by realname' );
+		$this->assertEquals( $t_user_id, $t_user['id'], 'user id as expected by realname' );
+		$this->assertEquals( $t_user_to_create['name'], $t_user['name'], 'user name as expected by realname' );
 	}
 
 	/**
@@ -263,7 +315,7 @@ class RestUserTests extends RestBase {
 	 */
 	public function testGetUserByIdZero() {
 		$t_response = $this->builder()->get( '/users/0' )->send();
-		$this->assertEquals( 400, $t_response->getStatusCode() );
+		$this->assertEquals( 404, $t_response->getStatusCode() );
 	}
 
 	/**
@@ -271,7 +323,7 @@ class RestUserTests extends RestBase {
 	 */
 	public function testGetUserByIdNegative() {
 		$t_response = $this->builder()->get( '/users/-1' )->send();
-		$this->assertEquals( 400, $t_response->getStatusCode() );
+		$this->assertEquals( 404, $t_response->getStatusCode() );
 	}
 
 	/**

--- a/tests/rest/RestUserTests.php
+++ b/tests/rest/RestUserTests.php
@@ -184,9 +184,9 @@ class RestUserTests extends RestBase {
 	}
 
 	/**
-	 * Test getting an existing user by id.
+	 * Test getting an existing user by username.
 	 */
-	public function testGetUserByRef() {
+	public function testGetUserByUsername() {
 		$t_user_to_create = array(
 			'name' => Faker::username(),
 			'email' => Faker::email(),
@@ -197,42 +197,17 @@ class RestUserTests extends RestBase {
 		$t_user_id = $this->deleteAfterRunUserIfCreated( $t_response );
 		$this->assertEquals( 201, $t_response->getStatusCode() );
 
-		# Get by Id
-		$t_response = $this->builder()->get( '/users/' . $t_user_id )->send();
-		$this->assertEquals( 200, $t_response->getStatusCode(), 'get_user_by_id' );
-
-		$t_body = json_decode( $t_response->getBody(), true );
-		$this->assertTrue( isset( $t_body['users'] ), 'users element exists by id' );
-		$this->assertEquals( 1, count( $t_body['users'] ), 'users count by id' );
-
-		# Get by Name
-		$t_response = $this->builder()->get( '/users/' . $t_user_to_create['name'] )->send();
+		$t_response = $this->builder()->get( '/users/username/' . $t_user_to_create['name'] )->send();
 		$this->assertEquals( 200, $t_response->getStatusCode(), 'get_user_by_name' );
 
 		$t_body = json_decode( $t_response->getBody(), true );
 		$this->assertTrue( isset( $t_body['users'] ), 'users element exists by name' );
 		$this->assertEquals( 1, count( $t_body['users'] ), 'users count by name' );
 
-		# Get by Email
-		$t_response = $this->builder()->get( '/users/' . $t_user_to_create['email'] )->send();
-		$this->assertEquals( 200, $t_response->getStatusCode(), 'get_user_by_email' );
-
-		$t_body = json_decode( $t_response->getBody(), true );
-		$this->assertTrue( isset( $t_body['users'] ), 'users element exists by email' );
-		$this->assertEquals( 1, count( $t_body['users'] ), 'users count by email' );
-
-		# Get by Real Name
-		$t_response = $this->builder()->get( '/users/' . $t_user_to_create['real_name'] )->send();
-		$this->assertEquals( 200, $t_response->getStatusCode(), 'get_user_by_realname' );
-
-		$t_body = json_decode( $t_response->getBody(), true );
-		$this->assertTrue( isset( $t_body['users'] ), 'users element exists by realname' );
-		$this->assertEquals( 1, count( $t_body['users'] ), 'users count by realname' );
-
 		$t_user = $t_body['users'][0];
-		$this->assertTrue( isset( $t_user['id'] ), 'user id element exists by realname' );
-		$this->assertEquals( $t_user_id, $t_user['id'], 'user id as expected by realname' );
-		$this->assertEquals( $t_user_to_create['name'], $t_user['name'], 'user name as expected by realname' );
+		$this->assertTrue( isset( $t_user['id'] ), 'user id element exists by username' );
+		$this->assertEquals( $t_user_id, $t_user['id'], 'user id as expected by username' );
+		$this->assertEquals( $t_user_to_create['name'], $t_user['name'], 'user name as expected by username' );
 	}
 
 	/**
@@ -248,7 +223,7 @@ class RestUserTests extends RestBase {
 		$this->assertEquals( 201, $t_response->getStatusCode() );
 
 		$t_response = $this->builder()->
-			get( '/users/' . $t_user_id, 'select=id,name,projects' )->
+			get( '/users/' . $t_user_id . '?select=id,name,projects' )->
 			send();
 		$this->assertEquals( 200, $t_response->getStatusCode() );
 
@@ -315,7 +290,7 @@ class RestUserTests extends RestBase {
 	 */
 	public function testGetUserByIdZero() {
 		$t_response = $this->builder()->get( '/users/0' )->send();
-		$this->assertEquals( 404, $t_response->getStatusCode() );
+		$this->assertEquals( 400, $t_response->getStatusCode() );
 	}
 
 	/**
@@ -323,7 +298,7 @@ class RestUserTests extends RestBase {
 	 */
 	public function testGetUserByIdNegative() {
 		$t_response = $this->builder()->get( '/users/-1' )->send();
-		$this->assertEquals( 404, $t_response->getStatusCode() );
+		$this->assertEquals( 400, $t_response->getStatusCode() );
 	}
 
 	/**


### PR DESCRIPTION
- Implemented UserGetCommand
- [27128](https://www.mantisbt.org/bugs/view.php?id=27128): Can not get userid from another user with REST API - Added `GET /users/username/:username` to get a user by name and `/users/:id` .
- [27133](https://www.mantisbt.org/bugs/view.php?id=27133) delete user by username - approach: get user info by username, then delete by id.
- [32357](https://www.mantisbt.org/bugs/view.php?id=32357): REST API: Support select for fields to return when getting user info - this applies to `/users/me`, `/users/:id`, `/users/username/:username` and include select query string with field names.