### PR TITLE
Support for sending mail custom header (phpmailer)

### DIFF
--- a/config_defaults_inc.php
+++ b/config_defaults_inc.php
@@ -757,6 +757,16 @@ $g_smtp_connection_mode = '';
 $g_smtp_port = 25;
 
 /**
+ * Send additional custom header
+ *
+ * Default: No additional custom header
+ * Additional headers can be included separated by , (comma) in format header_name1:value1, header_name2:value2, ....
+ * 
+ * @global string $g_smtp_customheader
+ */
+$g_smtp_customheader = '';
+
+/**
  * Enable DomainKeys Identified Mail (DKIM) Signatures (rfc6376).
  *
  * To successfully sign mails you need to enable DKIM and provide at least:

--- a/core/email_api.php
+++ b/core/email_api.php
@@ -1510,6 +1510,17 @@ function email_send( EmailData $p_email_data ) {
 	$t_mail->AddCustomHeader( 'Auto-Submitted:auto-generated' );
 	$t_mail->AddCustomHeader( 'X-Auto-Response-Suppress: All' );
 
+	# Send additional custom headers
+	if( !is_blank( config_get( 'smtp_customheader' ) ) ) {
+		
+		$customheader_config = config_get( 'smtp_customheader' );
+		$customheader_lines  = array_map('trim', explode(',', $customheader_config));
+		
+		foreach ($customheader_lines as $customheader) {
+			$t_mail->AddCustomHeader($customheader);
+		}
+	}
+
 	if( isset( $t_email_data->metadata['cc'] ) && $t_email_data->metadata['cc'] ) {
 		foreach( $t_email_data->metadata['cc'] as $cc ) {
 			$t_mail->addCC( trim( $cc ) );


### PR DESCRIPTION
Hi folks,

I'm opening this PR to implement a new variable in config/config_inc.php to add a Mail Custom Header to pass to core/email_api.php. 

Amazon SES implemented Configuration-Sets (groups of rules to verified identities), and AmazonSES requires the configuration-set to be sent in the mail header.

Using the PHP Mailer, I can do this manually, adding in core/email_api.php:
$t_mail->AddCustomHeader( 'X-SES-CONFIGURATION-SET: name-of-configuration-set' );

I suggest something like:
$g_smtp_customheader = 'X-SES-CONFIGURATION-SET: name-of-configuration-set'

See more details: https://mantisbt.org/bugs/view.php?id=35305

Thanks!