### PR TITLE
Fix a <style> tag that was incorrectly placed

### DIFF
--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -289,7 +289,15 @@ function layout_head_css() {
 
 	echo "\n";
 
-	# Print user font preference
+	# Set font preference
+	layout_user_font_preference();
+}
+
+/**
+ * Print user font preference
+ * @return void
+ */
+function layout_user_font_preference() {
 	$t_font_family = config_get( 'font_family', null, null, ALL_PROJECTS );
 	echo '<style>', "\n";
 	echo  '* { font-family: "' . $t_font_family . '"; } ', "\n";

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -135,9 +135,6 @@ function layout_page_header_end( $p_page_id = null) {
 		echo '<body ' . $t_body_id . 'class="skin-3">', "\n";
 	}
 
-	# Set user font preference
-	layout_user_font_preference();
-
 	event_signal( 'EVENT_LAYOUT_BODY_BEGIN' );
 
 	$g_error_send_page_header = false;
@@ -291,13 +288,8 @@ function layout_head_css() {
 	}
 
 	echo "\n";
-}
 
-/**
- * Print user font preference
- * @return void
- */
-function layout_user_font_preference() {
+	# Print user font preference
 	$t_font_family = config_get( 'font_family', null, null, ALL_PROJECTS );
 	echo '<style>', "\n";
 	echo  '* { font-family: "' . $t_font_family . '"; } ', "\n";
@@ -378,9 +370,6 @@ function layout_login_page_begin( $p_title = '' ) {
 	html_head_end();
 
 	echo '<body class="login-layout light-login">';
-
-	# Set font preference
-	layout_user_font_preference();
 
 	layout_main_container_begin();
 	layout_main_content_begin();

--- a/plugins/MantisCoreFormatting/files/markdown.css
+++ b/plugins/MantisCoreFormatting/files/markdown.css
@@ -28,7 +28,7 @@ blockquote {
  * inserting a style which applies the user-defined font to all elements
  * including the <span> elements which wrap the language tokens within the
  * <code> elements.
- * @see layout_user_font_preference()
+ * @see layout_head_css()
  *
  * This rule reapplies (forces) the monospace font to the code blocks, as per
  * its original definition in bootstrap.css.

--- a/plugins/MantisCoreFormatting/files/markdown.css
+++ b/plugins/MantisCoreFormatting/files/markdown.css
@@ -28,7 +28,7 @@ blockquote {
  * inserting a style which applies the user-defined font to all elements
  * including the <span> elements which wrap the language tokens within the
  * <code> elements.
- * @see layout_head_css()
+ * @see layout_user_font_preference()
  *
  * This rule reapplies (forces) the monospace font to the code blocks, as per
  * its original definition in bootstrap.css.


### PR DESCRIPTION
Fix a `<style>` tag that was incorrectly placed inside a `<body>` tag instead of a `<head>` tag.

Fix for: [#35180](https://mantisbt.org/bugs/view.php?id=35180)
