### PR TITLE
Use config API to access allow_browser_cache

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -4281,18 +4281,14 @@ $g_custom_headers = array();
 /**
  * Browser Caching Control.
  *
- * By default, we try to prevent the browser from caching anything.
- * $g_allow_browser_cache will defeat this for some cases.
+ * By default, we try to prevent the browser from caching anything. This setting
+ * will allow the browser to cache all pages. The upside will be better
+ * performance overall, but there may be cases where outdated information is
+ * displayed.
  *
- * Browser Page caching - This will allow the browser to cache all pages. The
- * upside will be better performance, but there may be cases where obsolete
- * information is displayed. Note that this will be bypassed (and caching is
- * allowed) for the bug report pages.
- *
- * @todo The code that references this config considers it ON if it is set (doesn't use config_get_global() / $g_global_settings)
  * @global int $g_allow_browser_cache
  */
-# $g_allow_browser_cache = ON;
+$g_allow_browser_cache = OFF;
 
 #################
 # Custom Fields #
@@ -5199,6 +5195,7 @@ $g_global_settings = array(
 	'absolute_path_default_upload_folder',
 	'admin_checks',
 	'allow_anonymous_login',
+	'allow_browser_cache',
 	'allow_permanent_cookie',
 	'allow_signup',
 	'anonymous_account',

--- a/core/http_api.php
+++ b/core/http_api.php
@@ -99,21 +99,20 @@ function http_content_disposition_header( $p_filename, $p_inline = false ) {
 
 /**
  * Set caching headers that will allow or prevent browser caching.
- * Use an explicit true/false value for the parameter to force the caching behavior.
- * Otherwise, use null or omit the oparameter to use default behavior.
- * The default behavior is to not cache, or the specified in the option $g_allow_browser_cache
- * @param null|boolean $p_allow_caching Force or not caching. Omitting or null, will use default behavior.
+ *
+ * @param bool|null $p_allow_caching True to force caching, false to disable it;
+ *                                   If null, use default behavior defined by
+ *                                   {@see $g_allow_browser_cache}.
+ *
  * @return void
  */
 function http_caching_headers( $p_allow_caching = null ) {
-	global $g_allow_browser_cache;
-
 	if( headers_sent() ) {
 		return;
 	}
 
 	if( $p_allow_caching === null ) {
-		$t_allow_caching = ( isset( $g_allow_browser_cache ) && ON == $g_allow_browser_cache );
+		$t_allow_caching = ON == config_get_global( 'allow_browser_cache' );
 	} else {
 		$t_allow_caching = $p_allow_caching;
 	}


### PR DESCRIPTION
Until now $g_allow_browser_cache config was handled in a non-standard way in in http_caching_headers(), i.e. by referencing it as a global variable instead of retrieving its value with config_get_global().

Moreover, the setting was commented out in config_default_inc.php (i.e. not defined) instead of being set to OFF.

This follows up on discussion in PR #1925.

Fixes [#33482](https://mantisbt.org/bugs/view.php?id=33482)