### PR TITLE
WIP: Introduce CS Fixer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,16 @@ env:
 
 jobs:
   include:
+    - name: Coding Standards
+      # stage: cs
+      php:
+        - 8.3
+      env: []
+      services: []
+      before_script: []
+      script:
+        - echo "Executing Mantis coding style checks"
+        - vendor/bin/ecs check
     # Add a specific build for Documentation
     - name: Documentation
       env: DOCBOOK=1

--- a/build/buildrelease.py
+++ b/build/buildrelease.py
@@ -38,6 +38,7 @@ exclude_list = (
     # Directories
     "docbook/",
     "tests/"
+    "ecs.php"
     )
 
 # Checksum types to includ in digest filese

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "require-dev": {
         "ext-zip": "*",
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^9.6",
+        "symplify/easy-coding-standard": "^12.1"
     },
     "repositories": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc8c59d7789077470a010a5b6d0a092b",
+    "content-hash": "def99b400e78ac217d6849b379e13d07",
     "packages": [
         {
             "name": "adodb/adodb-php",
@@ -2883,6 +2883,64 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
+            "name": "symplify/easy-coding-standard",
+            "version": "12.1.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/easy-coding-standard/easy-coding-standard.git",
+                "reference": "e3c4a241ee36704f7cf920d5931f39693e64afd5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/easy-coding-standard/easy-coding-standard/zipball/e3c4a241ee36704f7cf920d5931f39693e64afd5",
+                "reference": "e3c4a241ee36704f7cf920d5931f39693e64afd5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "conflict": {
+                "friendsofphp/php-cs-fixer": "<3.46",
+                "phpcsstandards/php_codesniffer": "<3.8",
+                "symplify/coding-standard": "<12.1"
+            },
+            "bin": [
+                "bin/ecs"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer",
+            "keywords": [
+                "Code style",
+                "automation",
+                "fixer",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/easy-coding-standard/easy-coding-standard/issues",
+                "source": "https://github.com/easy-coding-standard/easy-coding-standard/tree/12.1.14"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/rectorphp",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-02-23T13:10:40+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.3",
             "source": {
@@ -2951,5 +3009,5 @@
     "platform-overrides": {
         "php": "7.4.33"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,31 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+#
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <https://www.gnu.org/licenses/>.
+
+declare( strict_types = 1 );
+
+use Symplify\EasyCodingStandard\Config\ECSConfig;
+
+return ECSConfig::configure()
+    ->withPaths([
+        __DIR__ . '/',
+    ])
+	->withSkip([
+		__DIR__ . '/build',
+		__DIR__ . '/config',
+		__DIR__ . '/library',
+	])
+    ->withRules([])
+;


### PR DESCRIPTION
This PR is a continuation of the work started by @dregad to [add a CS fixer](https://github.com/mantisbt/mantisbt/compare/master...dregad:mantisbt:codesniffer). This is the first step with adding the "[easy coding standard](https://github.com/easy-coding-standard/easy-coding-standard)" to the CI. No fixers are added yet, these will be added in small steps to keep the changes small an reviewable.

Issue [#34400](https://mantisbt.org/bugs/view.php?id=34400)

First attempt: https://github.com/mantisbt/mantisbt/compare/master...dregad:mantisbt:codesniffer

Some sniffs are outdated, e.g. "Generic.Arrays.DisallowShortArraySyntax", others may no longer be relevant in other ways.

But there is a minimum of basic fixer that can help a lot. Better having just a few basic fixers that work than nothing at all.

For example [spaces_inside_parentheses](https://cs.symfony.com/doc/rules/whitespace/spaces_inside_parentheses.html) > `func( $arg, $arg2 )` to reduce situations [like this ](https://github.com/mantisbt/mantisbt/pull/1989#pullrequestreview-1985115982).



