### PR TITLE
Make "overdue" column sortable

### DIFF
--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -320,7 +320,6 @@ function column_is_sortable( $p_column ) {
 		case 'bugnotes_count':
 		case 'attachment_count':
 		case 'tags':
-		case 'overdue':
 		case 'additional_information':
 		case 'description':
 		case 'notes':

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -2326,8 +2326,13 @@ function filter_gpc_get( array $p_filter = null ) {
 function filter_get_visible_sort_properties_array( array $p_filter, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE ) {
 	# get visible columns
 	$t_visible_columns = helper_get_columns_to_view( $p_columns_target );
-	# filter out those that ar not sortable
+	# filter out those that are not sortable
 	$t_visible_columns = array_filter( $t_visible_columns, 'column_is_sortable' );
+
+	# Special handling for overdue column, which is equivalent to sorting by due_date
+	if( in_array( 'overdue', $t_visible_columns ) & !in_array( 'due_date', $t_visible_columns ) ) {
+		$t_visible_columns[] = 'due_date';
+	}
 
 	$t_sort_fields = explode( ',', $p_filter[FILTER_PROPERTY_SORT_FIELD_NAME] );
 	$t_dir_fields = explode( ',', $p_filter[FILTER_PROPERTY_SORT_DIRECTION] );

--- a/core/http_api.php
+++ b/core/http_api.php
@@ -229,7 +229,7 @@ function http_security_headers() {
 		http_csp_add( 'style-src', "'unsafe-inline'" );
 		http_csp_add( 'script-src', "'self'" );
 		http_csp_add( 'img-src', "'self'" );
-		http_csp_add( 'img-src', "'self' data:" );
+		http_csp_add( 'img-src', "data:" );
 
 		# White list the CDN urls (if enabled)
 		if ( config_get_global( 'cdn_enabled' ) == ON ) {


### PR DESCRIPTION
Until now, sorting the Issues list by clicking on the overdue column header only worked if the due_date column was also visible.

To fix the problem, we add due-date to the list of visible columns in filter_get_visible_sort_properties_array() function if it is not already part of the list.

Fixes [#34460](https://mantisbt.org/bugs/view.php?id=34460)