### PR TITLE
Reflect mysqlnd requirement in installer, admin checks and documentation

### DIFF
--- a/admin/check/check_database_inc.php
+++ b/admin/check/check_database_inc.php
@@ -91,9 +91,14 @@ check_print_test_row(
 
 if( db_is_mysql() ) {
 	check_print_test_warn_row(
-		'PHP support for MySQL driver',
+		'PHP support for legacy MySQL driver',
 		'mysql' != $t_database_type,
-		array( false => "'mysql' driver is deprecated as of PHP 5.5.0, please use 'mysqli' instead" )
+		array( false => "'mysql' driver is deprecated as of PHP 5.5.0 and has been removed as of PHP 7.0.0, please use 'mysqli' instead" )
+	);
+
+	check_print_test_row( 'PHP support for MySQL Native Driver',
+		function_exists( 'mysqli_stmt_get_result' ),
+		array( false => 'Check that the MySQL Native Driver (mysqlnd) has been compiled into your server.' )
 	);
 
 	check_print_test_warn_row(

--- a/docbook/Admin_Guide/en-US/Installation.xml
+++ b/docbook/Admin_Guide/en-US/Installation.xml
@@ -172,7 +172,7 @@
 							<term>Mandatory extensions</term>
 							<listitem><itemizedlist>
 								<listitem><para>The extension for the RDBMS being used (
-										mysqli,
+										mysqli with mysqlnd,
 										pgsql,
 										oci8,
 										sqlsrv
@@ -311,7 +311,9 @@
 								<entry>MySQL</entry>
 								<entry>5.5.35</entry>
 								<entry>5.6 or later</entry>
-								<entry>PHP extension: mysqli</entry>
+								<entry>PHP extension: mysqli
+									with MySQL Native driver (mysqlnd)
+								</entry>
 							</row>
 							<row>
 								<entry>MariaDB</entry>


### PR DESCRIPTION
With introduction of ADOdb 5.22, MySQL Native Driver is required for proper operations.

The installer now correctly detects if it's missing and prevents installation. The Admin checks also report the problem, and the requirement has been documented in Admin Guide.

Fixes [#33519](https://mantisbt.org/bugs/view.php?id=33519)