### PR TITLE
Fix Unknown named parameter $files error on PHP 8+

### DIFF
--- a/core/bugnote_api.php
+++ b/core/bugnote_api.php
@@ -312,7 +312,7 @@ function bugnote_add( $p_bug_id, $p_bugnote_text, $p_time_tracking = '0:00', $p_
 
 	# Event integration
 	if( $p_trigger_event ) {
-		event_signal( 'EVENT_BUGNOTE_ADD', array( $p_bug_id, $t_bugnote_id, 'files' => array() ) );
+		event_signal( 'EVENT_BUGNOTE_ADD', array( $p_bug_id, $t_bugnote_id, array() ) );
 	}
 
 	# only send email if the text is not blank, otherwise, it is just recording of time without a comment.

--- a/core/commands/IssueNoteAddCommand.php
+++ b/core/commands/IssueNoteAddCommand.php
@@ -278,7 +278,7 @@ class IssueNoteAddCommand extends Command {
 		email_bugnote_add( $t_note_id, $t_file_infos, /* user_exclude_ids */ $t_user_ids_that_got_mention_notifications );
 
 		# Event integration
-		event_signal( 'EVENT_BUGNOTE_ADD', array( $this->issue->id, $t_note_id, 'files' => $t_file_infos ) );
+		event_signal( 'EVENT_BUGNOTE_ADD', array( $this->issue->id, $t_note_id, $t_file_infos ) );
 
 		return array( 'id' => $t_note_id );
 	}

--- a/docbook/Developers_Guide/en-US/Events_Reference_Bug.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference_Bug.xml
@@ -462,9 +462,9 @@
 
 				<itemizedlist>
 					<title>Parameters</title>
-					<listitem><para>&lt;Integer&gt;: (Key = 0) Bug ID</para></listitem>
-					<listitem><para>&lt;Integer&gt;: (Key = 1) Bugnote ID</para></listitem>
-					<listitem><para>&lt;array&gt;: (Key = "files") Files info (name, size, id), starting 2.23.0</para></listitem>
+					<listitem><para>&lt;Integer&gt;: Bug ID</para></listitem>
+					<listitem><para>&lt;Integer&gt;: Bugnote ID</para></listitem>
+					<listitem><para>&lt;array&gt;: Files info (name, size, id), starting 2.23.0</para></listitem>
 				</itemizedlist>
 			</blockquote>
 		</blockquote>

--- a/search.php
+++ b/search.php
@@ -53,6 +53,7 @@ gpc_make_array( FILTER_PROPERTY_STATUS );
 gpc_make_array( FILTER_PROPERTY_REPORTER_ID );
 gpc_make_array( FILTER_PROPERTY_HANDLER_ID );
 gpc_make_array( FILTER_PROPERTY_PROJECT_ID );
+gpc_make_array( FILTER_PROPERTY_PROJECTION );
 gpc_make_array( FILTER_PROPERTY_RESOLUTION );
 gpc_make_array( FILTER_PROPERTY_BUILD );
 gpc_make_array( FILTER_PROPERTY_VERSION );
@@ -81,6 +82,7 @@ $t_my_filter[FILTER_PROPERTY_SEVERITY] = gpc_get_string_array( FILTER_PROPERTY_S
 $t_my_filter[FILTER_PROPERTY_STATUS] = gpc_get_string_array( FILTER_PROPERTY_STATUS, $t_meta_filter_any_array );
 
 $t_my_filter[FILTER_PROPERTY_PROJECT_ID] = gpc_get_string_array( FILTER_PROPERTY_PROJECT_ID, $t_meta_filter_any_array );
+$t_my_filter[FILTER_PROPERTY_PROJECTION] = gpc_get_string_array( FILTER_PROPERTY_PROJECTION, $t_meta_filter_any_array );
 $t_my_filter[FILTER_PROPERTY_RESOLUTION] = gpc_get_string_array( FILTER_PROPERTY_RESOLUTION, $t_meta_filter_any_array );
 $t_my_filter[FILTER_PROPERTY_BUILD] = gpc_get_string_array( FILTER_PROPERTY_BUILD, $t_meta_filter_any_array );
 $t_my_filter[FILTER_PROPERTY_FIXED_IN_VERSION] = gpc_get_string_array( FILTER_PROPERTY_FIXED_IN_VERSION, $t_meta_filter_any_array );


### PR DESCRIPTION
- Remove the array key when calling event_signal() in bugnote_add() and IssueNoteAddCommand::process().
- Update documentation

Fixes [#33058](https://www.mantisbt.org/bugs/view.php?id=33058)