### PR TITLE
Remove unneeded PHP version checks

### DIFF
--- a/core/classes/Tokenizer.class.php
+++ b/core/classes/Tokenizer.class.php
@@ -51,23 +51,11 @@ class Tokenizer
 		# Check syntax to make sure we get valid PHP code
 		# prepend 'return' statement to ensure the code is not actually executed
 		$t_code = 'return; ' . $p_code . ';';
-		if( version_compare( PHP_VERSION, '7', '>=' ) ) {
-			# In PHP >= 7, eval() throws a ParseError which we can catch
-			# and rethrow as an Exception
-			try {
-				eval( $t_code );
-			}
-			catch( ParseError $e ) {
-				throw new Exception( $e->getMessage() );
-			}
-		} else {
-			# In earlier PHP versions, eval() simply returns false and outputs
-			# an error message to STDERR, but this can't be capture using ob_
-			# functions so we suppress errors and throw a generic error message
-			$result = @eval( $t_code );
-			if( $result === false ) {
-				throw new Exception( 'syntax error' );
-			}
+		try {
+			eval( $t_code );
+		}
+		catch( ParseError $e ) {
+			throw new Exception( $e->getMessage() );
 		}
 
 		$t_tokens = token_get_all( '<?php ' . $p_code );

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -100,19 +100,17 @@ function ldap_connect_bind( $p_binddn = '', $p_password = '' ) {
 	}
 
 	# Set minimum TLS protocol version flag (ex: LDAP_OPT_X_TLS_PROTOCOL_TLS1_2).
-	if( version_compare( PHP_VERSION, '7.1.0', '>=' ) ) {
-		$t_tls_protocol_min = config_get_global( 'ldap_tls_protocol_min' );
-		if( $t_tls_protocol_min > 0 ) {
-			log_event( LOG_LDAP, 'Attempting to set minimum TLS protocol' );
-			$t_result = @ldap_set_option( $t_ds, LDAP_OPT_X_TLS_PROTOCOL_MIN, $t_tls_protocol_min );
-			if( !$t_result ) {
-				ldap_log_error( $t_ds );
-				log_event( LOG_LDAP, "Error: Failed to set minimum TLS version on LDAP server" );
-				trigger_error( ERROR_LDAP_UNABLE_TO_SET_MIN_TLS, ERROR );
+	$t_tls_protocol_min = config_get_global( 'ldap_tls_protocol_min' );
+	if( $t_tls_protocol_min > 0 ) {
+		log_event( LOG_LDAP, 'Attempting to set minimum TLS protocol' );
+		$t_result = @ldap_set_option( $t_ds, LDAP_OPT_X_TLS_PROTOCOL_MIN, $t_tls_protocol_min );
+		if( !$t_result ) {
+			ldap_log_error( $t_ds );
+			log_event( LOG_LDAP, "Error: Failed to set minimum TLS version on LDAP server" );
+			trigger_error( ERROR_LDAP_UNABLE_TO_SET_MIN_TLS, ERROR );
 
-				# Return required as function may be called with error suppressed
-				return false;
-			}
+			# Return required as function may be called with error suppressed
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Starting with MantisBT version 2.26.0 our PHP minimum version is 7.2.5. Checking for older PHP versions is no longer needed.

Fixes [#32901](https://www.mantisbt.org/bugs/view.php?id=32901)