### PR TITLE
Fix issue linebreak on sidebar in collapse mode

### DIFF
--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -716,6 +716,12 @@ ul.changelog > li, ul.roadmap > li {
         left: 43px;
     }
 
+    .sidebar.menu-min .nav-list > li > a > .menu-text {
+        min-width: 176px;
+        width: max-content;
+        padding-right: 12px;
+    }
+
     .rtl .sidebar.compact + .main-content {
         margin-left: auto !important;
         margin-right: 125px !important;


### PR DESCRIPTION
CSS remove width limit of the box.
Fixes https://www.mantisbt.org/bugs/view.php?id=33651
![screenshot-2024-02-16](https://github.com/mantisbt/mantisbt/assets/159786221/7e07a3cf-1a82-4d8d-99f9-865eebf2a17a)
![screenshot-2024-02-16-1](https://github.com/mantisbt/mantisbt/assets/159786221/c04191fb-5b79-40c0-8d41-7fe06db978f6)
