### PR TITLE
mc_issue_update: Don't delete due_date 

### DIFF
--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -1155,8 +1155,6 @@ function mc_issue_update( $p_username, $p_password, $p_issue_id, stdClass $p_iss
 	if( isset( $p_issue['due_date'] ) &&
 		access_has_project_level( config_get( 'due_date_update_threshold' ), $t_bug_data->project_id ) ) {
 		$t_bug_data->due_date = strtotime( $p_issue['due_date'] );
-	} else {
-		$t_bug_data->due_date = date_get_null();
 	}
 
 	mci_issue_set_custom_fields( $p_issue_id, $p_issue['custom_fields'] );


### PR DESCRIPTION
If don't have access level to modify it, then don't modify it (current code does erase the due date instead of leaving it as is).

Fixes [#34959](https://mantisbt.org/bugs/view.php?id=34959)