### PR TITLE
Fix clearing of Version fields via REST API

### DIFF
--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -946,13 +946,13 @@ function mci_get_version_id( $p_version, $p_project_id, $p_field_name = 'version
 	$t_version_for_error = '';
 
 	if( is_array( $p_version ) ) {
-		if( isset( $p_version['id'] ) && is_numeric( $p_version['id'] ) ) {
+		if( isset( $p_version['id'] ) && is_numeric( $p_version['id'] ) && $p_version['id'] != 0 ) {
 			$t_version_id = (int)$p_version['id'];
 			$t_version_for_error = $p_version['id'];
 			if( !version_exists( $t_version_id ) ) {
 				$t_version_id = false;
 			}
-		} elseif( isset( $p_version['name'] ) ) {
+		} elseif( isset( $p_version['name'] ) && !is_blank( $p_version['name'] ) ) {
 			$t_version_for_error = $p_version['name'];
 			$t_version_id = version_get_id( $p_version['name'], $p_project_id );
 		}

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -1010,12 +1010,15 @@ function mc_issue_update( $p_username, $p_password, $p_issue_id, stdClass $p_iss
 	$t_category = isset( $p_issue['category'] ) ? $p_issue['category'] : null;
 	$t_category_id = mci_get_category_id( $t_category, $t_project_id );
 
-	$fn_get_version_id = function( $p_version, int $p_project_id, string $p_field ): int {
-		return isset( $p_version ) ? mci_get_version_id( $p_version, $p_project_id, $p_field ) : 0;
+	$fn_get_version_id = function( string $p_field, array $p_issue, int $p_project_id ): int {
+		if( !isset( $p_issue[$p_field] ) ) {
+			return 0;
+		}
+		return mci_get_version_id( $p_issue[$p_field], $p_project_id, $p_field );
 	};
-	$t_version_id = $fn_get_version_id( $p_issue['version'], $t_project_id, 'version' );
-	$t_fixed_in_version_id = $fn_get_version_id( $p_issue['fixed_in_version'], $t_project_id, 'fixed_in_version' );
-	$t_target_version_id = $fn_get_version_id( $p_issue['target_version'], $t_project_id, 'target_version' );
+	$t_version_id = $fn_get_version_id( 'version', $p_issue, $t_project_id );
+	$t_fixed_in_version_id = $fn_get_version_id( 'fixed_in_version', $p_issue, $t_project_id );
+	$t_target_version_id = $fn_get_version_id( 'target_version', $p_issue, $t_project_id );
 
 	if( is_blank( $t_summary ) ) {
 		return ApiObjectFactory::faultBadRequest( 'Mandatory field \'summary\' is missing.' );

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -1010,6 +1010,19 @@ function mc_issue_update( $p_username, $p_password, $p_issue_id, stdClass $p_iss
 	$t_category = isset( $p_issue['category'] ) ? $p_issue['category'] : null;
 	$t_category_id = mci_get_category_id( $t_category, $t_project_id );
 
+	/**
+	 * Retrieve Id of Version to set.
+	 *
+	 * If the Version is not defined in the issue data, the function will return 0
+	 * which will cause the version field to be cleared when the Issue is updated.
+	 *
+	 * @param string $p_field      Version field to update.
+	 * @param array  $p_issue      Issue data.
+	 * @param int    $p_project_id
+	 *
+	 * @return int Version Id or 0 to unset the version
+	 * @throws ClientException
+	 */
 	$fn_get_version_id = function( string $p_field, array $p_issue, int $p_project_id ): int {
 		if( !isset( $p_issue[$p_field] ) ) {
 			return 0;
@@ -1114,6 +1127,14 @@ function mc_issue_update( $p_username, $p_password, $p_issue_id, stdClass $p_iss
 		$t_bug_data->platform = $p_issue['platform'];
 	}
 
+	/**
+	 * Returns the value to assign to Version field.
+	 *
+	 * @param int $p_version_id If 0, will return '' causing version to be unset.
+	 *
+	 * @return string Version
+	 * @throws ClientException
+	 */
 	$fn_set_version_field = function( int $p_version_id ): string {
 		/** @noinspection PhpUnhandledExceptionInspection */
 		return $p_version_id == 0 ? '' : version_get_field( $p_version_id, 'version' );

--- a/tests/rest/RestIssueTest.php
+++ b/tests/rest/RestIssueTest.php
@@ -252,7 +252,7 @@ class RestIssueTest extends RestBase {
 		$this->deleteIssueAfterRun( $t_issue['id'] );
 	}
 
-	public function testCreateIssueWithVersionObjectIdAndMistatchingName() {
+	public function testCreateIssueWithVersionObjectIdAndMismatchingName() {
 		$this->skipTestIfNotEnoughVersions( 2 );
 
 		$t_version_id = $this->versions[0]['id'];
@@ -365,7 +365,7 @@ class RestIssueTest extends RestBase {
 	 *
 	 * @param ResponseInterface $p_response
 	 *
-	 * @return integer Created issue Id
+	 * @return integer Created issue ID
 	 */
 	protected function assertIssueCreatedWithTag( $p_response ) {
 		$this->assertEquals( HTTP_STATUS_CREATED, $p_response->getStatusCode() );

--- a/tests/rest/RestIssueUpdateVersion.php
+++ b/tests/rest/RestIssueUpdateVersion.php
@@ -1,0 +1,186 @@
+<?php
+
+use Psr\Http\Message\ResponseInterface;
+
+require_once 'RestIssueTest.php';
+
+class RestIssueUpdateVersion extends RestBase
+{
+	const VERSION_FIELDS = ['version', 'target_version', 'fixed_in_version'];
+
+	/** @var int Version id */
+	protected $version_id;
+
+	/** @var int Issue id */
+	protected $issue_id;
+
+	/** @var string REST API endpoint for projet version */
+	protected $endpoint_version;
+	protected $endpoint_issue = '/issues/';
+
+	/**
+	 * Checks that response was successful and returns JSON body as object.
+	 *
+	 * @param ResponseInterface $p_response
+	 * @param int               $p_status_code Expected HTTP status code
+	 *
+	 * @return stdClass
+	 */
+	protected function getJson( ResponseInterface $p_response, $p_status_code = HTTP_STATUS_SUCCESS ) {
+		$this->assertEquals( $p_status_code,
+			$p_response->getStatusCode(),
+			"REST API returned unexpected Status Code"
+		);
+		return json_decode( $p_response->getBody(), false );
+	}
+
+	/**
+	 * Get the test Issue's current state.
+	 *
+	 * Checks that the Version fields are present.
+	 *
+	 * @return stdClass Issue Data from GET /issues endpoint
+	 */
+	protected function getTestIssue(): stdClass {
+		$t_response = $this->builder()->get( $this->endpoint_issue )->send();
+		$t_issue = $this->getJson( $t_response )->issues[0];
+
+		foreach( self::VERSION_FIELDS as $t_version_field ) {
+			$this->assertObjectHasAttribute( $t_version_field, $t_issue, "'$t_version_field' is set" );
+			$this->assertEquals( $this->version_id,
+				$t_issue->$t_version_field->id,
+				"'$t_version_field' id does not match"
+			);
+		}
+
+		return $t_issue;
+	}
+
+	/**
+	 * Test Setup - creates a test Version and Issue.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->endpoint_version = "/projects/$this->projectId/versions/";
+
+		# Add a test Version
+		$t_version_data = [
+			"name" => self::class . "_v" . rand(1, 9) . "." . rand(0, 99),
+			"description" => self::class . " test version",
+			"released" => true,
+		];
+		$t_response = $this->builder()->post( $this->endpoint_version, $t_version_data )->send();
+		$t_version = $this->getJson($t_response, HTTP_STATUS_CREATED )->version;
+		$this->version_id = $t_version->id;
+		$this->deleteAfterRunVersion($t_version->id);
+
+		# Create a test Issue with the version fields set
+		$t_version_data = ['id' => $this->version_id];
+		$t_issue_data = array_merge(
+			$this->getIssueToAdd(),
+			array_fill_keys( self::VERSION_FIELDS, $t_version_data)
+		);
+		$t_response = $this->builder()->post( '/issues', $t_issue_data )->send();
+		$t_issue = $this->getJson($t_response, HTTP_STATUS_CREATED )->issue;
+		$this->issue_id = $t_issue->id;
+		$this->endpoint_issue .= $t_issue->id;
+		$this->deleteIssueAfterRun($t_issue->id);
+	}
+
+	/**
+	 * Testing successful unsetting of version fields.
+	 *
+	 * @dataProvider providerUnsetVersionSuccess
+	 *
+	 * @param array|null|int $p_version_payload
+	 * @param int            $p_expected_status_code
+	 *
+	 * @return void
+	 */
+	public function testUnsetVersion( $p_version_payload, int $p_expected_status_code ): void {
+		$this->getTestIssue();
+
+		# Update the Issue and make sure the version fields are gone
+		$t_payload = array_fill_keys( self::VERSION_FIELDS, $p_version_payload );
+		$t_response = $this->builder()->patch( $this->endpoint_issue, $t_payload )->send();
+		$t_issue = $this->getJson( $t_response, $p_expected_status_code )->issues[0];
+		foreach( self::VERSION_FIELDS as $t_version_field ) {
+			$this->assertObjectNotHasAttribute($t_version_field, $t_issue, "'$t_version_field' was not unset" );
+		}
+	}
+
+	/**
+	 * Testing failing attempts to unset Version fields.
+	 *
+	 * @dataProvider providerUnsetVersionFailure
+	 *
+	 * @param array|null|int $p_version_payload
+	 * @param int            $p_expected_status_code
+	 *
+	 * @return void
+	 */
+	public function testFailToUnsetVersion( $p_version_payload, int $p_expected_status_code ): void {
+		$this->getTestIssue();
+
+		# Update the Issue and make sure the version fields are gone
+		$t_payload = array_fill_keys( self::VERSION_FIELDS, $p_version_payload );
+		$t_response = $this->builder()->patch( $this->endpoint_issue, $t_payload )->send();
+		$this->assertEquals(
+			$p_expected_status_code,
+			$t_response->getStatusCode(),
+			"Unexpected status code from REST API"
+		);
+	}
+
+	/**
+	 * Provide a series of valid Payloads to unset a Version field.
+	 *
+	 * Test case structure:
+	 *   <case> => array( <version payload>, <expected status code> )
+	 *
+	 * @return Generator List of test cases
+	 */
+	public function providerUnsetVersionSuccess(): Generator {
+		yield 'Version with id 0' => [ ['id' => 0], HTTP_STATUS_SUCCESS ];
+
+		# According to @vboctor these test cases should actually fail, but don't...
+		# For now the tests are designed to pass anyway, reflecting current API behavior.
+		# See discussion in #25407.
+		yield 'Null version' => [ null, HTTP_STATUS_SUCCESS ];
+		yield 'Blank version' => [ '', HTTP_STATUS_SUCCESS ];
+		yield 'Empty version' => [ [], HTTP_STATUS_SUCCESS ];
+		yield 'Version with null name' => [ ['name' => null], HTTP_STATUS_SUCCESS ];
+		yield 'Version with blank name' => [ ['name' => ''], HTTP_STATUS_SUCCESS ];
+
+		# @TODO should probably be BAD REQUEST (inconsistent API behavior compared to same values in version array)
+		yield 'Non-existing Numeric version' => [ 99999, HTTP_STATUS_SUCCESS ];
+		yield 'Invalid Numeric version' => [ -1, HTTP_STATUS_SUCCESS ];
+
+		# @TODO not sure what the correct behavior should be in this case
+		yield 'Version with neither id nor name' => [ ['xxx' => 'yyy'], HTTP_STATUS_SUCCESS ];
+	}
+
+	/**
+	 * Provide a series of failing Payloads to unset a Version field.
+	 * @return Generator List of test cases
+	 * @see  testUnsetVersion()
+	 *
+	 * @TODO Currently does not match expected behavior, see comments in {@see providerUnsetVersionSuccess}
+	 *
+	 * Test case structure:
+	 *    <case> => array( <version payload>, <expected status code> )
+	 *
+	 */
+	public function providerUnsetVersionFailure(): Generator {
+		# This is a dummy test case, to avoid a PHPUnit warning when the
+		# Provider returns nothing.
+		yield 'dummy' => [ ['id' => -1], HTTP_STATUS_BAD_REQUEST ];
+
+		//yield 'Numeric version' => [ 999, HTTP_STATUS_BAD_REQUEST ];
+		//yield 'Blank version' => [ '', HTTP_STATUS_BAD_REQUEST ];
+		//yield 'Version with blank name' => [ ['name' => ''], HTTP_STATUS_BAD_REQUEST ];
+	}
+}


### PR DESCRIPTION
Fixes [#25407](https://mantisbt.org/bugs/view.php?id=25407)

Also fixes the error message when an invalid version is provided ([#34410](https://mantisbt.org/bugs/view.php?id=34410)).

