### PR TITLE
The tokenizer php extension is required

### DIFF
--- a/admin/check/check_php_inc.php
+++ b/admin/check/check_php_inc.php
@@ -48,6 +48,7 @@ $t_extensions_required = array(
 	'pcre',
 	'reflection',
 	'session',
+	'tokenizer',
 );
 
 foreach( $t_extensions_required as $t_extension ) {

--- a/admin/check/check_php_inc.php
+++ b/admin/check/check_php_inc.php
@@ -43,11 +43,11 @@ $t_extensions_required = array(
 	'ctype', # required by PHPMailer
 	'date',
 	'hash',
-	'pcre',
-	'Reflection',
-	'session',
+	'json',
 	'mbstring',
-	'json'
+	'pcre',
+	'reflection',
+	'session',
 );
 
 foreach( $t_extensions_required as $t_extension ) {

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
         "php": "^7.4 || ^8.0",
         "ext-mbstring": "*",
         "ext-json": "*",
+        "ext-tokenizer": "*",
         "slim/slim": "^3.0",
         "guzzlehttp/guzzle": "^7.5",
         "vboctor/disposable_email_checker": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "69bc24c772c2f38535f59138e1fed01a",
+    "content-hash": "83d7d4140d35409a32390127222f5543",
     "packages": [
         {
             "name": "adodb/adodb-php",
@@ -2944,7 +2944,8 @@
     "platform": {
         "php": "^7.4 || ^8.0",
         "ext-mbstring": "*",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-tokenizer": "*"
     },
     "platform-dev": {
         "ext-zip": "*"

--- a/docbook/Admin_Guide/en-US/Installation.xml
+++ b/docbook/Admin_Guide/en-US/Installation.xml
@@ -187,7 +187,8 @@
 										filter,
 										hash,
 										json,
-										session
+										session,
+										tokenizer
 									</emphasis>
 									- Required to run MantisBT in general.
 									These are bundled with PHP, and enabled by default.


### PR DESCRIPTION
Without it, adm_config_set.php throws a "Call to undefined function
token_get_all()" error.

- add the extension to composer.json
- document the requirement in Admin Guide
- verify its presence in admin checks

Fixes [#35011](https://mantisbt.org/bugs/view.php?id=35011)