### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/api/soap/mantisconnect.php
+++ b/api/soap/mantisconnect.php
@@ -92,5 +92,11 @@ $t_server = new SoapServer( $t_wsdl_path,
 	array( 'features' => SOAP_USE_XSI_ARRAY_TYPE + SOAP_SINGLE_ELEMENT_ARRAYS )
 );
 
-$t_server->addFunction( SOAP_FUNCTIONS_ALL );
+// Get the list of public SOAP functions
+$t_soap_functions = array_filter( get_defined_functions()['user'],
+	function( string $p_name ) {
+		return strpos( $p_name, 'mc_' ) === 0;
+	}
+);
+$t_server->addFunction( $t_soap_functions );
 $t_server->handle();

--- a/api/soap/mc_issue_api.php
+++ b/api/soap/mc_issue_api.php
@@ -386,14 +386,17 @@ function mci_issue_get_due_date( BugData $p_bug ) {
 /**
  * Sets the supplied array of custom field values to the specified issue id.
  *
- * @param integer $p_issue_id       Issue id to apply custom field values to.
- * @param array   &$p_custom_fields The array of custom field values as described in the webservice complex types.
- * @param boolean $p_log_insert     Create history logs for new values.
- * @return boolean|SoapFault|RestFault true for success, otherwise fault.
+ * @param int         $p_issue_id      Issue id to apply custom field values to.
+ * @param array|null &$p_custom_fields The array of custom field values as described
+ *                                     in the webservice complex types.
+ * @param bool        $p_log_insert    Create history logs for new values.
+ *
+ * @return bool|SoapFault|RestFault true for success, otherwise fault.
+ * @throws ClientException
  */
-function mci_issue_set_custom_fields( $p_issue_id, array &$p_custom_fields = null, $p_log_insert = true ) {
+function mci_issue_set_custom_fields( $p_issue_id, ?array &$p_custom_fields, $p_log_insert = true ) {
 	# set custom field values on the submitted issue
-	if( isset( $p_custom_fields ) && is_array( $p_custom_fields ) ) {
+	if( isset( $p_custom_fields ) ) {
 		foreach( $p_custom_fields as $t_custom_field ) {
 			$t_custom_field = ApiObjectFactory::objectToArray( $t_custom_field );
 

--- a/core/access_api.php
+++ b/core/access_api.php
@@ -348,14 +348,14 @@ function access_has_project_level( $p_access_level, $p_project_id = null, $p_use
  *                                              - array: for an array threshold
  *                                              - string: for a threshold option which will be evaluated
  *                                                for each project context
- * @param array                 $p_project_ids  Array of project ids to check access against, default to null
+ * @param array|null            $p_project_ids  Array of project ids to check access against, default to null
  *                                               to use all user accessible projects
  * @param integer|null          $p_user_id      Integer representing user id, defaults to null to use current user.
  * @param integer               $p_limit        Maximum number of results, default is 0 for all results
  *
  * @return array                The filtered array of project ids
  */
-function access_project_array_filter( $p_access_level, array $p_project_ids = null, $p_user_id = null, $p_limit = 0 ) {
+function access_project_array_filter( $p_access_level, ?array $p_project_ids = null, ?int $p_user_id = null, int $p_limit = 0 ): array {
 	# Short circuit the check in this case
 	if( NOBODY == $p_access_level ) {
 		return array();
@@ -419,7 +419,7 @@ function access_project_array_filter( $p_access_level, array $p_project_ids = nu
  * @return bool            True if user has the specified access level in any of the projects.
  * @access public
  */
-function access_has_any_project_level( $p_access_level, array $p_project_ids = null, $p_user_id = null ) {
+function access_has_any_project_level( $p_access_level, ?array $p_project_ids = null, ?int $p_user_id = null ): bool {
 	# We only need 1 matching project to return positive
 	$t_matches = access_project_array_filter( $p_access_level, $p_project_ids, $p_user_id, 1 );
 	return !empty( $t_matches );
@@ -434,7 +434,7 @@ function access_has_any_project_level( $p_access_level, array $p_project_ids = n
  * @param array|null       $p_project_ids  Array of project ids to check access against.
  * @param int|null         $p_user_id      User id, defaults to null to use current user.
  */
-function access_ensure_any_project_level( $p_access_level, array $p_project_ids = null, $p_user_id = null ) {
+function access_ensure_any_project_level( $p_access_level, ?array $p_project_ids = null, ?int $p_user_id = null ): void {
 	if( !access_has_any_project_level( $p_access_level, $p_project_ids, $p_user_id ) ) {
 		access_denied();
 	}

--- a/core/bug_group_action_api.php
+++ b/core/bug_group_action_api.php
@@ -207,8 +207,8 @@ function bug_group_action_process( $p_action, $p_bug_id ) {
  *
  * @return array
  */
-function bug_group_action_get_commands( array $p_project_ids = null ) {
-	if( $p_project_ids === null || count( $p_project_ids ) == 0 ) {
+function bug_group_action_get_commands( array $p_project_ids = [] ) {
+	if( empty( $p_project_ids ) ) {
 		$p_project_ids = array( ALL_PROJECTS );
 	}
 

--- a/core/category_api.php
+++ b/core/category_api.php
@@ -400,7 +400,7 @@ function category_get_row( $p_category_id, $p_error_if_not_exists = true ) {
  * @return int|null An integer representing sort order.
  * @access public
  */
-function category_sort_rows_by_project( $p_category1, array $p_category2 = null ) {
+function category_sort_rows_by_project( $p_category1, ?array $p_category2 = null ) {
 	static $s_project_id = null;
 	if( is_null( $p_category2 ) ) {
 		# Set a target project

--- a/core/classes/BugFilterQuery.class.php
+++ b/core/classes/BugFilterQuery.class.php
@@ -240,7 +240,7 @@ class BugFilterQuery extends DbQuery {
 	 * @param integer $p_offset		Offset value
 	 * @return IteratorAggregate|boolean ADOdb result set or false if the query failed.
 	 */
-	public function execute( array $p_bind_array = null, $p_limit = null, $p_offset = null ) {
+	public function execute( array $p_bind_array = [], $p_limit = null, $p_offset = null ) {
 		if( $this->needs_rebuild ) {
 			$this->build_query();
 		}
@@ -1609,7 +1609,7 @@ class BugFilterQuery extends DbQuery {
 	 *
 	 * @return string
 	 */
-	protected function helper_convert_legacy_clause( $p_string, array $p_params = null ) {
+	protected function helper_convert_legacy_clause( $p_string, array $p_params = [] ) {
 		if( empty( $p_params ) ) {
 			# shortcut, if there are no parameters, there's no need to translate
 			return $p_string;

--- a/core/classes/DbQuery.class.php
+++ b/core/classes/DbQuery.class.php
@@ -166,18 +166,9 @@ class DbQuery {
 	 *
 	 * @return void
 	 */
-	public function __construct( $p_query_string = null, array $p_bind_array = null ) {
-		# Itialization
-		if( null === $p_query_string ) {
-			$this->query_string = '';
-		} else {
-			$this->query_string = $p_query_string;
-		}
-		if( null === $p_bind_array ) {
-			$this->query_bind_array = array();
-		} else {
-			$this->query_bind_array = $p_bind_array;
-		}
+	public function __construct( string $p_query_string = '', array $p_bind_array = [] ) {
+		$this->query_string = $p_query_string;
+		$this->query_bind_array = $p_bind_array;
 	}
 
 	/**
@@ -246,7 +237,7 @@ class DbQuery {
 	 *
 	 * @return IteratorAggregate|boolean ADOdb result set or false if the query failed.
 	 */
-	public function execute( array $p_bind_array = null, $p_limit = null, $p_offset = null ) {
+	public function execute( array $p_bind_array = [], $p_limit = null, $p_offset = null ) {
 		# For backwards compatibility with legacy code still relying on DB API,
 		# we need to save the parameters count before binding otherwise it will
 		# be reset after query execution, which will cause issues on RDBMS with
@@ -254,7 +245,7 @@ class DbQuery {
 		db_param_push();
 
 		# bind values if provided
-		if( null !== $p_bind_array ) {
+		if( !empty( $p_bind_array ) ) {
 			$this->bind_values( $p_bind_array );
 		}
 
@@ -785,16 +776,12 @@ class DbQuery {
 	 *
 	 * @return IteratorAggregate|false ADOdb result set or false if the query failed
 	 */
-	public static function compat_db_query( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_offset = -1, $p_pop_param = true ) {
+	public static function compat_db_query( string $p_query, array $p_params = [], int $p_limit = -1, int $p_offset = -1, bool $p_pop_param = true ) {
 		global $g_db_param;
-
-		if( !is_array( $p_arr_parms ) ) {
-			$p_arr_parms = array();
-		}
 
 		$t_query = new DbQuery();
 		$t_query->db_query_string = $p_query;
-		$t_query->db_param_array = $p_arr_parms;
+		$t_query->db_param_array = $p_params;
 
 		$t_query->process_sql_syntax();
 
@@ -806,7 +793,7 @@ class DbQuery {
 		# Restore ADOdb parameter count
 		$g_db_param->pop();
 
-		if( $p_pop_param && !empty( $p_arr_parms ) ) {
+		if( $p_pop_param && !empty( $p_params ) ) {
 			$g_db_param->pop();
 		}
 

--- a/core/custom_field_api.php
+++ b/core/custom_field_api.php
@@ -138,19 +138,18 @@ function custom_field_cache_row( $p_field_id, $p_trigger_errors = true ) {
 /**
  * Cache custom fields contained within an array of field id's.
  *
- * If ids parameter is omitted, all fields will be cached.
- *
- * @param array|null $p_cf_id_array Array of custom field ids.
+ * @param array $p_cf_id_array Array of custom field ids;
+ *                             if empty, all fields will be cached.
  *
  * @return void
  *
  * @access public
  */
-function custom_field_cache_array_rows( array $p_cf_id_array = null ) {
+function custom_field_cache_array_rows( array $p_cf_id_array = [] ): void {
 	global $g_cache_custom_field, $g_cache_name_to_id_map;
 
 	$c_cf_id_array = array();
-	$t_cache_all = ( null === $p_cf_id_array );
+	$t_cache_all = empty( $p_cf_id_array );
 
 	# cache main data
 	if( $t_cache_all ) {

--- a/core/custom_function_api.php
+++ b/core/custom_function_api.php
@@ -326,11 +326,11 @@ function custom_function_default_get_columns_to_view( $p_columns_target = COLUMN
  *
  * @return void
  */
-function custom_function_default_print_column_title( $p_column, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE, array $p_sort_properties = null ) {
+function custom_function_default_print_column_title( $p_column, $p_columns_target = COLUMNS_TARGET_VIEW_PAGE, array $p_sort_properties = [] ) {
 	global $t_sort, $t_dir;
 
 	# if no sort properties are provided, resort to deprecated golbal vars, to keep compatibility
-	if( null === $p_sort_properties ) {
+	if( empty( $p_sort_properties ) ) {
 		$t_main_sort_column = $t_sort;
 		$t_main_sort_dir = $t_dir;
 	} else {

--- a/core/database_api.php
+++ b/core/database_api.php
@@ -313,9 +313,9 @@ function db_query_bound() {
  *
  * @return IteratorAggregate|boolean adodb result set or false if the query failed.
  */
-function db_query( $p_query, array $p_arr_parms = null, $p_limit = -1, $p_offset = -1, $p_pop_param = true ) {
+function db_query( string $p_query, array $p_params = [], int $p_limit = -1, int $p_offset = -1, bool $p_pop_param = true ) {
 	# Use DbQuery class to execute the query
-	return DbQuery::compat_db_query( $p_query, $p_arr_parms, $p_limit, $p_offset, $p_pop_param );
+	return DbQuery::compat_db_query( $p_query, $p_params, $p_limit, $p_offset, $p_pop_param );
 }
 
 /**
@@ -962,7 +962,7 @@ function db_oracle_order_binds_sequentially( $p_query ) {
  *
  * @return string Query string with sorted bind variable numbers.
  */
-function db_oracle_adapt_query_syntax( $p_query, array &$p_arr_parms = null ) {
+function db_oracle_adapt_query_syntax( $p_query, array &$p_params = [] ) {
 	# Remove "AS" keyword, because not supported with table aliasing
 	# - Do not remove text literal within "'" quotes
 	# - Will remove all "AS", except when it's part of a "CAST(x AS y)" expression
@@ -1011,7 +1011,7 @@ function db_oracle_adapt_query_syntax( $p_query, array &$p_arr_parms = null ) {
 	$p_query = $t_query;
 
 	# Remove null bind variables in insert statements for default values support
-	if( is_array( $p_arr_parms ) ) {
+	if( is_array( $p_params ) ) {
 		preg_match( '/^[\s\n\r]*insert[\s\n\r]+(into){0,1}[\s\n\r]+(?P<table>[a-z0-9_]+)[\s\n\r]*\([\s\n\r]*[\s\n\r]*(?P<fields>[a-z0-9_,\s\n\r]+)[\s\n\r]*\)[\s\n\r]*values[\s\n\r]*\([\s\n\r]*(?P<values>[:a-z0-9_,\s\n\r]+)\)/i', $p_query, $t_matches );
 
 		if( isset( $t_matches['values'] ) ) { #if statement is a INSERT INTO ... (...) VALUES(...)
@@ -1020,7 +1020,7 @@ function db_oracle_adapt_query_syntax( $p_query, array &$p_arr_parms = null ) {
 			$t_fields_left = $t_matches['fields'];
 			$t_values_left = $t_matches['values'];
 
-			for( $t_arr_index = 0; $t_arr_index < count( $p_arr_parms ); $t_arr_index++ ) {
+			for( $t_arr_index = 0; $t_arr_index < count( $p_params ); $t_arr_index++ ) {
 				# inserting fieldname search
 				if( preg_match( '/^[\s\n\r]*([a-z0-9_]+)[\s\n\r]*,{0,1}([\d\D]*)\z/i', $t_fields_left, $t_fieldmatch ) ) {
 					$t_fields_left = $t_fieldmatch[2];
@@ -1032,27 +1032,27 @@ function db_oracle_adapt_query_syntax( $p_query, array &$p_arr_parms = null ) {
 					$t_values_arr[$i] = $t_valuematch[1];
 				}
 				# skip unsetting if bind array value not empty
-				if( $p_arr_parms[$t_arr_index] !== '' ) {
+				if( $p_params[$t_arr_index] !== '' ) {
 					$i++;
 				} else {
 					$t_arr_index--;
 					# Shift array and unset bind array element
-					for( $n = $i + 1; $n < count( $p_arr_parms ); $n++ ) {
-						$p_arr_parms[$n-1] = $p_arr_parms[$n];
+					for( $n = $i + 1; $n < count( $p_params ); $n++ ) {
+						$p_params[$n-1] = $p_params[$n];
 					}
 					unset( $t_fields_arr[$i] );
 					unset( $t_values_arr[$i] );
-					unset( $p_arr_parms[count( $p_arr_parms ) - 1] );
+					unset( $p_params[count( $p_params ) - 1] );
 				}
 			}
 
 			# Combine statement from arrays
 			$p_query = 'INSERT INTO ' . $t_matches['table'] . ' (' . $t_fields_arr[0];
-			for( $i = 1; $i < count( $p_arr_parms ); $i++ ) {
+			for( $i = 1; $i < count( $p_params ); $i++ ) {
 				$p_query = $p_query . ', ' . $t_fields_arr[$i];
 			}
 			$p_query = $p_query . ') values (' . $t_values_arr[0];
-			for( $i = 1; $i < count( $p_arr_parms ); $i++ ) {
+			for( $i = 1; $i < count( $p_params ); $i++ ) {
 				$p_query = $p_query . ', ' . $t_values_arr[$i];
 			}
 			$p_query = $p_query . ')';
@@ -1096,11 +1096,11 @@ function db_oracle_adapt_query_syntax( $p_query, array &$p_arr_parms = null ) {
 				$t_search_substr = $t_matches['before_var'] . $t_matches['var_name'] . $t_matches['dividers'] . $t_matches['bind_name'] . $t_matches['after_var'];
 				$t_replace_substr = $t_matches['before_var'] . $t_matches['var_name'] . '=:' . $t_matches['bind_name']. $t_matches['after_var'];
 
-				if( $p_arr_parms[$t_bind_num] === '' ) {
-					for( $n = $t_bind_num + 1; $n < count( $p_arr_parms ); $n++ ) {
-						$p_arr_parms[$n - 1] = $p_arr_parms[$n];
+				if( $p_params[$t_bind_num] === '' ) {
+					for( $n = $t_bind_num + 1; $n < count( $p_params ); $n++ ) {
+						$p_params[$n - 1] = $p_params[$n];
 					}
-					unset( $p_arr_parms[count( $p_arr_parms ) - 1] );
+					unset( $p_params[count( $p_params ) - 1] );
 					$t_replace_substr = $t_matches['before_var'] . $t_matches['var_name'] . ' IS NULL ' . $t_matches['after_var'];
 				}
 				$p_query = str_replace( $t_search_substr, $t_replace_substr, $p_query );
@@ -1126,11 +1126,11 @@ function db_oracle_adapt_query_syntax( $p_query, array &$p_arr_parms = null ) {
 					$t_search_substr = $t_matches['before_var'] . $t_matches['var_name'] . $t_matches['dividers'] . $t_matches['bind_name'] ;
 					$t_replace_substr = $t_matches['before_var'] . $t_matches['var_name'] . $t_matches['dividers'] . $t_matches['bind_name'] ;
 
-					if( $p_arr_parms[$t_bind_num] === '' ) {
-						for( $n = $t_bind_num + 1; $n < count( $p_arr_parms ); $n++ ) {
-							$p_arr_parms[$n - 1] = $p_arr_parms[$n];
+					if( $p_params[$t_bind_num] === '' ) {
+						for( $n = $t_bind_num + 1; $n < count( $p_params ); $n++ ) {
+							$p_params[$n - 1] = $p_params[$n];
 						}
-						unset( $p_arr_parms[count( $p_arr_parms ) - 1] );
+						unset( $p_params[count( $p_params ) - 1] );
 						$t_replace_substr = $t_matches['before_var'] . $t_matches['var_name'] . '=DEFAULT ';
 					}
 					$t_removed_set_where = str_replace( $t_search_substr, $t_replace_substr, $t_removed_set_where );

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -607,7 +607,7 @@ function email_signup( $p_user_id, $p_confirm_hash, $p_admin_name = '' ) {
 	# Send signup email regardless of mail notification pref
 	# or else users won't be able to sign up
 	if( !is_blank( $t_email ) ) {
-		email_store( $t_email, $t_subject, $t_message, null, true );
+		email_store( $t_email, $t_subject, $t_message, [], true );
 		log_event( LOG_EMAIL, 'Signup Email = %s, Hash = %s, User = @U%d', $t_email, $p_confirm_hash, $p_user_id );
 	}
 
@@ -660,7 +660,7 @@ function email_send_confirm_hash_url( $p_user_id, $p_confirm_hash, $p_reset_by_a
 	# Send password reset regardless of mail notification preferences
 	# or else users won't be able to receive their reset passwords
 	if( !is_blank( $t_email ) ) {
-		email_store( $t_email, $t_subject, $t_message, null, true );
+		email_store( $t_email, $t_subject, $t_message, [], true );
 		log_event( LOG_EMAIL, 'Password reset for user @U%d sent to %s', $p_user_id, $t_email );
 	} else {
 		log_event( LOG_EMAIL, 'Password reset for user @U%d not sent, email is empty', $p_user_id );
@@ -708,19 +708,19 @@ function email_notify_new_account( $p_username, $p_email ) {
 /**
  * Send a generic email.
  *
- * @param int        $p_bug_id                  A bug identifier.
- * @param string     $p_notify_type             Notification type, used to check who
- *                                              should get notified of such event.
- * @param int        $p_message_id              Message identifier to be translated
- *                                              and included at the top of the email message.
- * @param array|null $p_header_optional_params  Optional Parameters for $p_message_id
- *                                              (default null).
- * @param array      $p_extra_user_ids_to_email Array of additional users to email.
+ * @param int    $p_bug_id                   A bug identifier.
+ * @param string $p_notify_type              Notification type, used to check who
+ *                                           should get notified of such event.
+ * @param int    $p_message_id               Message identifier to be translated
+ *                                           and included at the top of the email message.
+ * @param array  $p_header_optional_params   Optional Parameters for $p_message_id
+ *                                           (default none).
+ * @param array   $p_extra_user_ids_to_email Array of additional users to email.
  *
  * @return void
  * @throws ClientException
  */
-function email_generic( $p_bug_id, $p_notify_type, $p_message_id = null, array $p_header_optional_params = null, array $p_extra_user_ids_to_email = array() ) {
+function email_generic( $p_bug_id, $p_notify_type, $p_message_id = null, array $p_header_optional_params = [], array $p_extra_user_ids_to_email = array() ) {
 	# @todo yarick123: email_collect_recipients(...) will be completely rewritten to provide additional information such as language, user access,..
 	# @todo yarick123:sort recipients list by language to reduce switches between different languages
 	$t_recipients = email_collect_recipients( $p_bug_id, $p_notify_type, $p_extra_user_ids_to_email );
@@ -730,16 +730,16 @@ function email_generic( $p_bug_id, $p_notify_type, $p_message_id = null, array $
 /**
  * Sends a generic email to the specific set of recipients.
  *
- * @param int        $p_bug_id                 A bug identifier
- * @param string     $p_notify_type            Notification type
- * @param array      $p_recipients             Array of recipients (key: user id, value: email address)
- * @param int        $p_message_id             Message identifier
- * @param array|null $p_header_optional_params Optional Parameters (default null)
+ * @param int     $p_bug_id                 A bug identifier
+ * @param string  $p_notify_type            Notification type
+ * @param array   $p_recipients             Array of recipients (key: user id, value: email address)
+ * @param int     $p_message_id             Message identifier
+ * @param array   $p_header_optional_params Optional Parameters (default none)
  *
  * @return void
  * @throws ClientException
  */
-function email_generic_to_recipients( $p_bug_id, $p_notify_type, array $p_recipients, $p_message_id = null, array $p_header_optional_params = null ) {
+function email_generic_to_recipients( int $p_bug_id, string $p_notify_type, array $p_recipients, $p_message_id = null, array $p_header_optional_params = [] ) {
 	if( empty( $p_recipients ) ) {
 		return;
 	}
@@ -1254,7 +1254,7 @@ function email_owner_changed($p_bug_id, $p_prev_handler_id, $p_new_handler_id ) 
 		}
 	}
 
-	email_generic( $p_bug_id, 'owner', $t_message_id, /* headers */ null, $t_extra_user_ids_to_email );
+	email_generic( $p_bug_id, 'owner', $t_message_id, /* headers */ [], $t_extra_user_ids_to_email );
 }
 
 /**
@@ -1287,18 +1287,18 @@ function email_bug_deleted( $p_bug_id ) {
 /**
  * Store email in queue for sending.
  *
- * @param string     $p_recipient Email recipient address.
- * @param string     $p_subject   Subject of email message.
- * @param string     $p_message   Body text of email message.
- * @param array|null $p_headers   Array of additional headers to send with the email.
- * @param bool       $p_force     True to force sending of emails in shutdown function,
- *                                even when using cronjob
- * @param array      $p_cc        Array of cc recipients.
- * @param array      $p_bcc       Array of bcc recipients.
+ * @param string $p_recipient Email recipient address.
+ * @param string $p_subject   Subject of email message.
+ * @param string $p_message   Body text of email message.
+ * @param array  $p_headers   Array of additional headers to send with the email.
+ * @param bool   $p_force     True to force sending of emails in shutdown function,
+ *                            even when using cronjob
+ * @param array  $p_cc        Array of cc recipients.
+ * @param array  $p_bcc       Array of bcc recipients.
  *
  * @return integer|null
  */
-function email_store( $p_recipient, $p_subject, $p_message, array $p_headers = null, $p_force = false, $p_cc = [], $p_bcc = [] ) {
+function email_store( string $p_recipient, string $p_subject, string $p_message, array $p_headers = [], $p_force = false, $p_cc = [], $p_bcc = [] ) {
 	global $g_email_shutdown_processing;
 
 	$t_recipient = trim( $p_recipient );
@@ -1317,7 +1317,7 @@ function email_store( $p_recipient, $p_subject, $p_message, array $p_headers = n
 	$t_email_data->subject = $t_subject;
 	$t_email_data->body = $t_message;
 	$t_email_data->metadata = array();
-	$t_email_data->metadata['headers'] = $p_headers === null ? array() : $p_headers;
+	$t_email_data->metadata['headers'] = $p_headers;
 	$t_email_data->metadata['cc'] = $p_cc;
 	$t_email_data->metadata['bcc'] = $p_bcc;
 
@@ -1795,7 +1795,7 @@ function email_user_mention( $p_bug_id, $p_mention_user_ids, $p_message, $p_remo
  * @return void
  * @throws ClientException
  */
-function email_bug_info_to_one_user( array $p_visible_bug_data, $p_message_id, $p_user_id, array $p_header_optional_params = null ) {
+function email_bug_info_to_one_user( array $p_visible_bug_data, string $p_message_id, int $p_user_id, array $p_header_optional_params = [] ) {
 	$t_user_email = user_get_email( $p_user_id );
 
 	# check whether email should be sent
@@ -1810,7 +1810,7 @@ function email_bug_info_to_one_user( array $p_visible_bug_data, $p_message_id, $
 	# build message
 	$t_message = lang_get_defaulted( $p_message_id );
 
-	if( is_array( $p_header_optional_params ) ) {
+	if( $p_header_optional_params ) {
 		$t_message = vsprintf( $t_message, $p_header_optional_params );
 	}
 

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -204,15 +204,19 @@ function error_handler( $p_type, $p_error, $p_file, $p_line ) {
 	# build an appropriate error string
 	$t_error_location = 'in \'' . $p_file .'\' line ' . $p_line;
 	$t_error_description = '\'' . $p_error . '\' ' . $t_error_location;
+
+	# PHP 8.4 compatibility, deprecation of E_STRICT constant
+	# Treat such errors as E_NOTICE
+	if( PHP_VERSION_ID < 80000 && $p_type == E_STRICT ) {
+		$p_type = E_NOTICE;
+	}
+
 	switch( $p_type ) {
 		case E_WARNING:
 			$t_error_type = 'SYSTEM WARNING';
 			break;
 		case E_NOTICE:
 			$t_error_type = 'SYSTEM NOTICE';
-			break;
-		case E_STRICT:
-			$t_error_type = 'STRICT NOTICE';
 			break;
 		case E_RECOVERABLE_ERROR:
 			# This should generally be considered fatal (like E_ERROR)

--- a/core/exceptions/ClientException.php
+++ b/core/exceptions/ClientException.php
@@ -32,7 +32,7 @@ class ClientException extends MantisException {
      * @param Throwable $p_previous The inner exception.
      * @return void
      */
-	function __construct( $p_message, $p_code, $p_params = array(), Throwable $p_previous = null ) {
+	function __construct( $p_message, $p_code, $p_params = array(), ?Throwable $p_previous = null ) {
 		parent::__construct( $p_message, $p_code, $p_params, $p_previous );
 	}
 }

--- a/core/exceptions/LegacyApiFaultException.php
+++ b/core/exceptions/LegacyApiFaultException.php
@@ -16,6 +16,8 @@
 
 namespace Mantis\Exceptions;
 
+use Throwable;
+
 /**
  * An exception that is triggered from a RestFault or SoapFault which is the legacy
  * way to trigger API errors.  This exception class should be removed once all APIs
@@ -33,7 +35,7 @@ class LegacyApiFaultException extends \Exception {
      * @param \Throwable $p_previous The inner exception.
      * @return void
      */
-	function __construct( $p_message, $p_code, \Throwable $p_previous = null ) {
+	function __construct( $p_message, $p_code, ?Throwable $p_previous = null ) {
 		parent::__construct( $p_message, $p_code, $p_previous );
 	}
 }

--- a/core/exceptions/MantisException.php
+++ b/core/exceptions/MantisException.php
@@ -36,7 +36,7 @@ class MantisException extends \Exception {
      * @param Throwable $p_previous The inner exception.
      * @return void
      */
-	function __construct( $p_message, $p_code, $p_params = array(), Throwable $p_previous = null ) {
+	function __construct( $p_message, $p_code, $p_params = array(), ?Throwable $p_previous = null ) {
 		parent::__construct( $p_message, $p_code, $p_previous );
 		$this->params = $p_params;
 	}

--- a/core/exceptions/ServiceException.php
+++ b/core/exceptions/ServiceException.php
@@ -16,6 +16,8 @@
 
 namespace Mantis\Exceptions;
 
+use Throwable;
+
 /**
  * An exception that is triggered due to a Mantis error.
  */
@@ -29,7 +31,7 @@ class ServiceException extends MantisException {
      * @param \Throwable $p_previous The inner exception.
      * @return void
      */
-	function __construct( $p_message, $p_code, $p_params = array(), \Throwable $p_previous = null ) {
+	function __construct( $p_message, $p_code, $p_params = array(), ?Throwable $p_previous = null ) {
 		parent::__construct( $p_message, $p_code, $p_params, $p_previous );
 	}
 }

--- a/core/exceptions/StateException.php
+++ b/core/exceptions/StateException.php
@@ -16,6 +16,8 @@
 
 namespace Mantis\Exceptions;
 
+use Throwable;
+
 /**
  * An exception that is triggered due to an error in the state of Mantis.
  * For example, the data in the database is inconsistent or invalid
@@ -32,7 +34,7 @@ class StateException extends MantisException {
      * @param \Throwable $p_previous The inner exception.
      * @return void
      */
-	function __construct( $p_message, $p_code, $p_params = array(), \Throwable $p_previous = null ) {
+	function __construct( $p_message, $p_code, $p_params = array(), ?Throwable $p_previous = null ) {
 		parent::__construct( $p_message, $p_code, $p_params, $p_previous );
 	}
 }

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -995,10 +995,12 @@ function filter_get_default_property( $p_filter_property, $p_view_type = null ) 
 }
 
 /**
- *  Get the standard filter that is to be used when no filter was previously saved.
- *  When creating specific filters, this can be used as a basis for the filter, where
- *  specific entries can be overridden.
- * @return mixed
+ * Get the standard filter that is to be used when no filter was previously saved.
+ *
+ * When creating specific filters, this can be used as a basis for the filter, where
+ * specific entries can be overridden.
+ *
+ * @return array
  */
 function filter_get_default() {
 	# Create empty array, validation will fill it with defaults
@@ -1007,13 +1009,16 @@ function filter_get_default() {
 }
 
 /**
- * Deserialize filter string
+ * Deserialize filter string.
+ *
  * Expected strings have this format: "<version>#<json string>" where:
- * - <version> is the versio number of the filter structure used. See constant FILTER_VERSION
+ * - <version> is the version number of the filter structure used. See constant FILTER_VERSION
  * - # is a separator
- * - <json string> is the json encoded filter array.
+ * - <json string> is the JSON-encoded filter array.
+ *
  * @param string $p_serialized_filter Serialized filter string.
- * @return mixed $t_filter array
+ *
+ * @return array|false $t_filter array
  * @see filter_ensure_valid_filter
  */
 function filter_deserialize( $p_serialized_filter ) {
@@ -1021,9 +1026,9 @@ function filter_deserialize( $p_serialized_filter ) {
 		return false;
 	}
 
-	#@TODO cproensa, we could accept a pure json array, without version prefix
-	# in this case, the filter version field inside the array is to be used
-	# and if not present, set the current filter version
+	# @TODO cproensa, we could accept a pure json array, without version prefix.
+	#       In this case, the filter version field inside the array is to be used
+	#       and if not present, set the current filter version
 
 	# check filter version mark
 	$t_setting_arr = explode( '#', $p_serialized_filter, 2 );
@@ -1999,7 +2004,7 @@ function filter_create_monitored_by( $p_project_id, $p_user_id ) {
  *
  * @return array The resulting filter array.
  */
-function filter_gpc_get( array $p_filter = null ) {
+function filter_gpc_get( ?array $p_filter = null ): array {
 	# Get or copy the view_type first as it's needed to get proper defaults
 	$f_view_type = gpc_get_string( 'view_type', null );
 	if( null === $f_view_type && is_array( $p_filter ) && isset( $p_filter['_view_type'] ) ) {
@@ -2545,7 +2550,7 @@ function filter_get_included_projects( array $p_filter, $p_project_id = null, $p
  * @return array|null A filter array
  * @throws ClientException
  */
-function filter_get( $p_filter_id, array $p_default = null ) {
+function filter_get( int $p_filter_id, ?array $p_default = null ) {
 	# if no default was provided, we will trigger an error if not found
 	$t_trigger_error = func_num_args() == 1;
 

--- a/core/filter_form_api.php
+++ b/core/filter_form_api.php
@@ -200,7 +200,7 @@ function print_filter_values_reporter_id( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_reporter_id( array $p_filter = null ) {
+function print_filter_reporter_id( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -286,7 +286,7 @@ function print_filter_values_user_monitor( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_user_monitor( array $p_filter = null ) {
+function print_filter_user_monitor( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -366,7 +366,7 @@ function print_filter_values_handler_id( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_handler_id( array $p_filter = null ) {
+function print_filter_handler_id( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -441,7 +441,7 @@ function print_filter_values_show_category( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_show_category( array $p_filter = null ) {
+function print_filter_show_category( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -475,7 +475,7 @@ function print_filter_values_platform( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_platform( array $p_filter = null ) {
+function print_filter_platform( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -511,7 +511,7 @@ function print_filter_values_os( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_os( array $p_filter = null ) {
+function print_filter_os( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -544,7 +544,7 @@ function print_filter_values_os_build( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_os_build( array $p_filter = null ) {
+function print_filter_os_build( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -604,7 +604,7 @@ function print_filter_values_show_severity( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_show_severity( array $p_filter = null ) {
+function print_filter_show_severity( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -663,7 +663,7 @@ function print_filter_values_show_resolution( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_show_resolution( array $p_filter = null ) {
+function print_filter_show_resolution( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -722,7 +722,7 @@ function print_filter_values_show_status( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_show_status( array $p_filter = null ) {
+function print_filter_show_status( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -785,7 +785,7 @@ function print_filter_values_hide_status( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_hide_status( array $p_filter = null ) {
+function print_filter_hide_status( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -847,7 +847,7 @@ function print_filter_values_show_build( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_show_build( array $p_filter = null ) {
+function print_filter_show_build( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -910,7 +910,7 @@ function print_filter_values_show_version( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_show_version( array $p_filter = null ) {
+function print_filter_show_version( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -974,7 +974,7 @@ function print_filter_values_show_fixed_in_version( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_show_fixed_in_version( array $p_filter = null ) {
+function print_filter_show_fixed_in_version( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -1038,7 +1038,7 @@ function print_filter_values_show_target_version( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_show_target_version( array $p_filter = null ) {
+function print_filter_show_target_version( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -1099,7 +1099,7 @@ function print_filter_values_show_priority( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_show_priority( array $p_filter = null ) {
+function print_filter_show_priority( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -1160,7 +1160,7 @@ function print_filter_values_show_profile( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_show_profile( array $p_filter = null ) {
+function print_filter_show_profile( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -1194,7 +1194,7 @@ function print_filter_values_per_page( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_per_page( array $p_filter = null ) {
+function print_filter_per_page( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -1232,7 +1232,7 @@ function print_filter_values_view_state( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_view_state( array $p_filter = null ) {
+function print_filter_view_state( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -1280,7 +1280,7 @@ function print_filter_values_sticky_issues( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_sticky_issues( array $p_filter = null ) {
+function print_filter_sticky_issues( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -1321,7 +1321,7 @@ function print_filter_values_highlight_changed( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_highlight_changed( array $p_filter = null ) {
+function print_filter_highlight_changed( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -1397,7 +1397,7 @@ function print_filter_values_do_filter_by_date( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_do_filter_by_date( $p_hide_checkbox = false, array $p_filter = null ) {
+function print_filter_do_filter_by_date( $p_hide_checkbox = false, ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -1553,7 +1553,7 @@ function print_filter_values_do_filter_by_last_updated_date( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_do_filter_by_last_updated_date( $p_hide_checkbox = false, array $p_filter = null ) {
+function print_filter_do_filter_by_last_updated_date( $p_hide_checkbox = false, ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -1700,7 +1700,7 @@ function print_filter_values_relationship_type( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_relationship_type( array $p_filter = null ) {
+function print_filter_relationship_type( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -1736,7 +1736,7 @@ function print_filter_values_tag_string( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_tag_string( array $p_filter = null ) {
+function print_filter_tag_string( ?array $p_filter = null ) {
 	global $g_filter;
 	if( !access_has_project_level( config_get( 'tag_view_threshold' ) ) ) {
 		return;
@@ -1812,7 +1812,7 @@ function print_filter_values_note_user_id( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_note_user_id( array $p_filter = null ) {
+function print_filter_note_user_id( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -1897,7 +1897,7 @@ function print_filter_values_plugin_field( array $p_filter, $p_field_name, $p_fi
  * @return void
  * @global array     $g_filter
  */
-function print_filter_plugin_field( $p_field_name, $p_filter_object, array $p_filter = null ) {
+function print_filter_plugin_field( $p_field_name, $p_filter_object, ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -2068,7 +2068,7 @@ function print_filter_values_custom_field_date( array $p_filter, $p_field_id ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_custom_field( $p_field_id, array $p_filter = null ) {
+function print_filter_custom_field( $p_field_id, ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -2164,7 +2164,7 @@ function print_filter_values_show_sort( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_show_sort( array $p_filter = null ) {
+function print_filter_show_sort( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -2243,7 +2243,7 @@ function print_filter_show_sort( array $p_filter = null ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_custom_field_date( $p_field_id, array $p_filter = null ) {
+function print_filter_custom_field_date( $p_field_id, ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -2381,7 +2381,7 @@ function print_filter_values_project_id( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_project_id( array $p_filter = null ) {
+function print_filter_project_id( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -2444,7 +2444,7 @@ function print_filter_values_projection( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_projection( array $p_filter = null ) {
+function print_filter_projection( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -2488,7 +2488,7 @@ function print_filter_values_match_type( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_match_type( array $p_filter = null ) {
+function print_filter_match_type( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;
@@ -3056,7 +3056,7 @@ function print_filter_values_search( array $p_filter ) {
  * @return void
  * @global array     $g_filter
  */
-function print_filter_search( array $p_filter = null ) {
+function print_filter_search( ?array $p_filter = null ) {
 	global $g_filter;
 	if( null === $p_filter ) {
 		$p_filter = $g_filter;

--- a/core/gpc_api.php
+++ b/core/gpc_api.php
@@ -211,11 +211,7 @@ function gpc_get_custom_field( $p_var_name, $p_custom_field_type, $p_default = n
 				$p_default = array( $p_default );
 			}
 			$t_values = gpc_get_string_array( $p_var_name, $p_default );
-			if( is_array( $t_values ) ) {
-				return implode( '|', $t_values );
-			} else {
-				return '';
-			}
+			return implode( '|', $t_values );
 		case CUSTOM_FIELD_TYPE_DATE:
 			$t_day = gpc_get_int( $p_var_name . '_day', 0 );
 			$t_month = gpc_get_int( $p_var_name . '_month', 0 );
@@ -245,7 +241,7 @@ function gpc_get_custom_field( $p_var_name, $p_custom_field_type, $p_default = n
  *
  * @return array
  */
-function gpc_get_string_array( $p_var_name, array $p_default = null ) {
+function gpc_get_string_array( string $p_var_name, array $p_default = [] ): array {
 	# Don't pass along a default unless one was given to us
 	# otherwise we prevent an error being triggered
 	$t_args = func_get_args();
@@ -282,7 +278,7 @@ function gpc_get_string_array( $p_var_name, array $p_default = null ) {
  *
  * @return array
  */
-function gpc_get_int_array( $p_var_name, array $p_default = null ) {
+function gpc_get_int_array( string $p_var_name, array $p_default = [] ): array {
 	# Don't pass along a default unless one was given to us
 	# otherwise we prevent an error being triggered
 	$t_args = func_get_args();
@@ -313,7 +309,7 @@ function gpc_get_int_array( $p_var_name, array $p_default = null ) {
  *
  * @return array
  */
-function gpc_get_bool_array( $p_var_name, array $p_default = null ) {
+function gpc_get_bool_array( string $p_var_name, array $p_default = [] ): array {
 	# Don't pass along a default unless one was given to us
 	# otherwise we prevent an error being triggered
 	$t_args = func_get_args();

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -434,19 +434,19 @@ function html_top_banner() {
 /**
  * Outputs a message to confirm an operation's result.
  *
- * @param array|null $p_buttons  Array of (URL, label) pairs used to generate
- *                               the buttons; if label is null or unspecified,
- *                               the default 'proceed' text will be displayed;
- *                               If the array is empty or not provided, no
- *                               buttons will be printed.
- * @param string     $p_message  Message to display to the user. If none is
- *                               provided, a default message will be printed
- * @param int        $p_type     One of the constants CONFIRMATION_TYPE_SUCCESS,
- *                               CONFIRMATION_TYPE_WARNING, CONFIRMATION_TYPE_FAILURE
+ * @param array  $p_buttons  Array of (URL, label) pairs used to generate
+ *                           the buttons; if label is null or unspecified,
+ *                           the default 'proceed' text will be displayed;
+ *                           If the array is empty or not provided, no
+ *                           buttons will be printed.
+ * @param string $p_message  Message to display to the user. If none is
+ *                           provided, a default message will be printed
+ * @param int    $p_type     One of the constants CONFIRMATION_TYPE_SUCCESS,
+ *                           CONFIRMATION_TYPE_WARNING, CONFIRMATION_TYPE_FAILURE
  *
  * @return void
  */
-function html_operation_confirmation( array $p_buttons = null, $p_message = '', $p_type = CONFIRMATION_TYPE_SUCCESS ) {
+function html_operation_confirmation( array $p_buttons = [], string $p_message = '', int $p_type = CONFIRMATION_TYPE_SUCCESS ): void {
 	switch( $p_type ) {
 		case CONFIRMATION_TYPE_FAILURE:
 			$t_alert_css = 'alert-danger';
@@ -727,7 +727,7 @@ function print_submenu( array $p_menu_items, $p_current_page = '', $p_event = nu
  *
  * @return void
  */
-function print_summary_submenu( $p_current_page = '' ) {
+function print_summary_submenu( string $p_current_page = '' ): void {
 	# Plugin / Event added options
 	$t_menu_items = plugin_menu_items( 'EVENT_SUBMENU_SUMMARY' );
 
@@ -941,9 +941,9 @@ function print_doc_menu( $p_page = '' ) {
  *
  * @return void
  */
-function print_summary_menu( $p_page = '', array $p_filter = null ) {
+function print_summary_menu( $p_page = '', ?array $p_filter = null ): void {
 	$t_link = 'summary_page.php';
-	$t_filter_param = $p_filter ? filter_get_temporary_key_param( $p_filter ) : null;
+	$t_filter_param = $p_filter ? filter_get_temporary_key_param( $p_filter ) : '';
 	if( $t_filter_param ) {
 		$t_link = helper_url_combine( $t_link, $t_filter_param );
 	}

--- a/core/install_helper_functions_api.php
+++ b/core/install_helper_functions_api.php
@@ -823,7 +823,7 @@ function install_print_unserialize_errors_csv( $p_table, $p_data ) {
 
 	# Generate CSV data
 	foreach( $p_data as $t_error ) {
-		fputcsv( $f, $t_error );
+		fputcsv( $f, $t_error, ',', '"', '' );
 	}
 	$t_csv .= stream_get_contents( $f, -1,0 );
 	fclose( $f );

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -687,13 +687,15 @@ function print_subproject_option_list( $p_parent_id, $p_project_id = null, $p_fi
 }
 
 /**
- * prints the profiles given the user id
- * @param integer $p_user_id   A user identifier.
- * @param integer $p_select_id ID to mark as selected; if 0, gets the user's default profile.
- * @param array   $p_profiles  Array of profiles.
+ * Prints the profiles given the user id.
+ *
+ * @param int        $p_user_id   A user identifier.
+ * @param int        $p_select_id ID to mark as selected; if 0, gets the user's default profile.
+ * @param array|null $p_profiles  Array of profiles.
+ *
  * @return void
  */
-function print_profile_option_list( $p_user_id, $p_select_id = 0, array $p_profiles = null ) {
+function print_profile_option_list( $p_user_id, $p_select_id = 0, ?array $p_profiles = null ) {
 	if( 0 == $p_select_id ) {
 		$p_select_id = profile_get_default( $p_user_id );
 	}
@@ -707,12 +709,12 @@ function print_profile_option_list( $p_user_id, $p_select_id = 0, array $p_profi
 
 /**
  * prints the profiles used in a certain project
- * @param integer $p_project_id A project identifier.
- * @param integer $p_select_id  ID to mark as selected; if 0, gets the user's default profile.
- * @param array   $p_profiles   Array of profiles.
+ * @param int        $p_project_id A project identifier.
+ * @param int        $p_select_id  ID to mark as selected; if 0, gets the user's default profile.
+ * @param array|null $p_profiles   Array of profiles.
  * @return void
  */
-function print_profile_option_list_for_project( $p_project_id, $p_select_id = 0, array $p_profiles = null ) {
+function print_profile_option_list_for_project( $p_project_id, $p_select_id = 0, ?array $p_profiles = null ) {
 	if( 0 == $p_select_id ) {
 		$p_select_id = profile_get_default( auth_get_current_user_id() );
 	}
@@ -1174,7 +1176,7 @@ function print_font_option_list( $p_font ) {
  *
  * @return void
  */
-function print_all_bug_action_option_list( array $p_project_ids = null ) {
+function print_all_bug_action_option_list( array $p_project_ids = [] ) {
 	$t_commands = bug_group_action_get_commands( $p_project_ids );
 	foreach ( $t_commands as $t_action_id => $t_action_label) {
 		echo '<option value="' . $t_action_id . '">' . $t_action_label . '</option>';
@@ -1472,7 +1474,7 @@ function print_manage_project_sort_link( $p_page, $p_string, $p_field, $p_dir, $
  *
  * @return void
  */
-function print_form_button( $p_action_page, $p_label, array $p_args_to_post = null, $p_security_token = null, $p_class = '' ) {
+function print_form_button( $p_action_page, $p_label, array $p_args_to_post = [], $p_security_token = null, $p_class = '' ) {
 	# TODO: ensure all uses of print_button supply arguments via $p_args_to_post (POST)
 	# instead of via $p_action_page (GET). Then only add the CSRF form token if
 	# arguments are being sent via the POST method.
@@ -2260,7 +2262,7 @@ function print_dropzone_template(){
  * @deprecated 2.0 use {@see print_form_button()} instead
  * @see form_security_token()
  */
-function print_button( $p_action_page, $p_label, array $p_args_to_post = null, $p_security_token = null ) {
+function print_button( $p_action_page, $p_label, array $p_args_to_post = [], $p_security_token = null ) {
 	error_parameters( __FUNCTION__, 'print_form_button' );
 	trigger_error( ERROR_DEPRECATED_SUPERSEDED, DEPRECATED );
 	print_form_button( $p_action_page, $p_label, $p_args_to_post, $p_security_token );

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -38,6 +38,8 @@
  * @uses utility_api.php
  */
 
+use Mantis\Exceptions\ClientException;
+
 require_api( 'access_api.php' );
 require_api( 'authentication_api.php' );
 require_api( 'bug_api.php' );
@@ -80,11 +82,12 @@ function summary_helper_print_row( $p_label, $p_open, $p_resolved, $p_closed, $p
  * Returns a string representation of the user, together with a link to the issues
  * acted on by the user ( reported, handled or commented on )
  *
- * @param integer $p_user_id A valid user identifier.
+ * @param int   $p_user_id A valid user identifier.
  * @param array $p_filter Filter array.
+ *
  * @return string
  */
-function summary_helper_get_developer_label( $p_user_id, array $p_filter = null ) {
+function summary_helper_get_developer_label( $p_user_id, array $p_filter = [] ) {
 	$t_user = string_display_line( user_get_name( $p_user_id ) );
 
 	$t_link_prefix = summary_get_link_prefix( $p_filter );
@@ -179,15 +182,16 @@ function summary_helper_get_bugratio( $p_bugs_open, $p_bugs_resolved, $p_bugs_cl
 }
 
 /**
- * Used in summary reports - this function prints out the summary for the given enum setting.
- * The enum field name is passed in through $p_enum.
- * A filter can be used to limit the visibility.
+ * Prints out the summary for the given enum setting.
  *
- * @param string $p_enum Enum field name.
- * @param array $p_filter Filter array.
+ * Used in summary reports.
+ *
+ * @param string $p_enum   Enum field name.
+ * @param array  $p_filter Filter array to limit the visibility.
+ *
  * @return void
  */
-function summary_print_by_enum( $p_enum, array $p_filter = null ) {
+function summary_print_by_enum( $p_enum, array $p_filter = [] ) {
 	$t_project_id = helper_get_current_project();
 
 	$t_project_filter = helper_project_specific_where( $t_project_id );
@@ -241,9 +245,9 @@ function summary_print_by_enum( $p_enum, array $p_filter = null ) {
 
 	foreach( $t_cache as $t_enum => $t_item) {
 		# Build up the hyperlinks to bug views
-		$t_bugs_open = isset( $t_item['open'] ) ? $t_item['open'] : 0;
-		$t_bugs_resolved = isset( $t_item['resolved'] ) ? $t_item['resolved'] : 0;
-		$t_bugs_closed = isset( $t_item['closed'] ) ? $t_item['closed'] : 0;
+		$t_bugs_open = $t_item['open'] ?? 0;
+		$t_bugs_resolved = $t_item['resolved'] ?? 0;
+		$t_bugs_closed = $t_item['closed'] ?? 0;
 		$t_bugs_total = $t_bugs_open + $t_bugs_resolved + $t_bugs_closed;
 		$t_bugs_ratio = summary_helper_get_bugratio( $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total_count);
 
@@ -296,14 +300,16 @@ function summary_print_by_enum( $p_enum, array $p_filter = null ) {
 }
 
 /**
- * Print list of open bugs with the highest activity score the score is calculated assigning
- * one "point" for each history event associated with the bug.
- * A filter can be used to limit the visibility.
+ * Print list of open bugs with the highest activity score.
  *
- * @param array $p_filter Filter array.
+ * The score is calculated assigning one "point" for each history event
+ * associated with the bug.
+ *
+ * @param array $p_filter Filter array to limit the visibility.
+ *
  * @return void
  */
-function summary_print_by_activity( array $p_filter = null ) {
+function summary_print_by_activity( array $p_filter = [] ) {
 	$t_project_id = helper_get_current_project();
 	$t_resolved = config_get( 'bug_resolved_status_threshold' );
 	$t_specific_where = helper_project_specific_where( $t_project_id );
@@ -361,12 +367,13 @@ function summary_print_by_activity( array $p_filter = null ) {
 
 /**
  * Print list of bugs opened from the longest time.
- * A filter can be used to limit the visibility.
  *
- * @param array $p_filter Filter array.
+ * @param array $p_filter Filter array to limit the visibility.
+ *
  * @return void
+ * @throws ClientException
  */
-function summary_print_by_age( array $p_filter = null ) {
+function summary_print_by_age( array $p_filter = [] ) {
 	$t_project_id = helper_get_current_project();
 	$t_resolved = config_get( 'bug_resolved_status_threshold' );
 
@@ -412,13 +419,13 @@ function summary_print_by_age( array $p_filter = null ) {
 }
 
 /**
- * print bug counts by assigned to each developer.
- * A filter can be used to limit the visibility.
+ * Print bug counts by assigned to each developer.
  *
- * @param array $p_filter Filter array.
+ * @param array $p_filter Filter array to limit the visibility.
+ *
  * @return void
  */
-function summary_print_by_developer( array $p_filter = null ) {
+function summary_print_by_developer( array $p_filter = [] ) {
 	$t_project_id = helper_get_current_project();
 
 	$t_specific_where = helper_project_specific_where( $t_project_id );
@@ -473,12 +480,12 @@ function summary_print_by_developer( array $p_filter = null ) {
 
 /**
  * Print bug counts by reporter id.
- * A filter can be used to limit the visibility.
  *
- * @param array $p_filter Filter array.
+ * @param array $p_filter Filter array to limit the visibility.
+ *
  * @return void
  */
-function summary_print_by_reporter( array $p_filter = null ) {
+function summary_print_by_reporter( array $p_filter = [] ) {
 	$t_reporter_summary_limit = config_get( 'reporter_summary_limit' );
 
 	$t_project_id = helper_get_current_project();
@@ -604,12 +611,11 @@ function summary_print_by_reporter( array $p_filter = null ) {
 
 /**
  * Print a bug count per category.
- * A filter can be used to limit the visibility.
  *
- * @param array $p_filter Filter array.
+ * @param array $p_filter Filter array to limit the visibility.
  * @return void
  */
-function summary_print_by_category( array $p_filter = null ) {
+function summary_print_by_category( array $p_filter = [] ) {
 	$t_summary_category_include_project = config_get( 'summary_category_include_project' );
 
 	$t_project_id = helper_get_current_project();
@@ -666,16 +672,17 @@ function summary_print_by_category( array $p_filter = null ) {
 
 /**
  * Print bug counts by project.
- * A filter can be used to limit the visibility.
+ *
  * @todo check p_cache - static?
  *
- * @param array   $p_projects Array of project id's.
- * @param integer $p_level    Indicates the depth of the project within the sub-project hierarchy.
- * @param array   $p_cache    Summary cache.
- * @param array   $p_filter   Filter array.
+ * @param array $p_projects Array of project id's.
+ * @param int   $p_level    Indicates the depth of the project within the sub-project hierarchy.
+ * @param array $p_cache    Summary cache.
+ * @param array $p_filter   Filter array to limit the visibility.
+ *
  * @return void
  */
-function summary_print_by_project( array $p_projects = array(), int $p_level = 0, array $p_cache = null, array $p_filter = null ) {
+function summary_print_by_project( array $p_projects = [], int $p_level = 0, array $p_cache = [], array $p_filter = [] ) {
 	$t_project_id = helper_get_current_project();
 
 	if( empty( $p_projects ) ) {
@@ -689,7 +696,7 @@ function summary_print_by_project( array $p_projects = array(), int $p_level = 0
 	}
 
 	# Retrieve statistics one time to improve performance.
-	if( null === $p_cache ) {
+	if( empty( $p_cache ) ) {
 		$t_query = new DBQuery();
 		$t_sql = 'SELECT project_id, status, COUNT( status ) AS bugcount FROM {bug}';
 		if( !empty( $p_filter ) ) {
@@ -744,13 +751,13 @@ function summary_print_by_project( array $p_projects = array(), int $p_level = 0
 
 /**
  * Print developer / resolution report.
- * A filter can be used to limit the visibility.
  *
  * @param string $p_resolution_enum_string Resolution enumeration string value.
- * @param array $p_filter Filter array.
+ * @param array $p_filter Filter array to limit the visibility.
+ *
  * @return void
  */
-function summary_print_developer_resolution( $p_resolution_enum_string, array $p_filter = null ) {
+function summary_print_developer_resolution( $p_resolution_enum_string, array $p_filter = [] ) {
 	$t_project_id = helper_get_current_project();
 
 	# Get the resolution values to use
@@ -880,13 +887,13 @@ function summary_print_developer_resolution( $p_resolution_enum_string, array $p
 
 /**
  * Print reporter / resolution report.
- * A filter can be used to limit the visibility.
  *
  * @param string $p_resolution_enum_string Resolution enumeration string value.
- * @param array $p_filter Filter array.
+ * @param array $p_filter Filter array to limit the visibility.
+ *
  * @return void
  */
-function summary_print_reporter_resolution( $p_resolution_enum_string, array $p_filter = null ) {
+function summary_print_reporter_resolution( $p_resolution_enum_string, array $p_filter = [] ) {
 	$t_reporter_summary_limit = config_get( 'reporter_summary_limit' );
 
 	$t_project_id = helper_get_current_project();
@@ -1019,14 +1026,14 @@ function summary_print_reporter_resolution( $p_resolution_enum_string, array $p_
 
 /**
  * Print reporter effectiveness report.
- * A filter can be used to limit the visibility.
  *
  * @param string $p_severity_enum_string   Severity enumeration string.
  * @param string $p_resolution_enum_string Resolution enumeration string.
- * @param array $p_filter Filter array.
+ * @param array  $p_filter                 Filter array to limit the visibility.
+ *
  * @return void
  */
-function summary_print_reporter_effectiveness( $p_severity_enum_string, $p_resolution_enum_string, array $p_filter = null ) {
+function summary_print_reporter_effectiveness( $p_severity_enum_string, $p_resolution_enum_string, array $p_filter = [] ) {
 	$t_reporter_summary_limit = config_get( 'reporter_summary_limit' );
 
 	$t_project_id = helper_get_current_project();
@@ -1140,13 +1147,13 @@ function summary_print_reporter_effectiveness( $p_severity_enum_string, $p_resol
 
 /**
  * Calculate time stats for resolved issues.
- * A filter can be used to limit the visibility.
  *
- * @param integer $p_project_id.
- * @param array $p_filter Filter array.
+ * @param int   $p_project_id
+ * @param array $p_filter     Filter array to limit the visibility.
+ *
  * @return array
  */
-function summary_helper_get_time_stats( $p_project_id, array $p_filter = null ) {
+function summary_helper_get_time_stats( $p_project_id, array $p_filter = [] ) {
 	$t_specific_where = helper_project_specific_where( $p_project_id );
 	$t_resolved = config_get( 'bug_resolved_status_threshold' );
 
@@ -1248,12 +1255,13 @@ function summary_helper_get_time_stats( $p_project_id, array $p_filter = null ) 
 
 /**
  * Returns a filter to be used in summary pages.
+ *
  * A temporary filter is retrieved if a valid temporary filter key is submitted
  * to the page as request parameter "filter".
  * If no filter key was provided, returns a generic filter that shows all
- * accesible issues by the user.
+ * accessible issues by the user.
  *
- * @return array	Filter array
+ * @return array Filter array
  */
 function summary_get_filter() {
 	$t_filter = null;
@@ -1274,14 +1282,18 @@ function summary_get_filter() {
 
 /**
  * Print filter related information for summary page.
+ *
  * If a filter has been applied, display a notice, bug count, link to view issues.
+ *
  * @param array $p_filter Filter array.
+ *
  * @return void
  */
-function summary_print_filter_info( array $p_filter = null ) {
-	if( null === $p_filter ) {
+function summary_print_filter_info( array $p_filter = [] ) {
+	if( empty( $p_filter ) ) {
 		return;
 	}
+
 	# If filter is temporary, then it has been provided explicitly.
 	# When no filter is specified for summary page, we receive a defaulted filter
 	# which don't have any specific id.
@@ -1307,15 +1319,16 @@ function summary_print_filter_info( array $p_filter = null ) {
 }
 
 /**
- * Calculate the number of "open" and "resolve" issues actions in the last X days.
- * This includes each and successive resolution transitions.
- * A filter can be used to limit the visibility.
+ * Calculate the number of "open" and "resolved" issues actions in the last X days.
  *
- * @param array $p_date_array   An array of integers representing days is passed in.
- * @param array $p_filter       Filter array.
- * @return array	Accumulated count for each day range.
+ * This includes each and successive resolution transitions.
+ *
+ * @param array $p_date_array An array of integers representing days is passed in.
+ * @param array $p_filter     Filter array to limit the visibility.
+ *
+ * @return array Accumulated count for each day range.
  */
-function summary_by_dates_bug_count( array $p_date_array, array $p_filter = null ) {
+function summary_by_dates_bug_count( array $p_date_array, array $p_filter = [] ) {
 	$t_project_id = helper_get_current_project();
 	$t_specific_where = helper_project_specific_where( $t_project_id );
 	$t_resolved = config_get( 'bug_resolved_status_threshold' );
@@ -1406,16 +1419,17 @@ function summary_by_dates_bug_count( array $p_date_array, array $p_filter = null
 }
 
 /**
- * This function shows the number of "open" and "resolve" issues actions in the
- * last X days. This includes each issue submission, and it's succesive resolve
+ * Show the number of "open" and "resolved" issues actions in the last X days.
+ *
+ * This includes each issue submission, and its successive resolved
  * and reopen transitions.
- * A filter can be used to limit the visibility.
  *
  * @param array $p_date_array An array of integers representing days is passed in.
- * @param array $p_filter Filter array.
+ * @param array $p_filter     Filter array to limit the visibility.
+ *
  * @return void
  */
-function summary_print_by_date( array $p_date_array, array $p_filter = null ) {
+function summary_print_by_date( array $p_date_array, array $p_filter = [] ) {
 	# clean and sort dates array
 	$t_date_array = array_values( $p_date_array );
 	sort( $t_date_array );
@@ -1476,9 +1490,15 @@ function summary_print_by_date( array $p_date_array, array $p_filter = null ) {
 	}
 }
 
-function summary_get_link_prefix( array $p_filter = null ) {
+/**
+ * Get a temporary filter link.
+ *
+ * @param array $p_filter
+ *
+ * @return string
+ */
+function summary_get_link_prefix( array $p_filter = [] ) {
 	$t_filter_action = filter_is_temporary( $p_filter ) ? FILTER_ACTION_PARSE_ADD : FILTER_ACTION_PARSE_NEW;
 	$t_link_prefix = 'view_all_set.php?type=' . $t_filter_action . '&temporary=y&new=1';
-	$t_link_prefix = helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
-	return $t_link_prefix;
+	return helper_url_combine( $t_link_prefix, filter_get_temporary_key_param( $p_filter ) );
 }

--- a/core/version_api.php
+++ b/core/version_api.php
@@ -101,7 +101,7 @@ class VersionData {
 	 *
 	 * @param array|null $p_row
 	 */
-	public function __construct( array $p_row = null ) {
+	public function __construct( ?array $p_row = null ) {
 		if( $p_row !== null ) {
 			$this->set_from_db_row( $p_row );
 		}

--- a/plugins/MantisGraph/core/graph_api.php
+++ b/plugins/MantisGraph/core/graph_api.php
@@ -210,7 +210,7 @@ function graph_cumulative_bydate( array $p_metrics, $p_wfactor = 1 ) {
  *
  * @return array
  */
-function create_bug_enum_summary( $p_enum_string, $p_enum, array $p_exclude_codes = array(), array $p_filter = null ) {
+function create_bug_enum_summary( $p_enum_string, $p_enum, array $p_exclude_codes = array(), array $p_filter = [] ) {
 	$t_project_id = helper_get_current_project();
 	$t_user_id = auth_get_current_user_id();
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
@@ -251,12 +251,12 @@ function create_bug_enum_summary( $p_enum_string, $p_enum, array $p_exclude_code
  *
  * @return array An array with keys being status names and values being number of issues with such status.
  */
-function create_bug_status_summary( array $p_filter = null ) {
+function create_bug_status_summary( array $p_filter = [] ) {
 	# When the provided filter is temporary, it's a filter that was explicitly applied to summary pages.
 	# Otherwise, it's a filter created by default by summary api.
 	# In that case, or if no filter has been provided, keep legacy behaviour where we exclude
 	# closed status in this graph
-	if( null === $p_filter || !filter_is_temporary( $p_filter ) ) {
+	if( empty( $p_filter ) || !filter_is_temporary( $p_filter ) ) {
 		$t_status_enum = config_get( 'status_enum_string' );
 		$t_statuses = MantisEnum::getValues( $t_status_enum );
 		$t_closed_threshold = config_get( 'bug_closed_status_threshold' );
@@ -276,13 +276,13 @@ function create_bug_status_summary( array $p_filter = null ) {
 }
 
 /**
- * Create summary for issues resolved by a developer
+ * Create summary for issues resolved by a developer.
  *
- * @param array|null $p_filter Filter array.
+ * @param array $p_filter Filter array.
  *
  * @return array with key being username and value being # of issues fixed.
  */
-function create_developer_resolved_summary( array $p_filter = null ) {
+function create_developer_resolved_summary( array $p_filter = [] ) {
 	$t_project_id = helper_get_current_project();
 	$t_user_id = auth_get_current_user_id();
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
@@ -328,13 +328,13 @@ function create_developer_resolved_summary( array $p_filter = null ) {
 }
 
 /**
- * Create summary for issues opened by a developer
+ * Create summary for issues opened by a developer.
  *
- * @param array|null $p_filter Filter array.
+ * @param array $p_filter Filter array.
  *
  * @return array with key being username and value being # of issues fixed.
  */
-function create_developer_open_summary( array $p_filter = null ) {
+function create_developer_open_summary( array $p_filter = [] ) {
 	$t_project_id = helper_get_current_project();
 	$t_user_id = auth_get_current_user_id();
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
@@ -378,13 +378,13 @@ function create_developer_open_summary( array $p_filter = null ) {
 }
 
 /**
- * Create summary table of reporters
+ * Create summary table of reporters.
  *
- * @param array|null $p_filter Filter array.
+ * @param array $p_filter Filter array.
  *
  * @return array
  */
-function create_reporter_summary( array $p_filter = null ) {
+function create_reporter_summary( array $p_filter = [] ) {
 	$t_project_id = helper_get_current_project();
 	$t_user_id = auth_get_current_user_id();
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
@@ -431,7 +431,7 @@ function create_reporter_summary( array $p_filter = null ) {
  *
  * @return array
  */
-function create_category_summary( array $p_filter = null ) {
+function create_category_summary( array $p_filter = [] ) {
 	$t_project_id = helper_get_current_project();
 	$t_user_id = auth_get_current_user_id();
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );
@@ -473,11 +473,11 @@ function create_category_summary( array $p_filter = null ) {
 /**
  * Generate cumulative graph data by date.
  *
- * @param array|null $p_filter Filter array.
+ * @param array $p_filter Filter array.
  *
- * @return array|null
+ * @return array
  */
-function create_cumulative_bydate( array $p_filter = null ) {
+function create_cumulative_bydate( array $p_filter = [] ) {
 	$t_res_val = config_get( 'bug_resolved_status_threshold' );
 	$t_seconds_per_day = SECONDS_PER_DAY;
 
@@ -559,7 +559,7 @@ function create_cumulative_bydate( array $p_filter = null ) {
 	}
 
 	if( !$t_calc_metrics ) {
-		return null;
+		return [];
 	}
 	ksort( $t_calc_metrics );
 
@@ -590,11 +590,11 @@ function graph_date_format( $p_date ) {
 /**
  * Create summary table of projects.
  *
- * @param array|null $p_filter Filter array.
+ * @param array $p_filter Filter array.
  *
  * @return array
  */
-function create_project_summary( array $p_filter = null ) {
+function create_project_summary( array $p_filter = [] ) {
 	$t_project_id = helper_get_current_project();
 	$t_user_id = auth_get_current_user_id();
 	$t_specific_where = helper_project_specific_where( $t_project_id, $t_user_id );

--- a/plugins/MantisGraph/pages/issues_trend_graph.php
+++ b/plugins/MantisGraph/pages/issues_trend_graph.php
@@ -48,7 +48,7 @@ $t_mantisgraph->print_submenu();
 
 <?php
 			$t_metrics = create_cumulative_bydate( $t_filter );
-			if ( $t_metrics != null ) {
+			if ( $t_metrics ) {
 				graph_cumulative_bydate( $t_metrics, 2 /*wfactor*/ );
 			}
 ?>

--- a/summary_page.php
+++ b/summary_page.php
@@ -107,7 +107,7 @@ print_summary_submenu();
 				<?php echo $t_summary_header ?>
 			</tr>
 		</thead>
-		<?php summary_print_by_project( array(), 0, null, $t_filter ); ?>
+		<?php summary_print_by_project( [], 0, [], $t_filter ); ?>
 	</table>
 	</div>
 

--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -93,7 +93,7 @@ function require_mantis_core() {
 
 
 # Set error reporting to the level to which Zend Framework code must comply.
-error_reporting( E_ALL | E_STRICT );
+error_reporting( E_ALL );
 
 # Determine the root, library, and tests directories of the framework
 # distribution.


### PR DESCRIPTION
This fixes all the PHP 8.4 compatibility issues that I know about, with the exception of those from Parsedown ([#35217](https://mantisbt.org/bugs/view.php?id=35217)).

- [#35215](https://mantisbt.org/bugs/view.php?id=35215) PHP 8.4: Implicitly nullable parameter types are deprecated  
- [#35214](https://mantisbt.org/bugs/view.php?id=35214) PHP 8.4: fputcsv() empty $escape parameter is deprecated  
- [#35213](https://mantisbt.org/bugs/view.php?id=35213) PHP 8.4: E_STRICT is deprecated  
- [#35283](https://mantisbt.org/bugs/view.php?id=35283) PHP 8.4: SOAP API throws SoapFault: Internal Service Error  
- [#35284](https://mantisbt.org/bugs/view.php?id=35284) Allow REST API to run on PHP 8.4 ignoring E_DEPRECATED notices  