### PR TITLE
PHPUnit 11.5 compatibility fix

### DIFF
--- a/plugins/MantisCoreFormatting/tests/MarkdownTest.php
+++ b/plugins/MantisCoreFormatting/tests/MarkdownTest.php
@@ -267,7 +267,7 @@ EOD;
 		$this->assertSame( '<p>' . $t_sample . '</p>', $this->parser->convert( $t_sample, true ) );
 	}
 
-	public function provideHeaders(): Generator {
+	static public function provideHeaders(): Generator {
 		# Valid headers
 		yield  'valid: # foo' => ['# foo', '<h1>foo</h1>'];
 		yield  'valid: ## foo' => ['## foo', '<h2>foo</h2>'];
@@ -303,7 +303,7 @@ EOD;
 	 * tested by the Parsedown tests. But they ensure that the Parsedown process is
 	 * not affected in any way, no matter what the value of "process_urls" is.
 	 */
-	public function provideEmails(): Generator {
+	static public function provideEmails(): Generator {
 		yield 'process_urls = ON; lorem <user@exmaple.com> ipsum' => [
 			'lorem <user@exmaple.com> ipsum',
 			ON,
@@ -358,7 +358,7 @@ EOD;
 	 * tested by the Parsedown tests. But they ensure that the Parsedown process is
 	 * not affected in any way, no matter what the value of "process_urls" is.
 	 */
-	public function provideUrls(): Generator {
+	static public function provideUrls(): Generator {
 		yield 'process_urls = ON; lorem <https://exmaple.com> ipsum' => [
 			'lorem <https://exmaple.com> ipsum',
 			ON,

--- a/plugins/MantisCoreFormatting/tests/MarkdownTest.php
+++ b/plugins/MantisCoreFormatting/tests/MarkdownTest.php
@@ -267,7 +267,7 @@ EOD;
 		$this->assertSame( '<p>' . $t_sample . '</p>', $this->parser->convert( $t_sample, true ) );
 	}
 
-	static public function provideHeaders(): Generator {
+	public static function provideHeaders(): Generator {
 		# Valid headers
 		yield  'valid: # foo' => ['# foo', '<h1>foo</h1>'];
 		yield  'valid: ## foo' => ['## foo', '<h2>foo</h2>'];
@@ -303,7 +303,7 @@ EOD;
 	 * tested by the Parsedown tests. But they ensure that the Parsedown process is
 	 * not affected in any way, no matter what the value of "process_urls" is.
 	 */
-	static public function provideEmails(): Generator {
+	public static function provideEmails(): Generator {
 		yield 'process_urls = ON; lorem <user@exmaple.com> ipsum' => [
 			'lorem <user@exmaple.com> ipsum',
 			ON,
@@ -358,7 +358,7 @@ EOD;
 	 * tested by the Parsedown tests. But they ensure that the Parsedown process is
 	 * not affected in any way, no matter what the value of "process_urls" is.
 	 */
-	static public function provideUrls(): Generator {
+	public static function provideUrls(): Generator {
 		yield 'process_urls = ON; lorem <https://exmaple.com> ipsum' => [
 			'lorem <https://exmaple.com> ipsum',
 			ON,

--- a/tests/Mantis/ConfigParserTest.php
+++ b/tests/Mantis/ConfigParserTest.php
@@ -201,7 +201,7 @@ class ConfigParserTest extends MantisCoreBase {
 	 *   <test case> => array( <string to test>, <expected type> )
 	 * @return array
 	 */
-	static public function providerScalarTypes() {
+	public static function providerScalarTypes() {
 		return array(
 			'Integer Zero' => array( '0', IsType::TYPE_INT ),
 			'Integer One' => array( '1', IsType::TYPE_INT ),
@@ -242,7 +242,7 @@ class ConfigParserTest extends MantisCoreBase {
 	 * @return array
 	 * Initialize the array test cases list
 	 */
-	static public function providerArrays() {
+	public static function providerArrays() {
 		/**
 		 * Template for new test cases
 		 * ---------------------------

--- a/tests/Mantis/ConfigParserTest.php
+++ b/tests/Mantis/ConfigParserTest.php
@@ -201,7 +201,7 @@ class ConfigParserTest extends MantisCoreBase {
 	 *   <test case> => array( <string to test>, <expected type> )
 	 * @return array
 	 */
-	public function providerScalarTypes() {
+	static public function providerScalarTypes() {
 		return array(
 			'Integer Zero' => array( '0', IsType::TYPE_INT ),
 			'Integer One' => array( '1', IsType::TYPE_INT ),
@@ -242,7 +242,7 @@ class ConfigParserTest extends MantisCoreBase {
 	 * @return array
 	 * Initialize the array test cases list
 	 */
-	public function providerArrays() {
+	static public function providerArrays() {
 		/**
 		 * Template for new test cases
 		 * ---------------------------

--- a/tests/Mantis/Helper/ArrayTransposeTest.php
+++ b/tests/Mantis/Helper/ArrayTransposeTest.php
@@ -71,7 +71,7 @@ class ArrayTransposeTest extends MantisCoreBase {
 	 * helper_array_transpose() should successfully transpose <test matrix>
 	 * into <expected transposition>.
 	 */
-	public function providerArrayTransposeValid(): Generator
+	static public function providerArrayTransposeValid(): Generator
 	{
 		yield 'Bidimensional simple array' => [
 			[['a'], ['b']],
@@ -125,7 +125,7 @@ class ArrayTransposeTest extends MantisCoreBase {
 	 *
 	 * @return Generator List of test cases
 	 */
-	public function providerArrayTransposeInvalid(): Generator {
+	static public function providerArrayTransposeInvalid(): Generator {
 		yield 'Simple array' => [
 			[1, 2]
 		];

--- a/tests/Mantis/Helper/ArrayTransposeTest.php
+++ b/tests/Mantis/Helper/ArrayTransposeTest.php
@@ -71,7 +71,7 @@ class ArrayTransposeTest extends MantisCoreBase {
 	 * helper_array_transpose() should successfully transpose <test matrix>
 	 * into <expected transposition>.
 	 */
-	static public function providerArrayTransposeValid(): Generator
+	public static function providerArrayTransposeValid(): Generator
 	{
 		yield 'Bidimensional simple array' => [
 			[['a'], ['b']],
@@ -125,7 +125,7 @@ class ArrayTransposeTest extends MantisCoreBase {
 	 *
 	 * @return Generator List of test cases
 	 */
-	static public function providerArrayTransposeInvalid(): Generator {
+	public static function providerArrayTransposeInvalid(): Generator {
 		yield 'Simple array' => [
 			[1, 2]
 		];

--- a/tests/Mantis/Helper/GetLinkAttributesTest.php
+++ b/tests/Mantis/Helper/GetLinkAttributesTest.php
@@ -61,7 +61,7 @@ class GetLinkAttributesTest extends MantisCoreBase
 		$this->restoreConfig( self::CFG_MAKE_LINKS, $t_old );
 	}
 
-	public function provideConfigurations(): Generator {
+	static public function provideConfigurations(): Generator {
 		yield 'LINKS_SAME_WINDOW' => [
 			LINKS_SAME_WINDOW,
 			'',
@@ -123,7 +123,7 @@ class GetLinkAttributesTest extends MantisCoreBase
 		$this->assertEquals( $p_external, helper_is_link_external( $p_url ), "URL is external" );
 	}
 
-	public function providerLinks(): Generator {
+	static public function providerLinks(): Generator {
 		yield 'External URL' => [
 			'https://example.com',
 			'external' => true,
@@ -163,7 +163,7 @@ class GetLinkAttributesTest extends MantisCoreBase
 		$this->restoreConfig( self::CFG_MAKE_LINKS, $t_old );
 	}
 
-	public function providerNoFollow(): Generator {
+	static public function providerNoFollow(): Generator {
 		yield 'LINKS_NOFOLLOW_EXTERNAL' => [
 			LINKS_NOFOLLOW_EXTERNAL,
 			'internal' => [],

--- a/tests/Mantis/Helper/GetLinkAttributesTest.php
+++ b/tests/Mantis/Helper/GetLinkAttributesTest.php
@@ -61,7 +61,7 @@ class GetLinkAttributesTest extends MantisCoreBase
 		$this->restoreConfig( self::CFG_MAKE_LINKS, $t_old );
 	}
 
-	static public function provideConfigurations(): Generator {
+	public static function provideConfigurations(): Generator {
 		yield 'LINKS_SAME_WINDOW' => [
 			LINKS_SAME_WINDOW,
 			'',
@@ -123,7 +123,7 @@ class GetLinkAttributesTest extends MantisCoreBase
 		$this->assertEquals( $p_external, helper_is_link_external( $p_url ), "URL is external" );
 	}
 
-	static public function providerLinks(): Generator {
+	public static function providerLinks(): Generator {
 		yield 'External URL' => [
 			'https://example.com',
 			true,
@@ -163,7 +163,7 @@ class GetLinkAttributesTest extends MantisCoreBase
 		$this->restoreConfig( self::CFG_MAKE_LINKS, $t_old );
 	}
 
-	static public function providerNoFollow(): Generator {
+	public static function providerNoFollow(): Generator {
 		yield 'LINKS_NOFOLLOW_EXTERNAL' => [
 			LINKS_NOFOLLOW_EXTERNAL,
 			[],

--- a/tests/Mantis/Helper/GetLinkAttributesTest.php
+++ b/tests/Mantis/Helper/GetLinkAttributesTest.php
@@ -126,18 +126,18 @@ class GetLinkAttributesTest extends MantisCoreBase
 	static public function providerLinks(): Generator {
 		yield 'External URL' => [
 			'https://example.com',
-			'external' => true,
+			true,
 		];
 
 		$t_path = config_get_global('path' );
 		yield 'Mantis URL' => [
 			$t_path,
-			'external' => false,
+			false,
 		];
 
 		yield 'Relative URL' => [
 			'/index.html',
-			'external' => false,
+			false,
 		];
 	}
 
@@ -166,14 +166,14 @@ class GetLinkAttributesTest extends MantisCoreBase
 	static public function providerNoFollow(): Generator {
 		yield 'LINKS_NOFOLLOW_EXTERNAL' => [
 			LINKS_NOFOLLOW_EXTERNAL,
-			'internal' => [],
-			'external' => ['rel' => 'nofollow'],
+			[],
+			['rel' => 'nofollow'],
 		];
 
 		yield 'LINKS_NOOPENER | LINKS_NOFOLLOW_EXTERNAL' => [
 			LINKS_NOOPENER | LINKS_NOFOLLOW_EXTERNAL,
-			'internal' => ['rel' => 'noopener'],
-			'external' => ['rel' => 'noopener,nofollow'],
+			['rel' => 'noopener'],
+			['rel' => 'noopener,nofollow'],
 		];
 	}
 }

--- a/tests/Mantis/MentionParsingTest.php
+++ b/tests/Mantis/MentionParsingTest.php
@@ -55,7 +55,7 @@ class MentionParsingTest extends MantisCoreBase {
 	 *   <test case> => array( <string to test>, <list of expected mentions>)
 	 * @return array
 	 */
-	public function provider() {
+	static public function provider() {
 		return array(
 			'NoMention' => array(
 				'some random string.',

--- a/tests/Mantis/MentionParsingTest.php
+++ b/tests/Mantis/MentionParsingTest.php
@@ -55,7 +55,7 @@ class MentionParsingTest extends MantisCoreBase {
 	 *   <test case> => array( <string to test>, <list of expected mentions>)
 	 * @return array
 	 */
-	static public function provider() {
+	public static function provider() {
 		return array(
 			'NoMention' => array(
 				'some random string.',

--- a/tests/Mantis/PluginTest.php
+++ b/tests/Mantis/PluginTest.php
@@ -101,7 +101,7 @@ class PluginTest extends MantisCoreBase {
 	 *
 	 * @return array List of test cases
 	 */
-	public function providerDependency() {
+	static public function providerDependency() {
 		return array(
 			array( '1.3.0', self::REQ_13, true ),
 			array( '1.3.0', self::REQ_130, true ),

--- a/tests/Mantis/PluginTest.php
+++ b/tests/Mantis/PluginTest.php
@@ -101,7 +101,7 @@ class PluginTest extends MantisCoreBase {
 	 *
 	 * @return array List of test cases
 	 */
-	static public function providerDependency() {
+	public static function providerDependency() {
 		return array(
 			array( '1.3.0', self::REQ_13, true ),
 			array( '1.3.0', self::REQ_130, true ),

--- a/tests/Mantis/PrepareTest.php
+++ b/tests/Mantis/PrepareTest.php
@@ -49,7 +49,7 @@ class PrepareTest extends MantisCoreBase {
 	 * Data provider for prepare_mailto_url() test
 	 * @return array
 	 */
-	public function providerMailTo() {
+	static public function providerMailTo() {
 		$t_test_data = array(
 			'Basic' => array( array( self::EMAIL, ''), 'mailto:' . self::EMAIL ),
 			'Subject' => array( array( self::EMAIL, 'subject'), 'mailto:' . self::EMAIL . '?subject=subject' ),
@@ -87,7 +87,7 @@ class PrepareTest extends MantisCoreBase {
 	 * @see testEmailLink
 	 * @return array
 	 */
-	public function providerEmailLink() {
+	static public function providerEmailLink() {
 		$t_email = self::EMAIL;
 		$t_text = 'Link Text';
 		$t_tooltip = 'Tooltip';

--- a/tests/Mantis/PrepareTest.php
+++ b/tests/Mantis/PrepareTest.php
@@ -49,7 +49,7 @@ class PrepareTest extends MantisCoreBase {
 	 * Data provider for prepare_mailto_url() test
 	 * @return array
 	 */
-	static public function providerMailTo() {
+	public static function providerMailTo() {
 		$t_test_data = array(
 			'Basic' => array( array( self::EMAIL, ''), 'mailto:' . self::EMAIL ),
 			'Subject' => array( array( self::EMAIL, 'subject'), 'mailto:' . self::EMAIL . '?subject=subject' ),
@@ -87,7 +87,7 @@ class PrepareTest extends MantisCoreBase {
 	 * @see testEmailLink
 	 * @return array
 	 */
-	static public function providerEmailLink() {
+	public static function providerEmailLink() {
 		$t_email = self::EMAIL;
 		$t_text = 'Link Text';
 		$t_tooltip = 'Tooltip';

--- a/tests/Mantis/StringTest.php
+++ b/tests/Mantis/StringTest.php
@@ -60,7 +60,7 @@ class StringTest extends MantisCoreBase {
 	 * Data provider for string sanitize test
 	 * @return array
 	 */
-	public function provider() {
+	static public function provider() {
 		$t_test_strings = array(
 			array( '', 'index.php' ),
 			array( 'abc.php', 'abc.php' ),

--- a/tests/Mantis/StringTest.php
+++ b/tests/Mantis/StringTest.php
@@ -60,7 +60,7 @@ class StringTest extends MantisCoreBase {
 	 * Data provider for string sanitize test
 	 * @return array
 	 */
-	static public function provider() {
+	public static function provider() {
 		$t_test_strings = array(
 			array( '', 'index.php' ),
 			array( 'abc.php', 'abc.php' ),

--- a/tests/Mantis/UserApiTest.php
+++ b/tests/Mantis/UserApiTest.php
@@ -81,7 +81,7 @@ class UserApiTest extends MantisCoreBase {
 	 *
 	 * @return array [email_address, user_id, unique]
 	 */
-	public function providerEmailUnique() {
+	static public function providerEmailUnique() {
 		[$t_user, $t_domain] = explode( '@', self::TEST_EMAIL );
 		$t_user_sql_like_pattern = substr_replace( $t_user, '_', 1, 1 );
 

--- a/tests/Mantis/UserApiTest.php
+++ b/tests/Mantis/UserApiTest.php
@@ -81,7 +81,7 @@ class UserApiTest extends MantisCoreBase {
 	 *
 	 * @return array [email_address, user_id, unique]
 	 */
-	static public function providerEmailUnique() {
+	public static function providerEmailUnique() {
 		[$t_user, $t_domain] = explode( '@', self::TEST_EMAIL );
 		$t_user_sql_like_pattern = substr_replace( $t_user, '_', 1, 1 );
 

--- a/tests/rest/RestIssueTest.php
+++ b/tests/rest/RestIssueTest.php
@@ -406,7 +406,7 @@ class RestIssueTest extends RestBase {
 	 * @return array List of test cases
 	 *
 	 */
-	public function providerTagsInvalid() {
+	static public function providerTagsInvalid() {
 		return array(
 			'EmptyTagElement' => array(
 				array(),

--- a/tests/rest/RestIssueTest.php
+++ b/tests/rest/RestIssueTest.php
@@ -406,7 +406,7 @@ class RestIssueTest extends RestBase {
 	 * @return array List of test cases
 	 *
 	 */
-	static public function providerTagsInvalid() {
+	public static function providerTagsInvalid() {
 		return array(
 			'EmptyTagElement' => array(
 				array(),

--- a/tests/rest/RestIssueUpdateVersion.php
+++ b/tests/rest/RestIssueUpdateVersion.php
@@ -143,7 +143,7 @@ class RestIssueUpdateVersion extends RestBase
 	 *
 	 * @return Generator List of test cases
 	 */
-	static public function providerUnsetVersionSuccess(): Generator {
+	public static function providerUnsetVersionSuccess(): Generator {
 		yield 'Version with id 0' => [ ['id' => 0], HTTP_STATUS_SUCCESS ];
 
 		# According to @vboctor these test cases should actually fail, but don't...
@@ -174,7 +174,7 @@ class RestIssueUpdateVersion extends RestBase
 	 *    <case> => array( <version payload>, <expected status code> )
 	 *
 	 */
-	static public function providerUnsetVersionFailure(): Generator {
+	public static function providerUnsetVersionFailure(): Generator {
 		# This is a dummy test case, to avoid a PHPUnit warning when the
 		# Provider returns nothing.
 		yield 'dummy' => [ ['id' => -1], HTTP_STATUS_BAD_REQUEST ];

--- a/tests/rest/RestIssueUpdateVersion.php
+++ b/tests/rest/RestIssueUpdateVersion.php
@@ -143,7 +143,7 @@ class RestIssueUpdateVersion extends RestBase
 	 *
 	 * @return Generator List of test cases
 	 */
-	public function providerUnsetVersionSuccess(): Generator {
+	static public function providerUnsetVersionSuccess(): Generator {
 		yield 'Version with id 0' => [ ['id' => 0], HTTP_STATUS_SUCCESS ];
 
 		# According to @vboctor these test cases should actually fail, but don't...
@@ -174,7 +174,7 @@ class RestIssueUpdateVersion extends RestBase
 	 *    <case> => array( <version payload>, <expected status code> )
 	 *
 	 */
-	public function providerUnsetVersionFailure(): Generator {
+	static public function providerUnsetVersionFailure(): Generator {
 		# This is a dummy test case, to avoid a PHPUnit warning when the
 		# Provider returns nothing.
 		yield 'dummy' => [ ['id' => -1], HTTP_STATUS_BAD_REQUEST ];

--- a/tests/rest/RestProjectVersionTest.php
+++ b/tests/rest/RestProjectVersionTest.php
@@ -308,7 +308,7 @@ class RestProjectVersionTest extends RestBase {
 	 *
 	 * @return array The test data
 	 */
-	public function providerVersionInvalidNames() {
+	static public function providerVersionInvalidNames() {
 		return array(
 			'empty' =>array( '' ),
 			'blank' => array( '   ' ),

--- a/tests/rest/RestProjectVersionTest.php
+++ b/tests/rest/RestProjectVersionTest.php
@@ -308,7 +308,7 @@ class RestProjectVersionTest extends RestBase {
 	 *
 	 * @return array The test data
 	 */
-	static public function providerVersionInvalidNames() {
+	public static function providerVersionInvalidNames() {
 		return array(
 			'empty' =>array( '' ),
 			'blank' => array( '   ' ),

--- a/tests/rest/RestUserTest.php
+++ b/tests/rest/RestUserTest.php
@@ -578,7 +578,7 @@ class RestUserTest extends RestBase {
 	 *
 	 * @return array test cases
 	 */
-	static public function providerInvalidUserNames() {
+	public static function providerInvalidUserNames() {
 		return array(
 			'blank_spaces' => array( ' ' ),
 			'blank_tabs' => array( "\t" ),
@@ -592,7 +592,7 @@ class RestUserTest extends RestBase {
 	 *
 	 * @return array test cases
 	 */
-	static public function providerValidUserNames() {
+	public static function providerValidUserNames() {
 		return array(
 			'regular' => array( Faker::username() ),
 			'with_spaces_in_middle' => array( "some user" ),

--- a/tests/rest/RestUserTest.php
+++ b/tests/rest/RestUserTest.php
@@ -578,7 +578,7 @@ class RestUserTest extends RestBase {
 	 *
 	 * @return array test cases
 	 */
-	public function providerInvalidUserNames() {
+	static public function providerInvalidUserNames() {
 		return array(
 			'blank_spaces' => array( ' ' ),
 			'blank_tabs' => array( "\t" ),
@@ -592,7 +592,7 @@ class RestUserTest extends RestBase {
 	 *
 	 * @return array test cases
 	 */
-	public function providerValidUserNames() {
+	static public function providerValidUserNames() {
 		return array(
 			'regular' => array( Faker::username() ),
 			'with_spaces_in_middle' => array( "some user" ),


### PR DESCRIPTION
Provider functions should be static.

Some GetLinkAttributesTest.php providers has mistyped parameter names (9cb002ec8ec401f8f7fca455f16834eb2f5d4036).

Fixes [#35223](https://mantisbt.org/bugs/view.php?id=35223).
