### PR TITLE
Refactoring and cleaning up includes

### DIFF
--- a/account_manage_columns_page.php
+++ b/account_manage_columns_page.php
@@ -56,6 +56,6 @@ current_user_ensure_unprotected();
 define( 'ACCOUNT_COLUMNS', true );
 
 define( 'MANAGE_COLUMNS_INC_ALLOW', true );
-include ( dirname( __FILE__ ) . '/manage_columns_inc.php' );
+include( __DIR__ . '/manage_columns_inc.php' );
 
 layout_page_end();

--- a/account_prefs_page.php
+++ b/account_prefs_page.php
@@ -61,7 +61,7 @@ auth_ensure_user_authenticated();
 current_user_ensure_unprotected();
 
 define( 'ACCOUNT_PREFS_INC_ALLOW', true );
-include( dirname( __FILE__ ) . '/account_prefs_inc.php' );
+include( __DIR__ . '/account_prefs_inc.php' );
 
 layout_page_header( lang_get( 'change_preferences_link' ) );
 

--- a/admin/check/check_integrity_inc.php
+++ b/admin/check/check_integrity_inc.php
@@ -34,7 +34,7 @@ if( !defined( 'CHECK_INTEGRITY_INC_ALLOW' ) ) {
 require_once( 'check_api.php' );
 require_api( 'config_api.php' );
 
-$t_this_directory = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
+$t_this_directory = __DIR__ . DIRECTORY_SEPARATOR;
 if( file_exists( $t_this_directory . 'integrity_release_blobs.php' ) ) {
 	require_once( $t_this_directory . 'integrity_release_blobs.php' );
 }

--- a/admin/check/index.php
+++ b/admin/check/index.php
@@ -40,7 +40,7 @@ define( 'MANTIS_MAINTENANCE_MODE', true );
 # of the tests, ensuring that the testing process hasn't frozen.
 define( 'COMPRESSION_DISABLED', true );
 
-require_once( dirname( __FILE__, 3 ) . '/core.php' );
+require_once( dirname( __DIR__, 2 ) . '/core.php' );
 
 require_once( 'check_api.php' );
 

--- a/admin/db_stats.php
+++ b/admin/db_stats.php
@@ -23,7 +23,7 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( dirname( __FILE__, 2 ) . '/core.php' );
+require_once( dirname( __DIR__ ) . '/core.php' );
 
 access_ensure_global_level( config_get_global( 'admin_site_threshold' ) );
 

--- a/admin/email_queue.php
+++ b/admin/email_queue.php
@@ -24,7 +24,7 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( dirname( __FILE__, 2 ) . '/core.php' );
+require_once( dirname( __DIR__ ) . '/core.php' );
 
 access_ensure_global_level( config_get_global( 'admin_site_threshold' ) );
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -23,7 +23,7 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( dirname( __FILE__, 2 ) . '/core.php' );
+require_once( dirname( __DIR__ ) . '/core.php' );
 
 access_ensure_global_level( config_get_global( 'admin_site_threshold' ) );
 

--- a/admin/install.php
+++ b/admin/install.php
@@ -970,7 +970,7 @@ if( 3 == $t_install_state ) {
 		config_set_global( 'db_table_plugin_prefix', $f_db_table_plugin_prefix );
 		config_set_global( 'db_table_suffix', $f_db_table_suffix );
 		# database_api references this
-		require_once( dirname( __FILE__ ) . '/schema.php' );
+		require_once( __DIR__ . '/schema.php' );
 		$g_db = ADONewConnection( $f_db_type );
 		$t_result = @$g_db->Connect( $f_hostname, $f_admin_username, $f_admin_password, $f_database_name );
 		if( !$f_log_queries ) {

--- a/admin/install.php
+++ b/admin/install.php
@@ -37,7 +37,7 @@ error_reporting( E_ALL );
 # and plugins will not be loaded.
 const MANTIS_MAINTENANCE_MODE = true;
 
-require_once( dirname( __FILE__, 2 ) . '/core.php' );
+require_once( dirname( __DIR__ ) . '/core.php' );
 require_api( 'install_helper_functions_api.php' );
 require_api( 'crypto_api.php' );
 $g_error_send_page_header = false; # bypass page headers in error handler
@@ -348,7 +348,7 @@ print_test( 'Checking if safe mode is enabled for install script',
 	);
 
 	foreach( $t_config_files as $t_file => $t_action ) {
-		$t_dir = dirname( __FILE__, 2 ) . '/';
+		$t_dir = dirname( __DIR__ ) . '/';
 		if( substr( $t_file, 0, 3 ) == 'mc_' ) {
 			$t_dir .= 'api/soap/';
 		}

--- a/admin/move_attachments.php
+++ b/admin/move_attachments.php
@@ -22,7 +22,7 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( dirname( __FILE__, 2 ) . '/core.php' );
+require_once( dirname( __DIR__ ) . '/core.php' );
 
 form_security_validate( 'move_attachments_project_select' );
 

--- a/admin/move_attachments_page.php
+++ b/admin/move_attachments_page.php
@@ -23,7 +23,7 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( dirname( __FILE__, 2 ) . '/core.php' );
+require_once( dirname( __DIR__ ) . '/core.php' );
 
 access_ensure_global_level( config_get_global( 'admin_site_threshold' ) );
 

--- a/admin/system_utils.php
+++ b/admin/system_utils.php
@@ -24,7 +24,7 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( dirname( __FILE__, 2 ) . '/core.php' );
+require_once( dirname( __DIR__ ) . '/core.php' );
 
 access_ensure_global_level( config_get_global( 'admin_site_threshold' ) );
 

--- a/admin/test_langs.php
+++ b/admin/test_langs.php
@@ -25,7 +25,7 @@
 define( 'PLUGINS_DISABLED', true );
 define( 'LANG_LOAD_DISABLED', true );
 
-$t_mantis_dir = dirname( __FILE__, 2 ) . '/';
+$t_mantis_dir = dirname( __DIR__ ) . '/';
 
 require_once( $t_mantis_dir . 'core.php' );
 

--- a/admin/upgrade_unattended.php
+++ b/admin/upgrade_unattended.php
@@ -104,7 +104,7 @@ if( !preg_match( '/^[a-zA-Z0-9_]+$/', $t_db_type ) ||
 }
 
 $GLOBALS['g_db_type'] = $t_db_type; # database_api references this
-require_once( dirname( __FILE__ ) . '/schema.php' );
+require_once( __DIR__ . '/schema.php' );
 $g_db = ADONewConnection( $t_db_type );
 
 echo "\nPost 1.0 schema changes\n";

--- a/admin/upgrade_unattended.php
+++ b/admin/upgrade_unattended.php
@@ -29,7 +29,7 @@
 # and plugins will not be loaded.
 define( 'MANTIS_MAINTENANCE_MODE', true );
 
-require_once( dirname( __FILE__, 2 ) . '/core.php' );
+require_once( dirname( __DIR__ ) . '/core.php' );
 require_api( 'crypto_api.php' );
 $g_error_send_page_header = false; # suppress page headers in the error handler
 
@@ -98,7 +98,7 @@ $t_db_type = config_get_global( 'db_type' );
 
 # install the tables
 if( !preg_match( '/^[a-zA-Z0-9_]+$/', $t_db_type ) ||
-	!file_exists( dirname( __FILE__, 2 ) . '/vendor/adodb/adodb-php/drivers/adodb-' . $t_db_type . '.inc.php' ) ) {
+	!file_exists( dirname( __DIR__ ) . '/vendor/adodb/adodb-php/drivers/adodb-' . $t_db_type . '.inc.php' ) ) {
 	echo 'Invalid db type ' . htmlspecialchars( $t_db_type ) . '.';
 	exit;
 }

--- a/api/rest/restcore/filters_rest.php
+++ b/api/rest/restcore/filters_rest.php
@@ -22,7 +22,7 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( dirname( __FILE__, 3 ) . '/soap/mc_filter_api.php'  );
+require_once( dirname( __DIR__, 2 ) . '/soap/mc_filter_api.php'  );
 
 use \Slim\Http\Request as SlimRequest;
 use \Slim\Http\Response as SlimResponse;

--- a/api/soap/mantisconnect.php
+++ b/api/soap/mantisconnect.php
@@ -62,7 +62,8 @@ if( !extension_loaded( 'soap' ) ) {
 }
 
 if( !mci_is_webservice_call() ) {
-	# if we have a documentation request, do some tidy up to prevent lame bot loops e.g. /mantisconnect.php/mc_enum_etas/mc_project_get_versions/
+	# if we have a documentation request, do some tidy up to prevent lame bot loops
+	# e.g. /mantisconnect.php/mc_enum_etas/mc_project_get_versions/
 	$t_parts = explode( 'mantisconnect.php/', strtolower( $_SERVER['SCRIPT_NAME'] ), 2 );
 	if( isset( $t_parts[1] ) && (strlen( $t_parts[1] ) > 0 ) ) {
 		echo 'This is not a SOAP webservice request, for documentation, see ' .  $t_parts[0] . 'mantisconnect.php';
@@ -71,7 +72,11 @@ if( !mci_is_webservice_call() ) {
 
 	header( 'Content-Type: text/xml' );
 	$t_wsdl = file_get_contents( 'mantisconnect.wsdl' );
-	$t_wsdl = str_replace( 'http://www.mantisbt.org/bugs/api/soap/mantisconnect.php', config_get_global( 'path' ).'api/soap/mantisconnect.php', $t_wsdl );
+	$t_wsdl = str_replace(
+		'http://www.mantisbt.org/bugs/api/soap/mantisconnect.php',
+		config_get_global( 'path' ).'api/soap/mantisconnect.php',
+		$t_wsdl
+	);
 	echo $t_wsdl;
 	exit();
 }

--- a/api/soap/mantisconnect.php
+++ b/api/soap/mantisconnect.php
@@ -34,6 +34,8 @@ $t_mantis_dir = dirname( __FILE__, 3 ) . DIRECTORY_SEPARATOR;
 $g_bypass_headers = true;
 $g_bypass_error_handler = true;
 
+$t_wsdl_path = __DIR__ . '/mantisconnect.wsdl';
+
 require_once( $t_mantis_dir . 'core.php' );
 
 /**
@@ -71,7 +73,7 @@ if( !mci_is_webservice_call() ) {
 	}
 
 	header( 'Content-Type: text/xml' );
-	$t_wsdl = file_get_contents( 'mantisconnect.wsdl' );
+	$t_wsdl = file_get_contents( $t_wsdl_path );
 	$t_wsdl = str_replace(
 		'http://www.mantisbt.org/bugs/api/soap/mantisconnect.php',
 		config_get_global( 'path' ).'api/soap/mantisconnect.php',
@@ -86,7 +88,7 @@ require_once( 'mc_core.php' );
 set_error_handler( 'mc_error_handler' );
 set_exception_handler( 'mc_error_exception_handler' );
 
-$t_server = new SoapServer( 'mantisconnect.wsdl',
+$t_server = new SoapServer( $t_wsdl_path,
 	array( 'features' => SOAP_USE_XSI_ARRAY_TYPE + SOAP_SINGLE_ELEMENT_ARRAYS )
 );
 

--- a/api/soap/mantisconnect.php
+++ b/api/soap/mantisconnect.php
@@ -28,7 +28,7 @@
 # This can not be a configuration option, then MantisConnect configuration
 # needs MantisBT to be included first to make use of the constants and possibly
 # configuration defined in MantisBT.
-$t_mantis_dir = dirname( __FILE__, 3 ) . DIRECTORY_SEPARATOR;
+$t_mantis_dir = dirname( __DIR__, 2 ) . '/';
 
 # Overrides for behaviors for core.php and its dependencies
 $g_bypass_headers = true;

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -522,7 +522,7 @@ function mci_project_get( $p_project_id, $p_lang, $p_detail ) {
  * @return true: offline, false: online
  */
 function mci_is_mantis_offline() {
-	$t_offline_file = dirname( __FILE__, 3 ) . DIRECTORY_SEPARATOR . 'mantis_offline.php';
+	$t_offline_file = dirname( __DIR__, 2 ) . '/mantis_offline.php';
 	return file_exists( $t_offline_file );
 }
 

--- a/api/soap/mc_core.php
+++ b/api/soap/mc_core.php
@@ -24,7 +24,7 @@
  */
 
 # constants and configurations
-$t_current_dir = dirname( __FILE__ ) . '/';
+$t_current_dir = __DIR__ . '/';
 
 # MantisConnect APIs
 #   mc_* = public methods

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -23,7 +23,7 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( dirname( __FILE__ ) . '/mc_core.php' );
+require_once( __DIR__ . '/mc_core.php' );
 
 use Mantis\Exceptions\ClientException;
 

--- a/api/soap/mc_issue_attachment_api.php
+++ b/api/soap/mc_issue_attachment_api.php
@@ -23,7 +23,7 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( dirname( __FILE__ ) . '/mc_core.php' );
+require_once( __DIR__ . '/mc_core.php' );
 
 /**
  * Get the issue attachment with the specified id.

--- a/api/soap/mc_project_attachment_api.php
+++ b/api/soap/mc_project_attachment_api.php
@@ -23,7 +23,7 @@
  * @link http://www.mantisbt.org
  */
 
-require_once( dirname( __FILE__ ) . '/mc_core.php' );
+require_once( __DIR__ . '/mc_core.php' );
 
 /**
  * Get the project attachment with the specified id.

--- a/billing_page.php
+++ b/billing_page.php
@@ -46,7 +46,7 @@ layout_page_begin();
 
 # Work break-down
 define( 'BILLING_INC_ALLOW', true );
-include( __DIR__ . DIRECTORY_SEPARATOR . 'billing_inc.php' );
+include( __DIR__ . '/billing_inc.php' );
 
 layout_page_end();
 

--- a/billing_page.php
+++ b/billing_page.php
@@ -46,7 +46,7 @@ layout_page_begin();
 
 # Work break-down
 define( 'BILLING_INC_ALLOW', true );
-include( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'billing_inc.php' );
+include( __DIR__ . DIRECTORY_SEPARATOR . 'billing_inc.php' );
 
 layout_page_end();
 

--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -66,7 +66,7 @@ $f_bug_id = gpc_get_int( 'id' );
 $t_bug = bug_get( $f_bug_id );
 
 $t_file = __FILE__;
-$t_mantis_dir = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
+$t_mantis_dir = __DIR__ . DIRECTORY_SEPARATOR;
 $t_show_page_header = false;
 $t_force_readonly = true;
 
@@ -422,4 +422,4 @@ layout_page_begin();
 </div>
 <?php
 define( 'BUG_VIEW_INC_ALLOW', true );
-include( dirname( __FILE__ ) . '/bug_view_inc.php' );
+include( __DIR__ . '/bug_view_inc.php' );

--- a/bug_relationship_graph.php
+++ b/bug_relationship_graph.php
@@ -201,8 +201,8 @@ layout_page_begin();
 $_GET['id'] = $f_bug_id;
 $t_show_page_header = false;
 $t_force_readonly = true;
-$t_mantis_dir = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
+$t_mantis_dir = __DIR__ . DIRECTORY_SEPARATOR;
 $t_file = __FILE__;
 
 define( 'BUG_VIEW_INC_ALLOW', true );
-include( dirname( __FILE__ ) . '/bug_view_inc.php' );
+include( __DIR__ . '/bug_view_inc.php' );

--- a/bug_reminder_page.php
+++ b/bug_reminder_page.php
@@ -183,7 +183,7 @@ layout_page_begin();
 $_GET['id'] = $f_bug_id;
 $t_show_page_header = false;
 $t_force_readonly = true;
-$t_mantis_dir = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
+$t_mantis_dir = __DIR__ . DIRECTORY_SEPARATOR;
 $t_file = __FILE__;
 
 define( 'BUG_VIEW_INC_ALLOW', true );

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -792,7 +792,7 @@ if( $t_bottom_buttons_enabled ) {
 
 <?php
 define( 'BUGNOTE_VIEW_INC_ALLOW', true );
-include( __DIR__ . DIRECTORY_SEPARATOR . 'bugnote_view_inc.php' );
+include( __DIR__ . '/bugnote_view_inc.php' );
 layout_page_end();
 
 last_visited_issue( $t_bug_id );

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -792,7 +792,7 @@ if( $t_bottom_buttons_enabled ) {
 
 <?php
 define( 'BUGNOTE_VIEW_INC_ALLOW', true );
-include( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'bugnote_view_inc.php' );
+include( __DIR__ . DIRECTORY_SEPARATOR . 'bugnote_view_inc.php' );
 layout_page_end();
 
 last_visited_issue( $t_bug_id );

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -163,7 +163,7 @@ $g_db_table_plugin_prefix = 'plugin';
  *
  * @global string $g_absolute_path
  */
-$g_absolute_path = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
+$g_absolute_path = __DIR__ . DIRECTORY_SEPARATOR;
 
 /**
  * Path to core folder.

--- a/core.php
+++ b/core.php
@@ -66,7 +66,7 @@ if( file_exists( 'mantis_offline.php' ) && !isset( $_GET['mbadmin'] ) ) {
 $g_request_time = microtime( true );
 
 # Load supplied constants
-require_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'constant_inc.php' );
+require_once( __DIR__ . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'constant_inc.php' );
 
 # Enforce our minimum PHP requirements
 if( version_compare( PHP_VERSION, PHP_MIN_VERSION, '<' ) ) {
@@ -86,10 +86,10 @@ if( php_sapi_name() != 'cli' ) {
 }
 
 # Load Composer autoloader
-require_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'vendor/autoload.php' );
+require_once( __DIR__ . DIRECTORY_SEPARATOR . 'vendor/autoload.php' );
 
 # Include default configuration settings
-require_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'config_defaults_inc.php' );
+require_once( __DIR__ . DIRECTORY_SEPARATOR . 'config_defaults_inc.php' );
 
 # Load user-defined constants (if required)
 global $g_config_path;

--- a/core.php
+++ b/core.php
@@ -103,6 +103,11 @@ if( $t_config_inc_found ) {
 	require_once( $g_config_path . 'config_inc.php' );
 }
 
+# Ensure we always have a consistent current working directory.
+# IIS with FastCGI seems to set CWD to directory where php.exe resides (see #33906).
+global $g_absolute_path;
+chdir( $g_absolute_path );
+
 # Set global path variables
 # NOTE: We store whether $g_path was defaulted, so we can later warn the admin
 # about the exposure to host header injection attacks if they didn't set it.

--- a/core.php
+++ b/core.php
@@ -103,11 +103,6 @@ if( $t_config_inc_found ) {
 	require_once( $g_config_path . 'config_inc.php' );
 }
 
-# Ensure we always have a consistent current working directory.
-# IIS with FastCGI seems to set CWD to directory where php.exe resides (see #33906).
-global $g_absolute_path;
-chdir( $g_absolute_path );
-
 # Set global path variables
 # NOTE: We store whether $g_path was defaulted, so we can later warn the admin
 # about the exposure to host header injection attacks if they didn't set it.

--- a/core.php
+++ b/core.php
@@ -66,7 +66,7 @@ if( file_exists( 'mantis_offline.php' ) && !isset( $_GET['mbadmin'] ) ) {
 $g_request_time = microtime( true );
 
 # Load supplied constants
-require_once( __DIR__ . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'constant_inc.php' );
+require_once( __DIR__ . '/core/constant_inc.php' );
 
 # Enforce our minimum PHP requirements
 if( version_compare( PHP_VERSION, PHP_MIN_VERSION, '<' ) ) {
@@ -86,10 +86,10 @@ if( php_sapi_name() != 'cli' ) {
 }
 
 # Load Composer autoloader
-require_once( __DIR__ . DIRECTORY_SEPARATOR . 'vendor/autoload.php' );
+require_once( __DIR__ . '/vendor/autoload.php' );
 
 # Include default configuration settings
-require_once( __DIR__ . DIRECTORY_SEPARATOR . 'config_defaults_inc.php' );
+require_once( __DIR__ . '/config_defaults_inc.php' );
 
 # Load user-defined constants (if required)
 global $g_config_path;
@@ -442,7 +442,7 @@ function autoload_mantis( $p_class ) {
 		return;
 	}
 
-	$t_require_path = $g_library_path . 'rssbuilder' . DIRECTORY_SEPARATOR . 'class.' . $p_class . '.inc.php';
+	$t_require_path = $g_library_path . 'rssbuilder/class.' . $p_class . '.inc.php';
 
 	if( file_exists( $t_require_path ) ) {
 		require_once( $t_require_path );

--- a/core/classes/FilterConverter.class.php
+++ b/core/classes/FilterConverter.class.php
@@ -21,11 +21,11 @@
  * @package MantisBT
  */
 
-$t_api_path = dirname( __FILE__, 3 ) . '/api/';
-require_once( $t_api_path . 'soap/mc_api.php' );
-require_once( $t_api_path . 'soap/mc_account_api.php' );
-require_once( $t_api_path . 'soap/mc_enum_api.php' );
-require_once( $t_api_path . 'soap/mc_project_api.php' );
+$t_api_path = dirname( __DIR__, 2 ) . '/api/soap/';
+require_once( $t_api_path . 'mc_api.php' );
+require_once( $t_api_path . 'mc_account_api.php' );
+require_once( $t_api_path . 'mc_enum_api.php' );
+require_once( $t_api_path . 'mc_project_api.php' );
 
 require_api( 'custom_field_api.php' );
 

--- a/core/commands/ConfigsSetCommand.php
+++ b/core/commands/ConfigsSetCommand.php
@@ -16,7 +16,7 @@
 
 use Mantis\Exceptions\ClientException;
 
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_api.php' );
+require_once( __DIR__ . '/../../api/soap/mc_api.php' );
 
 /**
  * A command that sets config options.

--- a/core/commands/ConfigsSetCommand.php
+++ b/core/commands/ConfigsSetCommand.php
@@ -16,7 +16,8 @@
 
 use Mantis\Exceptions\ClientException;
 
-require_once( __DIR__ . '/../../api/soap/mc_api.php' );
+$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+require_once( $t_soap_dir . 'mc_api.php' );
 
 /**
  * A command that sets config options.

--- a/core/commands/IssueAddCommand.php
+++ b/core/commands/IssueAddCommand.php
@@ -33,10 +33,11 @@ require_api( 'relationship_api.php' );
 require_api( 'string_api.php' );
 require_api( 'user_api.php' );
 
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_api.php' );
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_enum_api.php' );
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_issue_api.php' );
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_project_api.php' );
+$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+require_once( $t_soap_dir . 'mc_api.php' );
+require_once( $t_soap_dir . 'mc_enum_api.php' );
+require_once( $t_soap_dir . 'mc_issue_api.php' );
+require_once( $t_soap_dir . 'mc_project_api.php' );
 
 use Mantis\Exceptions\ClientException;
 

--- a/core/commands/IssueViewPageCommand.php
+++ b/core/commands/IssueViewPageCommand.php
@@ -33,11 +33,9 @@ require_api( 'relationship_api.php' );
 require_api( 'string_api.php' );
 require_api( 'user_api.php' );
 
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_account_api.php' );
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_api.php' );
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_enum_api.php' );
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_issue_api.php' );
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_project_api.php' );
+$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+require_once( $t_soap_dir . 'mc_api.php' );
+require_once( $t_soap_dir . 'mc_issue_api.php' );
 
 use Mantis\Exceptions\ClientException;
 

--- a/core/commands/ProjectAddCommand.php
+++ b/core/commands/ProjectAddCommand.php
@@ -16,8 +16,8 @@
 
 require_api( 'project_api.php' );
 
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_api.php' );
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_enum_api.php' );
+require_once( __DIR__ . '/../../api/soap/mc_api.php' );
+require_once( __DIR__ . '/../../api/soap/mc_enum_api.php' );
 
 use Mantis\Exceptions\ClientException;
 

--- a/core/commands/ProjectAddCommand.php
+++ b/core/commands/ProjectAddCommand.php
@@ -16,8 +16,8 @@
 
 require_api( 'project_api.php' );
 
-require_once( __DIR__ . '/../../api/soap/mc_api.php' );
-require_once( __DIR__ . '/../../api/soap/mc_enum_api.php' );
+$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+require_once( $t_soap_dir . 'mc_api.php' );
 
 use Mantis\Exceptions\ClientException;
 

--- a/core/commands/ProjectHierarchyAddCommand.php
+++ b/core/commands/ProjectHierarchyAddCommand.php
@@ -20,7 +20,7 @@ require_api( 'helper_api.php' );
 require_api( 'project_api.php' );
 require_api( 'project_hierarchy_api.php' );
 
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_api.php' );
+require_once( __DIR__ . '/../../api/soap/mc_api.php' );
 
 use Mantis\Exceptions\ClientException;
 

--- a/core/commands/ProjectHierarchyAddCommand.php
+++ b/core/commands/ProjectHierarchyAddCommand.php
@@ -20,7 +20,8 @@ require_api( 'helper_api.php' );
 require_api( 'project_api.php' );
 require_api( 'project_hierarchy_api.php' );
 
-require_once( __DIR__ . '/../../api/soap/mc_api.php' );
+$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+require_once( $t_soap_dir . 'mc_api.php' );
 
 use Mantis\Exceptions\ClientException;
 

--- a/core/commands/ProjectUpdateCommand.php
+++ b/core/commands/ProjectUpdateCommand.php
@@ -16,8 +16,8 @@
 
 require_api( 'project_api.php' );
 
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_api.php' );
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_enum_api.php' );
+$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+require_once( $t_soap_dir . 'mc_api.php' );
 
 use Mantis\Exceptions\ClientException;
 

--- a/core/commands/ProjectUsersAddCommand.php
+++ b/core/commands/ProjectUsersAddCommand.php
@@ -19,9 +19,8 @@ use Mantis\Exceptions\ClientException;
 require_api( 'authentication_api.php' );
 require_api( 'user_pref_api.php' );
 
-require_once( dirname( __FILE__, 3 ) . '/api/soap/mc_account_api.php' );
-require_once( dirname( __FILE__, 3 ) . '/api/soap/mc_api.php' );
-require_once( dirname( __FILE__, 3 ) . '/api/soap/mc_enum_api.php' );
+$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+require_once( $t_soap_dir . 'mc_api.php' );
 
 /**
  * Sample:

--- a/core/commands/ProjectUsersGetCommand.php
+++ b/core/commands/ProjectUsersGetCommand.php
@@ -19,8 +19,9 @@ use Mantis\Exceptions\ClientException;
 require_api( 'authentication_api.php' );
 require_api( 'user_pref_api.php' );
 
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_account_api.php' );
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_enum_api.php' );
+$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+require_once( $t_soap_dir . 'mc_account_api.php' );
+require_once( $t_soap_dir . 'mc_enum_api.php' );
 
 /**
  * Sample:

--- a/core/commands/UserTokenCreateCommand.php
+++ b/core/commands/UserTokenCreateCommand.php
@@ -19,8 +19,9 @@ require_api( 'api_token_api.php' );
 
 use Mantis\Exceptions\ClientException;
 
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_api.php' );
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_account_api.php' );
+$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+require_once( $t_soap_dir . 'mc_api.php' );
+require_once( $t_soap_dir . 'mc_account_api.php' );
 
 /**
  * A command that creates a user API token.

--- a/core/commands/UserTokenDeleteCommand.php
+++ b/core/commands/UserTokenDeleteCommand.php
@@ -19,9 +19,6 @@ require_api( 'api_token_api.php' );
 
 use Mantis\Exceptions\ClientException;
 
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_api.php' );
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_account_api.php' );
-
 /**
  * A command that creates a user API token.
  */

--- a/core/commands/UserUpdateCommand.php
+++ b/core/commands/UserUpdateCommand.php
@@ -22,8 +22,8 @@ require_api( 'user_api.php' );
 
 use Mantis\Exceptions\ClientException;
 
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_account_api.php' );
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_api.php' );
+$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+require_once( $t_soap_dir . 'mc_api.php' );
 
 /**
  * A command that updates a user account.

--- a/core/commands/VersionGetCommand.php
+++ b/core/commands/VersionGetCommand.php
@@ -20,8 +20,6 @@ require_api( 'helper_api.php' );
 
 use Mantis\Exceptions\ClientException;
 
-require_once( dirname( __FILE__ ) . '/../../api/soap/mc_api.php' );
-
 /**
  * A command that gets project versions.
  */

--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -271,7 +271,7 @@ function log_print_to_page() {
 function log_get_caller( $p_level = null ) {
 	$t_full_backtrace = debug_backtrace();
 	$t_backtrace = $t_full_backtrace;
-	$t_root_path = dirname( __FILE__, 2 ) . DIRECTORY_SEPARATOR;
+	$t_root_path = dirname( __DIR__ ) . DIRECTORY_SEPARATOR;
 
 	# Remove top trace, as it's this function
 	unset( $t_backtrace[0] );

--- a/css/status_config.php
+++ b/css/status_config.php
@@ -28,7 +28,7 @@
 # Prevent output of HTML in the content if errors occur
 define( 'DISABLE_INLINE_ERROR_REPORTING', true );
 
-@require_once( dirname( __FILE__, 2 ) . '/core.php' );
+@require_once( dirname( __DIR__ ) . '/core.php' );
 require_api( 'config_api.php' );
 
 /**

--- a/login_page.php
+++ b/login_page.php
@@ -138,7 +138,7 @@ $t_upgrade_required = false;
 
 if( config_get_global( 'admin_checks' ) == ON ) {
 	# Check if the admin directory is accessible
-	$t_admin_dir = dirname( __FILE__ ) . '/admin';
+	$t_admin_dir = __DIR__ . '/admin';
 	$t_admin_dir_is_accessible = @file_exists( $t_admin_dir . '/.' );
 	if( $t_admin_dir_is_accessible ) {
 		$t_warnings[] = lang_get( 'warning_admin_directory_present' );

--- a/login_password_page.php
+++ b/login_password_page.php
@@ -188,7 +188,7 @@ if( config_get_global( 'admin_checks' ) == ON && file_exists( __DIR__ .'/admin/.
 	}
 
 	# Check for db upgrade for versions > 1.0.0 using new installer and schema
-	require_once( 'admin' . DIRECTORY_SEPARATOR . 'schema.php' );
+	require_once( 'admin/schema.php' );
 	$t_upgrades_reqd = count( $g_upgrade ) - 1;
 
 	if( ( 0 < $t_db_version ) &&

--- a/login_password_page.php
+++ b/login_password_page.php
@@ -179,7 +179,7 @@ if( $f_error || $f_cookie_error || $f_reauthenticate ) {
 }
 
 $t_upgrade_required = false;
-if( config_get_global( 'admin_checks' ) == ON && file_exists( dirname( __FILE__ ) .'/admin/.' ) ) {
+if( config_get_global( 'admin_checks' ) == ON && file_exists( __DIR__ .'/admin/.' ) ) {
 	# since admin directory and db_upgrade lists are available check for missing db upgrades
 	# if db version is 0, we do not have a valid database.
 	$t_db_version = config_get( 'database_version', 0, ALL_USERS, ALL_PROJECTS );

--- a/manage_config_columns_page.php
+++ b/manage_config_columns_page.php
@@ -47,6 +47,6 @@ print_manage_config_menu( 'manage_config_columns_page.php' );
 define( 'MANAGE_COLUMNS', true );
 
 define( 'MANAGE_COLUMNS_INC_ALLOW', true );
-include ( dirname( __FILE__ ) . '/manage_columns_inc.php' );
+include( __DIR__ . '/manage_columns_inc.php' );
 
 layout_page_end();

--- a/manage_user_edit_page.php
+++ b/manage_user_edit_page.php
@@ -508,7 +508,7 @@ if( access_has_global_level( config_get( 'manage_user_threshold' ) )
 <!-- ACCOUNT PREFERENCES -->
 <?php
 define( 'ACCOUNT_PREFS_INC_ALLOW', true );
-include( dirname( __FILE__ ) . '/account_prefs_inc.php' );
+include( __DIR__ . '/account_prefs_inc.php' );
 edit_account_prefs(
 	$t_user['id'],
 	false,

--- a/my_view_page.php
+++ b/my_view_page.php
@@ -152,7 +152,7 @@ foreach( $t_boxes as $t_box_title => $t_box_display ) {
         echo '</div>';
         echo '<div class="col-xs-12 col-md-6">';
     }
-    include( __DIR__ . DIRECTORY_SEPARATOR . 'my_view_inc.php' );
+    include( __DIR__ . '/my_view_inc.php' );
     echo '<div class="space-10"></div>';
 }
 ?>

--- a/my_view_page.php
+++ b/my_view_page.php
@@ -152,7 +152,7 @@ foreach( $t_boxes as $t_box_title => $t_box_display ) {
         echo '</div>';
         echo '<div class="col-xs-12 col-md-6">';
     }
-    include( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'my_view_inc.php' );
+    include( __DIR__ . DIRECTORY_SEPARATOR . 'my_view_inc.php' );
     echo '<div class="space-10"></div>';
 }
 ?>

--- a/news_rss.php
+++ b/news_rss.php
@@ -49,7 +49,7 @@ require_api( 'rss_api.php' );
 require_api( 'string_api.php' );
 require_api( 'user_api.php' );
 require_api( 'utility_api.php' );
-require_lib( 'rssbuilder' . DIRECTORY_SEPARATOR . 'class.RSSBuilder.inc.php' );
+require_lib( 'rssbuilder/class.RSSBuilder.inc.php' );
 
 $f_username = gpc_get_string( 'username', null );
 $f_key = gpc_get_string( 'key', null );

--- a/plugins/MantisCoreFormatting/tests/MarkdownTest.php
+++ b/plugins/MantisCoreFormatting/tests/MarkdownTest.php
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
 
-require_once( dirname( __FILE__, 2 ) . '/../../tests/TestConfig.php' );
-require_once( dirname( __FILE__, 2 ) . '/core/MantisMarkdown.php' );
+require_once( dirname( __DIR__ ) . '/../../tests/TestConfig.php' );
+require_once( dirname( __DIR__ ) . '/core/MantisMarkdown.php' );
 
 # MantisBT Core API
 require_mantis_core();

--- a/print_all_bug_options_page.php
+++ b/print_all_bug_options_page.php
@@ -34,7 +34,7 @@ require_api( 'authentication_api.php' );
 require_api( 'html_api.php' );
 
 define( 'PRINT_ALL_BUG_OPTIONS_INC_ALLOW', true );
-include( dirname( __FILE__ ) . '/print_all_bug_options_inc.php' );
+include( __DIR__ . '/print_all_bug_options_inc.php' );
 
 auth_ensure_user_authenticated();
 

--- a/print_all_bug_options_reset.php
+++ b/print_all_bug_options_reset.php
@@ -46,7 +46,7 @@ require_api( 'lang_api.php' );
 require_api( 'print_api.php' );
 
 define( 'PRINT_ALL_BUG_OPTIONS_INC_ALLOW', true );
-include( dirname( __FILE__ ) . '/print_all_bug_options_inc.php' );
+include( __DIR__ . '/print_all_bug_options_inc.php' );
 
 form_security_validate( 'print_all_bug_options_reset' );
 

--- a/print_all_bug_options_update.php
+++ b/print_all_bug_options_update.php
@@ -46,7 +46,7 @@ require_api( 'lang_api.php' );
 require_api( 'print_api.php' );
 
 define( 'PRINT_ALL_BUG_OPTIONS_INC_ALLOW', true );
-include( dirname( __FILE__ ) . '/print_all_bug_options_inc.php' );
+include( __DIR__ . '/print_all_bug_options_inc.php' );
 
 form_security_validate( 'print_all_bug_options_update' );
 

--- a/scripts/cronjob.php
+++ b/scripts/cronjob.php
@@ -30,7 +30,7 @@
 global $g_bypass_headers;
 $g_bypass_headers = 1;
 
-require_once( dirname( __FILE__, 2 ) . '/core.php' );
+require_once( dirname( __DIR__ ) . '/core.php' );
 
 # Make sure this script doesn't run via the webserver
 if( php_sapi_name() != 'cli' ) {

--- a/scripts/send_emails.php
+++ b/scripts/send_emails.php
@@ -26,7 +26,7 @@
 global $g_bypass_headers;
 $g_bypass_headers = 1;
 
-require_once( dirname( __FILE__, 2 ) . '/core.php' );
+require_once( dirname( __DIR__ ) . '/core.php' );
 
 require_api( 'email_api.php' );
 

--- a/tests/Mantis/Helper/ArrayTransposeTest.php
+++ b/tests/Mantis/Helper/ArrayTransposeTest.php
@@ -26,7 +26,7 @@ declare( strict_types = 1 );
 
 use Mantis\Exceptions\ClientException;
 
-require_once dirname( __FILE__, 2 ) . '/MantisCoreBase.php';
+require_once dirname( __DIR__ ) . '/MantisCoreBase.php';
 
 /**
  * Test for helper_api::helper_array_transpose

--- a/tests/Mantis/Helper/GetLinkAttributesTest.php
+++ b/tests/Mantis/Helper/GetLinkAttributesTest.php
@@ -24,7 +24,7 @@
 
 declare( strict_types = 1 );
 
-require_once dirname( __FILE__, 2 ) . '/MantisCoreBase.php';
+require_once dirname( __DIR__ ) . '/MantisCoreBase.php';
 
 /**
  * Test for helper_api::helper_get_link_attributes

--- a/tests/Mantis/MantisCoreBase.php
+++ b/tests/Mantis/MantisCoreBase.php
@@ -24,7 +24,7 @@
  */
 
 # Includes
-require_once dirname( __FILE__, 2 ) . '/TestConfig.php';
+require_once dirname( __DIR__ ) . '/TestConfig.php';
 
 # MantisBT Core API
 require_mantis_core();

--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -100,7 +100,7 @@ error_reporting( E_ALL | E_STRICT );
 
 # Determine the root, library, and tests directories of the framework
 # distribution.
-$g_mantisRoot = dirname( __FILE__, 2 );
+$g_mantisRoot = dirname( __DIR__ );
 $g_mantisCore = $g_mantisRoot . '/core';
 $g_mantisLibrary = $g_mantisRoot . '/library';
 $g_mantisClasses = $g_mantisRoot . '/core/classes';

--- a/tests/rest/RestBase.php
+++ b/tests/rest/RestBase.php
@@ -27,7 +27,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use PHPUnit\Framework\TestCase;
 
 # Includes
-require_once dirname( __FILE__, 2 ) . '/TestConfig.php';
+require_once dirname( __DIR__ ) . '/TestConfig.php';
 
 # MantisBT Core API
 require_mantis_core();

--- a/tests/soap/SoapBase.php
+++ b/tests/soap/SoapBase.php
@@ -25,10 +25,10 @@
  */
 
 
-$t_root_path = dirname( __FILE__, 3 ) . DIRECTORY_SEPARATOR;
+$t_root_path = dirname( __DIR__, 2 );
 
 # MantisBT constants
-require_once ( $t_root_path . DIRECTORY_SEPARATOR . 'core/constant_inc.php' );
+require_once ( $t_root_path . '/core/constant_inc.php' );
 
 /**
  * Test cases for SoapEnum class.

--- a/tests/travis_create_api_token.php
+++ b/tests/travis_create_api_token.php
@@ -26,7 +26,7 @@
 global $g_bypass_headers;
 $g_bypass_headers = true;
 
-require_once( dirname( __FILE__, 2 ) . '/core.php' );
+require_once( dirname( __DIR__ ) . '/core.php' );
 require_api( 'api_token_api.php' );
 
 # Make sure this script doesn't run via the webserver

--- a/view.php
+++ b/view.php
@@ -28,9 +28,9 @@
 require_once( 'core.php' );
 
 $t_file = __FILE__;
-$t_mantis_dir = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
+$t_mantis_dir = __DIR__ . DIRECTORY_SEPARATOR;
 $t_show_page_header = true;
 $t_force_readonly = false;
 
 define( 'BUG_VIEW_INC_ALLOW', true );
-include( dirname( __FILE__ ) . '/bug_view_inc.php' );
+include( __DIR__ . '/bug_view_inc.php' );

--- a/view_all_bug_page.php
+++ b/view_all_bug_page.php
@@ -109,6 +109,6 @@ layout_page_header_end();
 layout_page_begin( __FILE__ );
 
 define( 'VIEW_ALL_INC_ALLOW', true );
-include( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'view_all_inc.php' );
+include( __DIR__ . DIRECTORY_SEPARATOR . 'view_all_inc.php' );
 
 layout_page_end();

--- a/view_all_bug_page.php
+++ b/view_all_bug_page.php
@@ -109,6 +109,6 @@ layout_page_header_end();
 layout_page_begin( __FILE__ );
 
 define( 'VIEW_ALL_INC_ALLOW', true );
-include( __DIR__ . DIRECTORY_SEPARATOR . 'view_all_inc.php' );
+include( __DIR__ . '/view_all_inc.php' );
 
 layout_page_end();


### PR DESCRIPTION
- Replace dirname( __FILE__ ) by __DIR__ (3)
- Replace unnecessary DIRECTORY_SEPARATOR by '/'

Fixes [#34468](https://mantisbt.org/bugs/view.php?id=34468)

Also, set current working dir in core.php as a follow-up to [#33906](https://mantisbt.org/bugs/view.php?id=33906), and related required adjustment to mantisconnect.php.