### PR TITLE
Optimize lang_load() function by replacing preg_replace()

### DIFF
--- a/core/lang_api.php
+++ b/core/lang_api.php
@@ -86,7 +86,7 @@ function lang_load( $p_lang, $p_dir = null ) {
 	$t_vars = get_defined_vars();
 
 	foreach( array_keys( $t_vars ) as $t_var ) {
-		if( str_starts_with( $t_var, 's_' ) ) {
+		if( strncmp( $t_var, 's_', 2 ) === 0 ) {
 			$g_lang_strings[$p_lang][substr( $t_var, 2 )] = $$t_var;
 		} else if( 'MANTIS_ERROR' == $t_var ) {
 			if( isset( $g_lang_strings[$p_lang][$t_var] ) ) {

--- a/core/lang_api.php
+++ b/core/lang_api.php
@@ -86,16 +86,15 @@ function lang_load( $p_lang, $p_dir = null ) {
 	$t_vars = get_defined_vars();
 
 	foreach( array_keys( $t_vars ) as $t_var ) {
-		$t_lang_var = preg_replace( '/^s_/', '', $t_var );
-		if( $t_lang_var != $t_var ) {
-			$g_lang_strings[$p_lang][$t_lang_var] = $$t_var;
+		if( str_starts_with( $t_var, 's_' ) ) {
+			$g_lang_strings[$p_lang][substr( $t_var, 2 )] = $$t_var;
 		} else if( 'MANTIS_ERROR' == $t_var ) {
-			if( isset( $g_lang_strings[$p_lang][$t_lang_var] ) ) {
+			if( isset( $g_lang_strings[$p_lang][$t_var] ) ) {
 				foreach( $$t_var as $t_key => $t_val ) {
-					$g_lang_strings[$p_lang][$t_lang_var][$t_key] = $t_val;
+					$g_lang_strings[$p_lang][$t_var][$t_key] = $t_val;
 				}
 			} else {
-				$g_lang_strings[$p_lang][$t_lang_var] = $$t_var;
+				$g_lang_strings[$p_lang][$t_var] = $$t_var;
 			}
 		}
 	}


### PR DESCRIPTION
 with str_starts_with(), and substr().

For 'auto' language and non-English browsers it was about 2500 preg_replace() calls per page load, making this function in the top 10 of CPU eaters according to xDebug2 profiler. No more.

Fixes: [#35198](https://mantisbt.org/bugs/view.php?id=35198).
