### PR TITLE
Add a new event EVENT_LDAP_CACHE_ATTRS to extend the LDAP attribute cache

### DIFF
--- a/core/events_inc.php
+++ b/core/events_inc.php
@@ -157,6 +157,9 @@ event_declare_many( array(
 
 	# Authentication Events
 	'EVENT_AUTH_USER_FLAGS' => EVENT_TYPE_FIRST,
+	
+	# LDAP Cache attribute names
+	'EVENT_LDAP_CACHE_ATTRS' => EVENT_TYPE_DEFAULT,
 
 	'EVENT_CRONJOB' => EVENT_TYPE_EXECUTE
 ) );

--- a/core/ldap_api.php
+++ b/core/ldap_api.php
@@ -261,6 +261,17 @@ function ldap_cache_user_data( $p_username ) {
 		config_get_global( 'ldap_realname_field' )
 	);
 
+	$t_extra_attrs = event_signal( 'EVENT_LDAP_CACHE_ATTRS', array( $p_username ) );
+	foreach( $t_extra_attrs as $t_plugin ) {
+		foreach( $t_plugin as $t_callback ) {
+			if( is_array( $t_callback ) ) {
+				$t_search_attrs = array_merge( $t_search_attrs, $t_callback );
+			} elseif( !is_null( $t_callback ) ) {
+				$t_search_attrs[] = $t_callback;
+			}
+		}
+	}
+	
 	log_event( LOG_LDAP, 'Searching for ' . $t_search_filter );
 	$t_sr = @ldap_search( $t_ds, $t_ldap_root_dn, $t_search_filter, $t_search_attrs );
 	if( $t_sr === false ) {

--- a/docbook/Developers_Guide/en-US/Events_Reference.xml
+++ b/docbook/Developers_Guide/en-US/Events_Reference.xml
@@ -175,19 +175,43 @@
 					for more details.
 				</para>
 			</blockquote>
+		</blockquote>
 
-			<blockquote id="dev.eventref.cronjob">
-				<title>EVENT_CRONJOB (Execute)</title>
+		<blockquote id="dev.eventref.cronjob">
+			<title>EVENT_CRONJOB (Execute)</title>
 
-				<blockquote>
-					<para>
-						This is an event that is triggered by the scripts/cronjob.php on
-						some recurring schedule (once an hour is recommended). Plugins
-						handle this event to execute recurring tasks.
-					</para>
-				</blockquote>
+			<blockquote>
+				<para>
+					This is an event that is triggered by the scripts/cronjob.php on
+					some recurring schedule (once an hour is recommended). Plugins
+					handle this event to execute recurring tasks.
+				</para>
 			</blockquote>
 		</blockquote>
+
+		<blockquote id="dev.eventref.ldap.cache_attrs">
+			<title>EVENT_LDAP_CACHE_ATTRS (Default)</title>
+
+			<blockquote>
+				<para>
+					An event that enables plugins to return a set of additional LDAP attribute names
+					to be cached on the very first read of the user attributes from the LDAP server.
+					The attributes defined by the <literal>$g_ldap_email_field</literal> and
+					<literal>$g_ldap_realname_field</literal> options are always read.
+					Later cached attributes can be accessed using the
+					<function>ldap_get_field_from_username()</function> function.
+				</para>
+				<itemizedlist>
+					<title>Parameters</title>
+					<listitem><para>&lt;Array&gt;: The user name</para></listitem>
+				</itemizedlist>
+				<itemizedlist>
+					<title>Return Value</title>
+					<listitem><para>&lt;Array&gt;: LDAP attribute names</para></listitem>
+				</itemizedlist>				
+			</blockquote>
+		</blockquote>
+
 	</section>
 
 	<xi:include href="Events_Reference_Output.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />


### PR DESCRIPTION
This new event will make it possible to fix any out of date LDAP plugins.

Fixes [35070](https://mantisbt.org/bugs/view.php?id=35070).
