### PR TITLE
Fix issues with REST API /filters and /issues?filter_id endpoints

### DIFF
--- a/api/soap/mc_filter_api.php
+++ b/api/soap/mc_filter_api.php
@@ -121,6 +121,15 @@ function mc_filter_get( $p_username, $p_password, $p_project_id, $p_filter_id = 
 		$t_result[] = $t_filter;
 	}
 
+	# A filter ID was given, but was not found
+	if( $p_filter_id !== null && !$t_result ) {
+		throw new \Mantis\Exceptions\ClientException(
+			"Filter '$p_filter_id' not found",
+			ERROR_FILTER_NOT_FOUND,
+			[$p_filter_id]
+		);
+	}
+
 	return $t_result;
 }
 

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2522,17 +2522,20 @@ function filter_get_included_projects( array $p_filter, $p_project_id = null, $p
 }
 
 /**
- * Returns a filter array structure for the given filter_id
+ * Returns a filter array structure for the given filter_id.
+ *
  * A default value can be provided to be used when the filter_id doesn't exists
- * or is not accessible
+ * or is not accessible.
  *
- *  You may pass in any array as a default (including null) but if
- *  you pass in *no* default then an error will be triggered if the filter
- *  cannot be found
+ * You may pass in any array as a default (including null) but if
+ * you pass in *no* default then an error will be triggered if the filter
+ * cannot be found.
  *
- * @param integer $p_filter_id Filter id
- * @param array $p_default     A filter array to return when id is not found
- * @return array	A filter array
+ * @param integer $p_filter_id Filter id.
+ * @param array   $p_default   A filter array to return when id is not found.
+ *
+ * @return array A filter array
+ * @throws ClientException
  */
 function filter_get( $p_filter_id, array $p_default = null ) {
 	# if no default was provided, we will trigger an error if not found
@@ -2553,7 +2556,7 @@ function filter_get( $p_filter_id, array $p_default = null ) {
 		}
 	}
 	$t_filter = filter_deserialize( $t_filter_string );
-	# If the unserialez data is not an array, the some error happened, eg, invalid format
+	# If the unserialized data is not an array, then some error happened, eg, invalid format
 	if( !is_array( $t_filter ) ) {
 		# Don't throw error, otherwise the user could not recover navigation easily
 		return filter_get_default();

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -84,6 +84,8 @@ require_api( 'utility_api.php' );
 require_api( 'version_api.php' );
 require_api( 'filter_form_api.php' );
 
+use Mantis\Exceptions\ClientException;
+
 /**
  * Filter array for the filter in use through view_all_bug_page.
  *
@@ -2541,8 +2543,11 @@ function filter_get( $p_filter_id, array $p_default = null ) {
 	# If value is false, it either doesn't exists or is not accessible
 	if( !$t_filter_string ) {
 		if( $t_trigger_error ) {
-			error_parameters( $p_filter_id );
-			trigger_error( ERROR_FILTER_NOT_FOUND, ERROR );
+			throw new ClientException(
+				"Filter id '$p_filter_id' not found",
+				ERROR_FILTER_NOT_FOUND,
+				[$p_filter_id]
+			);
 		} else {
 			return $p_default;
 		}

--- a/tests/rest/RestBase.php
+++ b/tests/rest/RestBase.php
@@ -72,7 +72,7 @@ abstract class RestBase extends TestCase {
 	/**
 	 * @var int User ID
 	 */
-	protected $userId = '1';
+	protected $userId = 1;
 
 	/**
 	 * @var int Project ID
@@ -111,6 +111,7 @@ abstract class RestBase extends TestCase {
 
 		if( array_key_exists( 'MANTIS_TESTSUITE_USERNAME', $GLOBALS ) ) {
 			$this->userName = $GLOBALS['MANTIS_TESTSUITE_USERNAME'];
+			$this->userId = user_get_id_by_name( $this->userName );
 		}
 
 		if( array_key_exists( 'MANTIS_TESTSUITE_PASSWORD', $GLOBALS ) ) {

--- a/tests/rest/RestBase.php
+++ b/tests/rest/RestBase.php
@@ -182,6 +182,18 @@ abstract class RestBase extends TestCase {
 	}
 
 	/**
+	 * Generate a Test Case reference (TestClass::TestCase).
+	 *
+	 * This can be used to associate the test data (e.g. Issue Summary, Project
+	 * Name, etc.) with a test case.
+	 * 
+	 * @return string
+	 */
+	protected function getTestCaseReference() {
+		return static::class . '::' . $this->getName();
+	}
+
+	/**
 	 * Returns a minimal data structure for tests to create a new Issue.
 	 *
 	 * The Issue Summary is set to TestClass::TestCase with an optional
@@ -192,7 +204,7 @@ abstract class RestBase extends TestCase {
 	 * @return array
 	 */
 	protected function getIssueToAdd( $p_suffix = '' ) {
-		$t_summary = static::class . '::' . $this->getName();
+		$t_summary = $this->getTestCaseReference();
 		if( $p_suffix ) {
 			$t_summary .= '-' . $p_suffix;
 		}

--- a/tests/rest/RestFiltersTest.php
+++ b/tests/rest/RestFiltersTest.php
@@ -1,0 +1,232 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mantis Webservice Tests
+ *
+ * @package Tests
+ * @copyright Copyright 2024 MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link https://mantisbt.org
+ */
+
+require_once 'RestBase.php';
+
+/**
+ * Tests for Filters and Issues matching Filter REST API endpoints.
+ *
+ * @group REST
+ */
+class RestFiltersTest extends RestBase
+{
+	const INVALID_FILTER_ID = -9999;
+
+	/** @var array List of filters to delete to delete in tearDown() */
+	protected $filterIdsToDelete = array();
+
+	/**
+	 * Create test issues for the test
+	 * @return void
+	 */
+
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		# Delete test filters
+		foreach( $this->filterIdsToDelete as $t_filter_id ) {
+			$this->builder()
+				 ->delete( $this->getFilterURL( $t_filter_id ) )
+				 ->send();
+		}
+	}
+
+
+	/**
+	 * Generate the API base URL get Issues matching filter.
+	 *
+	 * @param int|null $p_filter_id
+	 *
+	 * @return string API endpoint
+	 */
+	private function getFilterURL( ?int $p_filter_id = null ) {
+		return "/filters/$p_filter_id";
+	}
+
+	/**
+	 * Generate the API base URL get Issues matching filter.
+	 *
+	 * @param int|string $p_filter_id
+	 *
+	 * @return string API endpoint
+	 */
+	private function getIssueFilterURL( $p_filter_id ) {
+		return "/issues?filter_id=$p_filter_id";
+	}
+
+	/**
+	 * Retrieves available Filters.
+	 *
+	 * @param int|null $p_filter_id Optional Filter id, if not given returns
+	 *                              all filters
+	 *
+	 * @return array
+	 */
+	private function getFilters( ?int $p_filter_id = null) {
+		$t_endpoint = $this->getFilterURL( $p_filter_id );
+		$t_response = $this->builder()->get( $t_endpoint )->send();
+		$this->assertEquals( HTTP_STATUS_SUCCESS, $t_response->getStatusCode(),
+			"GET $t_endpoint successful"
+		);
+
+		$t_body = json_decode( $t_response->getBody(), true );
+		$this->assertArrayHasKey( 'filters', $t_body, "Response includes filters data" );
+		$this->assertIsArray( $t_body['filters'], "Filters data should be an array" );
+
+		return $t_body['filters'];
+	}
+
+	/**
+	 * Test case for GET /filters endpoint.
+	 *
+	 * @return void
+	 */
+	public function testGetAllFilters() {
+		$t_filters = $this->getFilters();
+	}
+
+	/**
+	 * Test case for GET /filters/:id endpoint.
+	 *
+	 * @return void
+	 */
+	public function testGetSpecificFilter() {
+		$this->getFilters(10);
+	}
+
+	/**
+	 * Test case for GET /filters/:id endpoint with invalid Filter Id.
+	 *
+	 * @return void
+	 */
+	public function testGetInvalidFilter() {
+		$t_endpoint = $this->getFilterURL( self::INVALID_FILTER_ID );
+		$t_response = $this->builder()->get( $t_endpoint )->send();
+		$this->assertEquals( HTTP_STATUS_NOT_FOUND, $t_response->getStatusCode(),
+			"Retrieve invalid filter"
+		);
+	}
+
+	/**
+	 * Test case for DELETE /filters/:id endpoint.
+	 *
+	 * @return void
+	 */
+	public function testDeleteFilter() {
+		# Create a test filter
+		$t_filter_id = filter_db_create_filter(
+			filter_serialize( filter_create_any() ),
+			auth_get_current_user_id(),
+			$this->getProjectId(),
+			$this->getTestCaseReference() . ' ' . rand(1, 10000),
+			false
+		);
+
+		# Delete the filter
+		$t_endpoint = $this->getFilterURL( $t_filter_id );
+		$t_response = $this->builder()->delete( $t_endpoint )->send();
+		$this->assertEquals( HTTP_STATUS_NO_CONTENT, $t_response->getStatusCode(),
+			"Deleting filter"
+		);
+
+		# Try to delete the filter again, should fail
+		$t_response = $this->builder()->delete( $t_endpoint )->send();
+		$this->assertEquals( HTTP_STATUS_NOT_FOUND, $t_response->getStatusCode(),
+			"Deleting non-existing filter"
+		);
+	}
+
+	/**
+	 * Test case for GET /issues?filter_id=:id endpoint.
+	 *
+	 * Creates a Filter listing resolved issues created by this test case, then
+	 * executes it twice:
+	 * - Once when no matching issues exist to ensure it returns an empty set
+	 * - Again with 2 issues created, one matching an one that does not
+	 *
+	 * @return void
+	 */
+	public function testGetIssuesMatchingFilter() {
+		# Create test filter - resolved issues created by this test case
+		$t_filter = filter_get_default();
+		$t_filter[FILTER_PROPERTY_SEARCH] = $this->getTestCaseReference();
+		$t_filter[FILTER_PROPERTY_STATUS] = RESOLVED;
+		$t_filter_id = filter_db_create_filter(
+			filter_serialize( $t_filter ),
+			$this->userId,
+			$this->getProjectId(),
+			$this->getTestCaseReference() . ' ' . rand(1, 10000),
+			false
+		);
+		$this->filterIdsToDelete[] = $t_filter_id;
+
+		# Get issues matching test filter - at this point there should be none
+		$t_response = $this->builder()->get( $this->getIssueFilterURL( $t_filter_id ) )->send();
+		$this->assertEquals( HTTP_STATUS_SUCCESS, $t_response->getStatusCode(),
+			"Retrieve issues matching test filter"
+		);
+		$t_body = json_decode( $t_response->getBody(), true );
+		$this->assertArrayHasKey('issues', $t_body, "Response includes issues key" );
+		$this->assertIsArray( $t_body['issues'], "Issues key is an array" );
+		$this->assertEmpty( $t_body['issues'], "Test filter should return no issues" );
+
+		# Create 2 test issues, 1 new and 1 resolved
+		$t_issue_to_add = $this->getIssueToAdd();
+		$t_response = $this->builder()->post( '/issues', $t_issue_to_add )->send();
+		$this->assertEquals( HTTP_STATUS_CREATED, $t_response->getStatusCode() );
+		$t_body = json_decode( $t_response->getBody() );
+		$this->deleteIssueAfterRun( $t_body->issue->id );
+
+		$t_issue_to_add = $this->getIssueToAdd();
+		$t_issue_to_add['status']['id'] = RESOLVED;
+		$t_response = $this->builder()->post( '/issues', $t_issue_to_add )->send();
+		$this->assertEquals( HTTP_STATUS_CREATED, $t_response->getStatusCode() );
+		$t_body = json_decode( $t_response->getBody() );
+		$this->deleteIssueAfterRun( $t_body->issue->id );
+
+		# Get issues matching test filter again
+		$t_response = $this->builder()->get( $this->getIssueFilterURL( $t_filter_id ) )->send();
+		$this->assertEquals( HTTP_STATUS_SUCCESS, $t_response->getStatusCode(),
+			"Retrieve issues matching test filter"
+		);
+		$t_body = json_decode( $t_response->getBody(), true );
+		$this->assertCount( 1, $t_body['issues'], "Counting issues matching test filter" );
+	}
+
+	/**
+	 * Test case for GET /issues?filter_id=:id endpoint with invalid Filter Id.
+	 *
+	 * @return void
+	 */
+	public function testGetIssuesMatchingInvalidFilter() {
+		$t_endpoint = $this->getIssueFilterURL( self::INVALID_FILTER_ID );
+		$t_response = $this->builder()->get( $t_endpoint )->send();
+		$this->assertEquals( HTTP_STATUS_NOT_FOUND, $t_response->getStatusCode(),
+			"Retrieve issues matching invalid filter"
+		);
+
+	}
+
+
+}

--- a/tests/rest/RestFiltersTest.php
+++ b/tests/rest/RestFiltersTest.php
@@ -129,7 +129,17 @@ class RestFiltersTest extends RestBase
 	 * @return void
 	 */
 	public function testGetAllFilters() {
+		# Get number of filters
+		$t_count_filters = count( $this->getFilters() );
+
+		# Create 2 test filters
+		$this->createTestFilter( filter_create_any() );
+		$this->createTestFilter( filter_create_reported_by( $this->getProjectId(), $this->userId ), true );
+
 		$t_filters = $this->getFilters();
+		$this->assertEquals( 2, count( $t_filters ) - $t_count_filters,
+			"Number of filters expected to be 2"
+		);
 	}
 
 	/**


### PR DESCRIPTION
Add PHPUnit tests for the 2 endpoints

Fix
- [#34586](https://mantisbt.org/bugs/view.php?id=34586): REST API GET /filters/{ID} returns empty array when ID does not exist
- [#34493](https://mantisbt.org/bugs/view.php?id=34493): REST API GET /issues endpoint returns HTML if given filter_id is not found
