### PR TITLE
Fix PHPUnit 10/11 compatibility of the name() method using

### DIFF
--- a/tests/rest/RestBase.php
+++ b/tests/rest/RestBase.php
@@ -189,18 +189,6 @@ abstract class RestBase extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
-	 * Generate a Test Case reference (TestClass::TestCase).
-	 *
-	 * This can be used to associate the test data (e.g. Issue Summary, Project
-	 * Name, etc.) with a test case.
-	 * 
-	 * @return string
-	 */
-	protected function getTestCaseReference() {
-		return $this->toString();
-	}
-
-	/**
 	 * Returns a minimal data structure for tests to create a new Issue.
 	 *
 	 * The Issue Summary is set to TestClass::TestCase with an optional
@@ -211,7 +199,7 @@ abstract class RestBase extends PHPUnit\Framework\TestCase {
 	 * @return array
 	 */
 	protected function getIssueToAdd( $p_suffix = '' ) {
-		$t_summary = $this->getTestCaseReference();
+		$t_summary = $this->toString();
 		if( $p_suffix ) {
 			$t_summary .= '-' . $p_suffix;
 		}

--- a/tests/rest/RestBase.php
+++ b/tests/rest/RestBase.php
@@ -24,6 +24,7 @@
  */
 
 use GuzzleHttp\Exception\GuzzleException;
+use PHPUnit\Framework\TestCase;
 
 # Includes
 require_once dirname( __DIR__ ) . '/TestConfig.php';
@@ -42,7 +43,7 @@ require_once __DIR__ . '/../core/Faker.php';
  * @requires extension curl
  * @group REST
  */
-abstract class RestBase extends PHPUnit\Framework\TestCase {
+abstract class RestBase extends TestCase {
 	/**
 	 * @var string Base path for REST API
 	 */

--- a/tests/rest/RestBase.php
+++ b/tests/rest/RestBase.php
@@ -197,8 +197,7 @@ abstract class RestBase extends PHPUnit\Framework\TestCase {
 	 * @return string
 	 */
 	protected function getTestCaseReference() {
-		return static::class . '::' . ( method_exists( $this, 'getName' ) ?
-			$this->getName() : $this->name() );
+		return $this->toString();
 	}
 
 	/**

--- a/tests/rest/RestBase.php
+++ b/tests/rest/RestBase.php
@@ -24,7 +24,6 @@
  */
 
 use GuzzleHttp\Exception\GuzzleException;
-use PHPUnit\Framework\TestCase;
 
 # Includes
 require_once dirname( __DIR__ ) . '/TestConfig.php';
@@ -43,7 +42,7 @@ require_once __DIR__ . '/../core/Faker.php';
  * @requires extension curl
  * @group REST
  */
-abstract class RestBase extends TestCase {
+abstract class RestBase extends PHPUnit\Framework\TestCase {
 	/**
 	 * @var string Base path for REST API
 	 */
@@ -198,7 +197,8 @@ abstract class RestBase extends TestCase {
 	 * @return string
 	 */
 	protected function getTestCaseReference() {
-		return static::class . '::' . $this->getName();
+		return static::class . '::' . ( method_exists( $this, 'getName' ) ?
+			$this->getName() : $this->name() );
 	}
 
 	/**

--- a/tests/rest/RestFiltersTest.php
+++ b/tests/rest/RestFiltersTest.php
@@ -115,7 +115,7 @@ class RestFiltersTest extends RestBase
 			filter_serialize( $p_filter ),
 			$this->userId,
 			$this->getProjectId(),
-			$this->getTestCaseReference() . ' ' . rand(1, 10000),
+			$this->toString() . ' ' . rand(1, 10000),
 			$p_public
 		);
 		$this->filterIdsToDelete[] = $t_filter_id;
@@ -203,7 +203,7 @@ class RestFiltersTest extends RestBase
 	public function testGetIssuesMatchingFilter() {
 		# Create test filter - resolved issues created by this test case
 		$t_filter = filter_get_default();
-		$t_filter[FILTER_PROPERTY_SEARCH] = $this->getTestCaseReference();
+		$t_filter[FILTER_PROPERTY_SEARCH] = $this->toString();
 		$t_filter[FILTER_PROPERTY_STATUS] = RESOLVED;
 		$t_filter_id = $this->createTestFilter( $t_filter );
 

--- a/tests/soap/ProjectTest.php
+++ b/tests/soap/ProjectTest.php
@@ -201,7 +201,8 @@ class ProjectTest extends SoapBase {
 	 */
 	protected function getNewProjectName() {
 		do {
-			$t_name = $this->getName() . '_' . rand();
+			$t_name = ( method_exists( $this, 'getName' ) ?
+				$this->getName() : $this->name() ) . '_' . rand();
 			$t_id = $this->client->mc_project_get_id_from_name( $this->userName, $this->password, $t_name );
 		} while( $t_id != 0 );
 		return $t_name;

--- a/tests/soap/ProjectTest.php
+++ b/tests/soap/ProjectTest.php
@@ -201,8 +201,7 @@ class ProjectTest extends SoapBase {
 	 */
 	protected function getNewProjectName() {
 		do {
-			$t_name = ( method_exists( $this, 'getName' ) ?
-				$this->getName() : $this->name() ) . '_' . rand();
+			$t_name = $this->toString() . '_' . rand();
 			$t_id = $this->client->mc_project_get_id_from_name( $this->userName, $this->password, $t_name );
 		} while( $t_id != 0 );
 		return $t_name;

--- a/tests/soap/SoapBase.php
+++ b/tests/soap/SoapBase.php
@@ -206,8 +206,7 @@ class SoapBase extends PHPUnit\Framework\TestCase {
 	 * @return array
 	 */
 	protected function getIssueToAdd( $p_suffix = '' ) {
-		$t_summary = static::class . '::' . ( method_exists( $this, 'getName' ) ?
-			$this->getName() : $this->name() );
+		$t_summary = $this->toString();
 		if( $p_suffix ) {
 			$t_summary .= '-' . $p_suffix;
 		}

--- a/tests/soap/SoapBase.php
+++ b/tests/soap/SoapBase.php
@@ -206,7 +206,8 @@ class SoapBase extends PHPUnit\Framework\TestCase {
 	 * @return array
 	 */
 	protected function getIssueToAdd( $p_suffix = '' ) {
-		$t_summary = static::class . '::' . $this->getName();
+		$t_summary = static::class . '::' . ( method_exists( $this, 'getName' ) ?
+			$this->getName() : $this->name() );
 		if( $p_suffix ) {
 			$t_summary .= '-' . $p_suffix;
 		}


### PR DESCRIPTION
Fix PHPUnit compatibility by updating to use the new name() method instead of the deprecated getName() method.

Fixes [#35223](https://mantisbt.org/bugs/view.php?id=35223).

Alternative to 7ccca0f9f991d692cd33156b48e2b90fc8bc0a45.