### PR TITLE
Don't call string_display() on already-escaped data

### DIFF
--- a/core/filter_form_api.php
+++ b/core/filter_form_api.php
@@ -267,7 +267,7 @@ function print_filter_values_user_monitor( array $p_filter ) {
 		} else if( true == $t_none_found ) {
 			echo lang_get( 'none' );
 		} else {
-			echo string_display( $t_output );
+			echo $t_output;
 		}
 	}
 }
@@ -343,7 +343,7 @@ function print_filter_values_handler_id( array $p_filter ) {
 		if( true == $t_any_found ) {
 			echo lang_get( 'any' );
 		} else {
-			echo string_display( $t_output );
+			echo $t_output;
 		}
 	}
 }


### PR DESCRIPTION
This causes display of `<br />` tags on Advanced Filter form when multiple values for Assigned To and Monitored by when `br` is not allowed in $g_valid_html_tags.

Fixes [#34018](https://mantisbt.org/bugs/view.php?id=34018)