### PR TITLE
Fix project_hierarchy_cache() to cache both full and enabled-only hierarchies

### DIFF
--- a/core/project_hierarchy_api.php
+++ b/core/project_hierarchy_api.php
@@ -31,9 +31,15 @@
 require_api( 'constant_inc.php' );
 require_api( 'database_api.php' );
 
+# We may need to build caches for either all projects or enabled projects or both
+$g_cache_project_hierarchy_enabled = null;
+$g_cache_project_hierarchy_all = null;
+$g_cache_project_inheritance_enabled = null;
+$g_cache_show_disabled_all = null;
+# To make it simpler for callers of project_hierarchy_cache(), we provide
+# these two aliases for the correct pair of caches above
 $g_cache_project_hierarchy = null;
 $g_cache_project_inheritance = null;
-$g_cache_show_disabled = null;
 
 /**
  * Add project to project hierarchy
@@ -146,14 +152,27 @@ function project_hierarchy_get_parent( $p_project_id, $p_show_disabled = false )
  * @return void
  */
 function project_hierarchy_cache( $p_show_disabled = false ) {
+	global $g_cache_project_hierarchy_enabled, $g_cache_project_inheritance_enabled;
+	global $g_cache_project_hierarchy_all, $g_cache_project_inheritance_all;
 	global $g_cache_project_hierarchy, $g_cache_project_inheritance;
-	global $g_cache_show_disabled;
 
-	if( !is_null( $g_cache_project_hierarchy ) && ( $g_cache_show_disabled == $p_show_disabled ) ) {
+	# Should disabled projects be shown and do we already cache the whole hierarchy?
+	if( ( !is_null( $p_show_disabled ) ) && !is_null( $g_cache_project_hierarchy_all ) ) {
+		# Set aliases to the whole hierarchy cache and return
+		$g_cache_project_hierarchy = $g_cache_project_hierarchy_all;
+		$g_cache_project_inheritance = $g_cache_project_inheritance_all;
 		return;
 	}
-	$g_cache_show_disabled = $p_show_disabled;
 
+	# Should disabled projects be hidden and do we already cache the enabled hierarchy?
+	if( ( is_null( $p_show_disabled ) ) && !is_null( $g_cache_project_hierarchy_enabled ) ) {
+		# Set aliases to the enabled hierarchy cache and return
+		$g_cache_project_hierarchy = $g_cache_project_hierarchy_enabled;
+		$g_cache_project_inheritance = $g_cache_project_inheritance_enabled;
+		return;
+	}
+
+	# Build the missing cache
 	db_param_push();
 	$t_enabled_clause = $p_show_disabled ? '1=1' : 'p.enabled = ' . db_param();
 
@@ -186,6 +205,15 @@ function project_hierarchy_cache( $p_show_disabled = false ) {
 		if( $t_row['inherit_parent'] ) {
 			$g_cache_project_inheritance[$t_project_id][$t_parent_id] = $t_parent_id;
 		}
+	}
+
+	# Copy aliases into the right pair of cache variables
+	if( is_null( $p_show_disabled ) ) {
+		$g_cache_project_hierarchy_enabled = $g_cache_project_hierarchy;
+		$g_cache_project_inheritance_enabled = $g_cache_project_inheritance;
+	} else {
+		$g_cache_project_hierarchy_all = $g_cache_project_hierarchy;
+		$g_cache_project_inheritance_all = $g_cache_project_inheritance;
 	}
 }
 


### PR DESCRIPTION
Currently, project_hierarchy_cache() caches either all projects or enabled project only, whichever was requested last.

The project edit page calls project_hierarchy_cache() for each subproject in turn, once for the whole hierarchy, and once for the enabled projects hierarchy, which causes a cache reload on each call.

This commit caches both hierarchies so that alternating calls will not cause cache reloads any more.

Fixes [#34526](https://mantisbt.org/bugs/view.php?id=34526)