### PR TITLE
Drop duplicate issues/$g_default_bug_view_status

### DIFF
--- a/docbook/Admin_Guide/en-US/config/issues.xml
+++ b/docbook/Admin_Guide/en-US/config/issues.xml
@@ -23,15 +23,6 @@
 		</para>
 		<variablelist>
 			<varlistentry>
-				<term>$g_default_bug_view_status</term>
-				 <listitem>
-					<para>
-						The default viewing status for the new bug (VS_PUBLIC or
-						VS_PRIVATE). The default is VS_PUBLIC.
-					</para>
-				</listitem>
-			</varlistentry>
-			<varlistentry>
 				<term>$g_private_bug_threshold</term>
 				 <listitem>
 					<para>


### PR DESCRIPTION
`$g_default_bug_view_status` shows up twice in the documentation:

- [issues/$g_default_bug_view_status](https://www.mantisbt.org/docs/master/en-US/Admin_Guide/html/admin.config.issues.html) - `⁠5.43.1. Public/Private view status`
- [defaults/$g_default_bug_view_status](https://www.mantisbt.org/docs/master/en-US/Admin_Guide/html/admin.config.defaults.html) - `⁠5.16. Default Preferences`

I've opt to drop `issues/$g_default_bug_view_status`, as it shows up in misc when you look in `./config_defaults_inc.php` in `# MantisBT Default Preferences #`


---

```
github/mantisbt % grep -R g_default_bug_view_status .
./config_defaults_inc.php: * @global integer $g_default_bug_view_status
./config_defaults_inc.php:$g_default_bug_view_status = VS_PUBLIC;
./docbook/Admin_Guide/en-US/config/issues.xml:				<term>$g_default_bug_view_status</term>
./docbook/Admin_Guide/en-US/config/defaults.xml:			<term>$g_default_bug_view_status</term>
github/mantisbt %
```