### PR TITLE
Update Version date conversion with non-US format

### DIFF
--- a/api/soap/mc_api.php
+++ b/api/soap/mc_api.php
@@ -208,11 +208,13 @@ class ApiObjectFactory {
 	}
 
 	/**
-	 * Convert a timestamp to a soap DateTime variable
-	 * @param integer $p_value Integer value to return as date time string.
-	 * @return datetime in expected API format.
+	 * Convert a timestamp to a soap DateTime variable or ISO-8601 date.
+	 *
+	 * @param int $p_value Unix Timestamp.
+	 *
+	 * @return SoapVar|string datetime in expected API format.
 	 */
-	static function datetime($p_value ) {
+	static function datetime( $p_value ) {
 		$t_string_value = self::datetimeString( $p_value );
 
 		if( ApiObjectFactory::$soap ) {
@@ -223,16 +225,27 @@ class ApiObjectFactory {
 	}
 
 	/**
-	 * Convert a timestamp to a DateTime string
-	 * @param integer $p_timestamp Integer value to format as date time string.
-	 * @return string for provided timestamp
+	 * Convert a timestamp to an ISO-8601 formatted DateTime string.
+	 *
+	 * @param int|null $p_timestamp Unix timestamp.
+	 *
+	 * @return string|null Formatted datetime.
 	 */
-	static function datetimeString($p_timestamp ) {
-		if( $p_timestamp == null || date_is_null( $p_timestamp ) ) {
-			return null;
-		}
+	static function datetimeString( $p_timestamp ) {
+		return date_timestamp_to_iso8601( $p_timestamp );
+	}
 
-		return date( 'c', (int)$p_timestamp );
+	/**
+	 * Converts a datetime string to a Unix timestamp.
+	 *
+	 * @param string $p_date_string Date string.
+	 *
+	 * @return int|null Unix timestamp, null when $p_date_string is blank.
+	 *
+	 * @throws ClientException When given string cannot be converted to Date.
+	 */
+	static function dateStringToTimestamp( $p_date_string ): ?int {
+		return date_string_to_timestamp( $p_date_string );
 	}
 
 	/**

--- a/core/commands/VersionAddCommand.php
+++ b/core/commands/VersionAddCommand.php
@@ -81,7 +81,9 @@ class VersionAddCommand extends Command {
 		}
 
 		$t_timestamp = $this->payload( 'timestamp', '' );
-		$this->timestamp = is_blank( $t_timestamp ) ? null : strtotime( $t_timestamp );
+		$this->timestamp = is_blank( $t_timestamp )
+			? null
+			: ( is_int( $t_timestamp ) ? $t_timestamp : strtotime( $t_timestamp ) );
 	}
 
 	/**

--- a/core/commands/VersionAddCommand.php
+++ b/core/commands/VersionAddCommand.php
@@ -80,10 +80,8 @@ class VersionAddCommand extends Command {
 				array( 'name' ) );
 		}
 
-		$t_timestamp = $this->payload( 'timestamp', '' );
-		$this->timestamp = is_blank( $t_timestamp )
-			? null
-			: ( is_int( $t_timestamp ) ? $t_timestamp : strtotime( $t_timestamp ) );
+		$t_date_string = $this->payload( 'timestamp', '' );
+		$this->timestamp = date_string_to_timestamp( $t_date_string );
 	}
 
 	/**

--- a/core/commands/VersionUpdateCommand.php
+++ b/core/commands/VersionUpdateCommand.php
@@ -154,8 +154,10 @@ class VersionUpdateCommand extends Command {
 		}
 
 		$t_timestamp = $this->payload( 'timestamp' );
-		if( !is_null( $t_timestamp ) && !is_blank( $t_timestamp ) ) {
-			$t_timestamp = strtotime( $t_timestamp );
+		if( !is_blank( $t_timestamp ) ) {
+			if( !is_int( $t_timestamp ) ) {
+				$t_timestamp = strtotime( $t_timestamp );
+			}
 			$t_version->date_order = $t_timestamp;
 		}
 

--- a/core/commands/VersionUpdateCommand.php
+++ b/core/commands/VersionUpdateCommand.php
@@ -153,12 +153,9 @@ class VersionUpdateCommand extends Command {
 			$t_version->obsolete = $t_obsolete;
 		}
 
-		$t_timestamp = $this->payload( 'timestamp' );
-		if( !is_blank( $t_timestamp ) ) {
-			if( !is_int( $t_timestamp ) ) {
-				$t_timestamp = strtotime( $t_timestamp );
-			}
-			$t_version->date_order = $t_timestamp;
+		$t_date_string = $this->payload( 'timestamp' );
+		if( !is_blank( $t_date_string ) ) {
+			$t_version->date_order = date_string_to_timestamp( $t_date_string );
 		}
 
 		version_update( $t_version );

--- a/manage_proj_ver_update.php
+++ b/manage_proj_ver_update.php
@@ -63,7 +63,7 @@ $t_data = array(
 		'description' => $f_description,
 		'released' => $f_released,
 		'obsolete' => $f_obsolete,
-		'timestamp' => $f_date_order
+		'timestamp' => date_strtotime( $f_date_order )
 	)
 );
 

--- a/manage_proj_ver_update.php
+++ b/manage_proj_ver_update.php
@@ -52,6 +52,7 @@ $f_obsolete	    = gpc_get_bool( 'obsolete' );
 
 $f_new_version	= trim( $f_new_version );
 $t_version = version_get( $f_version_id );
+$t_timestamp = date_strtotime( $f_date_order );
 
 $t_data = array(
 	'query' => array(
@@ -63,7 +64,7 @@ $t_data = array(
 		'description' => $f_description,
 		'released' => $f_released,
 		'obsolete' => $f_obsolete,
-		'timestamp' => date_strtotime( $f_date_order )
+		'timestamp' => date_timestamp_to_iso8601( $t_timestamp ),
 	)
 );
 


### PR DESCRIPTION
VersionAddCommand and VersionUpdateCommand now accept a Unix timestamp as payload for timestamp (date_order).

manage_proj_ver_update.php calls date_strtotime() on the $f_timestamp parameter to build the VersionUpdateCommand payload.

Fixes [#34928](https://mantisbt.org/bugs/view.php?id=34928)