### PR TITLE
33402 fix - Updating an Issue through the API sets all comments last edit timestamp

### DIFF
--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -1156,6 +1156,7 @@ function mc_issue_update( $p_username, $p_password, $p_issue_id, stdClass $p_iss
 
 				if( array_key_exists( $t_bugnote_id, $t_bugnotes_by_id ) ) {
 					$t_bugnote_changed = false;
+					$t_bugnote = $t_bugnotes_by_id[$t_bugnote_id];
 
 					if( $t_bugnote->note !== $t_note['text'] ) {
 						bugnote_set_text( $t_bugnote_id, $t_note['text'] );


### PR DESCRIPTION
Fix problem [33402](https://www.mantisbt.org/bugs/view.php?id=33402)

problem was, that it always compares the first bugnote to all other bugnotes