### PR TITLE
Do not display project name when category is not set

### DIFF
--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -1317,8 +1317,11 @@ function print_column_category_id( BugData $p_bug, $p_columns_target = COLUMNS_T
 	echo '<td class="column-category">';
 	echo '<div class="align-left">';
 
-	# type project name if viewing 'all projects' or if issue is in a subproject
-	if( ON == config_get( 'show_bug_project_links' ) && helper_get_current_project() != $p_bug->project_id ) {
+	# If category is set, type project name when viewing 'all projects' or if issue is in a subproject
+	if( ON == config_get( 'show_bug_project_links' )
+		&& helper_get_current_project() != $p_bug->project_id
+		&& $p_bug->category_id != 0
+	) {
 		echo '<span class="small project">[';
 		print_view_bug_sort_link( string_display_line( $t_project_name ), 'project_id', $t_sort, $t_dir, $p_columns_target );
 		echo ']</span>&#160;&#160;';


### PR DESCRIPTION
In projects with allow_no_category = ON, an Issue's category can be 0 (= no category), which by definition does not belong to any project so it does not make sense to prefix it with the project name in View issues page.

Fixes [#35235](https://mantisbt.org/bugs/view.php?id=35235)