### PR TITLE
Show delayed inline errors from print_header_redirect()

### DIFF
--- a/core/print_api.php
+++ b/core/print_api.php
@@ -96,7 +96,16 @@ require_api( 'version_api.php' );
  * @return boolean
  */
 function print_header_redirect( $p_url, $p_die = true, $p_sanitize = false, $p_absolute = false ) {
-	if( ON == config_get_global( 'stop_on_errors' ) && error_handled() ) {
+	if( error_handled() ) {
+		# Display a basic "proceed" page to show any pending errors, regardless
+		# of $g_stop_on_errors setting which is actually handled in
+		# html_meta_redirect(), called by layout_page_header().
+		layout_page_header( null, $p_url );
+		layout_page_begin();
+		echo '<br /><div class="center">';
+		print_link_button( $p_url, lang_get( 'proceed' ) );
+		echo '</div>';
+		layout_page_end();
 		return false;
 	}
 

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -102,6 +102,7 @@ function print_header_redirect( $p_url, $p_die = true, $p_sanitize = false, $p_a
 		# html_meta_redirect(), called by layout_page_header().
 		layout_page_header( null, $p_url );
 		layout_page_begin();
+		html_operation_successful( $p_url );
 		echo '<br /><div class="center">';
 		print_link_button( $p_url, lang_get( 'proceed' ) );
 		echo '</div>';


### PR DESCRIPTION
Following the deprecation of print_successful_redirect() function in issue #5189, calling it shows a blank page when $g_stop_on_errors = ON and $g_display_errors[E_USER_DEPRECATED] = DISPLAY_ERROR_INLINE because Mantis does not complete the redirection due to presence of a handled error.

print_header_redirect() now displays a basic "proceed" page, with redirection enabled only when $g_stop_on_errors = ON, allowing any delayed inline error messages to be shown.

Fixes [#33480](https://mantisbt.org/bugs/view.php?id=33480)