### PR TITLE
Remove "Operation Successful" from action pages

### DIFF
--- a/account_prefs_update.php
+++ b/account_prefs_update.php
@@ -139,10 +139,5 @@ user_pref_set( $f_user_id, $t_prefs, ALL_PROJECTS );
 
 form_security_purge( 'account_prefs_update' );
 
-layout_page_header( null, $f_redirect_url );
+print_header_redirect( $f_redirect_url );
 
-layout_page_begin();
-
-html_operation_successful( $f_redirect_url );
-
-layout_page_end();

--- a/account_prefs_update.php
+++ b/account_prefs_update.php
@@ -139,5 +139,5 @@ user_pref_set( $f_user_id, $t_prefs, ALL_PROJECTS );
 
 form_security_purge( 'account_prefs_update' );
 
-print_header_redirect( $f_redirect_url );
+print_successful_redirect( $f_redirect_url, /* force_show */ true );
 

--- a/account_prefs_update.php
+++ b/account_prefs_update.php
@@ -139,5 +139,5 @@ user_pref_set( $f_user_id, $t_prefs, ALL_PROJECTS );
 
 form_security_purge( 'account_prefs_update' );
 
-print_successful_redirect( $f_redirect_url, /* force_show */ true );
+print_header_redirect( $f_redirect_url, /* force_show */ true );
 

--- a/account_prefs_update.php
+++ b/account_prefs_update.php
@@ -139,5 +139,5 @@ user_pref_set( $f_user_id, $t_prefs, ALL_PROJECTS );
 
 form_security_purge( 'account_prefs_update' );
 
-print_header_redirect( $f_redirect_url, /* force_show */ true );
+print_header_redirect( $f_redirect_url );
 

--- a/account_prof_update.php
+++ b/account_prof_update.php
@@ -122,8 +122,4 @@ switch( $f_action ) {
 
 form_security_purge( $t_form_name );
 
-layout_page_header( null, $f_redirect_page );
-layout_page_begin();
-html_operation_successful( $f_redirect_page );
-layout_page_end();
-
+print_header_redirect( $f_redirect_page );

--- a/account_sponsor_update.php
+++ b/account_sponsor_update.php
@@ -79,11 +79,4 @@ foreach( $t_bug_list as $t_bug ) {
 
 form_security_purge( 'account_sponsor_update' );
 
-$t_redirect_url = 'account_sponsor_page.php';
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin();
-
-html_operation_successful( $t_redirect_url, lang_get( 'payment_updated' ) );
-
-layout_page_end();
+print_header_redirect( 'account_sponsor_page.php' );

--- a/account_update.php
+++ b/account_update.php
@@ -81,8 +81,6 @@ $f_password_current = gpc_get_string( 'password_current', '' );
 $f_password        	= gpc_get_string( 'password', '' );
 $f_password_confirm	= gpc_get_string( 'password_confirm', '' );
 
-$t_redirect_url = 'index.php';
-
 $t_update_email = false;
 $t_update_password = false;
 $t_update_realname = false;
@@ -136,21 +134,12 @@ if( !is_blank( $f_password ) ) {
 	}
 }
 
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin();
-
-$t_message = '';
-
 if( $t_update_email ) {
 	user_set_email( $t_user_id, $f_email );
-	$t_message .= lang_get( 'email_updated' );
 }
 
 if( $t_update_password ) {
 	user_set_password( $t_user_id, $f_password );
-	$t_message = is_blank( $t_message ) ? '' : $t_message . '<br />';
-	$t_message .= lang_get( 'password_updated' );
 
 	# Clear the verification token
 	if( $t_account_verification ) {
@@ -160,12 +149,8 @@ if( $t_update_password ) {
 
 if( $t_update_realname ) {
 	user_set_realname( $t_user_id, $t_realname );
-	$t_message = is_blank( $t_message ) ? '' : $t_message . '<br />';
-	$t_message .= lang_get( 'realname_updated' );
 }
 
 form_security_purge( 'account_update' );
 
-html_operation_successful( $t_redirect_url, $t_message );
-
-layout_page_end();
+print_header_redirect( 'index.php' );

--- a/adm_config_delete.php
+++ b/adm_config_delete.php
@@ -66,5 +66,5 @@ $t_command->execute();
 
 form_security_purge( 'adm_config_delete' );
 
-print_successful_redirect( 'adm_config_report.php' );
+print_header_redirect( 'adm_config_report.php' );
 

--- a/adm_config_set.php
+++ b/adm_config_set.php
@@ -121,4 +121,4 @@ $t_command->execute();
 
 form_security_purge( 'adm_config_set' );
 
-print_successful_redirect( 'adm_config_report.php' );
+print_header_redirect( 'adm_config_report.php' );

--- a/bug_monitor_add.php
+++ b/bug_monitor_add.php
@@ -66,4 +66,4 @@ $t_command->execute();
 
 form_security_purge( 'bug_monitor_add' );
 
-print_successful_redirect_to_bug( $f_bug_id );
+print_header_redirect_view( $f_bug_id );

--- a/bug_monitor_delete.php
+++ b/bug_monitor_delete.php
@@ -84,4 +84,4 @@ bug_unmonitor( $f_bug_id, $t_user_id );
 
 form_security_purge( 'bug_monitor_delete' );
 
-print_successful_redirect_to_bug( $f_bug_id );
+print_header_redirect_view( $f_bug_id );

--- a/bug_reminder.php
+++ b/bug_reminder.php
@@ -126,10 +126,5 @@ if( ON == config_get( 'store_reminders' ) ) {
 
 form_security_purge( 'bug_reminder' );
 
-layout_page_header( null, string_get_bug_view_url( $f_bug_id ) );
-layout_page_begin();
-
 $t_redirect = string_get_bug_view_url( $f_bug_id );
-html_operation_successful( $t_redirect );
-
-layout_page_end();
+print_header_redirect( $t_redirect );

--- a/bug_report.php
+++ b/bug_report.php
@@ -262,8 +262,6 @@ $t_issue_id = (int)$t_result['issue_id'];
 
 form_security_purge( 'bug_report' );
 
-layout_page_header_begin();
-
 if( $f_report_stay ) {
 	$t_fields = array(
 		'category_id', 'severity', 'reproducibility', 'profile_id', 'platform',
@@ -282,24 +280,7 @@ if( $f_report_stay ) {
 
 	$t_report_more_bugs_url = string_get_bug_report_url() . '?' . http_build_query( $t_data );
 
-	html_meta_redirect( $t_report_more_bugs_url );
+	print_header_redirect( $t_report_more_bugs_url );
 } else {
-	html_meta_redirect( string_get_bug_view_url( $t_issue_id ) );
+	print_header_redirect_view( $t_issue_id );
 }
-
-layout_page_header_end();
-
-layout_page_begin( 'bug_report_page.php' );
-
-$t_buttons = array(
-	array( string_get_bug_view_url( $t_issue_id ), sprintf( lang_get( 'view_submitted_bug_link' ), $t_issue_id ) ),
-	array( 'view_all_bug_page.php', lang_get( 'view_bugs_link' ) ),
-);
-
-if( $f_report_stay ) {
-	$t_buttons[] = array( $t_report_more_bugs_url, lang_get( 'report_more_bugs' ) );
-}
-
-html_operation_confirmation( $t_buttons, '', CONFIRMATION_TYPE_SUCCESS );
-
-layout_page_end();

--- a/bug_revision_drop.php
+++ b/bug_revision_drop.php
@@ -54,5 +54,5 @@ helper_ensure_confirmed( lang_get( 'confirm_revision_drop' ), lang_get( 'revisio
 bug_revision_drop( $f_revision_id );
 form_security_purge( 'bug_revision_drop' );
 
-print_successful_redirect_to_bug( $t_revision['bug_id'] );
+print_header_redirect_view( $t_revision['bug_id'] );
 

--- a/bug_stick.php
+++ b/bug_stick.php
@@ -59,4 +59,4 @@ bug_set_field( $f_bug_id, 'sticky', 'stick' == $f_action );
 
 form_security_purge( 'bug_stick' );
 
-print_successful_redirect_to_bug( $f_bug_id );
+print_header_redirect_view( $f_bug_id );

--- a/bug_update.php
+++ b/bug_update.php
@@ -509,4 +509,4 @@ if( $t_resolve_issue ) {
 
 form_security_purge( 'bug_update' );
 
-print_successful_redirect_to_bug( $f_bug_id );
+print_header_redirect_view( $f_bug_id );

--- a/bugnote_add.php
+++ b/bugnote_add.php
@@ -65,4 +65,4 @@ $t_command->execute();
 
 form_security_purge( 'bugnote_add' );
 
-print_successful_redirect_to_bug( $f_bug_id );
+print_header_redirect_view( $f_bug_id );

--- a/bugnote_delete.php
+++ b/bugnote_delete.php
@@ -50,4 +50,4 @@ $t_result = $t_command->execute();
 
 form_security_purge( 'bugnote_delete' );
 
-print_successful_redirect( string_get_bug_view_url( $t_result['issue_id'] ) . '#bugnotes' );
+print_header_redirect( string_get_bug_view_url( $t_result['issue_id'] ) . '#bugnotes' );

--- a/bugnote_set_view_state.php
+++ b/bugnote_set_view_state.php
@@ -87,4 +87,4 @@ bugnote_set_view_state( $f_bugnote_id, $f_private );
 
 form_security_purge( 'bugnote_set_view_state' );
 
-print_successful_redirect( string_get_bug_view_url( $t_bug_id ) . '#bugnotes' );
+print_header_redirect( string_get_bug_view_url( $t_bug_id ) . '#bugnotes' );

--- a/bugnote_update.php
+++ b/bugnote_update.php
@@ -90,4 +90,4 @@ event_signal( 'EVENT_BUGNOTE_EDIT', array( $t_bug_id, $f_bugnote_id ) );
 
 form_security_purge( 'bugnote_update' );
 
-print_successful_redirect( string_get_bugnote_view_url( $t_bug_id, $f_bugnote_id ) );
+print_header_redirect( string_get_bugnote_view_url( $t_bug_id, $f_bugnote_id ) );

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -151,9 +151,12 @@ function print_header_redirect_view( $p_bug_id ) {
  *
  * @param integer $p_bug_id A bug identifier.
  * @return void
- * @deprecated Use print_header_redirect() instead.
+ * @deprecated 2.26.0 Use print_header_redirect() instead.
  */
 function print_successful_redirect_to_bug( $p_bug_id ) {
+	error_parameters( __FUNCTION__ . '()', 'print_header_redirect()' );
+	trigger_error( ERROR_DEPRECATED_SUPERSEDED, DEPRECATED );
+
 	$t_url = string_get_bug_view_url( $p_bug_id );
 	print_header_redirect( $t_url );
 }
@@ -165,9 +168,12 @@ function print_successful_redirect_to_bug( $p_bug_id ) {
  * @param string $p_redirect_to URI to redirect to.
  * @param bool $p_force_show Force showing operation successful
  * @return void
- * @deprecated Use print_header_redirect() instead.
+ * @deprecated 2.26.0 Use print_header_redirect() instead.
  */
 function print_successful_redirect( $p_redirect_to, $p_force_show = false ) {
+	error_parameters( __FUNCTION__ . '()', 'print_header_redirect()' );
+	trigger_error( ERROR_DEPRECATED_SUPERSEDED, DEPRECATED );
+
 	print_header_redirect( $p_redirect_to );
 }
 

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -163,10 +163,11 @@ function print_successful_redirect_to_bug( $p_bug_id ) {
  * If the show query count is OFF, redirect right away.
  *
  * @param string $p_redirect_to URI to redirect to.
+ * @param bool $p_force_show Force showing operation successful
  * @return void
  */
-function print_successful_redirect( $p_redirect_to ) {
-	if( helper_log_to_page() ) {
+function print_successful_redirect( $p_redirect_to, $p_force_show = false ) {
+	if( $p_force_show || helper_log_to_page() ) {
 		layout_page_header( null, $p_redirect_to );
 		layout_page_begin();
 		echo '<br /><div class="center">';

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -151,11 +151,11 @@ function print_header_redirect_view( $p_bug_id ) {
  *
  * @param integer $p_bug_id A bug identifier.
  * @return void
+ * @deprecated Use print_header_redirect() instead.
  */
 function print_successful_redirect_to_bug( $p_bug_id ) {
 	$t_url = string_get_bug_view_url( $p_bug_id );
-
-	print_successful_redirect( $t_url );
+	print_header_redirect( $t_url );
 }
 
 /**
@@ -165,19 +165,10 @@ function print_successful_redirect_to_bug( $p_bug_id ) {
  * @param string $p_redirect_to URI to redirect to.
  * @param bool $p_force_show Force showing operation successful
  * @return void
+ * @deprecated Use print_header_redirect() instead.
  */
 function print_successful_redirect( $p_redirect_to, $p_force_show = false ) {
-	if( $p_force_show || helper_log_to_page() ) {
-		layout_page_header( null, $p_redirect_to );
-		layout_page_begin();
-		echo '<br /><div class="center">';
-		echo lang_get( 'operation_successful' ) . '<br />';
-		print_link_button( $p_redirect_to, lang_get( 'proceed' ) );
-		echo '</div>';
-		layout_page_end();
-	} else {
-		print_header_redirect( $p_redirect_to );
-	}
+	print_header_redirect( $p_redirect_to );
 }
 
 /**

--- a/docbook/Developers_Guide/en-US/Plugins_Building.xml
+++ b/docbook/Developers_Guide/en-US/Plugins_Building.xml
@@ -706,7 +706,7 @@ if( $f_reset ) {
     trigger_error( ERROR_CONFIG_OPT_INVALID, ERROR );
 }
 
-print_successful_redirect( plugin_page( 'config', true ) );
+print_header_redirect( plugin_page( 'config', true ) );
 ]]>
 			</programlisting>
 

--- a/manage_config_columns_reset.php
+++ b/manage_config_columns_reset.php
@@ -49,11 +49,4 @@ config_delete_for_user( 'excel_columns', $t_user_id );
 
 form_security_purge( 'manage_config_columns_reset' );
 
-$t_redirect_url = 'account_manage_columns_page.php';
-layout_page_header( lang_get( 'manage_email_config' ), $t_redirect_url );
-
-layout_page_begin();
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( 'account_manage_columns_page.php' );

--- a/manage_config_columns_set.php
+++ b/manage_config_columns_set.php
@@ -122,11 +122,4 @@ if( json_encode( config_get( 'excel_columns', '', $t_user_id, $t_project_id ) ) 
 form_security_purge( 'manage_config_columns_set' );
 
 $t_redirect_url = $t_account_page ? 'account_manage_columns_page.php' : 'manage_config_columns_page.php';
-
-layout_page_header();
-
-layout_page_begin();
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_config_email_set.php
+++ b/manage_config_email_set.php
@@ -56,16 +56,11 @@ auth_reauthenticate();
 $t_can_change_level = min( config_get_access( 'notify_flags' ), config_get_access( 'default_notify_flags' ) );
 access_ensure_project_level( $t_can_change_level );
 
-$t_redirect_url = 'manage_config_email_page.php';
 $t_project = helper_get_current_project();
 
 $f_flags			= gpc_get( 'flag', array() );
 $f_thresholds		= gpc_get( 'flag_threshold', array() );
 $f_actions_access	= gpc_get_int( 'notify_actions_access' );
-
-layout_page_header( lang_get( 'manage_email_config' ), $t_redirect_url );
-
-layout_page_begin();
 
 $t_access = current_user_get_access_level();
 $t_can_change_flags = $t_access >= config_get_access( 'notify_flags' );
@@ -171,6 +166,4 @@ if( isset( $t_notify_flags ) ) {
 
 form_security_purge( 'manage_config_email_set' );
 
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( 'manage_config_email_page.php' );

--- a/manage_config_revert.php
+++ b/manage_config_revert.php
@@ -87,12 +87,4 @@ if( '' != $f_revert ) {
 
 form_security_purge( 'manage_config_revert' );
 
-$t_redirect_url = $f_return;
-
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin();
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( $f_return );

--- a/manage_config_work_threshold_set.php
+++ b/manage_config_work_threshold_set.php
@@ -51,12 +51,6 @@ form_security_validate( 'manage_config_work_threshold_set' );
 
 auth_reauthenticate();
 
-$t_redirect_url = 'manage_config_work_threshold_page.php';
-
-layout_page_header( lang_get( 'manage_threshold_config' ), $t_redirect_url );
-
-layout_page_begin();
-
 $g_access = current_user_get_access_level();
 $g_project = helper_get_current_project();
 
@@ -250,6 +244,4 @@ set_capability_row( 'reminder_receive_threshold' );
 
 form_security_purge( 'manage_config_work_threshold_set' );
 
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( 'manage_config_work_threshold_page.php' );

--- a/manage_config_workflow_set.php
+++ b/manage_config_workflow_set.php
@@ -88,13 +88,8 @@ $t_can_change_level = min( config_get_access( 'status_enum_workflow' ), config_g
 		, config_get_access( 'bug_submit_status' ), config_get_access( 'bug_resolved_status_threshold' ), config_get_access( 'bug_reopen_status' ) );
 access_ensure_project_level( $t_can_change_level );
 
-$t_redirect_url = 'manage_config_workflow_page.php';
 $t_project = helper_get_current_project();
 $t_access = current_user_get_access_level();
-
-layout_page_header( lang_get( 'manage_workflow_config' ), $t_redirect_url );
-
-layout_page_begin( 'manage_overview_page.php' );
 
 # process the changes to threshold values
 $t_valid_thresholds = array(
@@ -252,6 +247,4 @@ if( min( config_get_access( 'set_status_threshold' ), config_get_access( 'report
 
 form_security_purge( 'manage_config_workflow_set' );
 
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( 'manage_config_workflow_page.php' );

--- a/manage_custom_field_create.php
+++ b/manage_custom_field_create.php
@@ -56,18 +56,12 @@ $f_name	= gpc_get_string( 'name' );
 
 $t_field_id = custom_field_create( $f_name );
 
+form_security_purge( 'manage_custom_field_create' );
+
 if( ON == config_get( 'custom_field_edit_after_create' ) ) {
 	$t_redirect_url = 'manage_custom_field_edit_page.php?field_id=' . $t_field_id;
 } else {
 	$t_redirect_url = 'manage_custom_field_page.php';
 }
 
-form_security_purge( 'manage_custom_field_create' );
-
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin( 'manage_overview_page.php' );
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_custom_field_delete.php
+++ b/manage_custom_field_delete.php
@@ -73,10 +73,4 @@ custom_field_destroy( $f_field_id );
 
 form_security_purge( 'manage_custom_field_delete' );
 
-layout_page_header( null, $f_return );
-
-layout_page_begin( 'manage_overview_page.php' );
-
-html_operation_successful( $f_return );
-
-layout_page_end();
+print_header_redirect( $f_return );

--- a/manage_custom_field_update.php
+++ b/manage_custom_field_update.php
@@ -85,10 +85,4 @@ custom_field_update( $f_field_id, $t_values );
 
 form_security_purge( 'manage_custom_field_update' );
 
-layout_page_header( null, $f_return );
-
-layout_page_begin( 'manage_overview_page.php' );
-
-html_operation_successful( $f_return );
-
-layout_page_end();
+print_header_redirect( $f_return );

--- a/manage_filter_delete.php
+++ b/manage_filter_delete.php
@@ -67,11 +67,4 @@ filter_db_delete_filter( $f_filter_id );
 
 form_security_purge( 'manage_filter_delete' );
 
-$t_redirect_page = 'manage_filter_page.php';
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin();
-
-html_operation_successful( $t_redirect_page );
-
-layout_page_end();
+print_header_redirect( 'manage_filter_page.php' );

--- a/manage_plugin_install.php
+++ b/manage_plugin_install.php
@@ -57,4 +57,4 @@ if( !is_null( $t_plugin ) ) {
 
 form_security_purge( 'manage_plugin_install' );
 
-print_successful_redirect( 'manage_plugin_page.php' );
+print_header_redirect( 'manage_plugin_page.php' );

--- a/manage_plugin_uninstall.php
+++ b/manage_plugin_uninstall.php
@@ -81,4 +81,4 @@ if( !is_null( $t_plugin ) ) {
 
 form_security_purge( 'manage_plugin_uninstall' );
 
-print_successful_redirect( 'manage_plugin_page.php' );
+print_header_redirect( 'manage_plugin_page.php' );

--- a/manage_plugin_update.php
+++ b/manage_plugin_update.php
@@ -79,4 +79,4 @@ foreach( $t_query->fetch_all() as $t_row ) {
 
 form_security_purge( 'manage_plugin_update' );
 
-print_successful_redirect( 'manage_plugin_page.php' );
+print_header_redirect( 'manage_plugin_page.php' );

--- a/manage_plugin_upgrade.php
+++ b/manage_plugin_upgrade.php
@@ -57,4 +57,4 @@ if( !is_null( $t_plugin ) && $t_plugin->status != MantisPlugin::STATUS_MISSING_P
 
 form_security_purge( 'manage_plugin_upgrade' );
 
-print_successful_redirect( 'manage_plugin_page.php' );
+print_header_redirect( 'manage_plugin_page.php' );

--- a/manage_proj_cat_delete.php
+++ b/manage_proj_cat_delete.php
@@ -84,7 +84,4 @@ if( $t_project_id == ALL_PROJECTS ) {
 	$t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $t_project_id . '#categories';
 }
 
-layout_page_header( null, $t_redirect_url );
-layout_page_begin( 'manage_overview_page.php' );
-html_operation_successful( $t_redirect_url );
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_proj_cat_update.php
+++ b/manage_proj_cat_update.php
@@ -83,7 +83,4 @@ if( $t_project_id == ALL_PROJECTS ) {
 	$t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $t_project_id . '#categories';
 }
 
-layout_page_header( null, $t_redirect_url );
-layout_page_begin( 'manage_overview_page.php' );
-html_operation_successful( $t_redirect_url );
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_proj_create.php
+++ b/manage_proj_create.php
@@ -108,9 +108,4 @@ if( 0 != $f_parent_id ) {
 
 form_security_purge( 'manage_proj_create' );
 
-layout_page_header( null, $t_redirect_url );
-layout_page_begin( 'manage_overview_page.php' );
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_proj_custom_field_add_existing.php
+++ b/manage_proj_custom_field_add_existing.php
@@ -63,11 +63,4 @@ custom_field_link( $f_field_id, $f_project_id );
 form_security_purge( 'manage_proj_custom_field_add_existing' );
 
 $t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id . '#customfields';
-
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin( 'manage_overview_page.php' );
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_proj_custom_field_remove.php
+++ b/manage_proj_custom_field_remove.php
@@ -84,10 +84,4 @@ custom_field_unlink( $f_field_id, $f_project_id );
 
 form_security_purge( 'manage_proj_custom_field_remove' );
 
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin( 'manage_overview_page.php' );
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_proj_custom_field_update.php
+++ b/manage_proj_custom_field_update.php
@@ -64,4 +64,4 @@ custom_field_set_sequence( $f_field_id, $f_project_id, $f_sequence );
 form_security_purge( 'manage_proj_custom_field_update' );
 
 $t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id . "#customfields";
-print_successful_redirect( $t_redirect_url, /* force_show */ true );
+print_header_redirect( $t_redirect_url );

--- a/manage_proj_custom_field_update.php
+++ b/manage_proj_custom_field_update.php
@@ -64,11 +64,4 @@ custom_field_set_sequence( $f_field_id, $f_project_id, $f_sequence );
 form_security_purge( 'manage_proj_custom_field_update' );
 
 $t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id . "#customfields";
-
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin( 'manage_overview_page.php' );
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_proj_custom_field_update.php
+++ b/manage_proj_custom_field_update.php
@@ -64,4 +64,4 @@ custom_field_set_sequence( $f_field_id, $f_project_id, $f_sequence );
 form_security_purge( 'manage_proj_custom_field_update' );
 
 $t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id . "#customfields";
-print_header_redirect( $t_redirect_url );
+print_successful_redirect( $t_redirect_url, /* force_show */ true );

--- a/manage_proj_subproj_add.php
+++ b/manage_proj_subproj_add.php
@@ -71,11 +71,4 @@ $t_command->execute();
 form_security_purge( 'manage_proj_subproj_add' );
 
 $t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id . '#subprojects';
-
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin( 'manage_overview_page.php' );
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_proj_subproj_delete.php
+++ b/manage_proj_subproj_delete.php
@@ -64,11 +64,4 @@ $t_command->execute();
 form_security_purge( 'manage_proj_subproj_delete' );
 
 $t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id . '#subprojects';
-
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin( 'manage_overview_page.php' );
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_proj_update_children.php
+++ b/manage_proj_update_children.php
@@ -67,4 +67,4 @@ foreach ( $t_subproject_ids as $t_subproject_id ) {
 
 form_security_purge( 'manage_proj_update_children' );
 
-print_successful_redirect( 'manage_proj_edit_page.php?project_id=' . $f_project_id . '#subprojects');
+print_header_redirect( 'manage_proj_edit_page.php?project_id=' . $f_project_id . '#subprojects' );

--- a/manage_proj_update_children.php
+++ b/manage_proj_update_children.php
@@ -67,4 +67,7 @@ foreach ( $t_subproject_ids as $t_subproject_id ) {
 
 form_security_purge( 'manage_proj_update_children' );
 
-print_header_redirect( 'manage_proj_edit_page.php?project_id=' . $f_project_id . '#subprojects' );
+$t_redirect_url =
+	'manage_proj_edit_page.php?project_id=' . $f_project_id . '#subprojects';
+
+print_header_redirect( $t_redirect_url );

--- a/manage_proj_user_remove.php
+++ b/manage_proj_user_remove.php
@@ -80,11 +80,4 @@ $t_command->execute();
 form_security_purge( 'manage_proj_user_remove' );
 
 $t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id;
-
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin( 'manage_overview_page.php' );
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_proj_user_update.php
+++ b/manage_proj_user_update.php
@@ -302,10 +302,7 @@ if( !$f_confirmed ) {
 	}
 
 	form_security_purge( 'manage_proj_user_update' );
+	
 	$t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id . '#project-users';
-	layout_page_header( null, $t_redirect_url );
-	layout_page_begin( 'manage_overview_page.php' );
-	html_operation_successful( $t_redirect_url );
-	layout_page_end();
-
+	print_header_redirect( $t_redirect_url );
 }

--- a/manage_proj_ver_add.php
+++ b/manage_proj_ver_add.php
@@ -95,9 +95,11 @@ if( $t_version_id == 0 ) {
 }
 
 if( $f_add_and_edit ) {
-	$t_redirect_url = 'manage_proj_ver_edit_page.php?version_id=' . $t_version_id;
+	$t_redirect_url =
+		'manage_proj_ver_edit_page.php?version_id=' . $t_version_id;
 } else {
-	$t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id . '#versions';
+	$t_redirect_url =
+		'manage_proj_edit_page.php?project_id=' . $f_project_id . '#versions';
 }
 
 print_header_redirect( $t_redirect_url );

--- a/manage_proj_ver_add.php
+++ b/manage_proj_ver_add.php
@@ -100,4 +100,4 @@ if( $f_add_and_edit ) {
 	$t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id . '#versions';
 }
 
-print_successful_redirect( $t_redirect_url );
+print_header_redirect( $t_redirect_url );

--- a/manage_proj_ver_add.php
+++ b/manage_proj_ver_add.php
@@ -100,7 +100,4 @@ if( $f_add_and_edit ) {
 	$t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $f_project_id . '#versions';
 }
 
-layout_page_header( null, $t_redirect_url );
-layout_page_begin( 'manage_overview_page.php' );
-html_operation_successful( $t_redirect_url );
-layout_page_end();
+print_successful_redirect( $t_redirect_url );

--- a/manage_proj_ver_delete.php
+++ b/manage_proj_ver_delete.php
@@ -68,7 +68,4 @@ $t_command->execute();
 form_security_purge( 'manage_proj_ver_delete' );
 
 $t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $t_version_info->project_id . '#versions';
-layout_page_header( null, $t_redirect_url );
-layout_page_begin( 'manage_overview_page.php' );
-html_operation_successful( $t_redirect_url );
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_proj_ver_update.php
+++ b/manage_proj_ver_update.php
@@ -73,7 +73,4 @@ $t_command->execute();
 form_security_purge( 'manage_proj_ver_update' );
 
 $t_redirect_url = 'manage_proj_edit_page.php?project_id=' . $t_version->project_id . '#versions';
-layout_page_header( null, $t_redirect_url );
-layout_page_begin( 'manage_overview_page.php' );
-html_operation_successful( $t_redirect_url );
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_user_create.php
+++ b/manage_user_create.php
@@ -99,15 +99,13 @@ $t_user_id = $t_result['id'];
 $t_redirect_url = 'manage_user_edit_page.php?user_id=' . $t_user_id;
 
 layout_page_header( null, $t_redirect_url );
-
 layout_page_begin( 'manage_overview_page.php' );
+
 $t_access_level = get_enum_element( 'access_levels', $f_access_level );
 $t_message = lang_get( 'created_user_part1' )
 	. ' <span class="bold">' . $f_username . '</span> '
 	. lang_get( 'created_user_part2' )
 	. ' <span class="bold">' . $t_access_level . '</span><br />';
 html_operation_successful( $t_redirect_url, $t_message );
-
-echo '</div>';
 
 layout_page_end();

--- a/manage_user_delete.php
+++ b/manage_user_delete.php
@@ -80,10 +80,4 @@ $t_command->execute();
 
 form_security_purge( 'manage_user_delete' );
 
-layout_page_header( null, 'manage_user_page.php' );
-
-layout_page_begin( 'manage_overview_page.php' );
-
-html_operation_successful( 'manage_user_page.php' );
-
-layout_page_end();
+print_header_redirect( 'manage_user_page.php' );

--- a/manage_user_impersonate.php
+++ b/manage_user_impersonate.php
@@ -49,12 +49,5 @@ auth_impersonate( $f_user_id );
 
 form_security_purge( 'manage_user_impersonate' );
 
-$t_redirect_to = config_get_global( 'default_home_page' );
-
-layout_page_header();
-
-layout_page_begin( null );
-
-html_operation_successful( $t_redirect_to );
-
-layout_page_end();
+$t_redirect_url = config_get_global( 'default_home_page' );
+print_header_redirect( $t_redirect_url );

--- a/manage_user_proj_delete.php
+++ b/manage_user_proj_delete.php
@@ -82,8 +82,4 @@ foreach( $f_projects as $t_project_id ) {
 form_security_purge( 'manage_user_proj_delete' );
 
 $t_redirect_url = 'manage_user_edit_page.php?user_id=' . $f_user_id;
-
-layout_page_header( null, $t_redirect_url );
-layout_page_begin( 'manage_overview_page.php' );
-html_operation_successful( $t_redirect_url );
-layout_page_end();
+print_header_redirect( $t_redirect_url );

--- a/manage_user_update.php
+++ b/manage_user_update.php
@@ -70,10 +70,7 @@ $t_data = array(
 $t_command = new UserUpdateCommand( $t_data );
 $t_command->execute();
 
-$t_redirect_url = 'manage_user_edit_page.php?user_id=' . (int)$f_user_id;
-
 form_security_purge( 'manage_user_update' );
-layout_page_header( null, $t_redirect_url );
-layout_page_begin( 'manage_overview_page.php' );
-html_operation_successful( $t_redirect_url );
-layout_page_end();
+
+$t_redirect_url = 'manage_user_edit_page.php?user_id=' . (int)$f_user_id;
+print_header_redirect( $t_redirect_url );

--- a/news_add.php
+++ b/news_add.php
@@ -65,12 +65,7 @@ form_security_purge( 'news_add' );
 $t_news_row = news_get_row( $t_news_id );
 
 layout_page_header();
-
 layout_page_begin( 'main_page.php' );
-
-echo '<div class="space-10"></div>';
 html_operation_successful( 'main_page.php' );
-
 print_news_entry_from_row( $t_news_row );
-
 layout_page_end();

--- a/plugins/MantisCoreFormatting/pages/config_edit.php
+++ b/plugins/MantisCoreFormatting/pages/config_edit.php
@@ -50,4 +50,4 @@ if( plugin_config_get( 'process_markdown' ) != $f_process_markdown ) {
 
 form_security_purge( 'plugin_format_config_edit' );
 
-print_successful_redirect( plugin_page( 'config', true ) );
+print_header_redirect( plugin_page( 'config', true ) );

--- a/plugins/XmlImportExport/pages/config.php
+++ b/plugins/XmlImportExport/pages/config.php
@@ -17,14 +17,10 @@ function config_set_if_needed( $p_name, $p_value ) {
 	}
 }
 
-$t_redirect_url = plugin_page( 'config_page', true );
-layout_page_header( null, $t_redirect_url );
-layout_page_begin();
-
 config_set_if_needed( 'import_threshold' , gpc_get_int( 'import_threshold' ) );
 config_set_if_needed( 'export_threshold' , gpc_get_int( 'export_threshold' ) );
 
 form_security_purge( 'plugin_XmlImportExport_config' );
 
-html_operation_successful( $t_redirect_url );
-layout_page_end();
+$t_redirect_url = plugin_page( 'config_page', true );
+print_header_redirect( $t_redirect_url );

--- a/print_all_bug_options_reset.php
+++ b/print_all_bug_options_reset.php
@@ -77,17 +77,16 @@ form_security_purge( 'print_all_bug_options_reset' );
 
 $t_redirect_url = 'print_all_bug_options_page.php';
 
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin();
-
 if( $t_result ) {
-	html_operation_successful( $t_redirect_url );
+	print_header_redirect( $t_redirect_url );
 } else {
+	layout_page_header( null, $t_redirect_url );
+	layout_page_begin();
+
 	echo '<div class="failure-msg">';
 	echo error_string( ERROR_GENERIC ) . '<br />';
 	print_link_button( $t_redirect_url, lang_get( 'proceed' ) );
 	echo '</div>';
-}
 
-layout_page_end();
+	layout_page_end();
+}

--- a/print_all_bug_options_update.php
+++ b/print_all_bug_options_update.php
@@ -86,17 +86,16 @@ $t_result = db_query( $t_query, array( $c_export, $t_user_id ) );
 
 form_security_purge( 'print_all_bug_options_update' );
 
-layout_page_header( null, $f_redirect_url );
-
-layout_page_begin();
-
 if( $t_result ) {
-	html_operation_successful( $f_redirect_url );
+	print_header_redirect( $f_redirect_url );
 } else {
+	layout_page_header( null, $f_redirect_url );
+	layout_page_begin();
+
 	echo '<div class="failure-msg">';
 	print error_string( ERROR_GENERIC ) . '<br />';
 	print_link_button( $f_redirect_url, lang_get( 'proceed' ) );
 	echo '</div>';
-}
 
-layout_page_end();
+	layout_page_end();
+}

--- a/proj_doc_add.php
+++ b/proj_doc_add.php
@@ -71,12 +71,4 @@ file_add( 0, $f_file, 'project', $f_title, $f_description );
 
 form_security_purge( 'proj_doc_add' );
 
-$t_redirect_url = 'proj_doc_page.php';
-
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin( 'proj_doc_page.php' );
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( 'proj_doc_page.php' );

--- a/proj_doc_delete.php
+++ b/proj_doc_delete.php
@@ -78,12 +78,4 @@ file_delete( $f_file_id, 'project' );
 
 form_security_purge( 'proj_doc_delete' );
 
-$t_redirect_url = 'proj_doc_page.php';
-
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin( 'proj_doc_page.php' );
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( 'proj_doc_page.php' );

--- a/proj_doc_update.php
+++ b/proj_doc_update.php
@@ -138,12 +138,4 @@ if( !$t_result ) {
 
 form_security_purge( 'proj_doc_update' );
 
-$t_redirect_url = 'proj_doc_page.php';
-
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin( 'proj_doc_page.php' );
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();
+print_header_redirect( 'proj_doc_page.php' );

--- a/set_project.php
+++ b/set_project.php
@@ -120,11 +120,3 @@ if( !is_blank( $c_ref ) ) {
 }
 
 print_header_redirect( $t_redirect_url, true, true );
-
-layout_page_header( null, $t_redirect_url );
-
-layout_page_begin();
-
-html_operation_successful( $t_redirect_url );
-
-layout_page_end();

--- a/tag_attach.php
+++ b/tag_attach.php
@@ -78,4 +78,5 @@ $t_command = new TagAttachCommand( $t_data );
 $t_command->execute();
 
 form_security_purge( 'tag_attach' );
-print_successful_redirect_to_bug( $f_bug_id );
+
+print_header_redirect_view( $f_bug_id );

--- a/tag_create.php
+++ b/tag_create.php
@@ -59,5 +59,5 @@ if( !is_null( $f_tag_name ) ) {
 }
 
 form_security_purge( 'tag_create' );
-print_successful_redirect( 'manage_tags_page.php' );
 
+print_header_redirect( 'manage_tags_page.php' );

--- a/tag_delete.php
+++ b/tag_delete.php
@@ -56,4 +56,4 @@ tag_delete( $f_tag_id );
 
 form_security_purge( 'tag_delete' );
 
-print_successful_redirect( 'manage_tags_page.php' );
+print_header_redirect( 'manage_tags_page.php' );

--- a/tag_detach.php
+++ b/tag_detach.php
@@ -48,4 +48,4 @@ $t_command->execute();
 
 form_security_purge( 'tag_detach' );
 
-print_successful_redirect_to_bug( $f_bug_id );
+print_header_redirect_view( $f_bug_id );

--- a/tag_update.php
+++ b/tag_update.php
@@ -72,4 +72,4 @@ tag_update( $f_tag_id, $f_new_name, $f_new_user_id, $f_new_description );
 form_security_purge( 'tag_update' );
 
 $t_url = 'tag_view_page.php?tag_id='.$f_tag_id;
-print_successful_redirect( $t_url );
+print_header_redirect( $t_url );


### PR DESCRIPTION
Removed operation successful from all pages except:

- Ones that show information in addition to "operation successful".
- Pages that don't reflect the changes or redirect to another page.

Fixes #[5189](https://www.mantisbt.org/bugs/view.php?id=5189)