### PR TITLE
Fix REST API endpoints failing on Windows

### DIFF
--- a/api/rest/index.php
+++ b/api/rest/index.php
@@ -89,6 +89,11 @@ if( version_compare( Slim\App::VERSION, '4.0', '<' )
 		string $p_file,
 		int    $p_line
 	): bool {
+		if( is_windows_server() ) {
+			# Convert to Unix-style path
+			$p_file = str_replace( '\\', '/', $p_file );
+		}
+
 		if( preg_match( '~/vendor/(?:\w+/){2}(.*)$~', $p_file, $t_matches ) ) {
 			# Selectively handle deprecation warnings
 			switch( $t_matches[1] ) {


### PR DESCRIPTION
When running on PHP >= 8.1, REST API calls throw errors on Windows, due to deprecated_errors_handler() function incorrectly expecting Unix-style path on offending file name.

Converting `\` to `/` in $p_file variable before processing fixes the problem.

Fixes [#33173](https://mantisbt.org/bugs/view.php?id=33173)