### PR TITLE
Remove deprecated db_prepare_string() function

### DIFF
--- a/core/database_api.php
+++ b/core/database_api.php
@@ -628,33 +628,6 @@ function db_close() {
 }
 
 /**
- * prepare a string before DB insertion
- * @param string $p_string Unprepared string.
- * @return string prepared database query string
- * @deprecated db_query should be used in preference to this function. This function may be removed in 1.2.0 final
- */
-function db_prepare_string( $p_string ) {
-	global $g_db;
-	$t_db_type = config_get_global( 'db_type' );
-
-	switch( $t_db_type ) {
-		case 'mssqlnative':
-		case 'odbc_mssql':
-			return addslashes( $p_string );
-		case 'mysqli':
-			$t_escaped = $g_db->qstr( $p_string, false );
-			return mb_substr( $t_escaped, 1, mb_strlen( $t_escaped ) - 2 );
-		case 'pgsql':
-			return pg_escape_string( $p_string );
-		case 'oci8':
-			return $p_string;
-		default:
-			error_parameters( 'db_type', $t_db_type );
-			trigger_error( ERROR_CONFIG_OPT_INVALID, ERROR );
-	}
-}
-
-/**
  * Prepare a binary string before DB insertion
  * Use of this function is required for some DB types, to properly encode
  * BLOB fields prior to calling db_query()

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -1323,7 +1323,11 @@ function file_move_bug_attachments( $p_bug_id, $p_project_id_to ) {
 			}
 			chmod( $t_disk_file_name_to, config_get( 'attachments_file_permissions' ) );
 			# Don't pop the parameters after query execution since we're in a loop
-			db_query( $t_query_disk_attachment_update, array( db_prepare_string( $t_path_to ), $c_bug_id, (int)$t_row['id'] ), -1, -1, false );
+			db_query( $t_query_disk_attachment_update,
+				array( $t_path_to, $c_bug_id, (int)$t_row['id'] ),
+				-1, -1,
+				false
+			);
 		} else {
 			trigger_error( ERROR_FILE_DUPLICATE, ERROR );
 		}

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1635,15 +1635,9 @@ function user_set_fields( $p_user_id, array $p_fields ) {
 	$t_parameters = array();
 
 	foreach ( $p_fields as $t_field_name => $t_field_value ) {
-		$c_field_name = db_prepare_string( $t_field_name );
-
-		if( count( $t_parameters ) == 0 ) {
-			$t_query .= ' SET '. $c_field_name. '=' . db_param();
-		} else {
-			$t_query .= ' , ' . $c_field_name. '=' . db_param();
-		}
-
-		array_push( $t_parameters, $t_field_value );
+		$t_query .= ( empty( $t_parameters ) ? ' SET ' :  ', ' )
+			. $t_field_name. '=' . db_param();
+		$t_parameters[] = $t_field_value;
 	}
 
 	$t_query .= ' WHERE id=' . db_param();


### PR DESCRIPTION
It was used in:

- user_set_fields() to escape the field names when building the SQL query to update the user data.
- file_move_bug_attachments() to escape the file path

Fixes [#32704](https://mantisbt.org/bugs/view.php?id=32704)