### PR TITLE
Optimisation of work with plugins files.

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -4861,7 +4861,7 @@ $g_manage_plugin_threshold = ADMINISTRATOR;
  */
 $g_plugin_mime_types = array(
 	'css' => 'text/css',
-	'js'  => 'text/javascript',
+	'js'  => 'application/javascript',
 	'gif' => 'image/gif',
 	'png' => 'image/png',
 	'jpg' => 'image/jpeg',

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -4865,7 +4865,9 @@ $g_plugin_mime_types = array(
 	'gif' => 'image/gif',
 	'png' => 'image/png',
 	'jpg' => 'image/jpeg',
-	'jpeg' => 'image/jpeg'
+	'jpeg' => 'image/jpeg',
+	'svg' => 'image/svg+xml',
+	'webp' => 'image/webp'
 );
 
 /**

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -1255,6 +1255,15 @@ function file_create_finfo() {
  * @return bool|string The mime type or false on failure.
  */
 function file_get_mime_type( $p_file_path ) {
+	global $g_plugin_mime_types;
+
+	# allow overriding the content type for specific text and image extensions
+	# see bug #13193 for details
+	$t_extension = pathinfo( $p_file_path, PATHINFO_EXTENSION );
+	if( $t_extension && array_key_exists( $t_extension, $g_plugin_mime_types ) ) {
+		return $g_plugin_mime_types[$t_extension];
+	}
+
 	if( !file_exists( $p_file_path ) ) {
 		return false;
 	}

--- a/core/file_api.php
+++ b/core/file_api.php
@@ -1255,15 +1255,6 @@ function file_create_finfo() {
  * @return bool|string The mime type or false on failure.
  */
 function file_get_mime_type( $p_file_path ) {
-	global $g_plugin_mime_types;
-
-	# allow overriding the content type for specific text and image extensions
-	# see bug #13193 for details
-	$t_extension = pathinfo( $p_file_path, PATHINFO_EXTENSION );
-	if( $t_extension && array_key_exists( $t_extension, $g_plugin_mime_types ) ) {
-		return $g_plugin_mime_types[$t_extension];
-	}
-
 	if( !file_exists( $p_file_path ) ) {
 		return false;
 	}

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -225,8 +225,6 @@ function plugin_file( $p_file, $p_redirect = false, $p_base_name = null ) {
  * @return void
  */
 function plugin_file_include( $p_filename, $p_basename = null ) {
-	global $g_plugin_mime_types;
-
 	if( is_null( $p_basename ) ) {
 		$t_current = plugin_get_current();
 	} else {
@@ -243,15 +241,6 @@ function plugin_file_include( $p_filename, $p_basename = null ) {
 	$t_file_info_type = file_get_mime_type( $t_file_path );
 	if( $t_file_info_type !== false ) {
 		$t_content_type = $t_file_info_type;
-	}
-
-	# allow overriding the content type for specific text and image extensions
-	# see bug #13193 for details
-	if( strpos( $t_content_type, 'text/' ) === 0 || strpos( $t_content_type, 'image/' ) === 0 ) {
-		$t_extension = pathinfo( $t_file_path, PATHINFO_EXTENSION );
-		if( $t_extension && array_key_exists( $t_extension, $g_plugin_mime_types ) ) {
-			$t_content_type =  $g_plugin_mime_types[$t_extension];
-		}
 	}
 
 	if( $t_content_type ) {

--- a/core/plugin_api.php
+++ b/core/plugin_api.php
@@ -263,7 +263,7 @@ function plugin_file_include( $p_filename, $p_basename = null ) {
 	header( 'Last-Modified: ' . gmdate( 'D, d M Y H:i:s \G\M\T', $t_mtime ) );
 	if( isset( $_SERVER['HTTP_IF_MODIFIED_SINCE'] )
 		&& ( $t_mtime <= strtotime( $_SERVER['HTTP_IF_MODIFIED_SINCE'] ) ) ) {
-		http_response_code( 304 );
+		http_response_code( HTTP_STATUS_NOT_MODIFIED );
 	} else {
 		readfile( $t_file_path );
 	}


### PR DESCRIPTION
* Instead of costly PHP detection, use own MIME type cache (assuming the plugins are trusted).
* Fix the 'Last-Modified' header.
* Replace the old 'text/javascript' with the actual 'application/javascript'.

Fixes: [35199](https://mantisbt.org/bugs/view.php?id=35199).
