### PR TITLE
Allow display of additional info for ERROR_GENERIC  messages

### DIFF
--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -244,6 +244,7 @@ define( 'PLUGIN_PRIORITY_HIGH', 5 );
 # error messages
 define( 'ERROR_PHP', -1 );
 define( 'ERROR_GENERIC', 0 );
+define( 'ERROR_GENERIC_DETAILS', 32 );
 define( 'ERROR_SQL', 1 );
 define( 'ERROR_REPORT', 3 );
 define( 'ERROR_NO_FILE_SPECIFIED', 4 );

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -646,6 +646,13 @@ function error_string( $p_error ) {
 		}
 	}
 
+	# Special handling for generic error type
+	# Append detailed error information if a parameter has been provided.
+	if( $p_error == ERROR_GENERIC && $g_error_parameters ) {
+		$t_error .= PHP_EOL . error_string( ERROR_GENERIC_DETAILS );
+		$g_error_parameters = [];
+	}
+
 	# Prepare error parameters for display
 	$t_parameters = $g_error_parameters;
 	foreach( $t_parameters as &$t_value ) {

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -275,8 +275,6 @@ function error_handler( $p_type, $p_error, $p_file, $p_line ) {
 			$t_error_description = $p_error . ' (' . $t_error_location . ')';
 	}
 
-	$t_error_description = nl2br( $t_error_description );
-
 	if( php_sapi_name() == 'cli' ) {
 		if( DISPLAY_ERROR_NONE != $t_method ) {
 			echo $t_error_type . ': ' . $t_error_description . "\n";
@@ -290,6 +288,8 @@ function error_handler( $p_type, $p_error, $p_file, $p_line ) {
 			exit(1);
 		}
 	} else {
+		$t_error_description = nl2br( $t_error_description );
+
 		switch( $t_method ) {
 			case DISPLAY_ERROR_HALT:
 				# disable any further event callbacks

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1610,7 +1610,8 @@ $s_timeline_more = 'More events...';
  */
 $s_missing_error_string = 'Missing Error String: %1$s';
 
-$MANTIS_ERROR[ERROR_GENERIC] = 'An error occurred during this action. You may wish to report this error to your local administrator.';
+$MANTIS_ERROR[ERROR_GENERIC] = 'An error occurred during this action. You may wish to report it to your local administrator.';
+$MANTIS_ERROR[ERROR_GENERIC_DETAILS] = 'Error details: %s';
 $MANTIS_ERROR[ERROR_SQL] = 'SQL error detected.';
 $MANTIS_ERROR[ERROR_REPORT] = 'There was an error in your report.';
 $MANTIS_ERROR[ERROR_NO_FILE_SPECIFIED] = 'No file specified.';


### PR DESCRIPTION
Fixes [#34613](https://mantisbt.org/bugs/view.php?id=34613)

Also fixes unexpected display of `<br>` HTML tag in error messages on CLI [#34612](https://mantisbt.org/bugs/view.php?id=34612).