### PR TITLE
Fix error updating issue with time-tracking notes

### DIFF
--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -1087,7 +1087,11 @@ function mci_get_time_tracking_from_note( $p_issue_id, array $p_note ) {
 		return '00:00';
 	}
 
-	return db_minutes_to_hhmm( $p_note['time_tracking'] );
+	if( is_numeric( $p_note['time_tracking'] ) ) {
+		return db_minutes_to_hhmm( $p_note['time_tracking'] );
+	}
+
+	return $p_note['time_tracking']['duration'];
 }
 
 /**


### PR DESCRIPTION
REST API returned Slim Application Error / Unsupported operand types when attempting to update an Issue with time tracking notes.

Regression introduced by 39ae82ad200d759b8eb56e8758fcdebb4686daf3.

Fixes [#29438](https://mantisbt.org/bugs/view.php?id=29438)