### PR TITLE
Enabling HTML emails based upon templates

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -942,6 +942,36 @@ $g_email_padding_length = 28;
  */
 $g_email_retry_in_days = 7;
 
+/**
+ * Use a HTML template to format emails
+ * When this OFF ( default) mails will be fully text based.
+ * If set to ON, tremplates will be used (to be maintained locally)
+ *
+ * @global int $g_email_use_template
+ */
+ $g_email_use_template = OFF;
+ 
+/**
+ * use the escape sequence for the mail template
+ * When this OFF ( default) mails, an escape sequence will not be used
+ *
+ * @global int $g_email_escape_template
+ */
+$g_email_escape_template = OFF;
+
+/**
+ * Set the physical location for the 3 templates.
+ * These locations can be outside the webroot but do ensure that the web-user has access to them.
+ * The available templates for new and existing bug are initially the same.
+ *
+ * @global string $g_email_newbug_template
+ * @global string $g_email_bug_template
+ * @global string $g_email_note_template
+ */
+$g_email_newbug_template = "/var/www/html/mantis2/core/templates/newbug_mailtemplate.html";
+$g_email_bug_template = "/var/www/html/mantis2/core/templates/bug_mailtemplate.html";
+$g_email_note_template = "/var/www/html/mantis2/core/templates/note_mailtemplate.html";
+
 ###########################
 # MantisBT Version String #
 ###########################

--- a/core/template_api.php
+++ b/core/template_api.php
@@ -1,0 +1,171 @@
+<?php
+
+function email_template_bug_message( $issue_data,$top_line ) {
+
+	// we move all data into an array called $variables
+	$variables = array();
+	$variables['top_line']		= $top_line;
+	$variables['project']		= $issue_data['email_project'];
+	$variables['category']		= $issue_data['email_category'];
+	$variables['bug_id']		= $issue_data['email_bug'];
+	$variables['reporter']		= $issue_data['email_reporter'];
+	$variables['hander']		= $issue_data['email_handler'];
+	$variables['severity']		= get_enum_element( 'severity', $issue_data['email_severity'], auth_get_current_user_id(), $issue_data['project_id']  );
+	$variables['status']		= get_enum_element( 'status', $issue_data['email_status'], auth_get_current_user_id(), $issue_data['project_id'] );
+	$variables['priority']		= get_enum_element( 'priority', $issue_data['email_priority'], auth_get_current_user_id(),$issue_data['project_id'] );
+	$variables['repro']			= get_enum_element( 'reproducibility', $issue_data['email_reproducibility'], auth_get_current_user_id(), $issue_data['project_id'] );
+	$variables['submitted']		= date( config_get( 'normal_date_format' ), $issue_data['email_date_submitted'] );
+	$variables['modified']		= date( config_get( 'normal_date_format' ), $issue_data['email_last_modified'] );
+	$variables['summary']		= $issue_data['email_summary'];
+	$variables['description']	= $issue_data['email_description'];
+	$variables['tags']			= $issue_data['email_tag'];
+	$variables['info']			= $issue_data['email_additional_information'];
+	$variables['steps']			= $issue_data['email_steps_to_reproduce'];
+	$variables['due_date']		= $issue_data['email_due_date'];
+	$variables['url']			= $issue_data['email_bug_view_url'];
+
+## process custom fields, looping through the array
+	$custom_fields = $issue_data['custom_fields'];
+	if (!empty($custom_fields)) {
+		$cfdata = '<table><tr><b><td width="40%">Field</td><td width="60%">Value</td></b></tr>';
+		foreach( $issue_data['custom_fields'] as $t_custom_field_name => $t_custom_field_data ) {
+			$cfdata .= '<tr><td>'.utf8_str_pad( lang_get_defaulted( $t_custom_field_name, null ) . ': ', $t_email_padding_length, ' ', STR_PAD_RIGHT ).'</td>';
+			$cfdata .= '<td>'.string_custom_field_value_for_email( $t_custom_field_data['value'], $t_custom_field_data['type'] ).'</td></tr>';
+		}
+	} else {
+		$cfdata = "Not Available";
+	}
+	$variables['cfdata'] = $cfdata ;
+
+## process the notes, looping through the array
+	$bugnotes = $issue_data['bugnotes'];
+	if (count( $bugnotes ) > 0 ) {
+		$notedata = '<table><tr><b><td width="15%">Date</td><td width="10%">Username</td><td width="75%">Note</td></b></tr>';
+		foreach( $bugnotes as $t_note ) {
+			$noteDate =  date( config_get( 'normal_date_format' ), $t_note->date_submitted );
+			$notereporter = user_get_username($t_note->reporter_id);
+			$notedata .= '<tr><td>'.$noteDate.'</td><td>'.$notereporter.'</td><td>'.$t_note->note.'</td></tr>';
+		}
+		$notedata .='</table>';
+	} else {
+		$notedata ='Not Available';
+	}
+	$variables['notedata'] = trim($notedata, " \t\n\r") ;
+
+## process the relationships, looping through the array
+	$relations = $issue_data['relations'];
+	if (!empty($relations)) {
+		$reldata = $relations;
+	} else {
+		$reldata = "Not Available";
+	}
+	$variables['reldata'] = $reldata ;
+
+## process the history, looping through the array
+	$history = $issue_data['history'];
+	if( count( $history)  > 0 ) {
+		$hisdata = '<table><tr><b><td width="15%">Date</td><td width="10%">Username</td><td width="25%">What</td><td width="50%">Change</td></b></tr>';
+		foreach( $history as $t_his ) {
+			$hisrecords++;
+			$hisDate = date( config_get( 'normal_date_format' ), $t_his['date'] );
+			$t_localized_item = history_localize_item( $t_his['field'], $t_his['type'], $t_his['old_value'], $t_his['new_value'], false );
+			$hisdata .= '<tr><td>'.$hisDate . '</td><td>' . utf8_str_pad( $t_his['username'], 15 ). '</td><td>' . utf8_str_pad( $t_localized_item['note'], 25 ) . '</td><td>'. utf8_str_pad( $t_localized_item['change'], 20 ) . '</td></tr>';
+			$lastdatestamp = $t_his['date'] ;
+		}
+		$hisdata .='</table>';	
+	} else {
+		$lastdatestamp = 0;
+		$hisdata = 'Not Available';
+	}
+	$variables['hisdata'] = trim($hisdata, " \t\n\r") ;
+
+## process the history, finding the last entries based upon $lastdastestamp
+	$newissue = false ;
+	If ($lastdatestamp<>0){
+		$history = $issue_data['history'];
+		$lasthisdata = '<table><tr><b><td width="15%">Date</td><td width="10%">Username</td><td width="25%">What</td><td width="50%">Change</td></b></tr>';
+		foreach( $history as $t_his ) {
+			if ( $t_his['date'] == $lastdatestamp ){
+				$hisDate = date( config_get( 'normal_date_format' ), $t_his['date'] );
+				$t_localized_item = history_localize_item( $t_his['field'], $t_his['type'], $t_his['old_value'], $t_his['new_value'], false );
+				$lasthisdata .= '<tr><td>'.$hisDate . '</td><td>' . utf8_str_pad( $t_his['username'], 15 ). '</td><td>' . utf8_str_pad( $t_localized_item['note'], 25 ) . '</td><td>'. utf8_str_pad( $t_localized_item['change'], 20 ) . '</td></tr>';
+	//			$lasthisdata .= $hisDate . " => " . utf8_str_pad( $t_his['username'], 15 ). " => " . utf8_str_pad( $t_localized_item['note'], 25 ). " => " . utf8_str_pad( $t_localized_item['change'], 20 ) . "<br>";
+				if ($t_his['type'] == 1) {
+					$newissue = true;
+				}
+			}
+		}
+		$lasthisdata .='</table>';	
+	} else {
+		$lasthisdata = 'Not Available';
+	}
+	$variables['lasthisdata'] = trim($lasthisdata, " \t\n\r") ;
+
+## next 2 are temp entries
+$variables['reference'] = $_SERVER['HTTP_REFERER'];
+$variables['mail_data'] = print_r($issue_data, true);
+##
+
+	// Load the template
+	
+	// first check if this is a new issue
+	if ( $newissue ){
+		$template_definition = config_get( 'email_newbug_template' );
+	} else {
+		$template_definition = config_get( 'email_bug_template' );
+	}
+	$template = file_get_contents($template_definition);
+	
+	// next assign the values to the template
+	foreach($variables as $key => $value) {
+		$template = str_replace('{{ '.$key.' }}', $value, $template);
+	}
+	return $template;
+
+}
+
+function email_template_bugnote( $p_bugnote, $p_project_id, $p_show_time_tracking, $p_horizontal_separator, $top_line , $p_date_format = null) {
+
+	$t_date_format = ( $p_date_format === null ) ? config_get( 'normal_date_format' ) : $p_date_format;
+
+	$t_last_modified = date( $t_date_format, $p_bugnote->last_modified );
+	$t_formatted_bugnote_id = bugnote_format_id( $p_bugnote->id );
+	$t_bugnote_link = string_process_bugnote_link( config_get( 'bugnote_link_tag' ) . $p_bugnote->id, false, false, true );
+
+	if( $p_show_time_tracking && $p_bugnote->time_tracking > 0 ) {
+		$t_time_tracking = ' ' . lang_get( 'time_tracking' ) . ' ' . db_minutes_to_hhmm( $p_bugnote->time_tracking ) . "\n";
+	} else {
+		$t_time_tracking = '';
+	}
+
+	if( user_exists( $p_bugnote->reporter_id ) ) {
+		$t_access_level = access_get_project_level( $p_project_id, $p_bugnote->reporter_id );
+		$t_access_level_string = ' (' . access_level_get_string( $t_access_level ) . ')';
+	} else {
+		$t_access_level_string = '';
+	}
+
+	// we move all data into an array called $variables
+	$variables = array();
+	$variables['top_line'] = $top_line;
+	$variables['note_id'] = $t_formatted_bugnote_id;
+	$reporter = user_get_name( $p_bugnote->reporter_id );
+	$variables['reporter'] = $reporter;
+	$variables['access'] = $t_access_level_string;
+	$variables['modified'] = $t_last_modified;
+	$variables['private'] =  $t_private;
+	$variables['timetrack'] = $t_time_tracking;
+	$variables['url'] = $t_bugnote_link;
+	$note = $p_bugnote->note;
+	$variables['note'] = $note;
+
+	// Load the template
+	$template_definition = config_get( 'email_note_template' );
+	$template = file_get_contents($template_definition);
+	
+	// next assign the values to the template
+	foreach($variables as $key => $value) {
+		$template = str_replace('{{ '.$key.' }}', $value, $template);
+	}
+	return $template;
+}

--- a/core/templates/bug_mailtemplate.html
+++ b/core/templates/bug_mailtemplate.html
@@ -1,0 +1,83 @@
+<!--
+Available fields to this template:
+	[email_bug] 					=> bug_id
+	[email_bug_view_url]			=> url
+	[email_handler]					=> handler
+	[email_reporter]				=> reporter
+	[email_project]					=> project
+	[email_category]				=> category
+	[email_tag]						=> tags
+	[email_date_submitted]			=> submitted
+	[email_last_modified]			=> modified
+	[email_due_date]				=> due_date
+	[email_status]					=> status
+	[email_severity]				=> severity
+	[email_priority]				=> priority
+	[email_reproducibility]			=> repro
+	[email_summary]					=> summary
+	[email_description] 			=> description
+	[email_additional_information]	=> info
+	[email_steps_to_reproduce]		=> steps
+	Custom fields					=> cfdata		
+	Notes							=> notedata ( as table )
+	Relations						=> reldata	( as table )
+	History							=> hisdata		
+	History (last entries)			=> lasthisdata	
+
+	## following 2 fields are available for testing purposes
+	Referer page					=> reference
+	Available data					=> mail_data
+
+	## how to use the fields
+	all elements ( only those you need of course) need to be referenced inbetween "{{" and "}}"
+
+	## changes
+	modification of contents takes place within core/template_api.php, function email_template_bug_message
+-->
+<style>
+body {
+    background-color: #93B874;
+}
+h1 {
+    background-color: #00b33c;
+}
+p {
+    background-color: #FFFFFF);
+}
+table, th, td {    margin: 0; padding: 0;font-size: 100%; font: inherit; vertical-align: baseline;border: 1px solid black;}
+</style>
+<body>
+<h2 style="color:red; background:black;">
+{{ top_line }}
+</h2>
+<br>
+<table>
+<tr><td><b>Issue-id </b> </td><td>{{ bug_id }} <a href={{ url }}> View all details inside the Issue Tracker</a></td></tr>
+<tr><td><b>Status </b></td><td> {{ status }}</td></tr>
+<tr><td><b>Submitted </b></td><td> {{ submitted }}</td></tr>
+<tr><td><b>Last Modified </b></td><td> {{ modified }}</td></tr>
+<tr><td><b>Priority </b></td><td> {{ priority }}</td></tr>
+<tr><td><b>Severity </b></td><td> {{ severity }}</td></tr>
+<tr><td><b>Reproducibility </b></td><td> {{ repro }}</td></tr>
+<tr><td><b>Reporter </b></td><td> {{ reporter }}</td></tr>
+<tr><td><b>Project</b></td><td> {{ project }}</td></tr>
+<tr><td><b>Category </b></td><td> {{ category }}</td></tr>
+<tr><td><b>Summary</b></td><td> {{ summary }}</td></tr>
+<tr><td><b>Description</B</td><td> {{ description }} </td></tr>
+<tr><td><b>Steps to reproduce </b></td><td>{{ steps }}</td></tr>
+<tr><td><b>Additional Information</b></td><td> {{ info }} </td></tr>
+<tr><td><b>Due-Date</b></td><td> {{ due_date }}</td></tr>
+<tr><td><b>Tags</b></td><td> {{ tags }}</td></tr>
+<tr><td><b>Custom Fields</b></td><td> {{ cfdata }} </td></tr>
+<tr><td><b>Relations</b></td><td> {{ reldata }} </td></tr>
+<tr><td><b>Notes</b></td><td> {{ notedata }} </td></tr>
+<tr><td><b>Last History</b></td><td>{{ lasthisdata }}</td></tr>
+<!-- skip for now, feel free to use
+<tr><td><b>All History</b></td><td>{{ hisdata }}</td></tr>
+<tr><td><b>Referer</b></td><td> {{ reference }}</td></tr>
+<tr><td><b>Available data</b></td><td><pre> {{ mail_data }}</pre></td></tr>
+-->
+<tr><td><b>On The Web </b> </td><td><a href={{ url }}> View all details inside the Issue Tracker</a></td></tr>
+</table>
+</body>
+</html>

--- a/core/templates/newbug_mailtemplate.html
+++ b/core/templates/newbug_mailtemplate.html
@@ -1,0 +1,84 @@
+<!--
+Available fields to this template:
+	[email_bug] 					=> bug_id
+	[email_bug_view_url]			=> url
+	[email_handler]					=> handler
+	[email_reporter]				=> reporter
+	[email_project]					=> project
+	[email_category]				=> category
+	[email_tag]						=> tags
+	[email_date_submitted]			=> submitted
+	[email_last_modified]			=> modified
+	[email_due_date]				=> due_date
+	[email_status]					=> status
+	[email_severity]				=> severity
+	[email_priority]				=> priority
+	[email_reproducibility]			=> repro
+	[email_summary]					=> summary
+	[email_description] 			=> description
+	[email_additional_information]	=> info
+	[email_steps_to_reproduce]		=> steps
+	Custom fields					=> cfdata		
+	Notes							=> notedata ( as table )
+	Relations						=> reldata	( as table )
+	History							=> hisdata		
+	History (last entries)			=> lasthisdata	
+
+	## following 2 fields are available for testing purposes
+	Referer page					=> reference
+	Available data					=> mail_data
+
+	## how to use the fields
+	all elements ( only those you need of course) need to be referenced inbetween "{{" and "}}"
+
+	## changes
+	modification of contents takes place within core/template_api.php, function email_template_bug_message
+-->
+<!DOCTYPE html>
+<style>
+body {
+    background-color: #93B874;
+}
+h1 {
+    background-color: #00b33c;
+}
+p {
+    background-color: #FFFFFF);
+}
+table, th, td {    margin: 0; padding: 0;font-size: 100%; font: inherit; vertical-align: baseline;border: 1px solid black;}
+</style>
+<body>
+<h2 style="color:red; background:black;">
+{{ top_line }}
+</h2>
+<br>
+<table>
+<tr><td><b>Issue-id </b> </td><td>{{ bug_id }} <a href={{ url }}> View all details inside the Issue Tracker</a></td></tr>
+<tr><td><b>Status </b></td><td> {{ status }}</td></tr>
+<tr><td><b>Submitted </b></td><td> {{ submitted }}</td></tr>
+<tr><td><b>Last Modified </b></td><td> {{ modified }}</td></tr>
+<tr><td><b>Priority </b></td><td> {{ priority }}</td></tr>
+<tr><td><b>Severity </b></td><td> {{ severity }}</td></tr>
+<tr><td><b>Reproducibility </b></td><td> {{ repro }}</td></tr>
+<tr><td><b>Reporter </b></td><td> {{ reporter }}</td></tr>
+<tr><td><b>Project</b></td><td> {{ project }}</td></tr>
+<tr><td><b>Category </b></td><td> {{ category }}</td></tr>
+<tr><td><b>Summary</b></td><td> {{ summary }}</td></tr>
+<tr><td><b>Description</B</td><td> {{ description }} </td></tr>
+<tr><td><b>Steps to reproduce </b></td><td>{{ steps }}</td></tr>
+<tr><td><b>Additional Information</b></td><td> {{ info }} </td></tr>
+<tr><td><b>Due-Date</b></td><td> {{ due_date }}</td></tr>
+<tr><td><b>Tags</b></td><td> {{ tags }}</td></tr>
+<tr><td><b>Custom Fields</b></td><td> {{ cfdata }} </td></tr>
+<tr><td><b>Relations</b></td><td> {{ reldata }} </td></tr>
+<tr><td><b>Notes</b></td><td> {{ notedata }} </td></tr>
+<tr><td><b>Last History</b></td><td>{{ lasthisdata }}</td></tr>
+<!-- skip for now, feel free to use
+<tr><td><b>All History</b></td><td>{{ hisdata }}</td></tr>
+<tr><td><b>Referer</b></td><td> {{ reference }}</td></tr>
+<tr><td><b>Available data</b></td><td><pre> {{ mail_data }}</pre></td></tr>
+-->
+<tr><td><b>On The Web </b> </td><td><a href={{ url }}> View all details inside the Issue Tracker</a></td></tr>
+</table>
+</body>
+</html>

--- a/core/templates/note_mailtemplate.html
+++ b/core/templates/note_mailtemplate.html
@@ -1,0 +1,27 @@
+<html>
+<style>
+body {
+    background-color: #93B874;
+}
+h1 {
+    background-color: #00b33c;
+}
+p {
+    background-color: #FFFFFF);
+}
+table, th, td {  
+	border: 1px solid black;}
+</style>
+<h2 style="color:red; background:black;">
+{{ top_line }}
+</h2>
+<br>
+<table>
+<tr><td><b>Note-id </b> </td><td>{{ note_id }} <a href={{ url }}> View Note inside the Issue Tracker</a></td></tr>
+<tr><td><b>Reporter </b></td><td> {{ reporter }}</td></tr>
+<tr><td><b>Access level </b></td><td> {{ access }}</td></tr>
+<tr><td><b>Last modified</b></td><td> {{ modified }}</td></tr>
+<tr><td><b>Private</b></td><td> {{ private }}</td></tr>
+<tr><td><b>Timetracking</b></td><td><pre> {{ timetrack }} </pre></td></tr>
+<tr><td><b>Note</b></td><td><pre> {{ note }} </pre></td></tr>
+</html>

--- a/docbook/Admin_Guide/en-US/config/email.xml
+++ b/docbook/Admin_Guide/en-US/config/email.xml
@@ -423,6 +423,36 @@ $g_notify_flags['new'] = array(
 			</listitem>
 		</varlistentry>
 		<varlistentry>
+			<term>$g_email_use_template</term>
+			<listitem>
+				<para>Use a HTML template to format emails, when this OFF ( default) mails will be fully text based. </para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
+			<term>$g_email_escape_template</term>
+			<listitem>
+				<para>Use the escape sequence for the mail template, when this OFF ( default) mails, an escape sequence will not be used</para>
+			</listitem>
+		</varlistentry>
+ 		<varlistentry>
+			<term>$g_email_newbug_template</term>
+			<listitem>
+				<para>Location of the template for new bugs, this location can be outside the webroot but do ensure that the web-user has access to it.</para>
+			</listitem>
+		</varlistentry>
+ 		<varlistentry>
+			<term>$g_email_bug_template</term>
+			<listitem>
+				<para>Location of the template for existing bugs, this location can be outside the webroot but do ensure that the web-user has access to it.</para>
+			</listitem>
+		</varlistentry>
+ 		<varlistentry>
+			<term>$g_email_note_template</term>
+			<listitem>
+				<para>Location of the template for bugnotes, this location can be outside the webroot but do ensure that the web-user has access to it.</para>
+			</listitem>
+		</varlistentry>
+		<varlistentry>
 			<term>$g_email_send_using_cronjob</term>
 			<listitem>
 				<para>Use a cron scheduler to send emails.</para>


### PR DESCRIPTION
These changes will allow users of the software to define their own templates for mails being send by MantisBT. Simple templates have been provided, these will be maintained by the local admin in order to reflect company lay-out.

This addresses https://mantisbt.org/bugs/view.php?id=12830