### PR TITLE
Added firebird database connection feature

### DIFF
--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -213,9 +213,16 @@ while( $t_row = db_fetch_array( $t_result ) ) {
 }
 
 # Build config query
+//Added by MAB - Feb/2024
+if (!db_is_firebird ())
 $t_sql = 'SELECT config_id, user_id, project_id, type, access_reqd,'
 		. ' CASE type WHEN :complex THEN null ELSE value END AS value'
 		. ' FROM {config} WHERE 1=1';
+else
+  $t_sql = 'SELECT config_id, user_id, project_id, type, access_reqd,'
+		. ' CASE type WHEN :complex THEN null ELSE "value" END AS "value"'
+		. ' FROM {config} WHERE 1=1';	
+		
 if( $t_filter_user_value != META_FILTER_NONE ) {
 	$t_sql .= ' AND user_id = :user_id';
 }

--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -1355,7 +1355,12 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
 	# COPY CUSTOM FIELDS
 	if( $p_copy_custom_fields ) {
 		db_param_push();
-		$t_query = 'SELECT field_id, bug_id, value, text FROM {custom_field_string} WHERE bug_id=' . db_param();
+		//Added by MAB - Feb/2024
+		if (!db_is_firebird())
+		  $t_query = 'SELECT field_id, bug_id, value, text FROM {custom_field_string} WHERE bug_id=' . db_param();
+		else
+		  $t_query = 'SELECT field_id, bug_id, "value", text FROM {custom_field_string} WHERE bug_id=' . db_param();	
+		
 		$t_result = db_query( $t_query, array( $t_bug_id ) );
 
 		while( $t_bug_custom = db_fetch_array( $t_result ) ) {
@@ -1365,9 +1370,17 @@ function bug_copy( $p_bug_id, $p_target_project_id = null, $p_copy_custom_fields
 			$c_text = $t_bug_custom['text'];
 
 			db_param_push();
-			$t_query = 'INSERT INTO {custom_field_string}
+			
+			//Added by MAB - Feb/2024
+			if (!db_is_firebird())
+			  $t_query = 'INSERT INTO {custom_field_string}
 						   ( field_id, bug_id, value, text )
 						   VALUES (' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ')';
+			else
+			  $t_query = 'INSERT INTO {custom_field_string}
+				  		   ( field_id, bug_id, "value", text )
+					  	   VALUES (' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ')';	
+			
 			db_query( $t_query, array( $c_field_id, $c_new_bug_id, $c_value, $c_text ) );
 		}
 	}

--- a/core/bug_revision_api.php
+++ b/core/bug_revision_api.php
@@ -60,12 +60,23 @@ function bug_revision_add( $p_bug_id, $p_user_id, $p_type, $p_value, $p_bugnote_
 	}
 
 	db_param_push();
-	$t_query = 'INSERT INTO {bug_revision} (
+	
+	//Added by MAB - Mar/2024
+	if (!db_is_firebird ())
+	  $t_query = 'INSERT INTO {bug_revision} (
 			bug_id, bugnote_id, user_id,
 			timestamp, type, value
 		) VALUES ( ' .
 			db_param() . ', ' . db_param() . ', ' . db_param() . ', ' .
 			db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
+	else
+	  $t_query = 'INSERT INTO {bug_revision} (
+			bug_id, bugnote_id, user_id,
+			"timestamp", type, "value"
+		) VALUES ( ' .
+			db_param() . ', ' . db_param() . ', ' . db_param() . ', ' .
+			db_param() . ', ' . db_param() . ', ' . db_param() . ' )';	
+	
 	db_query( $t_query, array(
 			$p_bug_id, $p_bugnote_id, $p_user_id,
 			$t_timestamp, $p_type, $p_value ) );
@@ -242,7 +253,12 @@ function bug_revision_last( $p_bug_id, $p_type = REV_ANY, $p_bugnote_id = 0 ) {
 		$t_query .= ' AND bugnote_id=0';
 	}
 
-	$t_query .= ' ORDER BY timestamp DESC';
+	//Added by MAB - Mar/2024
+	if (!db_is_firebird ())	
+	  $t_query .= ' ORDER BY timestamp DESC';
+    else
+      $t_query .= ' ORDER BY "timestamp" DESC';	
+  
 	$t_result = db_query( $t_query, $t_params, 1 );
 
 	$t_row = db_fetch_array( $t_result );

--- a/core/config_api.php
+++ b/core/config_api.php
@@ -366,11 +366,19 @@ function config_set( $p_option, $p_value, $p_user = NO_USER, $p_project = ALL_PR
 
 		db_param_push();
 		if( 0 < db_result( $t_result ) ) {
-			$t_set_query = 'UPDATE {config}
+			if (!db_is_firebird())
+			  $t_set_query = 'UPDATE {config}
 					SET value=' . db_param() . ', type=' . db_param() . ', access_reqd=' . db_param() . '
 					WHERE config_id = ' . db_param() . ' AND
 						project_id = ' . db_param() . ' AND
 						user_id = ' . db_param();
+			else
+			  $t_set_query = 'UPDATE {config}
+					SET "value"=' . db_param() . ', type=' . db_param() . ', access_reqd=' . db_param() . '
+					WHERE config_id = ' . db_param() . ' AND
+						project_id = ' . db_param() . ' AND
+						user_id = ' . db_param();					
+			
 			$t_params = array(
 				(string)$c_value,
 				$t_type,
@@ -380,10 +388,17 @@ function config_set( $p_option, $p_value, $p_user = NO_USER, $p_project = ALL_PR
 				(int)$p_user,
 			);
 		} else {
-			$t_set_query = 'INSERT INTO {config}
+			if (!db_is_firebird())
+			  $t_set_query = 'INSERT INTO {config}
 					( value, type, access_reqd, config_id, project_id, user_id )
 					VALUES
 					(' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ',' . db_param() . ' )';
+			else
+			  $t_set_query = 'INSERT INTO {config}
+				  	( "value", type, access_reqd, config_id, project_id, user_id )
+					  VALUES
+					  (' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ',' . db_param() . ' )';   					
+			
 			$t_params = array(
 				(string)$c_value,
 				$t_type,
@@ -769,7 +784,12 @@ function config_cache_all() {
 			$t_config_rows[] = $t_row;
 		}
 	} else {
-		$t_query = 'SELECT config_id, user_id, project_id, type,  value, access_reqd FROM {config}';
+		//Added by MAB - Dec/2023
+		if (!db_is_firebird())
+		  $t_query = 'SELECT config_id, user_id, project_id, type,  value, access_reqd FROM {config}';
+		else
+	      $t_query = 'SELECT config_id, user_id, project_id, type, "value", access_reqd FROM {config}';	
+	  
 		$t_result = db_query( $t_query );
 		while( false <> ( $t_row = db_fetch_array( $t_result ) ) ) {
 			$t_config_rows[] = $t_row;

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -46,6 +46,7 @@ define( 'DB_MIN_VERSION_MSSQL', '11.0.0' );  # MS SQL Server 2012
 define( 'DB_MIN_VERSION_MYSQL', '5.5.35' );  # See #20431
 define( 'DB_MIN_VERSION_PGSQL', '9.2' );     # Earliest supported version as of Nov 2016
 define( 'DB_MIN_VERSION_ORACLE', '11.2' );
+define( 'DB_MIN_VERSION_FIREBIRD', '4.0' );  # Firebird Server 4.0 - Added by MAB - Oct/2022
 
 # error types
 define( 'ERROR', E_USER_ERROR );
@@ -739,6 +740,7 @@ define( 'DB_TYPE_MYSQL', 1 );
 define( 'DB_TYPE_PGSQL', 2 );
 define( 'DB_TYPE_MSSQL', 3 );
 define( 'DB_TYPE_ORACLE', 4 );
+define( 'DB_TYPE_FIREBIRD', 5 ); //Added by MAB - May/2022
 
 # Database special capabilities identifiers
 define( 'DB_CAPABILITY_WINDOW_FUNCTIONS', 1 );

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -209,6 +209,9 @@ function db_check_database_support( $p_db_type ) {
 		case 'odbc_mssql':
 			$t_support = function_exists( 'odbc_connect' );
 			break;
+		case 'firebird':
+			$t_support = function_exists( 'ibase_connect' );
+			break;		
 		default:
 			$t_support = false;
 	}
@@ -231,6 +234,8 @@ function db_get_type( $p_driver_type ) {
 			return DB_TYPE_MSSQL;
 		case 'oci8':
 			return DB_TYPE_ORACLE;
+		case 'firebird':
+			return DB_TYPE_FIREBIRD;			
 		default:
 			return DB_TYPE_UNDEFINED;
 	}
@@ -240,9 +245,18 @@ function db_get_type( $p_driver_type ) {
  * Checks if the database driver is MySQL
  * @return boolean true if mysql
  */
+//I don't really know why this functions doesn't work, so I changed
+//to be like db_is_firebird, before the change, it allways returned True.
+//Changed by MAB - Jan/2024
+ 
 function db_is_mysql() {
-	global $g_db_functional_type;
-	return( DB_TYPE_MYSQL == $g_db_functional_type );
+	if (db_get_type(config_get_global( 'db_type' )) == DB_TYPE_MYSQL)
+      return True;
+	else
+      return False;		
+	
+	//global $g_db_functional_type;
+	//return( DB_TYPE_MYSQL == $g_db_functional_type );
 }
 
 /**
@@ -270,6 +284,20 @@ function db_is_mssql() {
 function db_is_oracle() {
 	global $g_db_functional_type;
 	return( DB_TYPE_ORACLE == $g_db_functional_type );
+}
+
+/**
+ * Checks if the database driver is Firebird
+ * @return boolean true if firebird
+ * Added by MAB - Jun/2022
+ */
+function db_is_firebird() {
+    if (db_get_type(config_get_global( 'db_type' )) == DB_TYPE_FIREBIRD)
+      return True;
+	else
+      return False;		
+	//global $g_db_functional_type;
+	//return( DB_TYPE_FIREBIRD == $g_db_functional_type );
 }
 
 /**
@@ -483,6 +511,9 @@ function db_insert_id( $p_table, $p_field = 'id' ) {
 			case DB_TYPE_PGSQL:
 				$t_query = 'SELECT currval(\'' . $p_table . '_' . $p_field . '_seq\')';
 				break;
+			case DB_TYPE_FIREBIRD: //Added by MAB - Feb/2024
+				$t_query = 'SELECT max(' . $p_field . ') FROM ' . $p_table;
+				break;			
 			default:
 				return $g_db->Insert_ID();
 	}
@@ -644,6 +675,8 @@ function db_prepare_binary_string( $p_string ) {
 		case 'mssqlnative':
 		case 'oci8':
 			# Fall through, mssqlnative, oci8 store raw data in BLOB
+		case 'firebird': //Added by MAB - Jan/2024
+            return $p_string;				
 		default:
 			return $p_string;
 	}

--- a/core/tokens_api.php
+++ b/core/tokens_api.php
@@ -196,9 +196,15 @@ function token_create( $p_type, $p_value, $p_expiry = TOKEN_EXPIRY, $p_user_id =
 	$c_expiry = time() + $p_expiry;
 
 	db_param_push();
-	$t_query = 'INSERT INTO {tokens}
+	if (!db_is_firebird())
+	  $t_query = 'INSERT INTO {tokens}
 					( type, value, timestamp, expiry, owner )
 					VALUES ( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';
+	else
+	  $t_query = 'INSERT INTO {tokens}
+		  			( type, "value", "timestamp", expiry, owner )
+			  		VALUES ( ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ', ' . db_param() . ' )';      					
+	
 	db_query( $t_query, array( $c_type, (string)$p_value, $c_timestamp, $c_expiry, $c_user_id ) );
 	return db_insert_id( db_get_table( 'tokens' ) );
 }
@@ -216,9 +222,16 @@ function token_update( $p_token_id, $p_value, $p_expiry = TOKEN_EXPIRY ) {
 	$c_expiry = time() + $p_expiry;
 
 	db_param_push();
-	$t_query = 'UPDATE {tokens}
+	
+	if (!db_is_firebird())
+	  $t_query = 'UPDATE {tokens}
 					SET value=' . db_param() . ', expiry=' . db_param() . '
 					WHERE id=' . db_param();
+	else
+	  $t_query = 'UPDATE {tokens}
+					SET "value"=' . db_param() . ', expiry=' . db_param() . '
+					WHERE id=' . db_param();   					
+	
 	db_query( $t_query, array( (string)$p_value, $c_expiry, $c_token_id ) );
 
 	return true;

--- a/manage_overview_page.php
+++ b/manage_overview_page.php
@@ -98,7 +98,26 @@ print_manage_menu( 'manage_overview_page.php' );
 		<tr>
 			<th class="category"><?php echo lang_get( 'database_version_description' ) ?></th>
 			<td><?php
-					$t_database_server_info = $g_db->ServerInfo();
+					//Added by MAB - Feb/2024
+					if (!db_is_firebird())
+					  $t_database_server_info = $g_db->ServerInfo();
+				    else {
+					  $t_database_hostname = config_get_global( 'hostname' );
+					  $t_database_username = config_get_global( 'db_username' );
+					  $t_database_password = config_get_global( 'db_password' );
+					  if (($firebird_service = ibase_service_attach($t_database_hostname, $t_database_username, $t_database_password)) != FALSE) {
+	                  $t_database_server_info['description'] = ibase_server_info($firebird_service, IBASE_SVC_SERVER_VERSION); 
+                      ibase_service_detach($firebird_service); 	
+	                  if (preg_match('/([0-9]+\.([0-9\.])+)/',$t_database_server_info['description'], $arr))
+	                    $t_database_server_info['version'] = $arr[1];
+	                  else 
+                        $t_database_server_info['version'] = '';
+	
+	                   $t_db_version = $t_database_server_info['version'];
+                      } 	  
+                      else
+                        $t_error = 'Error attaching Firebird Server Info ' . ibase_errmsg();		
+					}
 					echo $t_database_server_info['version'] . ', ' . $t_database_server_info['description']
 				?>
 			</td>

--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -289,14 +289,25 @@ function create_developer_resolved_summary( array $p_filter = null ) {
 	$t_resolved_status_threshold = config_get( 'bug_resolved_status_threshold' );
 
 	$t_query = new DBQuery();
-	$t_sql = 'SELECT handler_id, count(*) as count FROM {bug} WHERE ' . $t_specific_where
+	
+	if (!db_is_firebird ())
+	  $t_sql = 'SELECT handler_id, count(*) as count FROM {bug} WHERE ' . $t_specific_where
 		. ' AND handler_id <> :nouser AND status >= :status_resolved AND resolution = :resolution_fixed';
+	else
+	  $t_sql = 'SELECT handler_id, count(*) as countt FROM {bug} WHERE ' . $t_specific_where
+		  . ' AND handler_id <> :nouser AND status >= :status_resolved AND resolution = :resolution_fixed';		
+	
 	if( !empty( $p_filter ) ) {
 		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND {bug}.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
-	$t_sql .= ' GROUP BY handler_id ORDER BY count DESC';
+	
+	if (!db_is_firebird ())
+	  $t_sql .= ' GROUP BY handler_id ORDER BY count DESC';
+    else
+	  $t_sql .= ' GROUP BY handler_id ORDER BY countt DESC';			
+	
 	$t_query->sql( $t_sql );
 	$t_query->bind( array(
 		'nouser' => NO_USER,
@@ -308,7 +319,11 @@ function create_developer_resolved_summary( array $p_filter = null ) {
 	$t_handler_array = array();
 	$t_handler_ids = array();
 	while( $t_row = $t_query->fetch() ) {
-		$t_handler_array[$t_row['handler_id']] = (int)$t_row['count'];
+		if (!db_is_firebird ())
+		  $t_handler_array[$t_row['handler_id']] = (int)$t_row['count'];
+	    else
+		  $t_handler_array[$t_row['handler_id']] = (int)$t_row['countt'];							
+		
 		$t_handler_ids[] = $t_row['handler_id'];
 	}
 
@@ -341,14 +356,25 @@ function create_developer_open_summary( array $p_filter = null ) {
 	$t_resolved_status_threshold = config_get( 'bug_resolved_status_threshold' );
 
 	$t_query = new DBQuery();
-	$t_sql = 'SELECT handler_id, count(*) as count FROM {bug} WHERE ' . $t_specific_where
+	
+	if (!db_is_firebird ())
+	  $t_sql = 'SELECT handler_id, count(*) as count FROM {bug} WHERE ' . $t_specific_where
 		. ' AND handler_id <> :nouser AND status < :status_resolved';
+	else
+	  $t_sql = 'SELECT handler_id, count(*) as countt FROM {bug} WHERE ' . $t_specific_where
+		  . ' AND handler_id <> :nouser AND status < :status_resolved';		
+	
 	if( !empty( $p_filter ) ) {
 		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND {bug}.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
-	$t_sql .= ' GROUP BY handler_id ORDER BY count DESC';
+	
+	if (!db_is_firebird ())
+	  $t_sql .= ' GROUP BY handler_id ORDER BY count DESC';
+	else
+	  $t_sql .= ' GROUP BY handler_id ORDER BY countt DESC'; 			
+	
 	$t_query->sql( $t_sql );
 	$t_query->bind( array(
 		'nouser' => NO_USER,
@@ -358,7 +384,11 @@ function create_developer_open_summary( array $p_filter = null ) {
 	$t_handler_array = array();
 	$t_handler_ids = array();
 	while( $t_row = $t_query->fetch() ) {
-		$t_handler_array[$t_row['handler_id']] = (int)$t_row['count'];
+		if (!db_is_firebird ())
+		  $t_handler_array[$t_row['handler_id']] = (int)$t_row['count'];
+	    else
+          $t_handler_array[$t_row['handler_id']] = (int)$t_row['countt'];					
+		
 		$t_handler_ids[] = $t_row['handler_id'];
 	}
 
@@ -390,14 +420,25 @@ function create_reporter_summary( array $p_filter = null ) {
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
 
 	$t_query = new DBQuery();
-	$t_sql = 'SELECT reporter_id, count(*) as count FROM {bug} WHERE ' . $t_specific_where
+	
+	if (!db_is_firebird ())
+	  $t_sql = 'SELECT reporter_id, count(*) as count FROM {bug} WHERE ' . $t_specific_where
 		. ' AND resolution = :resolution_fixed';
+	else
+	  $t_sql = 'SELECT reporter_id, count(*) as countt FROM {bug} WHERE ' . $t_specific_where
+		  . ' AND resolution = :resolution_fixed';	
+	
 	if( !empty( $p_filter ) ) {
 		$t_subquery = filter_cache_subquery( $p_filter );
 		$t_sql .= ' AND {bug}.id IN :filter';
 		$t_query->bind( 'filter', $t_subquery );
 	}
-	$t_sql .= ' GROUP BY reporter_id ORDER BY count DESC';
+	
+	if (!db_is_firebird ())
+	  $t_sql .= ' GROUP BY reporter_id ORDER BY count DESC';
+    else
+	  $t_sql .= ' GROUP BY reporter_id ORDER BY countt DESC'; 		
+	
 	$t_query->sql( $t_sql );
 	$t_query->bind( 'resolution_fixed', FIXED );
 	$t_query->set_limit( 25 );
@@ -405,7 +446,11 @@ function create_reporter_summary( array $p_filter = null ) {
 	$t_reporter_arr = array();
 	$t_reporters = array();
 	while( $t_row = $t_query->fetch() ) {
-		$t_reporter_arr[$t_row['reporter_id']] = (int)$t_row['count'];
+		if (!db_is_firebird ())
+		  $t_reporter_arr[$t_row['reporter_id']] = (int)$t_row['count'];
+	    else
+		  $t_reporter_arr[$t_row['reporter_id']] = (int)$t_row['countt'];					
+		
 		$t_reporters[] = $t_row['reporter_id'];
 	}
 


### PR DESCRIPTION
Mantisbt support MySQL, Oracle, Postgres, etc database connections but not to Firebird; so, after a lot of hard work and patience I finally added firebird database connection feature.

The minnor version of firebird has to be 4.0, that is because the versions before 4.0 have limits the tables names length to 32 characters.

The database file must be created before the instalation, I recommend using the aliases file, create an alias and then use it in the instalation