### PR TITLE
Equalize the appearance of inline code and code blocks

### DIFF
--- a/plugins/MantisCoreFormatting/files/markdown.css
+++ b/plugins/MantisCoreFormatting/files/markdown.css
@@ -1,3 +1,17 @@
+/* Adjust color of inline code */
+code {
+    color: #333;
+    background-color: #f5f5f5;
+}
+
+/*
+ * Increases the distance between a code block
+ * and its previous line within a list.
+ */
+li > pre {
+    margin-top: .4rem;
+}
+
 /* quotes */
 blockquote {
     padding: 0.13em 1em;


### PR DESCRIPTION
Equalize the appearance of inline code and code blocks in color and adjust the distance from a code block to its previous line in list items.

Fixes

- [#22181](https://mantisbt.org/bugs/view.php?id=22181) Markdown different rendering between inline code (single backtick) and ``` blocks
- [#22485](https://mantisbt.org/bugs/view.php?id=22485)  Increase spacing before ``` blocks

|before|after|
|-- |-- |
|![mantis-code-before](https://github.com/mantisbt/mantisbt/assets/67791701/35dfcd29-4e2f-46dd-9445-fd0dae76291f)|![mantis-code-after](https://github.com/mantisbt/mantisbt/assets/67791701/0009af77-19e6-4c98-8b26-65f6f101e703)|