### PR TITLE
Ignore unknown properties in BugData::__set()

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -320,7 +320,9 @@ class BugData {
 	}
 
 	/**
-	 * Overloaded Function handling property sets
+	 * Overloaded Function handling property sets.
+	 *
+	 * Unknown properties will be ignored.
 	 *
 	 * @param string $p_name  Property name.
 	 * @param string $p_value Value to set.
@@ -376,6 +378,12 @@ class BugData {
 				$p_value = db_mysql_fix_utf8( $p_value );
 				break;
 
+			default:
+				# Silently skip unknown columns
+				if( !property_exists( $this, $p_name ) ) {
+					return;
+				}
+
 		}
 		$this->$p_name = $p_value;
 	}
@@ -407,6 +415,9 @@ class BugData {
 
 	/**
 	 * Fast-load database row into the object.
+	 *
+	 * If the database row contains columns not defined as BugData properties,
+	 * those columns will be ignored.
 	 *
 	 * @param array $p_row Database result to load into a bug object.
 	 *


### PR DESCRIPTION
Avoids PHP 8.2 "Creation of dynamic property" deprecation warnings in Roadmap and Changelog pages.

Fixes [#34106](https://mantisbt.org/bugs/view.php?id=34106)