### PR TITLE
Move fastcgi_finish_request() to email shutdown function

### DIFF
--- a/core/email_api.php
+++ b/core/email_api.php
@@ -2272,6 +2272,9 @@ function email_shutdown_function() {
 	log_event( LOG_EMAIL_VERBOSE, $t_msg );
 
 	if( $g_email_shutdown_processing ) {
+		if( function_exists( 'fastcgi_finish_request' ) ) {
+			fastcgi_finish_request();
+		}
 		email_send_all();
 	}
 }

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -545,10 +545,6 @@ function html_body_end() {
  */
 function html_end() {
 	echo '</html>', "\n";
-
-	if( function_exists( 'fastcgi_finish_request' ) ) {
-		fastcgi_finish_request();
-	}
 }
 
 /**


### PR DESCRIPTION
This was originally added to html_end() to improve performance when using php-fpm and sending mail synchronously [1], back when the function was calling email_send_all(), i.e. before issue #17460 moved that to email_shutdown_function().

This is now causing issues as the HTTP response code is not set when an error occurs and FastCGI is used.

Fixes [#34828](https://mantisbt.org/bugs/view.php?id=34828), [#34634](https://mantisbt.org/bugs/view.php?id=34634) 

[1]: see commit cea405ccf228fd2c6ac694574a74e87396b14f1f

Follow-up on PR #2028