### PR TITLE
Remove function check_php_version

### DIFF
--- a/admin/check/check_php_inc.php
+++ b/admin/check/check_php_inc.php
@@ -38,12 +38,6 @@ require_api( 'utility_api.php' );
 
 check_print_section_header_row( 'PHP' );
 
-check_print_test_row(
-	'Version of <a href="http://en.wikipedia.org/wiki/PHP">PHP</a> installed is at least ' . PHP_MIN_VERSION,
-	version_compare( phpversion(), PHP_MIN_VERSION, '>=' ),
-	'PHP version ' . phpversion() . ' is currently installed on this server.'
-);
-
 # $t_extensions_required lists the extensions required to run Mantis in general
 $t_extensions_required = array(
 	'date',

--- a/admin/install.php
+++ b/admin/install.php
@@ -292,7 +292,7 @@ if( 0 == $t_install_state ) {
 <?php
 	print_test(
 		'Checking PHP version (your version is ' . phpversion() . ')',
-		check_php_version( phpversion() ),
+		version_compare( phpversion(), PHP_MIN_VERSION, '>=' ),
 		true,
 		'Upgrade to a more recent version of PHP'
 	);

--- a/admin/install.php
+++ b/admin/install.php
@@ -287,17 +287,8 @@ if( $t_config_exists ) {
 
 if( 0 == $t_install_state ) {
 	?>
-
-<!-- Check PHP Version -->
+<!-- Check UTF-8 support -->
 <?php
-	print_test(
-		'Checking PHP version (your version is ' . phpversion() . ')',
-		version_compare( phpversion(), PHP_MIN_VERSION, '>=' ),
-		true,
-		'Upgrade to a more recent version of PHP'
-	);
-
-	# UTF-8 support check
 	# We need the 'mbstring' extension
 	print_test(
 		'Checking UTF-8 support',

--- a/core/install_helper_functions_api.php
+++ b/core/install_helper_functions_api.php
@@ -31,27 +31,6 @@
 require_api( 'database_api.php' );
 
 /**
- * Checks a PHP version number against the version of PHP currently in use
- * @param string $p_version Version string to compare.
- * @return boolean true if the PHP version in use is equal to or greater than the supplied version string
- */
-function check_php_version( $p_version ) {
-	if( $p_version == PHP_MIN_VERSION ) {
-		return true;
-	} else {
-		if( function_exists( 'version_compare' ) ) {
-			if( version_compare( phpversion(), PHP_MIN_VERSION, '>=' ) ) {
-				return true;
-			} else {
-				return false;
-			}
-		} else {
-			return false;
-		}
-	}
-}
-
-/**
  * Legacy pre-1.2 date function used for upgrading from datetime to integer
  * representation of dates in the database.
  * @return string Formatted date representing unixtime(0) + 1 second, ready for database insertion


### PR DESCRIPTION
function check_php_version is questionable in some terms
- check for $p_version == PHP_MIN_VERSION will hardly ever evaluate to true in real life (who is running exactly PHP 7.0.0?)
- parameter $p_version is not used in else case, this was hardly what was wanted, but did not introduce any bug, as phpversion() is used instead of the parameter
- check function_exists( 'version_compare' ) is not necessary as
  - according documentation, version_compare() is available starting from PHP 4.1 [1]
  - we use version_compare() at various other places in code without checking if it exists

Thus
- remove the function
- replace the single place where it's called by using version_compare()

Fixes #32714

[1] https://www.php.net/manual/de/function.version-compare.php