### PR TITLE
Fix broken graphs on systems with case-sensitive file systems

### DIFF
--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -198,7 +198,7 @@ class MantisGraphPlugin extends MantisPlugin  {
 			html_javascript_cdn_link( $t_link . 'chartjs-plugin-colorschemes.min.js', self::CHARTJS_COLORSCHEMES_HASH );
 		} else {
 			$t_scripts = array(
-				'Chart-' . self::CHARTJS_VERSION . '.min.js',
+				'chart-' . self::CHARTJS_VERSION . '.min.js',
 				'chartjs-plugin-colorschemes-' . self::CHARTJS_COLORSCHEMES_VERSION . '.min.js',
 			);
 			foreach( $t_scripts as $t_script ) {


### PR DESCRIPTION
Regression introduced when upgrading chart.js library Reproducible only with default setting $g_cdn_enabled = OFF;

Issue [#34847](https://mantisbt.org/bugs/view.php?id=34847)