### PR TITLE
Exception when version to delete does not exist

### DIFF
--- a/core/commands/VersionDeleteCommand.php
+++ b/core/commands/VersionDeleteCommand.php
@@ -77,12 +77,9 @@ class VersionDeleteCommand extends Command {
 			throw new ClientException( 'Access denied to delete version', ERROR_ACCESS_DENIED );
 		}
 
-		$this->version_id = helper_parse_id( $this->query( 'version_id' ), 'version_id' );
-		if( !version_exists( $this->version_id ) ) {
-			return;
-		}
-
 		# Make sure that version belongs to the project
+		# No need to check if version exists, version_get_field() will take care of it
+		$this->version_id = helper_parse_id( $this->query( 'version_id' ), 'version_id' );
 		$t_project_id_from_version = version_get_field( $this->version_id, 'project_id' );
 		if( $t_project_id_from_version !== $this->project_id ) {
 			throw new ClientException(
@@ -98,10 +95,6 @@ class VersionDeleteCommand extends Command {
 	 * @return void
 	 */
 	protected function process() {
-		if( !version_exists( $this->version_id ) ) {
-			return;
-		}
-
 		global $g_project_override;
 
 		$t_prev_project_id = $g_project_override;

--- a/tests/rest/RestProjectVersionTest.php
+++ b/tests/rest/RestProjectVersionTest.php
@@ -168,7 +168,7 @@ class RestProjectVersionTest extends RestBase {
 
 		// Delete a version that doesn't exists
 		$t_response = $this->builder()->delete( $this->ver_base_url . $t_version['id'] )->send();
-		$this->assertEquals( HTTP_STATUS_NO_CONTENT, $t_response->getStatusCode() );
+		$this->assertEquals( HTTP_STATUS_NOT_FOUND, $t_response->getStatusCode() );
 	}
 
 	/**


### PR DESCRIPTION
The initial implementation of VersionDeleteCommand (see #1883) did not throw an exception when given a non-existing version number, causing the REST API to succeed with HTTP 204 (version deleted) when it should in fact have failed.

The Command now throws a ClientException, resulting in the API returning a 404 (not found) in this situation.

Note: the version_exists() call before retrieving the project id with version_get_field() is not necessary, as the latter already perform this check (via version_cache_row()).

PHPUnit test has been updated accordingly.

Fixes [#30415](https://mantisbt.org/bugs/view.php?id=30415)