### PR TITLE
Request for improvement of plugin_file_path() function.

### DIFF
--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -185,21 +185,17 @@ function plugin_route_group( $p_base_name = null ) {
 }
 
 /**
- * Return a path to a plugin file.
- * @param string $p_filename  File name.
- * @param string $p_base_name Plugin base name.
- * @return mixed File path or false if FNF
+ * Return a path to a plugin file(s).
+ * @param string $p_filename  File name (if it is not set, the function will return a directory).
+ * @param string $p_base_name Plugin base name (defaults to the current plugin).
+ * @return mixed File path or false if file cannot be found
  */
-function plugin_file_path( $p_filename = null, $p_base_name = null ) {
-	$t_file_path = config_get_global( 'plugin_path' );
-	if( is_null( $p_base_name ) ) {
-		$t_file_path .= plugin_get_current() . DIRECTORY_SEPARATOR;
-	} else {
-		$t_file_path .= $p_base_name . DIRECTORY_SEPARATOR;
-	}
-	$t_file_path .= 'files' . DIRECTORY_SEPARATOR;
+function plugin_file_path( $p_filename = '', $p_base_name = '' ) {
+	$t_file_path = config_get_global( 'plugin_path' )
+		. ( $p_base_name ? $p_base_name : plugin_get_current() ) . DIRECTORY_SEPARATOR
+		. 'files' . DIRECTORY_SEPARATOR;
 
-	if( is_null( $p_filename ) ) {
+	if( !$p_filename ) {
 		return $t_file_path;
 	}
 	$t_file_path .= $p_filename;

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -190,10 +190,19 @@ function plugin_route_group( $p_base_name = null ) {
  * @param string $p_base_name Plugin base name.
  * @return mixed File path or false if FNF
  */
-function plugin_file_path( $p_filename, $p_base_name ) {
+function plugin_file_path( $p_filename = null, $p_base_name = null ) {
 	$t_file_path = config_get_global( 'plugin_path' );
-	$t_file_path .= $p_base_name . DIRECTORY_SEPARATOR;
-	$t_file_path .= 'files' . DIRECTORY_SEPARATOR . $p_filename;
+	if( is_null( $p_base_name ) ) {
+		$t_file_path .= plugin_get_current() . DIRECTORY_SEPARATOR;
+	} else {
+		$t_file_path .= $p_base_name . DIRECTORY_SEPARATOR;
+	}
+	$t_file_path .= 'files' . DIRECTORY_SEPARATOR;
+
+	if( is_null( $p_filename ) ) {
+		return $t_file_path;
+	}
+	$t_file_path .= $p_filename;
 
 	return( is_file( $t_file_path ) ? $t_file_path : false );
 }

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -185,14 +185,14 @@ function plugin_route_group( $p_base_name = null ) {
 }
 
 /**
- * Return a path to a plugin file(s).
- * @param string $p_filename  File name (if it is not set, the function will return a directory).
+ * Returns the path to a plugin file, or the plugin's files directory.
+ * @param string $p_filename  File name; if not set, the function will return the plugin's files directory.
  * @param string $p_base_name Plugin base name (defaults to the current plugin).
- * @return mixed File path or false if file cannot be found
+ * @return string|false File path or false if file cannot be found.
  */
 function plugin_file_path( $p_filename = '', $p_base_name = '' ) {
 	$t_file_path = config_get_global( 'plugin_path' )
-		. ( $p_base_name ? $p_base_name : plugin_get_current() ) . DIRECTORY_SEPARATOR
+		. ( $p_base_name ?: plugin_get_current() ) . DIRECTORY_SEPARATOR
 		. 'files' . DIRECTORY_SEPARATOR;
 
 	if( !$p_filename ) {

--- a/docbook/Developers_Guide/en-US/Plugins_Building.xml
+++ b/docbook/Developers_Guide/en-US/Plugins_Building.xml
@@ -402,8 +402,9 @@ layout_page_end();
 			<para>
 				Adding non-PHP files, such as images or CSS stylesheets, follows a very similar
 				pattern as pages.  Files should be placed in the plugin's
-				<filename>files/</filename> directory, and can only contain a single period in
-				the name.  The file's URI is generated with the <function>plugin_file()</function>
+				<filename>files/</filename> directory, the path to this directory can be
+				retrived by <function>plugin_file_path()</function> function.
+				The file's URI is generated with the <function>plugin_file()</function>
 				function.
 			</para>
 			<para>
@@ -421,7 +422,11 @@ p.foo {
 			<programlisting><filename>Example/pages/foo.php</filename><![CDATA[
 ...
 
-<link rel="stylesheet" type="text/css" href="<?php echo plugin_file( 'foo.css' ) ?>" />
+<link
+	rel="stylesheet"
+	type="text/css"
+	href="<?php echo plugin_file( 'foo.css' ) ?>"
+/>
 <p class="foo">
     Our custom stylesheet paints this text red.
 </p>

--- a/docbook/Developers_Guide/en-US/Plugins_Building.xml
+++ b/docbook/Developers_Guide/en-US/Plugins_Building.xml
@@ -403,7 +403,7 @@ layout_page_end();
 				Adding non-PHP files, such as images or CSS stylesheets, follows a very similar
 				pattern as pages.  Files should be placed in the plugin's
 				<filename>files/</filename> directory, the path to this directory can be
-				retrived by <function>plugin_file_path()</function> function.
+				retrieved by <function>plugin_file_path()</function> function.
 				The file's URI is generated with the <function>plugin_file()</function>
 				function.
 			</para>


### PR DESCRIPTION
This PR improved plugin_file_path() to support automatically detecting the current plugin (when $p_base_name = null) and retrieving the plugin's "files" directory path (when $p_filename = null). This will allow plugins to dynamically provide files from their directory. Currently, their ‘files’ directory is hard-coded but not easy accessible.

Fixes: [35082](https://mantisbt.org/bugs/view.php?id=35082).
