### PR TITLE
REST API: Support impersonation of users

### DIFF
--- a/tests/core/RequestBuilder.php
+++ b/tests/core/RequestBuilder.php
@@ -97,6 +97,17 @@ class RequestBuilder {
 	}
 
 	/**
+	 * Impersonates the specified user
+	 *
+	 * @param string $p_username The username of user to impersonate
+	 * @return RequestBuilder
+	 */
+	public function impersonate( $p_username ) {
+		$this->headers['X-Mantis-Username'] = $p_username;
+		return $this;
+	}
+
+	/**
 	 * Build a GET request with optional query string
 	 *
 	 * @param string|null $p_query_string The query string or null.

--- a/tests/rest/AllTests.php
+++ b/tests/rest/AllTests.php
@@ -26,6 +26,7 @@
 /**
  * Test config
  */
+require_once __DIR__ . '/RestImpersonateUserTests.php';
 require_once __DIR__ . '/RestIssueTests.php';
 require_once __DIR__ . '/RestProjectVersionTests.php';
 require_once __DIR__ . '/RestUserTests.php';
@@ -53,6 +54,7 @@ class RestAllTests extends PHPUnit\Framework\TestSuite
 	public static function suite() {
 		$t_suite = new RestAllTests( 'REST API' );
 
+		$t_suite->addTestSuite( 'RestImpersonateUserTests' );
 		$t_suite->addTestSuite( 'RestIssueTests' );
 		$t_suite->addTestSuite( 'RestProjectVersionTests' );
 		$t_suite->addTestSuite( 'RestUserTests' );

--- a/tests/rest/RestImpersonateUserTests.php
+++ b/tests/rest/RestImpersonateUserTests.php
@@ -1,0 +1,158 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mantis Webservice Tests
+ *
+ * @package Tests
+ * @subpackage UnitTests
+ * @copyright Copyright MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ */
+
+require_once 'RestBase.php';
+
+/**
+ * Test fixture for user impersonation via API.
+ *
+ * @requires extension curl
+ * @group REST
+ */
+class RestImpersonateUserTests extends RestBase {
+	/**
+	 * Setup test fixture
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+	}
+
+	/**
+	 * Tear down the test fixture.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	/**
+	 * Test /users/me API without impersonation
+	 */
+	public function testWithoutImpersonation() {
+		$t_response = $this->builder()->get( '/users/me' )->send();
+		$this->assertEquals( 200, $t_response->getStatusCode() );
+	}
+
+	/**
+	 * Test /users/me API with impersonation for user that doesn't exist.
+	 */
+	public function testImpersonateUserDoesntExist() {
+		$t_response = $this->builder()->get( '/users/me' )->impersonate( 'DoesNotExist' )->send();
+		$this->assertEquals( 404, $t_response->getStatusCode() );
+	}
+
+	/**
+	 * Test /users/me API with impersonating self
+	 */
+	public function testImpersonateSelf() {
+		$t_response = $this->builder()->get( '/users/me' )->impersonate( 'administrator' )->send();
+		$this->assertEquals( 403, $t_response->getStatusCode() );
+	}
+
+	/**
+	 * Test /users/me API with impersonation for user that exists.
+	 */
+	public function testImpersonateUser() {
+		$t_username = Faker::username();
+
+		$t_user_to_create = array(
+			'name' => $t_username,
+			'access_level' => array( 'name' => 'viewer' )
+		);
+
+		# Create a user
+		$t_response = $this->builder()->post( '/users', $t_user_to_create )->send();
+		$this->deleteAfterRunUserIfCreated( $t_response );
+		$this->assertEquals( 201, $t_response->getStatusCode() );
+
+		# Validate admin user information
+		$t_response = $this->builder()->get( '/users/me' )->send();
+		$this->assertEquals( 200, $t_response->getStatusCode() );
+		$t_user = json_decode( $t_response->getBody(), true );
+		$this->assertNotEquals( $t_username, $t_user['name'] );
+
+		# Validate impersonated user information
+		$t_response = $this->builder()->get( '/users/me' )->impersonate( $t_username )->send();
+		$this->assertEquals( 200, $t_response->getStatusCode() );
+		$t_user = json_decode( $t_response->getBody(), true );
+		$this->assertEquals( $t_username, $t_user['name'] );
+		$this->assertEquals( $t_user_to_create['access_level']['name'], $t_user['access_level']['name'] );
+	}
+
+	/**
+	 * Test /users/me API with impersonation for a disabled user
+	 */
+	public function testImpersonateUserDisabled() {
+		$t_username = Faker::username();
+
+		$t_user_to_create = array(
+			'name' => $t_username,
+			'access_level' => array( 'name' => 'viewer' ),
+			'enabled' => false
+		);
+
+		# Create a user
+		$t_response = $this->builder()->post( '/users', $t_user_to_create )->send();
+		$this->deleteAfterRunUserIfCreated( $t_response );
+		$this->assertEquals( 201, $t_response->getStatusCode() );
+
+		# Validate impersonated user information
+		$t_response = $this->builder()->get( '/users/me' )->impersonate( $t_username )->send();
+		$this->assertEquals( 403, $t_response->getStatusCode() );
+	}
+
+	/**
+	 * Test /users/me API with impersonation where user doesn't have impersonation access level
+	 */
+	public function testImpersonateUserWithoutImpersonationAccessLevel() {
+		$t_username = Faker::username();
+
+		$t_user_to_create = array(
+			'name' => $t_username,
+			'access_level' => array( 'name' => 'viewer' ),
+			'enabled' => false
+		);
+
+		# Create a user
+		$t_response = $this->builder()->post( '/users', $t_user_to_create )->send();
+		$this->deleteAfterRunUserIfCreated( $t_response );
+		$this->assertEquals( 201, $t_response->getStatusCode() );
+		$t_body = json_decode( $t_response->getBody(), true );
+		$this->assertTrue( isset( $t_body['user'] ) );
+		$t_user = $t_body['user'];
+
+		# Create API token for user
+		$t_response = $this->builder()->post( '/users/' . $t_user['id'] . '/token', $t_user_to_create )->send();
+		$this->assertEquals( 201, $t_response->getStatusCode() );
+		$t_body = json_decode( $t_response->getBody(), true );
+		$this->assertTrue( isset( $t_body['user'] ) );
+		$t_token = $t_body['token'];
+
+		# Validate impersonating disabled user fails
+		$t_response = $this->builder()->get( '/users/me' )->token( $t_token )->impersonate( 'administrator' )->send();
+		$this->assertEquals( 403, $t_response->getStatusCode() );
+	}
+}

--- a/tests/rest/RestUserTests.php
+++ b/tests/rest/RestUserTests.php
@@ -375,6 +375,26 @@ class RestUserTests extends RestBase {
 	}
 
 	/**
+	 * Test attempt to delete self.
+	 * 
+	 * @return void
+	 */
+	public function testDeleteCurrentUserWithImpersonation() {
+		$t_username = Faker::username();
+		$t_user_to_create = array(
+			'name' => $t_username,
+			'access_level' => array( 'name' => 'administrator' )
+		);
+
+		$t_response = $this->builder()->post( '/users', $t_user_to_create )->send();
+		$t_user_id = $this->deleteAfterRunUserIfCreated( $t_response );
+		$this->assertEquals( 201, $t_response->getStatusCode() );
+
+		$t_response = $this->builder()->delete( '/users/' . $t_user_id )->impersonate( $t_username )->send();
+		$this->assertEquals( 400, $t_response->getStatusCode() );
+	}
+
+	/**
 	 * Test deleting the current logged in user (anonymous).
 	 */
 	public function testDeleteCurrentUserAnonymous() {


### PR DESCRIPTION
[32469](https://www.mantisbt.org/bugs/view.php?id=32469): REST API: Support impersonation of users

- Useful for administrator (or user with impersonation rights) to impersonate a user without creating an API token.
- Useful for testing - quickly impersonating a user to take actions on their behalf (negative/positive tests)
