### PR TITLE
Fix overflowing text in collapsed sidebar menu

### DIFF
--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -704,6 +704,13 @@ ul.changelog > li, ul.roadmap > li {
         margin-left: 43px !important;
     }
 
+    .sidebar.menu-min .nav-list > li > a > .menu-text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        padding-right: 8px;
+    }
+
     .sidebar.compact, .sidebar.compact.navbar-collapse {
         width: 125px;
     }

--- a/js/common.js
+++ b/js/common.js
@@ -636,6 +636,16 @@ $(document).ready( function() {
 			.addClass(getColorClassName(me.val()));
 		me.data('prev', me.val());
 	});
+
+	/**
+	 * Add a title attribute to collapsed menu items overflowing the menu's width,
+	 * so user can view the ellipsified text.
+	 */
+	$('..sidebar.menu-min .nav-list > li > a > .menu-text').forEach(function (elem) {
+		if (parseFloat(window.getComputedStyle(elem).width) === parseFloat(window.getComputedStyle(elem.parentElement).width)) {
+			elem.setAttribute('title', elem.textContent);
+		}
+	});
 });
 
 function setBugLabel() {


### PR DESCRIPTION
- CSS now truncates text and appends an ellipsis if it is too wide
- A title attribute is added to those menu items, so the truncated text is visible in full when hovering over it

Fixes [#33651](https://mantisbt.org/bugs/view.php?id=33651)

New behavior:

![image](https://github.com/mantisbt/mantisbt/assets/449891/59892ec5-a8e8-4be2-bca3-3e6f228d74f6)


