### PR TITLE
Refactor Profile API - new ProfileData class

### DIFF
--- a/account_prof_edit_page.php
+++ b/account_prof_edit_page.php
@@ -35,6 +35,8 @@
  * @uses lang_api.php
  * @uses profile_api.php
  * @uses string_api.php
+ *
+ * @noinspection PhpUnhandledExceptionInspection
  */
 
 require_once( 'core.php' );
@@ -58,25 +60,15 @@ auth_ensure_user_authenticated();
 
 current_user_ensure_unprotected();
 
-$f_profile_id	= gpc_get_int( 'profile_id' );
+$f_profile_id = gpc_get_int( 'profile_id' );
 $f_redirect_page = gpc_get_string( 'redirect', 'account_prof_menu_page.php' );
 
-profile_ensure_can_update( $f_profile_id );
-
-$t_row = profile_get_row( $f_profile_id );
-/**
- * @var $v_id
- * @var $v_user_id
- * @var $v_platform
- * @var $v_os
- * @var $v_os_build
- * @var $v_description
- */
-extract( $t_row, EXTR_PREFIX_ALL, 'v' );
+$t_profile = new ProfileData( $f_profile_id );
+$t_profile->ensure_can_update();
 
 layout_page_header();
 
-if( profile_is_global( $f_profile_id ) ) {
+if( $t_profile->is_global() ) {
 	layout_page_begin( 'manage_overview_page.php' );
 	print_manage_menu( 'manage_prof_menu_page.php' );
 } else {
@@ -91,7 +83,7 @@ if( profile_is_global( $f_profile_id ) ) {
 	<form method="post" action="account_prof_update.php">
 		<?php  echo form_security_field( 'account_prof_update' )?>
 		<input type="hidden" name="action" value="update" />
-		<input type="hidden" name="profile_id" value="<?php echo $v_id ?>" />
+		<input type="hidden" name="profile_id" value="<?php echo $t_profile->id ?>" />
 		<input type="hidden" name="redirect" value="<?php echo string_attribute( $f_redirect_page ) ?>" />
 
 		<div class="widget-box widget-color-blue2">
@@ -117,7 +109,7 @@ if( profile_is_global( $f_profile_id ) ) {
 								<td>
 									<input id="platform" name="platform" type="text" required
 										   class="input-sm" size="32" maxlength="32"
-										   value="<?php echo string_attribute( $v_platform ) ?>"
+										   value="<?php echo string_attribute( $t_profile->platform ) ?>"
 									/>
 								</td>
 							</tr>
@@ -131,7 +123,7 @@ if( profile_is_global( $f_profile_id ) ) {
 								<td>
 									<input id="os" name="os" type="text" required
 										   class="input-sm" size="32" maxlength="32"
-										   value="<?php echo string_attribute( $v_os ) ?>"
+										   value="<?php echo string_attribute( $t_profile->os ) ?>"
 									/>
 								</td>
 							</tr>
@@ -145,7 +137,7 @@ if( profile_is_global( $f_profile_id ) ) {
 								<td>
 									<input id="os_build" name="os_build" type="text" required
 										   class="input-sm" size="16" maxlength="16"
-										   value="<?php echo string_attribute( $v_os_build ) ?>"
+										   value="<?php echo string_attribute( $t_profile->os_build ) ?>"
 									/>
 								</td>
 							</tr>
@@ -160,7 +152,7 @@ if( profile_is_global( $f_profile_id ) ) {
 									<textarea id="description" name="description"
 											  class="form-control"
 											  cols="60" rows="8">
-<?php echo string_textarea( $v_description ) ?>
+<?php echo string_textarea( $t_profile->description ) ?>
 </textarea>
 								</td>
 							</tr>

--- a/account_prof_update.php
+++ b/account_prof_update.php
@@ -33,6 +33,8 @@
  * @uses gpc_api.php
  * @uses print_api.php
  * @uses profile_api.php
+ *
+ * @noinspection PhpUnhandledExceptionInspection
  */
 
 require_once( 'core.php' );
@@ -61,9 +63,10 @@ $f_redirect_page = gpc_get_string( 'redirect', 'account_prof_menu_page.php' );
 
 if( $f_action != 'add' ) {
 	$f_profile_id = gpc_get_int( 'profile_id' );
-	profile_ensure_can_update( $f_profile_id );
+	$t_profile = new ProfileData( $f_profile_id );
+	$t_profile->ensure_can_update();
 
-	$t_user_id = profile_is_global( $f_profile_id ) ? ALL_USERS : auth_get_current_user_id();
+	$t_user_id = $t_profile->is_global() ? ALL_USERS : auth_get_current_user_id();
 }
 
 switch( $f_action ) {
@@ -74,9 +77,7 @@ switch( $f_action ) {
 		$f_description	= gpc_get_string( 'description' );
 		$t_user_id		= gpc_get_int( 'user_id' );
 
-		if( ALL_USERS == $t_user_id ) {
-			access_ensure_global_level( config_get( 'manage_global_profile_threshold' ), $t_user_id );
-		} else {
+		if( ALL_USERS != $t_user_id ) {
 			$t_user_id = auth_get_current_user_id();
 			access_ensure_global_level( config_get( 'add_profile_threshold' ), $t_user_id );
 		}
@@ -90,21 +91,25 @@ switch( $f_action ) {
 		$f_os_build = gpc_get_string( 'os_build' );
 		$f_description = gpc_get_string( 'description' );
 
+		/** @noinspection PhpUndefinedVariableInspection */
 		profile_update( $t_user_id, $f_profile_id, $f_platform, $f_os, $f_os_build, $f_description );
 		break;
 
 	case 'delete':
+		/** @noinspection PhpUndefinedVariableInspection */
 		helper_ensure_confirmed(
 			sprintf( lang_get( 'delete_profile_confirm_msg' ),
-				string_attribute( profile_get_name( $f_profile_id ) )
+				string_attribute( $t_profile->get_name() )
 			),
 			lang_get( 'delete_profile' )
 		);
 
+		/** @noinspection PhpUndefinedVariableInspection */
 		profile_delete( $t_user_id, $f_profile_id );
 		break;
 
 	case 'make_default':
+		/** @noinspection PhpUndefinedVariableInspection */
 		current_user_set_pref( 'default_profile', $f_profile_id );
 		break;
 }

--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -584,18 +584,18 @@ function mci_profile_as_array_by_id( $p_profile_id ) {
 	}
 
 	try {
-		$t_profile = profile_get_row( $t_profile_id );
+		$t_profile = new ProfileData( $t_profile_id );
 	} catch (ClientException $e) {
 		return null;
 	}
 
 	return array(
 		'id' => $t_profile_id,
-		'user' => mci_account_get_array_by_id( $t_profile['user_id'] ),
-		'platform' => $t_profile['platform'],
-		'os' => $t_profile['os'],
-		'os_build' => $t_profile['os_build'],
-		'description' => $t_profile['description']
+		'user' => mci_account_get_array_by_id( $t_profile->user_id ),
+		'platform' => $t_profile->platform,
+		'os' => $t_profile->os,
+		'os_build' => $t_profile->os_build,
+		'description' => $t_profile->description
 	);
 }
 

--- a/core/commands/IssueAddCommand.php
+++ b/core/commands/IssueAddCommand.php
@@ -298,22 +298,18 @@ class IssueAddCommand extends Command {
 
 		# if a profile was selected then let's use that information
 		if( $this->issue->profile_id != 0 ) {
-			if( profile_is_global( $this->issue->profile_id ) ) {
-				$t_row = user_get_profile_row( ALL_USERS, $this->issue->profile_id );
-			} else {
-				$t_row = user_get_profile_row( $this->issue->reporter_id, $this->issue->profile_id );
-			}
+			$t_profile = user_get_profile( $this->issue->reporter_id, $this->issue->profile_id );
 
 			if( is_blank( $this->issue->platform ) ) {
-				$this->issue->platform = $t_row['platform'];
+				$this->issue->platform = $t_profile->platform;
 			}
 
 			if( is_blank( $this->issue->os ) ) {
-				$this->issue->os = $t_row['os'];
+				$this->issue->os = $t_profile->os;
 			}
 
 			if( is_blank( $this->issue->os_build ) ) {
-				$this->issue->os_build = $t_row['os_build'];
+				$this->issue->os_build = $t_profile->os_build;
 			}
 		}
 

--- a/core/filter_form_api.php
+++ b/core/filter_form_api.php
@@ -1100,7 +1100,8 @@ function print_filter_values_show_profile( array $p_filter ) {
 			if( filter_field_is_any( $t_current ) ) {
 				$t_any_found = true;
 			} else {
-				$t_this_string = profile_get_name( $t_current );
+				$t_profile = new ProfileData( $t_current );
+				$t_this_string = $t_profile->get_name();
 			}
 			if( !$t_first_flag ) {
 				$t_output .= '<br />';

--- a/core/user_api.php
+++ b/core/user_api.php
@@ -1626,27 +1626,24 @@ function user_get_reported_open_bug_count( $p_user_id, $p_project_id = ALL_PROJE
 }
 
 /**
- * Return a profile row.
+ * Return Profile data information.
  *
  * @param int $p_user_id    A valid user identifier.
  * @param int $p_profile_id The profile identifier to retrieve.
  *
- * @return array
+ * @return ProfileData
+ * @throws ClientException if Profile is not found.
  */
-function user_get_profile_row( $p_user_id, $p_profile_id ) {
-	db_param_push();
-	$t_query = 'SELECT * FROM {user_profile}
-				  WHERE id=' . db_param() . ' AND
-						user_id=' . db_param();
-	$t_result = db_query( $t_query, array( $p_profile_id, $p_user_id ) );
-
-	$t_row = db_fetch_array( $t_result );
-
-	if( !$t_row ) {
-		trigger_error( ERROR_USER_PROFILE_NOT_FOUND, ERROR );
+function user_get_profile( $p_user_id, $p_profile_id ) {
+	$t_profile = new ProfileData( $p_profile_id );
+	if( !$t_profile->is_global() && $t_profile->user_id != $p_user_id ) {
+		throw new ClientException(
+			"Profile '$p_profile_id' not found for user '$p_user_id'.",
+			ERROR_USER_PROFILE_NOT_FOUND
+		);
 	}
 
-	return $t_row;
+	return $t_profile;
 }
 
 /**

--- a/print_all_bug_page_word.php
+++ b/print_all_bug_page_word.php
@@ -450,8 +450,8 @@ foreach( $t_related_custom_field_ids as $t_custom_field_id ) {
 <?php
 	# account profile description
 	if( $t_bug->profile_id > 0 ) {
-		$t_profile_row = profile_get_row( $t_bug->profile_id );
-		$t_profile_description = string_display( $t_profile_row['description'] );
+		$t_profile = new ProfileData( $t_bug->profile_id );
+		$t_profile_description = string_display( $t_profile->description );
 
 ?>
 <tr>


### PR DESCRIPTION
Using an object to handle Profiles avoids repeated SQL queries to retrieve the same Profile information from the database.

This initial implementation only supports read-only operations for now; add, update and delete are still managed with legacy functions.

These 3 functions have been replaced by ProfileData methods, which they are now simple proxies for. They have been marked as deprecated, and will be removed in a future release.
- profile_get_row()
- profile_get_name()
- profile_is_global()

Fixes [#34824](https://mantisbt.org/bugs/view.php?id=34824)