### PR TITLE
Fix handling of relative URLs in helper_get_root_domain() 

### DIFF
--- a/core/config_api.php
+++ b/core/config_api.php
@@ -246,15 +246,19 @@ function config_get_access( $p_option, $p_user = null, $p_project = null ) {
 }
 
 /**
- * Returns true if the specified configuration option exists (Either a
- * value or default can be found), false otherwise
+ * Checks if the specified configuration option exists as an override in the
+ * database.
  *
- * @param string  $p_option  Configuration option.
- * @param integer $p_user    A user identifier.
- * @param integer $p_project A project identifier.
- * @return boolean
+ * @param string $p_option  Configuration option.
+ * @param int    $p_user    A user identifier.
+ * @param int    $p_project A project identifier.
+ *
+ * @return bool True if the option exists, false otherwise.
+ *
+ * @since 2.28.0
  */
-function config_is_set( $p_option, $p_user = null, $p_project = null ) {
+
+function config_is_set_in_database( $p_option, $p_user = null, $p_project = null ) {
 	global $g_cache_config, $g_cache_filled;
 
 	if( !$g_cache_filled ) {
@@ -265,8 +269,11 @@ function config_is_set( $p_option, $p_user = null, $p_project = null ) {
 	$t_users = array( ALL_USERS );
 	if( ( null === $p_user ) && ( auth_is_user_authenticated() ) ) {
 		$t_users[] = auth_get_current_user_id();
-	} else if( !in_array( $p_user, $t_users ) ) {
-		$t_users[] = $p_user;
+	}
+	else {
+		if( !in_array( $p_user, $t_users ) ) {
+			$t_users[] = $p_user;
+		}
 	}
 	$t_users[] = ALL_USERS;
 
@@ -277,8 +284,11 @@ function config_is_set( $p_option, $p_user = null, $p_project = null ) {
 		if( ALL_PROJECTS <> $t_selected_project ) {
 			$t_projects[] = $t_selected_project;
 		}
-	} else if( !in_array( $p_project, $t_projects ) ) {
-		$t_projects[] = $p_project;
+	}
+	else {
+		if( !in_array( $p_project, $t_projects ) ) {
+			$t_projects[] = $p_project;
+		}
 	}
 
 	foreach( $t_users as $t_user ) {
@@ -289,7 +299,24 @@ function config_is_set( $p_option, $p_user = null, $p_project = null ) {
 		}
 	}
 
-	return isset( $GLOBALS['g_' . $p_option] );
+	return false;
+}
+
+/**
+ * Checks if the specified configuration option exists anywhere.
+ *
+ * Returns true if either a value in the database or a default defined in a
+ * global variable can be found.
+ *
+ * @param string $p_option  Configuration option.
+ * @param int    $p_user    A user identifier.
+ * @param int    $p_project A project identifier.
+ *
+ * @return bool True if the option exists, false otherwise.
+ */
+function config_is_set( $p_option, $p_user = null, $p_project = null ) {
+	return config_is_set_in_database( $p_option, $p_user, $p_project )
+		|| isset( $GLOBALS['g_' . $p_option] );
 }
 
 /**

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -625,6 +625,25 @@ function helper_mantis_url( $p_url ) {
 }
 
 /**
+ * Check if URL is external.
+ *
+ * @param string $p_url Url to check.
+ *
+ * @return bool True if URL does not belong to the same root domain as MantisBT
+ *              {@see $g_path}, false if it does.
+ */
+function helper_is_link_external( string $p_url ): bool {
+	$t_link_root_domain = helper_get_root_domain( $p_url );
+	if( !$t_link_root_domain ) {
+		# No domain = relative URL = internal
+		return false;
+	}
+
+	$t_mantis_root_domain = helper_get_root_domain( config_get_global( 'path' ) );
+	return $t_link_root_domain != $t_mantis_root_domain;
+}
+
+/**
  * convert a duration string in "[h]h:mm" to an integer (minutes)
  * @param string $p_hhmm A string in [h]h:mm format to convert.
  * @param string $p_field The field name.
@@ -924,6 +943,9 @@ function helper_get_link_attributes( $p_return_array = true, $p_is_external_link
  */
 function helper_get_root_domain( $p_url ) {
 	$t_host = parse_url( $p_url, PHP_URL_HOST );
+	if( !$t_host ) {
+		return '';
+	}
 	if ( filter_var( $t_host, FILTER_VALIDATE_IP ) ) {
 		return $t_host; // Return IP address as is
 	}

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -520,11 +520,9 @@ function string_insert_hrefs( $p_string ) {
 		$s_url_regex,
 		function ( $p_match ) {
 			$t_url = $p_match[1];
-			# Check if link is external
-			$t_mantis_root_domain = helper_get_root_domain( config_get_global( 'path' ) );
-			$p_is_external_link = $t_mantis_root_domain != helper_get_root_domain( $t_url );
+			$t_is_external_link = helper_is_link_external( $t_url );
 			# Set the link's target and type according to configuration
-			$t_link_attributes = helper_get_link_attributes( false, $p_is_external_link );
+			$t_link_attributes = helper_get_link_attributes( false, $t_is_external_link );
 			$t_url_href = 'href="' . rtrim( $t_url, '.' ) . '"';
 			return "<a {$t_url_href}{$t_link_attributes}>{$t_url}</a>";
 		},

--- a/plugins/MantisCoreFormatting/core/MantisMarkdown.php
+++ b/plugins/MantisCoreFormatting/core/MantisMarkdown.php
@@ -250,11 +250,10 @@ class MantisMarkdown extends Parsedown
 	{
 		if( isset( $Excerpt['element']['attributes'] ) ) {
 			# Check if link is external
-			$t_mantis_root_domain = helper_get_root_domain( config_get_global( 'path' ) );
-			$p_is_external_link = $t_mantis_root_domain != helper_get_root_domain( $Excerpt['element']['attributes']['href'] );
+			$t_is_external_link = helper_is_link_external( $Excerpt['element']['attributes']['href'] );
 			$Excerpt['element']['attributes'] = array_replace(
 				$Excerpt['element']['attributes'],
-				helper_get_link_attributes( true, $p_is_external_link )
+				helper_get_link_attributes( true, $t_is_external_link )
 			);
 		}
 

--- a/tests/Mantis/Helper/GetLinkAttributesTest.php
+++ b/tests/Mantis/Helper/GetLinkAttributesTest.php
@@ -60,7 +60,13 @@ class GetLinkAttributesTest extends MantisCoreBase
 		$this->restoreConfig( self::CFG_MAKE_LINKS, $t_old );
 	}
 
-	public function provideConfigurations(): \Generator {
+	public function provideConfigurations(): Generator {
+		yield 'LINKS_SAME_WINDOW' => [
+			LINKS_SAME_WINDOW,
+			'',
+			[],
+		];
+
 		yield 'LINKS_NEW_WINDOW' => [
 			LINKS_NEW_WINDOW,
 			'target="_blank"',

--- a/tests/Mantis/Helper/GetLinkAttributesTest.php
+++ b/tests/Mantis/Helper/GetLinkAttributesTest.php
@@ -33,6 +33,8 @@ require_once dirname( __DIR__ ) . '/MantisCoreBase.php';
  */
 class GetLinkAttributesTest extends MantisCoreBase
 {
+	const CFG_MAKE_LINKS = 'html_make_links';
+
 	/**
 	 * Link attributes are correctly created according to the
 	 * configuration of "$g_html_make_links"
@@ -48,12 +50,14 @@ class GetLinkAttributesTest extends MantisCoreBase
 	 * @dataProvider provideConfigurations
 	 */
 	public function testHelperReturnsArrayOrString( int $p_config, string $p_string, array $p_array ): void {
-		config_set('html_make_links', $p_config );
+		$t_old = $this->setConfig( self::CFG_MAKE_LINKS, $p_config );
 
 		# 1.
 		$this->assertSame( $p_array, helper_get_link_attributes() );
 		# 2.
 		$this->assertSame( $p_string, trim( helper_get_link_attributes( false ) ) );
+
+		$this->restoreConfig( self::CFG_MAKE_LINKS, $t_old );
 	}
 
 	public function provideConfigurations(): \Generator {

--- a/tests/Mantis/Helper/GetLinkAttributesTest.php
+++ b/tests/Mantis/Helper/GetLinkAttributesTest.php
@@ -37,20 +37,20 @@ class GetLinkAttributesTest extends MantisCoreBase
 
 	/**
 	 * Link attributes are correctly created according to the
-	 * configuration of "$g_html_make_links"
+	 * configuration of {@see $g_html_make_links}.
 	 *
 	 * 1. Helper returns an array on default.
 	 * 2. Helper returns the attributes as a string if the
 	 *    argument "p_return_array" is set to false.
 	 *
-	 * @param int $p_config                  The configuration for "$g_html_make_links"
+	 * @param int $p_value                   Value for $g_html_make_links config
 	 * @param string $p_string               The expected result as a string
 	 * @param array<string, string> $p_array The expected result as an array
 	 *
 	 * @dataProvider provideConfigurations
 	 */
-	public function testHelperReturnsArrayOrString( int $p_config, string $p_string, array $p_array ): void {
-		$t_old = $this->setConfig( self::CFG_MAKE_LINKS, $p_config );
+	public function testHelperReturnsArrayOrString( int $p_value, string $p_string, array $p_array ): void {
+		$t_old = $this->setConfig( self::CFG_MAKE_LINKS, $p_value );
 
 		# 1.
 		$this->assertSame( $p_array, helper_get_link_attributes() );

--- a/tests/Mantis/MantisCoreBase.php
+++ b/tests/Mantis/MantisCoreBase.php
@@ -104,5 +104,34 @@ abstract class MantisCoreBase extends PHPUnit\Framework\TestCase {
 		);
 	}
 
+	/**
+	 * Sets the given configuration and returns its old value.
+	 *
+	 * @param string $p_config Configuration option name.
+	 * @param mixed  $p_value  Configuration option value.
+	 *
+	 * @return mixed The config's old value, false if it was not set in the database.
+	 */
+	protected function setConfig( string $p_config, $p_value ) {
+		$t_old = config_is_set_in_database( $p_config ) ? config_get( $p_config ) : false;
+		config_set( $p_config, $p_value );
+
+		return $t_old;
+	}
+
+	/**
+	 * Restores a configuration to its initial state.
+	 *
+	 * @param string $p_config Configuration option name.
+	 * @param mixed  $p_value  Configuration option value. If false, the config
+	 *                         will be deleted.
+	 */
+	protected function restoreConfig( string $p_config, $p_value ) {
+		if( $p_value === false ) {
+			config_delete( $p_config );
+		} else {
+			config_set( $p_config, $p_value );
+		}
+	}
 }
 


### PR DESCRIPTION
Fixes [#35210](https://mantisbt.org/bugs/view.php?id=35210) 

Also improves PHPUnit tests 
- New config_is_set_in_database() API function ([#35211](https://mantisbt.org/bugs/view.php?id=35211)), required for:
- Allows to set/restore configs ([#35212](https://mantisbt.org/bugs/view.php?id=35212))
- New test cases covering helper_is_link_external() and LINKS_NOFOLLOW_EXTERNAL
- Add missing data set for LINKS_SAME_WINDOW 
- Code cleanup