### PR TITLE
When moving issues, disable current project

### DIFF
--- a/bug_actiongroup_page.php
+++ b/bug_actiongroup_page.php
@@ -333,8 +333,13 @@ if( $t_multiple_projects ) {
 			switch( $f_action ) {
 				case 'COPY':
 				case 'MOVE':
-					print_project_option_list( null /* $p_project_id */, false /* $p_include_all_projects */,
-							null /* $p_filter_project_id */, false /* $p_trace */, true /* $p_can_report_only */ );
+					print_project_option_list(
+						null,
+						false,
+						$t_multiple_projects ? null : $t_project_id,
+						false,
+						true
+					);
 					break;
 				case 'ASSIGN':
 					print_assign_to_option_list( 0, $t_project_id );

--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -518,50 +518,19 @@ $g_email_notifications_verbose = OFF;
 /**
  * Sets the default email notifications values for different user categories.
  *
- * In combination with *notify_flags* (see below), this config option controls
+ * In combination with {@see $g_notify_flags}, this config option controls
  * who should get email notifications on different actions/statuses.
  *
  * The user categories are:
- *
- *      'reporter': the reporter of the bug
- *       'handler': the handler of the bug
- *       'monitor': users who are monitoring a bug
- *      'bugnotes': users who have added a bugnote to the bug
- *      'category': category owners
- *      'explicit': users who are explicitly specified by the code based on the
- *                  action (e.g. user added to monitor list).
- * 'threshold_max': all users with access <= max
- * 'threshold_min': ..and with access >= min
- *
- * The second config option (notify_flags) sets overrides for specific
- * actions/statuses. If a user category is not listed for an action, the
- * default from the config option above is used.  The possible actions are:
- *
- *             'new': a new bug has been added
- *           'owner': a bug has been assigned to a new owner
- *        'reopened': a bug has been reopened
- *         'deleted': a bug has been deleted
- *         'updated': a bug has been updated
- *         'bugnote': a bugnote has been added to a bug
- *         'sponsor': sponsorship has changed on this bug
- *        'relation': a relationship has changed on this bug
- *         'monitor': an issue is monitored.
- *        '<status>': eg: 'resolved', 'closed', 'feedback', 'acknowledged', etc.
- *                     this list corresponds to $g_status_enum_string
- *
- * Examples:
- * - If you wanted to have all developers get notified of new bugs you might
- *   add the following lines to your config file:
- *
- *   $g_notify_flags['new']['threshold_min'] = DEVELOPER;
- *   $g_notify_flags['new']['threshold_max'] = DEVELOPER;
- *
- * - You might want to do something similar so all managers are notified when a
- *   bug is closed.
- * - If you did not want reporters to be notified when a bug is closed
- *   (only when it is resolved) you would use:
- *
- *   $g_notify_flags['closed']['reporter'] = OFF;
+ # - `reporter`:      the Issue's reporter
+ * - `handler`:       the user assigned to the Issue
+ * - `monitor`:       users who are monitoring the Issue
+ * - `bugnotes`:      users who have added a bugnote to the Issue
+ * - `category`:      category owners
+ * - `explicit`:      users who are explicitly specified by the code based on the
+ *                    action (e.g. user added to monitor list).
+ * - `threshold_max`: all users with access level <= max
+ * - `threshold_min`: ...and with access level >= min
  *
  * @see $g_notify_flags
  * @global array $g_default_notify_flags
@@ -580,12 +549,40 @@ $g_default_notify_flags = array(
 /**
  * Sets notifications overrides for specific actions/statuses.
  *
- * See above for detailed information. As an example of how to use this config
- * option, the default setting
+ * If a user category is not listed for an action, the default defined by
+ * {@see $g_default_notify_flags} is used.
+ *
+ * Possible actions are:
+ * - `new`:      a new Issue has been added
+ * - `owner`:    an Issue has been assigned to a new owner
+ * - `reopened`: an Issue has been reopened
+ * - `deleted`:  an Issue has been deleted
+ * - `updated`:  an Issue has been updated
+ * - `bugnote`:  a bugnote has been added to an Issue
+ * - `sponsor`:  sponsorship has changed on this Issue
+ * - `relation`: a relationship has changed on this Issue
+ * - `monitor`:  an Issue is monitored.
+ * - `<status>`: A status code, as defined in {@see $g_status_enum_string},
+ *               eg: 'resolved', 'closed', 'feedback', 'acknowledged`, etc.
+ *
+ * Examples:
+ *  - If you wanted to have all developers get notified of new bugs you could
+ *    add the following lines to your config file:
+ *
+ *    $g_notify_flags['new']['threshold_min'] = DEVELOPER;
+ *    $g_notify_flags['new']['threshold_max'] = DEVELOPER;
+ *
+ *  - You might want to do something similar so all managers are notified when a
+ *    bug is closed.
+ *  - If you did not want reporters to be notified when a bug is closed
+ *    (only when it is resolved) you would use:
+ *
+ *    $g_notify_flags['closed']['reporter'] = OFF;
+ *
+ * The default setting
  * - disables bugnotes notifications on new bugs (not needed in this case)
- * - disables all notifications for monitoring event, except explicit
- * example of how to use this config option.
-
+ * - disables all notifications for the monitoring event, except explicit
+ *
  * @see $g_default_notify_flags
  * @global array $g_notify_flags
  */

--- a/docbook/Admin_Guide/en-US/config/email.xml
+++ b/docbook/Admin_Guide/en-US/config/email.xml
@@ -63,123 +63,157 @@
 		<varlistentry>
 			<term>$g_default_notify_flags</term>
 			<listitem>
-				<para>Associates a default notification flag with each action,
-					to control who should be notified. The default will be used
-					if the action is not defined in <emphasis>$g_notify_flags</emphasis>
-					or if the flag is not included in the specific action definition.
+				<para>Sets the default email notifications values for different 
+					user categories.
 				</para>
-				<para>The list of actions include:
-					<emphasis>new</emphasis>,
-					<emphasis>assigned</emphasis>,
-					<emphasis>resolved</emphasis>,
-					<emphasis>bugnote</emphasis>,
-					<emphasis>reopened</emphasis>,
-					<emphasis>closed</emphasis>,
-					<emphasis>deleted</emphasis>,
-					<emphasis>feedback</emphasis>.
+				<para>In combination with <emphasis>$g_notify_flags</emphasis>, 
+					this config option controls who should get email notifications 
+					on different actions/statuses.
+
+					See <xref linkend="admin.customize.email" />
+					for examples of customizing the notification flags.
 				</para>
-				<para>The default is:
-<programlisting>
-$g_default_notify_flags = array(
-	'reporter'      =&gt; ON,
-	'handler'       =&gt; ON,
-	'monitor'       =&gt; ON,
-	'bugnotes'      =&gt; ON,
-	'category'      =&gt; ON,
-	'explicit'      =&gt; ON,
-	'threshold_min' =&gt; NOBODY,
-	'threshold_max' =&gt; NOBODY
-);
-</programlisting>
-					<emphasis>threshold_min</emphasis> and
-					<emphasis>threshold_max</emphasis> are used to send messages to all
-					members of the project whose status is
+				<para>The user categories are:
 					<itemizedlist>
-						<listitem>
-							<para>greater than or equal to <emphasis>threshold_min</emphasis>, and</para>
+						<listitem><para>
+							<literal>reporter</literal>:
+							the Issue's reporter
+							</para>
 						</listitem>
-						<listitem>
-							<para>less than or equal to <emphasis>threshold_max</emphasis>.</para>
+						<listitem><para>
+							<literal>handler</literal>:
+							the user assigned to the Issue
+							</para>
+						</listitem>
+						<listitem><para>
+							<literal>monitor</literal>:
+							users who are monitoring the Issue
+							</para>
+						</listitem>
+						<listitem><para>
+							<literal>bugnotes</literal>:
+							users who have added a bugnote to the Issue
+							</para>
+						</listitem>
+						<listitem><para>
+							<literal>category</literal>:
+							category owners
+							</para>
+						</listitem>
+						<listitem><para>
+							<literal>explicit</literal>:
+							users who are explicitly specified by the code based on the
+							action (e.g. user added to monitor list).
+							</para>
+						</listitem>
+						<listitem><para>
+							<literal>threshold_min</literal> and
+							<literal>threshold_max</literal> are used to send messages to all
+							members of the project whose access level is
+							<itemizedlist>
+								<listitem>
+									<para>greater than or equal to <emphasis>threshold_min</emphasis>, and</para>
+								</listitem>
+								<listitem>
+									<para>less than or equal to <emphasis>threshold_max</emphasis>.</para>
+								</listitem>
+							</itemizedlist>
+
+							To send notifications to everyone, set
+							<emphasis>threshold_min</emphasis> to ANYBODY and
+							<emphasis>threshold_max</emphasis> to NOBODY.
+							To send to all DEVELOPERS and above, use DEVELOPER and
+							NOBODY respectively.
+						</para>
 						</listitem>
 					</itemizedlist>
-				</para>
-				<para>Sending messages to everyone would set
-					<emphasis>threshold_min</emphasis> to ANYBODY and
-					<emphasis>threshold_max</emphasis> to NOBODY.
-					To send to all DEVELOPERS and above, use DEVELOPER and
-					NOBODY respectively.
 				</para>
 			</listitem>
 		</varlistentry>
 		<varlistentry>
 			<term>$g_notify_flags</term>
 			<listitem>
-				<para>Defines the specific notification flags when they are
-					different from the defaults defined in
-					<emphasis>$g_default_notify_flags</emphasis>.
+				<para>Sets notifications overrides for specific actions/statuses.
 				</para>
-				<para>For example, the following code overrides the default by
-					disabling notifications to bugnote authors and users
-					monitoring the bug when submitting a new bug:
-<programlisting>
-$g_notify_flags['new'] = array(
-	'bugnotes' =&gt; OFF,
-	'monitor' =&gt; OFF,
-);
-</programlisting>
-				See <xref linkend="admin.customize.email" />
-				for further examples of customizing the notification flags.
+				<para>If a user category is not listed for an action, the default 
+					defined by<emphasis>$g_default_notify_flags</emphasis> is used.
 				</para>
 				<para>Available actions include:
 					<itemizedlist>
 						<listitem>
-							<para><emphasis>new</emphasis>:
-								a new bug has been added
+							<para><literal>new</literal>:
+								a new Issue has been added
 							</para>
 						</listitem>
 						<listitem>
-							<para><emphasis>reopened</emphasis>:
-								the bug has been reopened
+							<para><literal>reopened</literal>:
+								an Issue has been reopened
 							</para>
 						</listitem>
 						<listitem>
-							<para><emphasis>deleted</emphasis>:
-								a bug has been deleted
+							<para><literal>deleted</literal>:
+								an Issue has been deleted
 							</para>
 						</listitem>
 						<listitem>
-							<para><emphasis>owner</emphasis>:
-								the bug has been assigned a new owner
+							<para><literal>owner</literal>:
+								an Issue has been assigned to a new owner
 							</para>
 						</listitem>
 						<listitem>
-							<para><emphasis>bugnote</emphasis>:
+							<para><literal>bugnote</literal>:
 								a bugnote has been added to a bug
 							</para>
 						</listitem>
 						<listitem>
-							<para><emphasis>sponsor</emphasis>:
-								the sponsorship for the bug has changed
+							<para><literal>sponsor</literal>:
+								the sponsorship for the Issue has changed
 								(added, deleted or updated)
 							</para>
 						</listitem>
 						<listitem>
-							<para><emphasis>relation</emphasis>:
-								a relationship for the bug has changed
+							<para><literal>relation</literal>:
+								a relationship for the Issue has changed
 								(added, deleted or updated)
 							</para>
 						</listitem>
 						<listitem>
-							<para><emphasis>monitor</emphasis>:
+							<para><literal>monitor</literal>:
 								a user is added to the monitor list.
 							</para>
 						</listitem>
+						<listitem>
+							<para><emphasis>status</emphasis>:
+								A status code, as defined in
+								<emphasis>$g_status_enum_string</emphasis>,
+								(see <xref linkend="admin.config.misc" />).
+								For example:
+								<emphasis>resolved</emphasis>,
+								<emphasis>closed</emphasis>,
+								<emphasis>feedback</emphasis>.
+								<emphasis>acknowledged</emphasis>,
+								etc.
+
+								<note><para>
+									Spaces in the status code are replaced with
+									underscores ('_') when creating the action.
+								</para>
+								</note>
+							</para>
+						</listitem>
 					</itemizedlist>
-					In addition, an action can match the bug status in
-					<emphasis>$g_status_enum_string</emphasis>. Note that spaces
-					in the string are replaced with underscores ('_') when
-					creating the action. Thus, using the defaults, 'feedback'
-					would be a valid action.
+				</para>
+				<para>For example, the following code overrides the default by
+					disabling notifications to bugnote authors and users
+					monitoring the bug when acknowledging a new bug:
+<programlisting>
+$g_notify_flags['acknowledged'] = array(
+	'bugnotes' =&gt; OFF,
+	'monitor' =&gt; OFF,
+);
+</programlisting>
+					See <xref linkend="admin.customize.email" />
+					for further examples of customizing the notification flags.
 				</para>
 			</listitem>
 		</varlistentry>


### PR DESCRIPTION
If the issues being moved all belong to a single project, then the user
should not be able to select that project as target.

Fixes [#34876](https://mantisbt.org/bugs/view.php?id=34876)