### PR TITLE
fix #35179 Could not use plugins filters with "Permalink"

### DIFF
--- a/search.php
+++ b/search.php
@@ -149,19 +149,19 @@ $t_plugin_filters = filter_get_plugin_filters();
 foreach( $t_plugin_filters as $t_field_name => $t_filter_object ) {
     switch( $t_filter_object->type ) {
         case FILTER_TYPE_STRING:
-            $t_my_filter[$t_field_name] = gpc_get_string( $t_field_name, $t_meta_filter_any_array[$t_field_name] );
+            $t_my_filter[$t_field_name] = gpc_get_string( $t_field_name, $t_meta_filter_any_array );
             break;
         case FILTER_TYPE_INT:
-            $t_my_filter[$t_field_name] = gpc_get_int( $t_field_name, $t_meta_filter_any_array[$t_field_name] );
+            $t_my_filter[$t_field_name] = gpc_get_int( $t_field_name, $t_meta_filter_any_array );
             break;
         case FILTER_TYPE_BOOLEAN:
-            $t_my_filter[$t_field_name] = gpc_get_bool( $t_field_name, $t_meta_filter_any_array[$t_field_name]);
+            $t_my_filter[$t_field_name] = gpc_get_bool( $t_field_name, $t_meta_filter_any_array );
             break;
         case FILTER_TYPE_MULTI_STRING:
-            $t_my_filter[$t_field_name] = gpc_get_string_array( $t_field_name, $t_meta_filter_any_array[$t_field_name] );
+            $t_my_filter[$t_field_name] = gpc_get_string_array( $t_field_name, $t_meta_filter_any_array );
             break;
         case FILTER_TYPE_MULTI_INT:
-            $t_my_filter[$t_field_name] = gpc_get_int_array( $t_field_name, $t_meta_filter_any_array[$t_field_name] );
+            $t_my_filter[$t_field_name] = gpc_get_int_array( $t_field_name, $t_meta_filter_any_array );
             break;
     }
 }


### PR DESCRIPTION
fixes: [#35179](https://mantisbt.org/bugs/view.php?id=35179)
Before modification, filters created through plugins broke "Permalink" functionality with an error.
The functionality as never work properly and was fixed on my side since I pushed it in 2018. 
Sorry for the correction delay.