### PR TITLE
Fix testProjectUpdateVersion()

### DIFF
--- a/tests/rest/RestProjectVersionTest.php
+++ b/tests/rest/RestProjectVersionTest.php
@@ -291,7 +291,8 @@ class RestProjectVersionTest extends RestBase {
 		$this->assertTrue( $t_version_result['obsolete'] );
 		$this->assertTrue( $t_version_result['released'] );
 
-		$t_version_patch = array( 'timestamp' => time() );
+		$t_now = new DateTimeImmutable();
+		$t_version_patch = array( 'timestamp' => $t_now->format( 'c' ) );
 		$t_response = $this->builder()->patch( $this->ver_base_url . $t_version['id'], $t_version_patch )->send();
 		$this->assertEquals( HTTP_STATUS_SUCCESS, $t_response->getStatusCode() );
 		$t_version_result = json_decode( $t_response->getBody(), true );


### PR DESCRIPTION
The assertion to test the version update (PATCH request) was incorrectly setting the timestamp in the updated version data as a Unix timestamp instead of a date string to be parsed by strtotime().

Depending on the current time, the timestamp is sometimes converted by the strtotime() call in VersionUpdateCommand to a date that is not supported by the database which causes the SQL UPDATE statement in version_update() to fail.

Fixes [#33374](https://www.mantisbt.org/bugs/view.php?id=33374)