### PR TITLE
Fix overflowing text in collapsed sidebar menu (v3)

### DIFF
--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -716,6 +716,12 @@ ul.changelog > li, ul.roadmap > li {
         left: 43px;
     }
 
+    .sidebar.menu-min .nav-list > li > a > .menu-text {
+        min-width: 176px;
+        width: max-content;
+        padding-right: 12px;
+    }
+
     .rtl .sidebar.compact + .main-content {
         margin-left: auto !important;
         margin-right: 125px !important;

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -602,6 +602,11 @@ ul.changelog > li, ul.roadmap > li {
   border-right-width: 0px;
 }
 
+.sidebar:not(.menu-min) {
+    min-width: 190px;
+    width: auto;
+}
+
 .sidebar.menu-min .nav-list > li > a > .menu-text {
     width: max-content;
     padding-right: 12px;
@@ -646,6 +651,10 @@ ul.changelog > li, ul.roadmap > li {
     .sidebar.menu-min + .main-content {
         margin-right: auto  !important;
         margin-left: 43px !important;
+    }
+
+    .sidebar:not(.min-width) {
+        min-width: auto;
     }
 
     .sidebar.compact, .sidebar.compact.navbar-collapse {

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -602,6 +602,11 @@ ul.changelog > li, ul.roadmap > li {
   border-right-width: 0px;
 }
 
+.sidebar.menu-min .nav-list > li > a > .menu-text {
+    width: max-content;
+    padding-right: 12px;
+}
+
 /* Small devices (tablets, 768px and up) */
 @media (min-width: 768px) {
     .page-content {
@@ -714,11 +719,6 @@ ul.changelog > li, ul.roadmap > li {
 
     .sidebar.menu-min ~ .footer .footer-inner {
         left: 43px;
-    }
-
-    .sidebar.menu-min .nav-list > li > a > .menu-text {
-        width: max-content;
-        padding-right: 12px;
     }
 
     .rtl .sidebar.compact + .main-content {

--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -717,7 +717,6 @@ ul.changelog > li, ul.roadmap > li {
     }
 
     .sidebar.menu-min .nav-list > li > a > .menu-text {
-        min-width: 176px;
         width: max-content;
         padding-right: 12px;
     }


### PR DESCRIPTION
Fixes [#33651](https://mantisbt.org/bugs/view.php?id=33651), replaces PRs #1967 and #1968

New behavior: dynamically resize:
- the menu-text's width in collapsed sidebar menu 
![image](https://github.com/mantisbt/mantisbt/assets/449891/b6a9b69f-cc09-4492-a153-6bb258ec737d)
- the whole sidebar menu's width in responsive mode when it's not collapsed 
![image](https://github.com/mantisbt/mantisbt/assets/449891/99512820-bcf0-4d4c-9bc4-d5c18ebda3d2)

