### PR TITLE
Graphviz API & Workflow Graph refactoring, bug fixes and improvements 

### DIFF
--- a/admin/check/check_config_inc.php
+++ b/admin/check/check_config_inc.php
@@ -32,8 +32,12 @@ if( !defined( 'CHECK_CONFIG_INC_ALLOW' ) ) {
 # MantisBT Check API
 require_once( 'check_api.php' );
 
+global $g_config_path, $g_absolute_path, $g_log_level, $g_log_destination,
+	   $g_show_detailed_errors, $g_debug_email, $g_limit_reporters;
+
 check_print_section_header_row( 'Configuration' );
 
+/** @noinspection HtmlUnknownTarget */
 check_print_test_row( 'config_inc.php configuration file exists',
 	file_exists( $g_config_path . 'config_inc.php' ),
 	array( false => 'Please use <a href="install.php">install.php</a> to perform the initial installation of MantisBT.' )

--- a/admin/check/check_display_inc.php
+++ b/admin/check/check_display_inc.php
@@ -33,6 +33,7 @@ if( !defined( 'CHECK_DISPLAY_INC_ALLOW' ) ) {
 # MantisBT Check API
 require_once( 'check_api.php' );
 require_api( 'config_api.php' );
+require_api( 'graphviz_api.php' );
 
 check_print_section_header_row( 'Display' );
 
@@ -66,3 +67,33 @@ check_print_test_row(
 	array( false => 'The value of the bugnote_link_tag option cannot be blank/null.' )
 );
 
+# Graphviz library
+if( config_get( 'relationship_graph_enable' ) ) {
+	# graphviz_path validity is checked in check_paths_inc.php
+	$t_graphviz_path = config_get_global( 'graphviz_path' );
+
+	# Get list of Graphviz tools from the Graph class constants
+	$t_reflect_graph = new ReflectionClass( Graph::class );
+	$t_tools = array_filter( $t_reflect_graph->getConstants(),
+		function( $p_key ) {
+			return strpos( $p_key, 'TOOL_' ) === 0;
+		},
+		ARRAY_FILTER_USE_KEY
+	);
+
+	# Check each tool's availability
+	$t_unavailable = [];
+	foreach( $t_tools as $t_tool ) {
+		$t_tool_path = $t_graphviz_path . $t_tool;
+		if( !is_executable( $t_tool_path ) ) {
+			$t_unavailable[] = $t_tool;
+		}
+	}
+	check_print_test_row(
+		"Graphviz tools (" .implode( ', ', $t_tools ) . ") are required to display relationship graphs",
+		empty( $t_unavailable ),
+		[ false => implode( ', ', $t_unavailable )
+			. " not found in $t_graphviz_path or not executable. "
+		]
+	);
+}

--- a/admin/check/check_paths_inc.php
+++ b/admin/check/check_paths_inc.php
@@ -54,7 +54,8 @@ $t_path_config_names = array(
 	'class_path',
 	'library_path',
 	'config_path',
-	'language_path'
+	'language_path',
+	'graphviz_path',
 );
 
 # Handle file upload default path only if attachments stored on disk

--- a/admin/check/check_paths_inc.php
+++ b/admin/check/check_paths_inc.php
@@ -30,6 +30,8 @@ if( !defined( 'CHECK_PATHS_INC_ALLOW' ) ) {
 	return;
 }
 
+global $g_failed_test;
+
 # MantisBT Check API
 require_once( 'check_api.php' );
 require_api( 'config_api.php' );

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -4470,43 +4470,34 @@ $g_rss_enabled = ON;
 /**
  * Enable relationship graphs support.
  *
- * Show issue relationships using graphs.
+ * Show issue relationships and workflow transitions using graphs.
  *
  * In order to use this feature, you must first install GraphViz.
  * @see https://www.graphviz.org/ Graphviz homepage
- *
- * Refer to the notes near the top of core/graphviz_api.php and
- * core/relationship_graph_api.php for more information.
+ * @see $g_graphviz_path
  *
  * @global int $g_relationship_graph_enable
  */
 $g_relationship_graph_enable = OFF;
 
 /**
- * Complete path to dot and neato tools.
+ * Complete path to the Graphviz tools.
  *
- * Your webserver must have execute permission to these programs in order to
- * generate relationship graphs.
+ * {@see https://graphviz.org/ Graphviz} must be installed on your server.
+ * Mantis uses the following tools :
+ * - Relationship graphs: dot, neato
+ * - Workflow transitions graph: dot
  *
- * NOTE: On windows, the IIS user may require permissions to cmd.exe to be able
- * to use PHP's proc_open.
+ * NOTES:
+ * - Requires trailing `/`
+ * - The webserver must have execute permission to these programs in order to
+ *   generate the graphs.
+ * - On Windows, the IIS user may require permissions to cmd.exe to be able
+ *   to use PHP's {@see proc_open()}
  *
- * @global string $g_dot_tool
+ * @global string $g_graphviz_path
  */
-$g_dot_tool = '/usr/bin/dot';
-
-/**
- * Complete path to dot and neato tools.
- *
- * Your webserver must have execute permission to these programs in order to
- * generate relationship graphs.
- *
- * NOTE: On windows, the IIS user may require permissions to cmd.exe to be able
- * to use PHP's proc_open.
- *
- * @global string $g_neato_tool
- */
-$g_neato_tool = '/usr/bin/neato';
+$g_graphviz_path = '/usr/bin/';
 
 /**
  * Font name and size, as required by Graphviz.
@@ -5173,7 +5164,6 @@ $g_global_settings = array(
 	'default_home_page',
 	'default_language',
 	'display_errors',
-	'dot_tool',
 	'email_dkim_domain',
 	'email_dkim_enable',
 	'email_dkim_identity',
@@ -5195,6 +5185,7 @@ $g_global_settings = array(
 	'fileinfo_magic_db_file',
 	'form_security_validation',
 	'global_settings',
+	'graphviz_path',
 	'hostname',
 	'html_valid_tags',
 	'html_valid_tags_single_line',
@@ -5226,7 +5217,6 @@ $g_global_settings = array(
 	'long_process_timeout',
 	'manage_config_cookie',
 	'manual_url',
-	'neato_tool',
 	'path',
 	'plugin_path',
 	'plugins_enabled',

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -244,6 +244,7 @@ define( 'PLUGIN_PRIORITY_HIGH', 5 );
 # error messages
 define( 'ERROR_PHP', -1 );
 define( 'ERROR_GENERIC', 0 );
+define( 'ERROR_GENERIC_DETAILS', 32 );
 define( 'ERROR_SQL', 1 );
 define( 'ERROR_REPORT', 3 );
 define( 'ERROR_NO_FILE_SPECIFIED', 4 );

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -449,6 +449,9 @@ define( 'ERROR_CRYPTO_MASTER_SALT_INVALID', 2900 );
 # ERROR_API_TOKEN_*
 define( 'ERROR_API_TOKEN_NAME_NOT_UNIQUE', 3000 );
 
+# ERROR_GRAPH_*
+define( 'ERROR_GRAPH_TOOL_NOT_FOUND', 3100 );
+
 # Generic position constants
 define( 'POSITION_NONE', 0 );
 define( 'POSITION_TOP', 1 );

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -646,6 +646,13 @@ function error_string( $p_error ) {
 		}
 	}
 
+	# Special handling for generic error type
+	# Append detailed error information if a parameter has been provided.
+	if( $p_error == ERROR_GENERIC && $g_error_parameters ) {
+		$t_error .= PHP_EOL . error_string( ERROR_GENERIC_DETAILS );
+		$g_error_parameters = [];
+	}
+
 	# Prepare error parameters for display
 	$t_parameters = $g_error_parameters;
 	foreach( $t_parameters as &$t_value ) {

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -275,8 +275,6 @@ function error_handler( $p_type, $p_error, $p_file, $p_line ) {
 			$t_error_description = $p_error . ' (' . $t_error_location . ')';
 	}
 
-	$t_error_description = nl2br( $t_error_description );
-
 	if( php_sapi_name() == 'cli' ) {
 		if( DISPLAY_ERROR_NONE != $t_method ) {
 			echo $t_error_type . ': ' . $t_error_description . "\n";
@@ -290,6 +288,8 @@ function error_handler( $p_type, $p_error, $p_file, $p_line ) {
 			exit(1);
 		}
 	} else {
+		$t_error_description = nl2br( $t_error_description );
+
 		switch( $t_method ) {
 			case DISPLAY_ERROR_HALT:
 				# disable any further event callbacks

--- a/core/graphviz_api.php
+++ b/core/graphviz_api.php
@@ -54,6 +54,7 @@ class Graph {
 	 */
 	const TOOL_DOT = 'dot';
 	const TOOL_NEATO = 'neato';
+	const TOOL_CIRCO = 'circo';
 
 	/**
 	 * Constant(s) defining the output formats supported by dot and neato.

--- a/core/graphviz_api.php
+++ b/core/graphviz_api.php
@@ -73,42 +73,42 @@ class Graph {
 	/**
 	 * Name
 	 */
-	public $name = 'G';
+	protected $name = 'G';
 
 	/**
 	 * Attributes
 	 */
-	public $attributes = array();
+	protected $attributes = array();
 
 	/**
 	 * Default node
 	 */
-	public $default_node = null;
+	protected $default_node = null;
 
 	/**
 	 * Default edge
 	 */
-	public $default_edge = null;
+	protected $default_edge = null;
 
 	/**
 	 * Nodes
 	 */
-	public $nodes = array();
+	protected $nodes = array();
 
 	/**
 	 * Edges
 	 */
-	public $edges = array();
+	protected $edges = array();
 
 	/**
 	 * Graphviz tool
 	 */
-	public $graphviz_tool;
+	protected $graphviz_tool;
 
 	/**
 	 * Formats
 	 */
-	public $formats = array(
+	protected $formats = array(
 		'dot' => array(
 			'binary' => false,
 			'type' => self::GRAPHVIZ_ATTRIBUTED_DOT,
@@ -212,7 +212,7 @@ class Graph {
 	 * @param array  $p_attributes Attributes.
 	 * @param string $p_tool       Graph generation tool.
 	 */
-	function __construct( $p_name = 'G', array $p_attributes = array(), $p_tool = 'neato' ) {
+	public function __construct( $p_name = 'G', array $p_attributes = array(), $p_tool = 'neato' ) {
 		if( is_string( $p_name ) ) {
 			$this->name = $p_name;
 		}
@@ -227,7 +227,7 @@ class Graph {
 	 * @param array $p_attributes Attributes.
 	 * @return void
 	 */
-	function set_attributes( array $p_attributes ) {
+	public function set_attributes( array $p_attributes ) {
 		if( is_array( $p_attributes ) ) {
 			$this->attributes = $p_attributes;
 		}
@@ -238,7 +238,7 @@ class Graph {
 	 * @param array $p_attributes Attributes.
 	 * @return void
 	 */
-	function set_default_node_attr( array $p_attributes ) {
+	public function set_default_node_attr( array $p_attributes ) {
 		if( is_array( $p_attributes ) ) {
 			$this->default_node = $p_attributes;
 		}
@@ -249,7 +249,7 @@ class Graph {
 	 * @param array $p_attributes Attributes.
 	 * @return void
 	 */
-	 function set_default_edge_attr( array $p_attributes ) {
+	public function set_default_edge_attr( array $p_attributes ) {
 		if( is_array( $p_attributes ) ) {
 			$this->default_edge = $p_attributes;
 		}
@@ -261,7 +261,7 @@ class Graph {
 	 * @param array  $p_attributes Attributes.
 	 * @return void
 	 */
-	 function add_node( $p_name, array $p_attributes = array() ) {
+	public function add_node( $p_name, array $p_attributes = array() ) {
 		if( is_array( $p_attributes ) ) {
 			$this->nodes[$p_name] = $p_attributes;
 		}
@@ -274,7 +274,7 @@ class Graph {
 	 * @param array  $p_attributes Attributes.
 	 * @return void
 	 */
-	 function add_edge( $p_src, $p_dst, array $p_attributes = array() ) {
+	public function add_edge( $p_src, $p_dst, array $p_attributes = array() ) {
 		if( is_array( $p_attributes ) ) {
 			$this->edges[] = array(
 				'src' => $p_src,
@@ -290,7 +290,7 @@ class Graph {
 	 * @param string $p_dst Destination.
 	 * @return boolean
 	 */
-	function is_edge_present( $p_src, $p_dst ) {
+	public function is_edge_present( $p_src, $p_dst ) {
 		foreach( $this->edges as $t_edge ) {
 			if( $t_edge['src'] == $p_src && $t_edge['dst'] == $p_dst ) {
 				return true;
@@ -303,14 +303,14 @@ class Graph {
 	 * Generates an undirected graph representation (suitable for neato).
 	 * @return void
 	 */
-	function generate() {
+	public function generate() {
 		echo 'graph ' . $this->name . ' {' . "\n";
 
-		$this->_print_graph_defaults();
+		$this->print_graph_defaults();
 
 		foreach( $this->nodes as $t_name => $t_attr ) {
 			$t_name = '"' . addcslashes( $t_name, "\0..\37\"\\" ) . '"';
-			$t_attr = $this->_build_attribute_list( $t_attr );
+			$t_attr = $this->build_attribute_list( $t_attr );
 			echo "\t" . $t_name . ' ' . $t_attr . ";\n";
 		}
 
@@ -318,7 +318,7 @@ class Graph {
 			$t_src = '"' . addcslashes( $t_edge['src'], "\0..\37\"\\" ) . '"';
 			$t_dst = '"' . addcslashes( $t_edge['dst'], "\0..\37\"\\" ) . '"';
 			$t_attr = $t_edge['attributes'];
-			$t_attr = $this->_build_attribute_list( $t_attr );
+			$t_attr = $this->build_attribute_list( $t_attr );
 			echo "\t" . $t_src . ' -- ' . $t_dst . ' ' . $t_attr . ";\n";
 		}
 
@@ -331,7 +331,7 @@ class Graph {
 	 * @param boolean $p_headers Whether to sent http headers.
 	 * @return void
 	 */
-	function output( $p_format = 'dot', $p_headers = false ) {
+	public function output( $p_format = 'dot', $p_headers = false ) {
 		# Check if it is a recognized format.
 		if( !isset( $this->formats[$p_format] ) ) {
 			trigger_error( ERROR_GENERIC, ERROR );
@@ -390,11 +390,12 @@ class Graph {
 	}
 
 	/**
-	 * PROTECTED function to build a node or edge attribute list.
+	 * Build a node or edge attribute list.
+	 *
 	 * @param array $p_attributes Attributes.
 	 * @return string
 	 */
-	function _build_attribute_list( array $p_attributes ) {
+	protected function build_attribute_list( array $p_attributes ) {
 		if( empty( $p_attributes ) ) {
 			return '';
 		}
@@ -421,10 +422,11 @@ class Graph {
 	}
 
 	/**
-	 * PROTECTED function to print graph attributes and defaults.
+	 * Print graph attributes and defaults.
+	 *
 	 * @return void
 	 */
-	function _print_graph_defaults() {
+	protected function print_graph_defaults() {
 		foreach( $this->attributes as $t_name => $t_value ) {
 			if( !preg_match( '/[a-zA-Z]+/', $t_name ) ) {
 				continue;
@@ -442,12 +444,12 @@ class Graph {
 		}
 
 		if( null !== $this->default_node ) {
-			$t_attr = $this->_build_attribute_list( $this->default_node );
+			$t_attr = $this->build_attribute_list( $this->default_node );
 			echo "\t" . 'node ' . $t_attr . ";\n";
 		}
 
 		if( null !== $this->default_edge ) {
-			$t_attr = $this->_build_attribute_list( $this->default_edge );
+			$t_attr = $this->build_attribute_list( $this->default_edge );
 			echo "\t" . 'edge ' . $t_attr . ";\n";
 		}
 	}
@@ -471,14 +473,14 @@ class Digraph extends Graph {
 	 * Generates a directed graph representation (suitable for dot).
 	 * @return void
 	 */
-	function generate() {
+	public function generate() {
 		echo 'digraph ' . $this->name . ' {' . "\n";
 
-		$this->_print_graph_defaults();
+		$this->print_graph_defaults();
 
 		foreach( $this->nodes as $t_name => $t_attr ) {
 			$t_name = '"' . addcslashes( $t_name, "\0..\37\"\\" ) . '"';
-			$t_attr = $this->_build_attribute_list( $t_attr );
+			$t_attr = $this->build_attribute_list( $t_attr );
 			echo "\t" . $t_name . ' ' . $t_attr . ";\n";
 		}
 
@@ -486,7 +488,7 @@ class Digraph extends Graph {
 			$t_src = '"' . addcslashes( $t_edge['src'], "\0..\37\"\\" ) . '"';
 			$t_dst = '"' . addcslashes( $t_edge['dst'], "\0..\37\"\\" ) . '"';
 			$t_attr = $t_edge['attributes'];
-			$t_attr = $this->_build_attribute_list( $t_attr );
+			$t_attr = $this->build_attribute_list( $t_attr );
 			echo "\t" . $t_src . ' -> ' . $t_dst . ' ' . $t_attr . ";\n";
 		}
 

--- a/core/graphviz_api.php
+++ b/core/graphviz_api.php
@@ -112,6 +112,11 @@ class Graph {
 	protected $edges = array();
 
 	/**
+	 * @var string Graphviz path
+	 */
+	protected $graphviz_path;
+
+	/**
 	 * @var string Graphviz tool
 	 */
 	protected $graphviz_tool;
@@ -232,8 +237,8 @@ class Graph {
 
 		$this->set_attributes( $p_attributes );
 
-		$t_graphviz_path = config_get_global( 'graphviz_path' );
-		$this->graphviz_tool = $t_graphviz_path . $p_tool;
+		$this->graphviz_path = config_get_global( 'graphviz_path' );
+		$this->graphviz_tool = $p_tool;
 	}
 
 	/**
@@ -361,7 +366,7 @@ class Graph {
 		}
 
 		# Graphviz tool missing or not executable
-		if( !is_executable( $this->graphviz_tool ) ) {
+		if( !is_executable( $this->tool_path() ) ) {
 			trigger_error( ERROR_GENERIC, ERROR );
 		}
 
@@ -371,7 +376,7 @@ class Graph {
 		$t_dot_source = ob_get_clean();
 
 		# Start dot process
-		$t_command = escapeshellcmd( $this->graphviz_tool . ' -T' . $p_format );
+		$t_command = escapeshellcmd( $this->tool_path() . ' -T' . $p_format );
 		$t_stderr = tempnam( sys_get_temp_dir(), 'graphviz' );
 		$t_descriptors = array(
 			0 => array( 'pipe', 'r', ),
@@ -486,6 +491,15 @@ class Graph {
 			$t_attr = $this->build_attribute_list( $this->default_edge );
 			echo "\t" . 'edge ' . $t_attr . ";\n";
 		}
+	}
+
+	/**
+	 * Gets the path to the Graphviz tool.
+	 *
+	 * @return string
+	 */
+	protected function tool_path() {
+		return $this->graphviz_path . $this->graphviz_tool;
 	}
 }
 

--- a/core/graphviz_api.php
+++ b/core/graphviz_api.php
@@ -453,7 +453,13 @@ class Graph {
 			}
 
 			if( is_string( $t_value ) ) {
-				$t_value = '"' . addcslashes( $t_value, "\0..\37\"\\" ) . '"';
+				if( $t_name == 'label' && $t_value != strip_tags( $t_value ) ) {
+					// It's an HTML-like label
+					// @see https://graphviz.org/doc/info/shapes.html#html
+					$t_value = '<' . $t_value. '>';
+				} else {
+					$t_value = '"' . addcslashes( $t_value, "\0..\37\"\\" ) . '"';
+				}
 			} else if( is_integer( $t_value ) or is_float( $t_value ) ) {
 				$t_value = (string)$t_value;
 			} else {

--- a/core/graphviz_api.php
+++ b/core/graphviz_api.php
@@ -362,12 +362,14 @@ class Graph {
 	public function output( $p_format = 'dot', $p_headers = false ) {
 		# Check if it is a recognized format.
 		if( !isset( $this->formats[$p_format] ) ) {
+			error_parameters( "Invalid Graph format '$p_format'." );
 			trigger_error( ERROR_GENERIC, ERROR );
 		}
 
 		# Graphviz tool missing or not executable
 		if( !is_executable( $this->tool_path() ) ) {
-			trigger_error( ERROR_GENERIC, ERROR );
+			error_parameters( $this->graphviz_tool );
+			trigger_error( ERROR_GRAPH_TOOL_NOT_FOUND, ERROR );
 		}
 
 		# Retrieve the source dot document into a buffer
@@ -399,6 +401,7 @@ class Graph {
 		$t_error = file_get_contents( $t_stderr );
 		unlink( $t_stderr );
 		if( $t_error ) {
+			error_parameters( $t_error );
 			trigger_error( ERROR_GENERIC, ERROR );
 		}
 

--- a/core/graphviz_api.php
+++ b/core/graphviz_api.php
@@ -39,9 +39,10 @@ require_api( 'constant_inc.php' );
 require_api( 'utility_api.php' );
 
 /**
- * Base class for graph creation and manipulation. By default,
- * undirected graphs are generated. For directed graphs, use Digraph
- * class.
+ * Base class for graph creation and manipulation.
+ *
+ * Generates undirected graphs are generated.
+ * For directed graphs, use {@see Digraph} class.
  */
 class Graph {
 
@@ -71,42 +72,43 @@ class Graph {
 	const GRAPHVIZ_PDF = 28;
 
 	/**
-	 * Name
+	 * @var string Name
 	 */
 	protected $name = 'G';
 
 	/**
-	 * Attributes
+	 * @var array Attributes
 	 */
 	protected $attributes = array();
 
 	/**
-	 * Default node
+	 * @var array Default node attributes
 	 */
 	protected $default_node = null;
 
 	/**
-	 * Default edge
+	 * @var array Default edge attributes
 	 */
 	protected $default_edge = null;
 
 	/**
-	 * Nodes
+	 * @var array Nodes
 	 */
 	protected $nodes = array();
 
 	/**
-	 * Edges
+	 * @var array Edges
 	 */
 	protected $edges = array();
 
 	/**
-	 * Graphviz tool
+	 * @var string Graphviz tool
 	 */
 	protected $graphviz_tool;
 
 	/**
-	 * Formats
+	 * Graphviz output formats
+	 * @see https://graphviz.org/docs/outputs/
 	 */
 	protected $formats = array(
 		'dot' => array(
@@ -208,9 +210,10 @@ class Graph {
 
 	/**
 	 * Constructor for Graph objects.
-	 * @param string $p_name       Graph name.
-	 * @param array  $p_attributes Attributes.
-	 * @param string $p_tool       Graph generation tool.
+	 *
+	 * @param string $p_name       Graph name
+	 * @param array  $p_attributes Attributes
+	 * @param string $p_tool       Graph generation tool (one of the TOOL_* constants)
 	 */
 	public function __construct( $p_name = 'G', array $p_attributes = array(), $p_tool = 'neato' ) {
 		if( is_string( $p_name ) ) {
@@ -224,7 +227,9 @@ class Graph {
 
 	/**
 	 * Sets graph attributes.
+	 *
 	 * @param array $p_attributes Attributes.
+	 *
 	 * @return void
 	 */
 	public function set_attributes( array $p_attributes ) {
@@ -235,7 +240,9 @@ class Graph {
 
 	/**
 	 * Sets default attributes for all nodes of the graph.
+	 *
 	 * @param array $p_attributes Attributes.
+	 *
 	 * @return void
 	 */
 	public function set_default_node_attr( array $p_attributes ) {
@@ -246,7 +253,9 @@ class Graph {
 
 	/**
 	 * Sets default attributes for all edges of the graph.
+	 *
 	 * @param array $p_attributes Attributes.
+	 *
 	 * @return void
 	 */
 	public function set_default_edge_attr( array $p_attributes ) {
@@ -257,8 +266,10 @@ class Graph {
 
 	/**
 	 * Adds a node to the graph.
+	 *
 	 * @param string $p_name       Node name.
 	 * @param array  $p_attributes Attributes.
+	 *
 	 * @return void
 	 */
 	public function add_node( $p_name, array $p_attributes = array() ) {
@@ -269,9 +280,11 @@ class Graph {
 
 	/**
 	 * Adds an edge to the graph.
+	 *
 	 * @param string $p_src        Source.
 	 * @param string $p_dst        Destination.
 	 * @param array  $p_attributes Attributes.
+	 *
 	 * @return void
 	 */
 	public function add_edge( $p_src, $p_dst, array $p_attributes = array() ) {
@@ -286,8 +299,10 @@ class Graph {
 
 	/**
 	 * Check if an edge is already present.
+	 *
 	 * @param string $p_src Source.
 	 * @param string $p_dst Destination.
+	 *
 	 * @return boolean
 	 */
 	public function is_edge_present( $p_src, $p_dst ) {
@@ -301,6 +316,7 @@ class Graph {
 
 	/**
 	 * Generates an undirected graph representation (suitable for neato).
+	 *
 	 * @return void
 	 */
 	public function generate() {
@@ -327,8 +343,10 @@ class Graph {
 
 	/**
 	 * Outputs a graph image or map in the specified format.
+	 *
 	 * @param string  $p_format  Graphviz output format.
 	 * @param boolean $p_headers Whether to sent http headers.
+	 *
 	 * @return void
 	 */
 	public function output( $p_format = 'dot', $p_headers = false ) {
@@ -393,6 +411,7 @@ class Graph {
 	 * Build a node or edge attribute list.
 	 *
 	 * @param array $p_attributes Attributes.
+	 *
 	 * @return string
 	 */
 	protected function build_attribute_list( array $p_attributes ) {
@@ -455,12 +474,15 @@ class Graph {
 	}
 }
 
+
 /**
  * Directed graph creation and manipulation.
  */
 class Digraph extends Graph {
+
 	/**
 	 * Constructor for Digraph objects.
+	 *
 	 * @param string $p_name       Name of the graph.
 	 * @param array  $p_attributes Attributes.
 	 * @param string $p_tool       Graphviz tool.
@@ -471,6 +493,7 @@ class Digraph extends Graph {
 
 	/**
 	 * Generates a directed graph representation (suitable for dot).
+	 *
 	 * @return void
 	 */
 	public function generate() {

--- a/core/graphviz_api.php
+++ b/core/graphviz_api.php
@@ -233,9 +233,7 @@ class Graph {
 	 * @return void
 	 */
 	public function set_attributes( array $p_attributes ) {
-		if( is_array( $p_attributes ) ) {
-			$this->attributes = $p_attributes;
-		}
+		$this->attributes = $p_attributes;
 	}
 
 	/**
@@ -246,9 +244,7 @@ class Graph {
 	 * @return void
 	 */
 	public function set_default_node_attr( array $p_attributes ) {
-		if( is_array( $p_attributes ) ) {
-			$this->default_node = $p_attributes;
-		}
+		$this->default_node = $p_attributes;
 	}
 
 	/**
@@ -259,9 +255,7 @@ class Graph {
 	 * @return void
 	 */
 	public function set_default_edge_attr( array $p_attributes ) {
-		if( is_array( $p_attributes ) ) {
-			$this->default_edge = $p_attributes;
-		}
+		$this->default_edge = $p_attributes;
 	}
 
 	/**

--- a/core/graphviz_api.php
+++ b/core/graphviz_api.php
@@ -327,6 +327,9 @@ class Graph {
 	/**
 	 * Generates an undirected graph representation (suitable for neato).
 	 *
+	 * To test the generated graph, use the
+	 * {@see http://magjac.com/graphviz-visual-editor/ Graphviz Visual Editor}
+	 *
 	 * @return void
 	 */
 	public function generate() {
@@ -525,6 +528,9 @@ class Digraph extends Graph {
 
 	/**
 	 * Generates a directed graph representation (suitable for dot).
+	 *
+	 * To test the generated graph, use the
+	 * {@see http://magjac.com/graphviz-visual-editor/ Graphviz Visual Editor}
 	 *
 	 * @return void
 	 */

--- a/core/graphviz_api.php
+++ b/core/graphviz_api.php
@@ -38,35 +38,38 @@
 require_api( 'constant_inc.php' );
 require_api( 'utility_api.php' );
 
-# constant(s) defining the output formats supported by dot and neato.
-define( 'GRAPHVIZ_ATTRIBUTED_DOT', 0 );
-define( 'GRAPHVIZ_PS', 1 );
-define( 'GRAPHVIZ_HPGL', 2 );
-define( 'GRAPHVIZ_PCL', 3 );
-define( 'GRAPHVIZ_MIF', 4 );
-define( 'GRAPHVIZ_PLAIN', 6 );
-define( 'GRAPHVIZ_PLAIN_EXT', 7 );
-define( 'GRAPHVIZ_GIF', 11 );
-define( 'GRAPHVIZ_JPEG', 12 );
-define( 'GRAPHVIZ_PNG', 13 );
-define( 'GRAPHVIZ_WBMP', 14 );
-define( 'GRAPHVIZ_XBM', 15 );
-define( 'GRAPHVIZ_ISMAP', 16 );
-define( 'GRAPHVIZ_IMAP', 17 );
-define( 'GRAPHVIZ_CMAP', 18 );
-define( 'GRAPHVIZ_CMAPX', 19 );
-define( 'GRAPHVIZ_VRML', 20 );
-define( 'GRAPHVIZ_SVG', 25 );
-define( 'GRAPHVIZ_SVGZ', 26 );
-define( 'GRAPHVIZ_CANONICAL_DOT', 27 );
-define( 'GRAPHVIZ_PDF', 28 );
-
 /**
  * Base class for graph creation and manipulation. By default,
  * undirected graphs are generated. For directed graphs, use Digraph
  * class.
  */
 class Graph {
+
+	/**
+	 * Constant(s) defining the output formats supported by dot and neato.
+	 */
+	const GRAPHVIZ_ATTRIBUTED_DOT = 0;
+	const GRAPHVIZ_PS = 1;
+	const GRAPHVIZ_HPGL = 2;
+	const GRAPHVIZ_PCL = 3;
+	const GRAPHVIZ_MIF = 4;
+	const GRAPHVIZ_PLAIN = 6;
+	const GRAPHVIZ_PLAIN_EXT = 7;
+	const GRAPHVIZ_GIF = 11;
+	const GRAPHVIZ_JPEG = 12;
+	const GRAPHVIZ_PNG = 13;
+	const GRAPHVIZ_WBMP = 14;
+	const GRAPHVIZ_XBM = 15;
+	const GRAPHVIZ_ISMAP = 16;
+	const GRAPHVIZ_IMAP = 17;
+	const GRAPHVIZ_CMAP = 18;
+	const GRAPHVIZ_CMAPX = 19;
+	const GRAPHVIZ_VRML = 20;
+	const GRAPHVIZ_SVG = 25;
+	const GRAPHVIZ_SVGZ = 26;
+	const GRAPHVIZ_CANONICAL_DOT = 27;
+	const GRAPHVIZ_PDF = 28;
+
 	/**
 	 * Name
 	 */
@@ -108,97 +111,97 @@ class Graph {
 	public $formats = array(
 		'dot' => array(
 			'binary' => false,
-			'type' => GRAPHVIZ_ATTRIBUTED_DOT,
+			'type' => self::GRAPHVIZ_ATTRIBUTED_DOT,
 			'mime' => 'text/x-graphviz',
 		),
 		'ps' => array(
 			'binary' => false,
-			'type' => GRAPHVIZ_PS,
+			'type' => self::GRAPHVIZ_PS,
 			'mime' => 'application/postscript',
 		),
 		'hpgl' => array(
 			'binary' => true,
-			'type' => GRAPHVIZ_HPGL,
+			'type' => self::GRAPHVIZ_HPGL,
 			'mime' => 'application/vnd.hp-HPGL',
 		),
 		'pcl' => array(
 			'binary' => true,
-			'type' => GRAPHVIZ_PCL,
+			'type' => self::GRAPHVIZ_PCL,
 			'mime' => 'application/vnd.hp-PCL',
 		),
 		'mif' => array(
 			'binary' => true,
-			'type' => GRAPHVIZ_MIF,
+			'type' => self::GRAPHVIZ_MIF,
 			'mime' => 'application/vnd.mif',
 		),
 		'gif' => array(
 			'binary' => true,
-			'type' => GRAPHVIZ_GIF,
+			'type' => self::GRAPHVIZ_GIF,
 			'mime' => 'image/gif',
 		),
 		'jpg' => array(
 			'binary' => false,
-			'type' => GRAPHVIZ_JPEG,
+			'type' => self::GRAPHVIZ_JPEG,
 			'mime' => 'image/jpeg',
 		),
 		'jpeg' => array(
 			'binary' => true,
-			'type' => GRAPHVIZ_JPEG,
+			'type' => self::GRAPHVIZ_JPEG,
 			'mime' => 'image/jpeg',
 		),
 		'png' => array(
 			'binary' => true,
-			'type' => GRAPHVIZ_PNG,
+			'type' => self::GRAPHVIZ_PNG,
 			'mime' => 'image/png',
 		),
 		'wbmp' => array(
 			'binary' => true,
-			'type' => GRAPHVIZ_WBMP,
+			'type' => self::GRAPHVIZ_WBMP,
 			'mime' => 'image/vnd.wap.wbmp',
 		),
 		'xbm' => array(
 			'binary' => false,
-			'type' => GRAPHVIZ_XBM,
+			'type' => self::GRAPHVIZ_XBM,
 			'mime' => 'image/x-xbitmap',
 		),
 		'ismap' => array(
 			'binary' => false,
-			'type' => GRAPHVIZ_ISMAP,
+			'type' => self::GRAPHVIZ_ISMAP,
 			'mime' => 'text/plain',
 		),
 		'imap' => array(
 			'binary' => false,
-			'type' => GRAPHVIZ_IMAP,
+			'type' => self::GRAPHVIZ_IMAP,
 			'mime' => 'application/x-httpd-imap',
 		),
 		'cmap' => array(
 			'binary' => false,
-			'type' => GRAPHVIZ_CMAP,
+			'type' => self::GRAPHVIZ_CMAP,
 			'mime' => 'text/html',
 		),
 		'cmapx' => array(
 			'binary' => false,
-			'type' => GRAPHVIZ_CMAPX,
+			'type' => self::GRAPHVIZ_CMAPX,
 			'mime' => 'application/xhtml+xml',
 		),
 		'vrml' => array(
 			'binary' => true,
-			'type' => GRAPHVIZ_VRML,
+			'type' => self::GRAPHVIZ_VRML,
 			'mime' => 'x-world/x-vrml',
 		),
 		'svg' => array(
 			'binary' => false,
-			'type' => GRAPHVIZ_SVG,
+			'type' => self::GRAPHVIZ_SVG,
 			'mime' => 'image/svg+xml',
 		),
 		'svgz' => array(
 			'binary' => true,
-			'type' => GRAPHVIZ_SVGZ,
+			'type' => self::GRAPHVIZ_SVGZ,
 			'mime' => 'image/svg+xml',
 		),
 		'pdf' => array(
 			'binary' => true,
-			'type' => GRAPHVIZ_PDF,
+			'type' => self::GRAPHVIZ_PDF,
 			'mime' => 'application/pdf',
 		),
 	);

--- a/core/graphviz_api.php
+++ b/core/graphviz_api.php
@@ -47,6 +47,15 @@ require_api( 'utility_api.php' );
 class Graph {
 
 	/**
+	 * Constants defining the Graphviz tools' names.
+	 *
+	 * These are the names of the executables in the directory defined by
+	 * {@see $g_graphviz_path}.
+	 */
+	const TOOL_DOT = 'dot';
+	const TOOL_NEATO = 'neato';
+
+	/**
 	 * Constant(s) defining the output formats supported by dot and neato.
 	 */
 	const GRAPHVIZ_ATTRIBUTED_DOT = 0;
@@ -215,14 +224,15 @@ class Graph {
 	 * @param array  $p_attributes Attributes
 	 * @param string $p_tool       Graph generation tool (one of the TOOL_* constants)
 	 */
-	public function __construct( $p_name = 'G', array $p_attributes = array(), $p_tool = 'neato' ) {
+	public function __construct( $p_name = 'G', array $p_attributes = array(), $p_tool = Graph::TOOL_NEATO ) {
 		if( is_string( $p_name ) ) {
 			$this->name = $p_name;
 		}
 
 		$this->set_attributes( $p_attributes );
 
-		$this->graphviz_tool = $p_tool;
+		$t_graphviz_path = config_get_global( 'graphviz_path' );
+		$this->graphviz_tool = $t_graphviz_path . $p_tool;
 	}
 
 	/**

--- a/core/obsolete.php
+++ b/core/obsolete.php
@@ -235,3 +235,5 @@ config_obsolete( 'display_project_padding' );
 
 # changes in 2.27.0
 config_obsolete( 'allow_file_cache' );
+config_obsolete( 'dot_tool', 'graphviz_path' );
+config_obsolete( 'neato_tool', 'graphviz_path' );

--- a/core/relationship_graph_api.php
+++ b/core/relationship_graph_api.php
@@ -156,7 +156,6 @@ function relgraph_generate_rel_graph( $p_bug_id, $p_show_summary = false ) {
 	$t_graph_fontsize = config_get( 'relationship_graph_fontsize' );
 	$t_graph_fontpath = get_font_path();
 	$t_view_on_click = config_get( 'relationship_graph_view_on_click' );
-	$t_neato_tool = config_get_global( 'neato_tool' );
 
 	$t_graph_attributes = array(
 		'overlap'	=> 'false',
@@ -167,7 +166,7 @@ function relgraph_generate_rel_graph( $p_bug_id, $p_show_summary = false ) {
 		$t_graph_attributes['fontpath'] = $t_graph_fontpath;
 	}
 
-	$t_graph = new Graph( $t_id_string, $t_graph_attributes, $t_neato_tool );
+	$t_graph = new Graph( $t_id_string, $t_graph_attributes );
 
 	$t_graph->set_default_node_attr( array (
 			'fontname'	=> $t_graph_fontname,
@@ -287,7 +286,6 @@ function relgraph_generate_dep_graph( $p_bug_id, $p_horizontal = false, $p_show_
 	$t_graph_fontsize = config_get( 'relationship_graph_fontsize' );
 	$t_graph_fontpath = get_font_path();
 	$t_view_on_click = config_get( 'relationship_graph_view_on_click' );
-	$t_dot_tool = config_get_global( 'dot_tool' );
 
 	$t_graph_attributes = array();
 
@@ -302,7 +300,7 @@ function relgraph_generate_dep_graph( $p_bug_id, $p_horizontal = false, $p_show_
 		$t_graph_orientation = 'vertical';
 	}
 
-	$t_graph = new Digraph( $t_id_string, $t_graph_attributes, $t_dot_tool );
+	$t_graph = new Digraph( $t_id_string, $t_graph_attributes, Graph::TOOL_DOT );
 
 	$t_graph->set_default_node_attr( array (
 			'fontname'	=> $t_graph_fontname,

--- a/docbook/Admin_Guide/en-US/config/relationship.xml
+++ b/docbook/Admin_Guide/en-US/config/relationship.xml
@@ -10,11 +10,12 @@
 		<emphasis>dependencies</emphasis> and a full
 		<emphasis>relationships</emphasis> graph.
 	</para>
+	<para>It is also possible to visualize the Workflow transitions.
+	</para>
 
 	<important>
 		<para>This feature relies on the external
-			<emphasis>dot</emphasis> and <emphasis>neato</emphasis> tools
-			from the <ulink url="https://www.graphviz.org/">GraphViz</ulink>
+			<ulink url="https://www.graphviz.org/">GraphViz</ulink>
 			library, which must be installed separately.
 		</para>
 		<para>Most Linux distributions have a GraphViz package available
@@ -39,6 +40,21 @@
 			</itemizedlist>
 		</para>
 	</important>
+
+	<para>The following Graphviz tools are used:</para>
+	<itemizedlist>
+		<listitem><para>
+			Relationship graphs: <literal>dot</literal>, <literal>neato</literal>
+		</para></listitem>
+		<listitem><para>
+			Workflow transitions graph (see
+			<xref linkend="admin.lifecycle.workflow.transitions" />):
+			<literal>dot</literal>
+		</para></listitem>
+	</itemizedlist>
+	<para>The webserver must have execute permission to these programs
+		in order to generate the graphs.
+	</para>
 
 	<variablelist>
 		<varlistentry>
@@ -100,25 +116,29 @@
 			</listitem>
 		</varlistentry>
 		<varlistentry>
-			<term>$g_dot_tool</term>
+			<term>$g_graphviz_path</term>
 			<listitem>
-				<para>
-					The full path for the dot tool.  The webserver must have execute
-					permission to this program in order to generate relationship graphs.
-					This configuration option is not relevant for Windows.  The default
-					value is '/usr/bin/dot'.
+				<para>Complete path to the
+					<ulink url="https://graphviz.org/ Graphviz">Graphviz</ulink> tools
+					(for details, see the note at the beginning of
+					<xref linkend="admin.config.relationship" />).
 				</para>
-			</listitem>
-		</varlistentry>
-		<varlistentry>
-			<term>$g_neato_tool</term>
-			<listitem>
-				<para>
-					The full path for the neato tool.  The webserver must have execute
-					permission to this program in order to generate relationship graphs.
-					This configuration option is not relevant for Windows.  The default
-					value is '/usr/bin/neato'.
+				<para>Requires trailing '/'.
+					The default	value is <literal>/usr/bin/</literal>.
 				</para>
+				<warning>
+					<itemizedlist>
+						<listitem><para>
+							The webserver must have execute permission to these programs
+							in order to generate the graphs.
+						</para></listitem>
+						<listitem><para>
+							On Windows, the IIS user may require permissions to
+							cmd.exe to be able to use PHP's
+							<ulink url="https://www.php.net/manual/en/function.proc-open.php">proc_open()</ulink>
+						</para></listitem>
+					</itemizedlist>
+				</warning>
 			</listitem>
 		</varlistentry>
 		<varlistentry>

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1610,7 +1610,8 @@ $s_timeline_more = 'More events...';
  */
 $s_missing_error_string = 'Missing Error String: %1$s';
 
-$MANTIS_ERROR[ERROR_GENERIC] = 'An error occurred during this action. You may wish to report this error to your local administrator.';
+$MANTIS_ERROR[ERROR_GENERIC] = 'An error occurred during this action. You may wish to report it to your local administrator.';
+$MANTIS_ERROR[ERROR_GENERIC_DETAILS] = 'Error details: %s';
 $MANTIS_ERROR[ERROR_SQL] = 'SQL error detected.';
 $MANTIS_ERROR[ERROR_REPORT] = 'There was an error in your report.';
 $MANTIS_ERROR[ERROR_NO_FILE_SPECIFIED] = 'No file specified.';

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1756,6 +1756,7 @@ $MANTIS_ERROR[ERROR_API_TOKEN_NAME_NOT_UNIQUE] = 'API token name "%s" is already
 $MANTIS_ERROR[ERROR_LOGFILE_NOT_WRITABLE] = 'The file specified in $g_log_destination "%s" is not writable.';
 $MANTIS_ERROR[ERROR_MONITOR_ACCESS_TOO_LOW] = 'Added user does not have sufficient access rights to monitor this issue.';
 $MANTIS_ERROR[ERROR_USER_TOKEN_NOT_FOUND] = 'User API token with id "%d" not found.';
+$MANTIS_ERROR[ERROR_GRAPH_TOOL_NOT_FOUND] = 'Graphviz tool "%s" not found or execution failed. Make sure the library is installed and $g_graphviz_path is correctly set.';
 
 # dropzone.js - placeholders format is defined by the library
 $s_dropzone_default_message = 'Attach files by dragging & dropping, selecting or pasting them.';

--- a/workflow_graph_img.php
+++ b/workflow_graph_img.php
@@ -45,7 +45,9 @@ if( !config_get( 'relationship_graph_enable' ) ) {
 
 compress_enable();
 
-$t_status_arr  = MantisEnum::getAssocArrayIndexedByValues( config_get( 'status_enum_string' ) );
+$t_status_enum   = config_get( 'status_enum_string' );
+$t_status_ids    = MantisEnum::getValues( $t_status_enum );
+$t_status_labels = lang_get( 'status_enum_string' );
 
 $t_graph_fontname = config_get( 'relationship_graph_fontname' );
 $t_graph_fontsize = config_get( 'relationship_graph_fontsize' );
@@ -70,13 +72,15 @@ $t_graph->set_default_edge_attr( array ( 'style' => 'solid',
 										 'color' => '#0000C0',
 										 'dir'   => 'forward' ) );
 
-foreach ( $t_status_arr as $t_from_status => $t_from_label ) {
-	$t_enum_status = MantisEnum::getAssocArrayIndexedByValues( config_get( 'status_enum_string' ) );
-	foreach ( $t_enum_status as $t_to_status_id => $t_to_status_label ) {
-		if( workflow_transition_edge_exists( $t_from_status, $t_to_status_id ) ) {
-			$t_graph->add_edge( MantisEnum::getLabel( lang_get( 'status_enum_string' ), $t_from_status ),
-			                    MantisEnum::getLabel( lang_get( 'status_enum_string' ), $t_to_status_id ),
-			                    array() );
+foreach ( $t_status_ids as $t_from_id ) {
+	$t_graph->add_node(
+		$t_from_id,
+		[ 'label' => MantisEnum::getLocalizedLabel( $t_status_enum, $t_status_labels, $t_from_id ) ]
+	);
+
+	foreach ( $t_status_ids as $t_to_id ) {
+		if( workflow_transition_edge_exists( $t_from_id, $t_to_id ) ) {
+			$t_graph->add_edge( $t_from_id, $t_to_id );
 		}
 	}
 }

--- a/workflow_graph_img.php
+++ b/workflow_graph_img.php
@@ -74,8 +74,8 @@ foreach ( $t_status_arr as $t_from_status => $t_from_label ) {
 	$t_enum_status = MantisEnum::getAssocArrayIndexedByValues( config_get( 'status_enum_string' ) );
 	foreach ( $t_enum_status as $t_to_status_id => $t_to_status_label ) {
 		if( workflow_transition_edge_exists( $t_from_status, $t_to_status_id ) ) {
-			$t_graph->add_edge( string_no_break( MantisEnum::getLabel( lang_get( 'status_enum_string' ), $t_from_status ) ),
-			                    string_no_break( MantisEnum::getLabel( lang_get( 'status_enum_string' ), $t_to_status_id ) ),
+			$t_graph->add_edge( MantisEnum::getLabel( lang_get( 'status_enum_string' ), $t_from_status ),
+			                    MantisEnum::getLabel( lang_get( 'status_enum_string' ), $t_to_status_id ),
 			                    array() );
 		}
 	}

--- a/workflow_graph_img.php
+++ b/workflow_graph_img.php
@@ -57,7 +57,7 @@ if( !empty( $t_graph_fontpath ) ) {
 	$t_graph_attributes['fontpath'] = $t_graph_fontpath;
 }
 
-$t_graph = new Graph( 'workflow', $t_graph_attributes, Graph::TOOL_DOT );
+$t_graph = new Graph( 'workflow', $t_graph_attributes, Graph::TOOL_CIRCO );
 
 $t_graph->set_default_node_attr( array ( 'fontname' => $t_graph_fontname,
 										 'fontsize' => $t_graph_fontsize,

--- a/workflow_graph_img.php
+++ b/workflow_graph_img.php
@@ -50,7 +50,6 @@ $t_status_arr  = MantisEnum::getAssocArrayIndexedByValues( config_get( 'status_e
 $t_graph_fontname = config_get( 'relationship_graph_fontname' );
 $t_graph_fontsize = config_get( 'relationship_graph_fontsize' );
 $t_graph_fontpath = get_font_path();
-$t_dot_tool = config_get_global( 'dot_tool' );
 
 $t_graph_attributes = array();
 
@@ -58,7 +57,7 @@ if( !empty( $t_graph_fontpath ) ) {
 	$t_graph_attributes['fontpath'] = $t_graph_fontpath;
 }
 
-$t_graph = new Graph( 'workflow', $t_graph_attributes, $t_dot_tool );
+$t_graph = new Graph( 'workflow', $t_graph_attributes, Graph::TOOL_DOT );
 
 $t_graph->set_default_node_attr( array ( 'fontname' => $t_graph_fontname,
 										 'fontsize' => $t_graph_fontsize,


### PR DESCRIPTION
Fixes the following issues:

- [#34614](https://mantisbt.org/bugs/view.php?id=34614):	Refactoring GraphViz API and Workflow Graph
- [#34607](https://mantisbt.org/bugs/view.php?id=34607):	Incorrect Workflow Graph display if the status name contains a space

- [#34611](https://mantisbt.org/bugs/view.php?id=34611):	Allow HTML-like labels in relationship graphs
- [#34610](https://mantisbt.org/bugs/view.php?id=34610):	Poor error handling in relationship graphs generation
- [#34609](https://mantisbt.org/bugs/view.php?id=34609):	Redundant config settings g_dot_tool and $g_neato_tool
- [#34608](https://mantisbt.org/bugs/view.php?id=34608):	Workflow Graph display is difficult to read
