### PR TITLE
Configuration to require fixed_in_version

### DIFF
--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -324,15 +324,27 @@ layout_page_begin();
 			&& !bug_is_readonly( $f_bug_id )
 			&& access_has_bug_level( config_get( 'update_bug_threshold' ), $f_bug_id )
 		) {
+			$t_fixed_in_version_required = false;
+			$t_fixed_in_version_value = $t_bug->fixed_in_version;
+			if ( $f_new_status == RESOLVED ) {
+				$t_fixed_in_version_required = config_get( 'bug_fixed_in_version_required', null, null, $t_bug->project_id ) != OFF;
+				if ( is_blank( $t_fixed_in_version_value ) && !is_blank( $t_bug->target_version ) && config_get( 'bug_fixed_in_version_required', null, null, $t_bug->project_id ) != OFF ) {
+					$t_fixed_in_version_value = $t_bug->target_version;
+				}
+			}
 ?>
 			<!-- Fixed in Version -->
 			<tr>
 				<th class="category">
+					<?php echo $t_fixed_in_version_required ? '<span class="required">*</span> ' : ''; ?>
 					<?php echo lang_get( 'fixed_in_version' ) ?>
 				</th>
 				<td>
-					<select name="fixed_in_version" class="input-sm">
-						<?php print_version_option_list( $t_bug->fixed_in_version, $t_bug->project_id, VERSION_ALL ) ?>
+					<select name="fixed_in_version" class="input-sm" <?php
+						echo helper_get_tab_index();
+						echo $t_fixed_in_version_required ? ' required' : '';
+					?>>
+						<?php print_version_option_list( $t_fixed_in_version_value, $t_bug->project_id, VERSION_ALL ) ?>
 					</select>
 				</td>
 			</tr>

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2300,7 +2300,13 @@ $g_bug_submit_status = NEW_;
 $g_bug_assigned_status = ASSIGNED;
 
 /**
- * Required fixed_in_version in RESOLVED state.
+ * In RESOLVED state fixed_in_version default from target_version.
+ * @global integer $g_bug_fixed_in_version_from_target_version
+ */
+$g_bug_fixed_in_version_from_target_version = OFF;
+
+/**
+ * In RESOLVED state fixed_in_version is required.
  * @global integer $g_bug_fixed_in_version_required
  */
 $g_bug_fixed_in_version_required = OFF;

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -2300,6 +2300,12 @@ $g_bug_submit_status = NEW_;
 $g_bug_assigned_status = ASSIGNED;
 
 /**
+ * Required fixed_in_version in RESOLVED state.
+ * @global integer $g_bug_fixed_in_version_required
+ */
+$g_bug_fixed_in_version_required = OFF;
+
+/**
  * Status to assign to the bug when reopened.
  * @global integer $g_bug_reopen_status
  */

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -508,6 +508,16 @@ class BugData {
 			category_ensure_exists( $this->category_id );
 		}
 
+		if ( $this->status == RESOLVED ) {
+			if ( is_blank( $this->fixed_in_version ) && !is_blank( $this->target_version ) && config_get( 'bug_fixed_in_version_from_target_version', null, null, $this->project_id ) != OFF ) {
+				$this->fixed_in_version = $this->target_version;
+			}
+			if ( is_blank( $this->fixed_in_version ) && config_get( 'bug_fixed_in_version_required', null, null, $this->project_id ) != OFF ) {
+				error_parameters( lang_get( 'fixed_in_version' ) );
+				trigger_error( ERROR_EMPTY_FIELD, ERROR );
+			}
+		}
+
 		if( !is_blank( $this->duplicate_id ) && ( $this->duplicate_id != 0 ) && ( $this->id == $this->duplicate_id ) ) {
 			trigger_error( ERROR_BUG_DUPLICATE_SELF, ERROR );
 			# never returns


### PR DESCRIPTION
I would need a mechanism to ensure that 'fixed_in_version' are always filled in before the bug reaches the Resolved state. The reason is to populate the changelog for a specific project.

Resolving issues having a target version should set the fixed in version by default.

Fixes [#21734](https://mantisbt.org/bugs/view.php?id=21734)