### PR TITLE
Also returns obsolete project versions through REST API

### DIFF
--- a/api/rest/restcore/projects_rest.php
+++ b/api/rest/restcore/projects_rest.php
@@ -275,11 +275,17 @@ function rest_project_version_get( \Slim\Http\Request $p_request, \Slim\Http\Res
 	}
 
 	$t_version_id = $p_args['version_id'] ?? $p_request->getParam( 'version_id' );
+	$t_released = (bool)$_request->getQueryParam( 'released', true );
+	$t_obsolete = (bool)$_request->getQueryParam( 'obsolete', false );
+	$t_inherited = (bool)$_request->getQueryParam( 'inherited', false );
 
 	$t_data = array(
 		'query' => array(
 			'project_id' => $t_project_id,
-			'version_id' => $t_version_id
+			'version_id' => $t_version_id,
+			'r_released' => $t_released,
+			'r_obsolete' => $t_obsolete,
+			'r_inherited' => $t_inherited
 		)
 	);
 

--- a/core/commands/VersionGetCommand.php
+++ b/core/commands/VersionGetCommand.php
@@ -40,6 +40,27 @@ class VersionGetCommand extends Command {
 	 * @var integer|null
 	 */
 	private $version_id;
+	
+	/**
+	 * The released versions will be returned.
+	 *
+	 * @var boolean
+	 */
+	private $r_released;
+	
+	/**
+	 * The obsolete versions will be returned.
+	 *
+	 * @var boolean
+	 */
+	private $r_obsolete;
+	
+	/**
+	 * The inherited versions will be returned.
+	 *
+	 * @var boolean
+	 */
+	private $r_inherited;
 
 	/**
 	 * $p_data['query'] is expected to contain:
@@ -100,9 +121,9 @@ class VersionGetCommand extends Command {
 		if( is_null( $this->version_id ) ) {
 			$t_versions = version_get_all_rows(
 				$this->project_id,
-				/* released */ $this->query( 'released' ),
-				/* obsolete */ $this->query( 'obsolete', false ),
-				/* inherit */ $this->query( 'inherit', false ) );
+				/* released */ $this->query( 'released', $r_released ),
+				/* obsolete */ $this->query( 'obsolete', $r_obsolete ),
+				/* inherit */ $this->query( 'inherit', $r_inherited ) );
 
 			$t_versions = array_map( 'VersionGetCommand::VersionRowToArray', $t_versions );
 		} else {


### PR DESCRIPTION
Hello,

It should be possible to access *obsolete* versions through API otherwise it is impossible to dynamically manage them because there is no other way to get them (other than going manually with the id).

Ideally a query parameter would be the best.

Fixes [#34578](https://mantisbt.org/bugs/view.php?id=34578)