### PR TITLE
Adapt Database Admin Checks to new MySQL release model

### DIFF
--- a/admin/check/check_api.php
+++ b/admin/check/check_api.php
@@ -56,7 +56,7 @@ function check_error_handler( $p_type, $p_error, $p_file, $p_line ) {
 
 	# Do not handle PHP errors that have already been caught by MantisBT. These
 	# are likely triggered by the admin checks script itself, so we let PHP
-	# process them, otherwise the check will fail silently.x§
+	# process them, otherwise the check will fail silently.
 	if( $p_type == E_USER_ERROR && $p_error == ERROR_PHP ) {
 		return false;
 	}

--- a/admin/check/check_api.php
+++ b/admin/check/check_api.php
@@ -192,13 +192,20 @@ function check_print_test_result( $p_result ) {
 }
 
 /**
- * Print Check Test Row
- * @param string  $p_description Description.
- * @param boolean $p_pass        Whether test passed.
- * @param string  $p_info        Information.
- * @return boolean
+ * Print Check Test Row.
+ *
+ * @param string $p_description Check's description.
+ * @param bool   $p_pass        True if test passed.
+ * @param null   $p_info        Optional additional information to print below the description.
+ *                              If a string is given, the message is always displayed;
+ *                              Providing array with true/false keys allows differentiated
+ *                              messages depending on the Check's result, and if a key is
+ *                              missing then the message is not printed.
+ * @param bool   $p_warning     True if it's a Warning check.
+ *
+ * @return bool
  */
-function check_print_test_row( $p_description, $p_pass, $p_info = null ) {
+function check_print_test_row( $p_description, $p_pass, $p_info = null, $p_warning = false ) {
 	global $g_show_all;
 	$t_unhandled = check_unhandled_errors_exist();
 	if( !$g_show_all && $p_pass && !$t_unhandled ) {
@@ -217,7 +224,7 @@ function check_print_test_row( $p_description, $p_pass, $p_info = null ) {
 
 	if( $p_pass && !$t_unhandled ) {
 		$t_result = GOOD;
-	} elseif( $t_unhandled == E_DEPRECATED ) {
+	} elseif( $p_warning && !$t_unhandled || $t_unhandled == E_DEPRECATED ) {
 		$t_result = WARN;
 	} else {
 		$t_result = BAD;
@@ -232,41 +239,20 @@ function check_print_test_row( $p_description, $p_pass, $p_info = null ) {
 }
 
 /**
- * Print Check Test Warning Row
- * @param string  $p_description Description.
- * @param boolean $p_pass        Whether test passed.
- * @param string  $p_info        Information.
- * @return boolean
+ * Print Check Test Warning Row.
+ *
+ * @param string       $p_description Check's description.
+ * @param bool         $p_pass        True if test passed.
+ * @param string|array $p_info        Optional additional information to print below the description.
+ *                                    If a string is given, the message is always displayed;
+ *                                    Providing array with true/false keys allows differentiated
+ *                                    messages depending on the Check's result, and if a key is
+ *                                    missing then the message is not printed.
+ *
+ * @return bool
  */
 function check_print_test_warn_row( $p_description, $p_pass, $p_info = null ) {
-	global $g_show_all;
-	$t_unhandled = check_unhandled_errors_exist();
-	if( !$g_show_all && $p_pass && !$t_unhandled ) {
-		return $p_pass;
-	}
-	echo "\t<tr>\n\t\t<td>$p_description";
-	if( $p_info !== null ) {
-		if( is_array( $p_info ) && isset( $p_info[$p_pass] ) ) {
-			echo '<br /><em>' . $p_info[$p_pass] . '</em>';
-		} else if( !is_array( $p_info ) ) {
-			echo '<br /><em>' . $p_info . '</em>';
-		}
-	}
-	echo "</td>\n";
-	if( $p_pass && !$t_unhandled ) {
-		$t_result = GOOD;
-	} elseif( !$t_unhandled || $t_unhandled == E_DEPRECATED ) {
-		$t_result = WARN;
-	} else {
-		$t_result = BAD;
-	}
-	check_print_test_result( $t_result );
-	echo "\t</tr>\n";
-
-	if( $t_unhandled ) {
-		check_print_error_rows();
-	}
-	return $p_pass;
+	return check_print_test_row( $p_description, $p_pass, $p_info, true );
 }
 
 /**

--- a/admin/check/check_database_inc.php
+++ b/admin/check/check_database_inc.php
@@ -248,12 +248,22 @@ if( db_is_mysql() ) {
 	$t_mysql_ga_release = false;
 	$t_date_end_active_support = $t_date_end_of_life = null;
 	if( !array_key_exists( $t_db_major_version, $t_versions ) ) {
+		$t_param = [
+			'category_id' => 12, # db mysql
+			'product_version' => MANTIS_VERSION,
+			'reproducibility' => 10, # always
+			'priority' => 20, # low
+			'summary' => "MySQL version $t_db_major_version is not defined in Admin Checks",
+			'description' => "Please add the missing version to " . basename( __FILE__ ) . ".",
+		];
+		$t_report_bug_url = 'https://mantisbt.org/bugs/bug_report_page.php?' . http_build_query( $t_param );
 		check_print_test_warn_row(
 			'MySQL Lifecycle and Release Support data availability',
 			false,
 			array(
 				false => 'Release information for MySQL ' . $t_db_major_version
 					. ' series is not available, unable to perform the lifecycle checks.'
+					. ' Please <a href="' . $t_report_bug_url . '">report the issue</a>.'
 			) );
 	} else {
 		$t_version = $t_versions[$t_db_major_version];

--- a/admin/check/check_database_inc.php
+++ b/admin/check/check_database_inc.php
@@ -223,9 +223,10 @@ $t_date_format = config_get( 'short_date_format' );
 # MySQL support checking
 if( db_is_mysql() ) {
 	# The list below was built based on information found in the FAQ [1]
-	# [1]: https://dev.mysql.com/doc/refman/8.0/en/faqs-general.html
+	# [1]: https://dev.mysql.com/doc/refman/8.4/en/faqs-general.html
+	# @TODO consider using https://endoflife.date/mysql to retrieve this data
 	$t_versions = array(
-		# Series >= Type, GA status, GA date
+		# Series => Type, Version when GA status was achieved, GA date
 		'5.0' => array( 'GA', '5.0.15', '2005-10-19' ),
 		'5.1' => array( 'GA', '5.1.30', '2008-11-14' ),
 		'5.4' => array( 'Discontinued' ),
@@ -234,6 +235,10 @@ if( db_is_mysql() ) {
 		'5.7' => array( 'GA', '5.7.9', '2015-10-21' ),
 		'6.0' => array( 'Discontinued' ),
 		'8.0' => array( 'GA', '8.0.11', '2018-04-19' ),
+		'8.1' => array( 'Innovation', '8.1.0', '2023-07-18' ),
+		'8.2' => array( 'Innovation', '8.2.0', '2023-10-25' ),
+		'8.3' => array( 'Innovation', '8.3.0', '2024-01-16' ),
+		'8.4' => array( 'LTS', '8.4.0', '2024-04-30' ),
 	);
 	$t_support_url = 'https://www.mysql.com/support/';
 

--- a/admin/check/check_database_inc.php
+++ b/admin/check/check_database_inc.php
@@ -48,7 +48,7 @@ if( isset( $ADODB_vers ) ) {
 	# Upstream bug report: http://phplens.com/lens/lensforum/msgs.php?id=18320
 	# This bug has been fixed in ADOdb 5.11 (May 5, 2010) but we still
 	# need to use the backwards compatible approach to detect ADOdb <5.11.
-	if( preg_match( '/^[Vv]([0-9\.]+)/', $ADODB_vers, $t_matches ) == 1 ) {
+	if( preg_match( '/^[Vv]([0-9.]+)/', $ADODB_vers, $t_matches ) == 1 ) {
 		$t_adodb_version_check_ok = version_compare( $t_matches[1], DB_MIN_VERSION_ADODB, '>=' );
 		$t_adodb_version_info = 'ADOdb version ' . htmlentities( $t_matches[1] ) . ' was found.';
 	}
@@ -61,7 +61,7 @@ if( isset( $ADODB_vers ) ) {
 	);
 }
 check_print_test_row(
-	'Version of <a href="http://en.wikipedia.org/wiki/ADOdb">ADOdb</a> available is at least ' . DB_MIN_VERSION_ADODB,
+	'Version of <a href="https://adodb.org">ADOdb</a> available is at least ' . DB_MIN_VERSION_ADODB,
 	$t_adodb_version_check_ok,
 	$t_adodb_version_info
 );
@@ -72,7 +72,7 @@ if( !$t_adodb_version_check_ok ) {
 
 $t_database_dsn = config_get_global( 'dsn' );
 check_print_info_row(
-	'Using a custom <a href="http://en.wikipedia.org/wiki/Database_Source_Name">Database Source Name</a> (DSN) for connecting to the database',
+	'Using a custom <a href="https://en.wikipedia.org/wiki/Database_Source_Name">Database Source Name</a> (DSN) for connecting to the database',
 	$t_database_dsn ? 'Yes' : 'No'
 );
 
@@ -178,7 +178,7 @@ check_print_test_row(
 if( !db_is_connected() ) {
 	return;
 }
-
+global $g_db;
 $t_database_server_info = $g_db->ServerInfo();
 $t_db_version = $t_database_server_info['version'];
 preg_match( '/^([0-9]+)\.[0-9+]/', $t_db_version, $t_matches );
@@ -430,6 +430,7 @@ check_print_test_warn_row(
 );
 
 if( db_is_mysql() ) {
+	global $g_database_name;
 	# Check DB's default collation
 	$t_query = 'SELECT default_collation_name
 		FROM information_schema.schemata


### PR DESCRIPTION
MySQL changed their lifecycle model to [Innovation and LTS releases][1]. This requires adapting the MySQL Admin Checks, as the logic for the old General Availability (GA) model is not compatbile.

- releases <= 8.0 use the former model with a GA version marking start of official support, 5 years active + 3 years extended) after which the release is considered end-of-life
- LTS releases basically follow the same model, but the GA version  is always the .0 (8.4.0 is the first LTS release)
- Innovation releases support ends when the next version is released,  or 3 months after go-live if the next release is not defined

The PR also adds information about MySQL releases 8.1 to 8.4, and includes some code cleanup

Fixes [#34480](https://mantisbt.org/bugs/view.php?id=34480), [#34492](https://mantisbt.org/bugs/view.php?id=34492)

[1]: https://blogs.oracle.com/mysql/post/introducing-mysql-innovation-and-longterm-support-lts-versions