### PR TITLE
Drop duplicate status/$g_allow_reporter_close

### DIFF
--- a/docbook/Admin_Guide/en-US/config/status.xml
+++ b/docbook/Admin_Guide/en-US/config/status.xml
@@ -211,14 +211,6 @@
 			</listitem>
 		</varlistentry>
 		<varlistentry>
-			<term>$g_allow_reporter_close</term>
-			<listitem>
-				<para>If set, the bug reporter is allowed to close their own bugs,
-					regardless of their access level. The default is OFF.
-				</para>
-			</listitem>
-		</varlistentry>
-		<varlistentry>
 			<term>$g_allow_reporter_reopen</term>
 			<listitem>
 				<para>If set, the bug reporter is allowed to reopen their own bugs


### PR DESCRIPTION
`$g_allow_reporter_close` shows up twice in the documentation:

- [status/$g_allow_reporter_close](https://www.mantisbt.org/docs/master/en-US/Admin_Guide/html/admin.config.status.html) - `⁠5.22. Status Settings`
- [misc/$g_allow_reporter_close](https://www.mantisbt.org/docs/master/en-US/Admin_Guide/html/admin.config.misc.html) - `⁠5.24. Misc`

I've opt to drop `status/$g_allow_reporter_close`, as it shows up in misc when you look in `./config_defaults_inc.php` its in `# MantisBT Misc Settings #`


---

```
github/mantisbt % grep -R g_allow_reporter_close .
./config_defaults_inc.php: * @global integer $g_allow_reporter_close
./config_defaults_inc.php:$g_allow_reporter_close	 = OFF;
./docbook/Admin_Guide/en-US/Page_Descriptions.xml:                                <entry>$g_allow_reporter_close</entry>
./docbook/Admin_Guide/en-US/config/status.xml:			<term>$g_allow_reporter_close</term>
./docbook/Admin_Guide/en-US/config/misc.xml:			<term>$g_allow_reporter_close</term>
github/mantisbt %
```