### PR TITLE
Fix HTML errors and warnings

### DIFF
--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1340,7 +1340,7 @@ function filter_draw_selection_area() {
 					<form method="post" action="view_all_set.php">
 						<input type="hidden" name="type" value="<?php echo FILTER_ACTION_LOAD ?>" />
 						<select id="filter-bar-query-id" class="input-xs">
-							<option value="-1"></option>
+							<option value="-1">&nbsp;</option>
 							<?php
 							$t_source_query_id = isset( $t_filter['_source_query_id'] ) ? (int)$t_filter['_source_query_id'] : -1;
 							foreach( $t_stored_queries_arr as $t_query_id => $t_query_name ) {
@@ -1417,7 +1417,7 @@ function filter_draw_selection_area() {
 							<input type="hidden" name="type" value="<?php echo FILTER_ACTION_LOAD ?>" />
 							<label><?php echo lang_get( 'load' ) ?>
 								<select class="input-s" name="source_query_id">
-									<option value="-1"></option>
+									<option value="-1">&nbsp;</option>
 									<?php
 									$t_source_query_id = isset( $t_filter['_source_query_id'] ) ? (int)$t_filter['_source_query_id'] : -1;
 									foreach( $t_stored_queries_arr as $t_query_id => $t_query_name ) {
@@ -2417,7 +2417,7 @@ function filter_print_view_type_toggle( $p_url, $p_view_type ) {
 	}
 
 	echo '<li>';
-	printf( '<a href="%s">%s</i>&#160;&#160;%s</a>',
+	printf( '<a href="%s">%s&#160;&#160;%s</a>',
 		$t_url,
 		icon_get( $t_icon, 'ace-icon' ),
 		lang_get( $t_lang_string )

--- a/core/filter_form_api.php
+++ b/core/filter_form_api.php
@@ -2900,10 +2900,10 @@ function filter_form_draw_inputs( $p_filter, $p_for_screen = true, $p_static = f
 		$t_row2->render();
 		$t_row3->render();
 		$t_row_extra->render();
-		echo '<tr class="spacer"></tr>';
+		$t_section_last->render_spacer();
 		$t_section_last->render();
 		if( $p_show_search ) {
-			echo '<tr class="spacer"></tr>';
+			$t_section_search->render_spacer();
 			$t_section_search->render();
 		}
 		?>

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -119,7 +119,8 @@ function html_rss_link() {
 	global $g_rss_feed_url;
 
 	if( $g_rss_feed_url !== null ) {
-		echo '<link rel="alternate" type="application/rss+xml" title="RSS" href="' . string_attribute( $g_rss_feed_url ) . '" />' . "\n";
+		echo "\t", '<link rel="alternate" type="application/rss+xml" title="RSS" href="',
+			string_attribute( $g_rss_feed_url ), '">', "\n";
 	}
 }
 
@@ -129,7 +130,7 @@ function html_rss_link() {
  * @return void
  */
 function html_javascript_link( $p_filename ) {
-	echo "\t", '<script type="text/javascript" src="', helper_mantis_url( 'js/' . $p_filename ), '"></script>', "\n";
+	echo "\t", '<script src="', helper_mantis_url( 'js/' . $p_filename ), '"></script>', "\n";
 }
 
 /**
@@ -143,7 +144,7 @@ function html_javascript_cdn_link( $p_url, $p_hash = '' ) {
 	if( $p_hash !== '' ) {
 		$t_integrity = 'integrity="' . $p_hash . '" ';
 	}
-	echo "\t", '<script type="text/javascript" src="', $p_url, '" ', $t_integrity, 'crossorigin="anonymous"></script>', "\n";
+	echo "\t", '<script src="', $p_url, '" ', $t_integrity, 'crossorigin="anonymous"></script>', "\n";
 }
 
 /**
@@ -168,7 +169,7 @@ function html_head_begin() {
  * @return void
  */
 function html_content_type() {
-	echo "\t", '<meta http-equiv="Content-type" content="text/html; charset=utf-8" />', "\n";
+	echo "\t", '<meta charset="utf-8">', "\n";
 }
 
 /**
@@ -351,8 +352,8 @@ function html_head_javascript() {
 		helper_mantis_url( 'javascript_config.php' ),
 		'cache_key=' . helper_generate_cache_key( array( 'user' ) )
 	);
-	echo "\t" . '<script type="text/javascript" src="' . $t_javascript_config . '"></script>' . "\n";
-	echo "\t" . '<script type="text/javascript" src="' . $t_javascript_translations . '"></script>' . "\n";
+	echo "\t" . '<script src="' . $t_javascript_config . '"></script>' . "\n";
+	echo "\t" . '<script src="' . $t_javascript_translations . '"></script>' . "\n";
 
 	if ( config_get_global( 'cdn_enabled' ) == ON ) {
 		# JQuery

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1249,6 +1249,14 @@ class TableGridLayout {
 	}
 
 	/**
+	 * Prints HTML code for a spacer row
+	 * @param string $p_class Class of the row ('spacer' by default)
+	 */
+	public function render_spacer( $p_class = 'spacer' ) {
+		echo '<tr class="', $p_class, '"><td colspan="', $this->cols, '"></td></tr>';
+	}
+
+	/**
 	 * Prints HTML code for an empty TD cell
 	 * @param integer $p_colspan Colspan attribute for cell
 	 */

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -1295,7 +1295,7 @@ function layout_scroll_up_button() {
 function layout_login_page_logo() {
 	?>
 	<div class="login-logo">
-		<img src="<?php echo helper_mantis_url( config_get_global( 'logo_image' ) ); ?>">
+		<img src="<?php echo helper_mantis_url( config_get_global( 'logo_image' ) ); ?>" alt="<?php echo string_html_specialchars( config_get( 'window_title' ) ); ?>">
 	</div>
 	<?php
 }

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -161,9 +161,9 @@ function layout_page_begin( $p_active_sidebar_page = null ) {
 
 	layout_breadcrumbs();
 
-	layout_main_content_row_begin();
-
 	layout_page_content_begin();
+
+	layout_main_content_row_begin();
 
 	if( auth_is_user_authenticated() ) {
 		if( ON == config_get( 'show_project_menu_bar' ) ) {
@@ -185,8 +185,8 @@ function layout_page_end() {
 
 	event_signal( 'EVENT_LAYOUT_CONTENT_END' );
 
-	layout_page_content_end();
 	layout_main_content_row_end();
+	layout_page_content_end();
 	layout_main_content_end();
 
 	layout_footer();

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -1015,7 +1015,7 @@ function layout_main_content_end() {
  * @return void
  */
 function layout_page_content_begin() {
-	echo '  <div class="page-content">' , "\n";
+	echo '<div class="page-content">' , "\n";
 }
 
 /**
@@ -1031,7 +1031,6 @@ function layout_page_content_end() {
 	echo '</div>' , "\n";
 }
 
-
 /**
  * Render breadcrumbs bar.
  * @return void
@@ -1045,6 +1044,8 @@ function layout_breadcrumbs() {
 
 	# Login information
 	echo '<ul class="breadcrumb">' , "\n";
+	echo '  <li>';
+	print_icon( 'fa-user', 'home-icon active' );
 	if( current_user_is_anonymous() ) {
 		$t_return_page = $_SERVER['SCRIPT_NAME'];
 		if( isset( $_SERVER['QUERY_STRING'] ) && !is_blank( $_SERVER['QUERY_STRING'] )) {
@@ -1053,18 +1054,16 @@ function layout_breadcrumbs() {
 
 		$t_return_page = string_url( $t_return_page );
 
-		echo ' <li>';
-		print_icon( 'fa-user', 'home-icon active' );
-		echo lang_get( 'anonymous' ) . ' </li>' . "\n";
+		echo '  ' . lang_get( 'anonymous' ) . "\n";
 
-		echo '<div class="btn-group btn-corner">' . "\n";
+		echo '  <div class="btn-group btn-corner">' . "\n";
 		echo '	<a href="' . helper_mantis_url( auth_login_page( 'return=' . $t_return_page ) ) .
 			'" class="btn btn-primary btn-xs">' . lang_get( 'login' ) . '</a>' . "\n";
 		if( auth_signup_enabled() ) {
 			echo '	<a href="' . helper_mantis_url( 'signup_page.php' ) . '" class="btn btn-primary btn-xs">' .
 				lang_get( 'signup_link' ) . '</a>' . "\n";
 		}
-		echo '</div>' . "\n";
+		echo '  </div></li>' . "\n";
 
 	} else {
 		$t_protected = current_user_get_field( 'protected' );
@@ -1073,8 +1072,6 @@ function layout_breadcrumbs() {
 		$t_realname = current_user_get_field( 'realname' );
 		$t_display_realname = is_blank( $t_realname ) ? '' : ' ( ' . string_html_specialchars( $t_realname ) . ' ) ';
 
-		echo '  <li>';
-		print_icon( 'fa-user', 'home-icon active' );
 		$t_page = ( OFF == $t_protected ) ? 'account_page.php' : 'my_view_page.php';
 		echo '  <a href="' . helper_mantis_url( $t_page ) . '">' .
 			$t_display_username . $t_display_realname . '</a>' . "\n";

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -244,7 +244,7 @@ function layout_is_rtl() {
  * @return void
  */
 function layout_head_meta() {
-	echo '<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />' . "\n";
+	echo "\t" , '<meta name="viewport" content="width=device-width, initial-scale=1.0">' , "\n";
 }
 
 /**

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -240,7 +240,7 @@ function layout_is_rtl() {
  * @return void
  */
 function layout_head_meta() {
-	echo "\t" , '<meta name="viewport" content="width=device-width, initial-scale=1.0">' , "\n";
+	echo "\t" , '<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0">' , "\n";
 }
 
 /**

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -161,16 +161,15 @@ function layout_page_begin( $p_active_sidebar_page = null ) {
 
 	layout_breadcrumbs();
 
+	layout_main_content_row_begin();
+
 	layout_page_content_begin();
 
 	if( auth_is_user_authenticated() ) {
 		if( ON == config_get( 'show_project_menu_bar' ) ) {
-			echo '<div class="row">' , "\n";
 			print_project_menu_bar();
-			echo '</div>' , "\n";
 		}
 	}
-	echo '<div class="row">' , "\n";
 
 	event_signal( 'EVENT_LAYOUT_CONTENT_BEGIN' );
 }
@@ -186,9 +185,8 @@ function layout_page_end() {
 
 	event_signal( 'EVENT_LAYOUT_CONTENT_END' );
 
-	echo '</div>' , "\n";
-
 	layout_page_content_end();
+	layout_main_content_row_end();
 	layout_main_content_end();
 
 	layout_footer();
@@ -225,8 +223,6 @@ function layout_admin_page_end() {
 	html_body_end();
     html_end();
 }
-
-
 
 /**
  * Check if the layout is setup for right to left languages
@@ -287,8 +283,6 @@ function layout_head_css() {
 		html_css_link( 'ace-rtl.min.css', $t_cache_key );
 	}
 
-	echo "\n";
-
 	# Set font preference
 	layout_user_font_preference();
 }
@@ -345,34 +339,14 @@ function layout_body_javascript() {
 
 /**
  * Print opening markup for login/signup/register pages
+ * @param string $p_page_title page title
  * @return void
  */
-function layout_login_page_begin( $p_title = '' ) {
-	html_begin();
-	html_head_begin();
-	html_content_type();
-
-	global $g_robots_meta;
-	if( !is_blank( $g_robots_meta ) ) {
-		echo "\t", '<meta name="robots" content="', $g_robots_meta, '" />', "\n";
-	}
-
-	html_title( $p_title );
-	layout_head_meta();
-	html_css();
-	layout_head_css();
-	html_rss_link();
-
-	$t_favicon_image = config_get_global( 'favicon_image' );
-	if( !is_blank( $t_favicon_image ) ) {
-		echo "\t", '<link rel="shortcut icon" href="', helper_mantis_url( $t_favicon_image ), '" type="image/x-icon" />', "\n";
-	}
-
-	# Advertise the availability of the browser search plug-ins.
-	echo "\t", '<link rel="search" type="application/opensearchdescription+xml" title="MantisBT: Text Search" href="' . string_sanitize_url( 'browser_search_plugin.php?type=text', true) . '" />' . "\n";
-	echo "\t", '<link rel="search" type="application/opensearchdescription+xml" title="MantisBT: Issue Id" href="' . string_sanitize_url( 'browser_search_plugin.php?type=id', true) . '" />' . "\n";
+function layout_login_page_begin( $p_page_title = '' ) {
+	# Login page shouldn't be indexed by search engines
+	html_robots_noindex();
 	
-	html_head_javascript();
+	layout_page_header_begin( $p_page_title );
 	
 	event_signal( 'EVENT_LAYOUT_RESOURCES' );
 	html_head_end();
@@ -381,7 +355,7 @@ function layout_login_page_begin( $p_title = '' ) {
 
 	layout_main_container_begin();
 	layout_main_content_begin();
-	echo '<div class="row">';
+	layout_main_content_row_begin();
 }
 
 /**
@@ -389,12 +363,13 @@ function layout_login_page_begin( $p_title = '' ) {
  * @return void
  */
 function layout_login_page_end() {
-	echo '</div>';
+	layout_main_content_row_end();
 	layout_main_content_end();
 	layout_main_container_end();
 	layout_body_javascript();
 
-	echo '</body>', "\n";
+	html_body_end();
+	html_end();
 }
 
 /**
@@ -1007,6 +982,22 @@ function layout_main_content_begin() {
  * @return void
  */
 function layout_main_content_end() {
+	echo '</div>' , "\n";
+}
+
+/**
+ * Render opening markup for main content row
+ * @return void
+ */
+function layout_main_content_row_begin() {
+	echo '<div class="row">' , "\n";
+}
+
+/**
+ * Render closing markup for main content row
+ * @return void
+ */
+function layout_main_content_row_end() {
 	echo '</div>' , "\n";
 }
 

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -238,6 +238,15 @@ function string_url( $p_string ) {
 }
 
 /**
+ * Build a URL-encoded query string from an array of key value pairs.
+ * @param  array $p_params Query string parameters.
+ * @return string
+ */
+function string_build_query( array $p_params ): string {
+	return http_build_query( $p_params, '', '&', PHP_QUERY_RFC3986 );
+}
+
+/**
  * validate the url as part of this site before continuing
  * @param string  $p_url             URL to be processed.
  * @param boolean $p_return_absolute Whether to return the absolute URL to this Mantis instance.

--- a/lost_pwd_page.php
+++ b/lost_pwd_page.php
@@ -131,6 +131,7 @@ layout_login_page_begin();
 	</div>
 	</div>
 </div>
+</div>
 
 <?php
 layout_login_page_end();

--- a/manage_proj_create_page.php
+++ b/manage_proj_create_page.php
@@ -86,7 +86,6 @@ $f_parent_id = gpc_get( 'parent_id', null );
 		<div class="widget-body">
 		<div class="widget-main no-padding">
 		<div class="table-responsive">
-		<table class="table table-bordered table-condensed table-striped">
 		<fieldset>
 <?php
 	echo form_security_field( 'manage_proj_create' );
@@ -95,7 +94,7 @@ $f_parent_id = gpc_get( 'parent_id', null );
 ?>
 				<input type="hidden" name="parent_id" value="<?php echo $f_parent_id ?>" />
 <?php } ?>
-
+		<table class="table table-bordered table-condensed table-striped">
 			<tr>
 				<td class="category">
 					<span class="required">*</span>
@@ -194,8 +193,8 @@ $f_parent_id = gpc_get( 'parent_id', null );
 			</tr>
 
 			<?php event_signal( 'EVENT_MANAGE_PROJECT_CREATE_FORM' ) ?>
-		</fieldset>
 		</table>
+		</fieldset>
 		</div>
 		</div>
 		</div>
@@ -205,8 +204,8 @@ $f_parent_id = gpc_get( 'parent_id', null );
 				   value="<?php echo lang_get( 'add_project_button' ) ?>" />
 		</div>
 	</div>
-	</div>
 	</form>
+	</div>
 </div>
 
 <?php

--- a/manage_proj_edit_page.php
+++ b/manage_proj_edit_page.php
@@ -108,10 +108,10 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 <div class="widget-body">
 <div class="widget-main no-padding">
 	<div class="table-responsive">
-		<table class="table table-bordered table-condensed table-striped">
 		<fieldset>
 			<?php echo form_security_field( 'manage_proj_update' ) ?>
 			<input type="hidden" name="project_id" value="<?php echo $f_project_id ?>" />
+			<table class="table table-bordered table-condensed table-striped">
 			<tr>
 				<td class="category">
 					<label for="project-name">
@@ -212,10 +212,9 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 </textarea>
 				</td>
 			</tr>
-
 			<?php event_signal( 'EVENT_MANAGE_PROJECT_UPDATE_FORM', array( $f_project_id ) ); ?>
+			</table>
 		</fieldset>
-		</table>
 		</div>
 		</div>
 		</div>
@@ -331,12 +330,12 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 								<thead>
 								<tr>
 									<th><?php echo lang_get( 'name' ) ?></th>
-									<th><?php echo lang_get( 'status' ) ?></th>
-									<th><?php echo lang_get( 'enabled' ) ?></th>
-									<th><?php echo lang_get( 'inherit' ) ?></th>
-									<th><?php echo lang_get( 'view_status' ) ?></th>
+									<th class="center"><?php echo lang_get( 'status' ) ?></th>
+									<th class="center"><?php echo lang_get( 'enabled' ) ?></th>
+									<th class="center"><?php echo lang_get( 'inherit' ) ?></th>
+									<th class="center"><?php echo lang_get( 'view_status' ) ?></th>
 									<th><?php echo lang_get( 'description' ) ?></th>
-									<th colspan="2"><?php echo lang_get( 'actions' ) ?></th>
+									<th class="center"><?php echo lang_get( 'actions' ) ?></th>
 								</tr>
 								</thead>
 
@@ -464,7 +463,7 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 				<th><?php echo lang_get( 'category' ) ?></th>
 				<th class="center"><?php echo lang_get( 'enabled' ) ?></th>
 				<th><?php echo lang_get( 'assign_to' ) ?></th>
-				<th colspan="2" class="center"><?php echo lang_get( 'actions' ) ?></th>
+				<th class="center"><?php echo lang_get( 'actions' ) ?></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -580,10 +579,10 @@ print_manage_menu( 'manage_proj_edit_page.php' );
 		<thead>
 			<tr>
 				<th><?php echo lang_get( 'version' ) ?></th>
-				<th><?php echo lang_get( 'released' ) ?></th>
-				<th><?php echo lang_get( 'obsolete' ) ?></th>
-				<th><?php echo lang_get( 'timestamp' ) ?></th>
-				<th><?php echo lang_get( 'actions' ) ?></th>
+				<th class="center"><?php echo lang_get( 'released' ) ?></th>
+				<th class="center"><?php echo lang_get( 'obsolete' ) ?></th>
+				<th class="center"><?php echo lang_get( 'timestamp' ) ?></th>
+				<th class="center"><?php echo lang_get( 'actions' ) ?></th>
 			</tr>
 		</thead>
 		<tbody>
@@ -845,7 +844,7 @@ event_signal( 'EVENT_MANAGE_PROJECT_PAGE', array( $f_project_id ) );
 								</option>
 								<?php print_project_option_list( null, false, $f_project_id ); ?>
 							</select>
-							<span class=form-inline">
+							<span class="form-inline">
 								<button name="copy_from" class="btn btn-sm btn-primary btn-white btn-round" value="1">
 									<?php echo lang_get( 'copy_users_from' ) ?>
 								</button>

--- a/manage_proj_page.php
+++ b/manage_proj_page.php
@@ -251,7 +251,6 @@ print_manage_menu( 'manage_proj_page.php' );
 				<?php } ?>
 			</tr>
 		</thead>
-
 		<tbody>
 <?php
 			foreach( $t_categories as $t_category ) {
@@ -263,25 +262,24 @@ print_manage_menu( 'manage_proj_page.php' );
 				<td><?php echo prepare_user_name( $t_category['user_id'] ) ?></td>
 				<?php if( $t_can_update_global_cat ) { ?>
 				<td class="center">
-<?php
-					$t_id = urlencode( $t_id );
-					$t_project_id = urlencode( ALL_PROJECTS );
-					echo '<div class="btn-group inline">';
-					echo '<div class="pull-left">';
-					print_form_button(
-						"manage_proj_cat_edit_page.php?category_id=$t_id&project_id=$t_project_id",
-						lang_get( 'edit' )
-					);
-					echo '</div>';
-					echo '<div class="pull-left">';
-					print_form_button(
-						"manage_proj_cat_delete.php?category_id=$t_id&project_id=$t_project_id",
-						lang_get( 'delete' )
-					);
-					echo '</div>';
-?>
+					<div class="btn-group inline">
+						<div class="pull-left"><?php
+						$t_id = urlencode( $t_id );
+						$t_project_id = urlencode( ALL_PROJECTS );
+						print_form_button(
+							"manage_proj_cat_edit_page.php?category_id=$t_id&project_id=$t_project_id",
+							lang_get( 'edit' )
+						); ?>
+						</div>
+						<div class="pull-left"><?php
+						print_form_button(
+							"manage_proj_cat_delete.php?category_id=$t_id&project_id=$t_project_id",
+							lang_get( 'delete' )
+						); ?>
+						</div>
+					</div>
 				</td>
-			<?php } ?>
+				<?php } ?>
 			</tr>
 <?php
 			} # end for loop

--- a/manage_tags_page.php
+++ b/manage_tags_page.php
@@ -202,9 +202,9 @@ print_manage_menu( 'manage_tags_page.php' );
 			<div class="widget-main no-padding">
 		<div class="form-container">
 		<div class="table-responsive">
-		<table class="table table-bordered table-condensed table-striped">
 		<fieldset>
 			<?php echo form_security_field( 'tag_create' ); ?>
+			<table class="table table-bordered table-condensed table-striped">
 			<tr>
 				<td class="category">
 					<label for="tag-name">
@@ -227,8 +227,8 @@ print_manage_menu( 'manage_tags_page.php' );
 					<textarea class="form-control" id="tag-description" name="description" cols="80" rows="6"></textarea>
 				</td>
 			</tr>
+			</table>
 		</fieldset>
-		</table>
 		</div>
 		</div>
 		</div>

--- a/my_view_inc.php
+++ b/my_view_inc.php
@@ -70,22 +70,30 @@ $t_hide_status_default = config_get( 'hide_status_default' );
 $t_default_show_changed = config_get( 'default_show_changed' );
 
 $c_filter['assigned'] = filter_create_assigned_to_unresolved( helper_get_current_project(), $t_current_user_id );
-$t_url_link_parameters['assigned'] = FILTER_PROPERTY_HANDLER_ID . '=' . $t_current_user_id . '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_bug_resolved_status_threshold;
+$t_url_link_parameters['assigned'] = [
+	FILTER_PROPERTY_HANDLER_ID => $t_current_user_id,
+	FILTER_PROPERTY_HIDE_STATUS => $t_bug_resolved_status_threshold,
+];
 
 # @TODO cproensa: make this value configurable
 $t_recent_days = 30;
 $c_filter['recent_mod'] = filter_create_recently_modified( $t_recent_days );
-$t_url_link_parameters['recent_mod'] = FILTER_PROPERTY_HIDE_STATUS . '=none'
-		. '&' . FILTER_PROPERTY_FILTER_BY_LAST_UPDATED_DATE . '=' . $c_filter['recent_mod'][FILTER_PROPERTY_FILTER_BY_LAST_UPDATED_DATE]
-		. '&' . FILTER_PROPERTY_LAST_UPDATED_END_DAY . '=' . $c_filter['recent_mod'][FILTER_PROPERTY_LAST_UPDATED_END_DAY]
-		. '&' . FILTER_PROPERTY_LAST_UPDATED_END_MONTH . '=' . $c_filter['recent_mod'][FILTER_PROPERTY_LAST_UPDATED_END_MONTH]
-		. '&' . FILTER_PROPERTY_LAST_UPDATED_END_YEAR . '=' . $c_filter['recent_mod'][FILTER_PROPERTY_LAST_UPDATED_END_YEAR]
-		. '&' . FILTER_PROPERTY_LAST_UPDATED_START_DAY . '=' . $c_filter['recent_mod'][FILTER_PROPERTY_LAST_UPDATED_START_DAY]
-		. '&' . FILTER_PROPERTY_LAST_UPDATED_START_MONTH . '=' . $c_filter['recent_mod'][FILTER_PROPERTY_LAST_UPDATED_START_MONTH]
-		. '&' . FILTER_PROPERTY_LAST_UPDATED_START_YEAR . '=' . $c_filter['recent_mod'][FILTER_PROPERTY_LAST_UPDATED_START_YEAR];
+$t_url_link_parameters['recent_mod'] = [
+	FILTER_PROPERTY_HIDE_STATUS => 'none',
+	FILTER_PROPERTY_FILTER_BY_LAST_UPDATED_DATE => $c_filter['recent_mod'][FILTER_PROPERTY_FILTER_BY_LAST_UPDATED_DATE],
+	FILTER_PROPERTY_LAST_UPDATED_END_DAY => $c_filter['recent_mod'][FILTER_PROPERTY_LAST_UPDATED_END_DAY],
+	FILTER_PROPERTY_LAST_UPDATED_END_MONTH => $c_filter['recent_mod'][FILTER_PROPERTY_LAST_UPDATED_END_MONTH],
+	FILTER_PROPERTY_LAST_UPDATED_END_YEAR => $c_filter['recent_mod'][FILTER_PROPERTY_LAST_UPDATED_END_YEAR],
+	FILTER_PROPERTY_LAST_UPDATED_START_DAY => $c_filter['recent_mod'][FILTER_PROPERTY_LAST_UPDATED_START_DAY],
+	FILTER_PROPERTY_LAST_UPDATED_START_MONTH => $c_filter['recent_mod'][FILTER_PROPERTY_LAST_UPDATED_START_MONTH],
+	FILTER_PROPERTY_LAST_UPDATED_START_YEAR => $c_filter['recent_mod'][FILTER_PROPERTY_LAST_UPDATED_START_YEAR],
+];
 
 $c_filter['reported'] = filter_create_reported_by( helper_get_current_project(), $t_current_user_id );
-$t_url_link_parameters['reported'] = FILTER_PROPERTY_REPORTER_ID . '=' . $t_current_user_id . '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_hide_status_default;
+$t_url_link_parameters['reported'] = [
+	FILTER_PROPERTY_REPORTER_ID => $t_current_user_id,
+	FILTER_PROPERTY_HIDE_STATUS => $t_hide_status_default,
+];
 
 $c_filter['resolved'] = array(
 	FILTER_PROPERTY_CATEGORY_ID => array(
@@ -120,16 +128,24 @@ $c_filter['resolved'] = array(
 		'0' => META_FILTER_ANY,
 	),
 );
-$t_url_link_parameters['resolved'] = FILTER_PROPERTY_STATUS . '=' . $t_bug_resolved_status_threshold . '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_hide_status_default;
-
+$t_url_link_parameters['resolved'] = [
+	FILTER_PROPERTY_STATUS => $t_bug_resolved_status_threshold,
+	FILTER_PROPERTY_HIDE_STATUS => $t_hide_status_default,
+];
 
 $c_filter['unassigned'] = filter_create_assigned_to_unresolved( helper_get_current_project(), 0 );
-$t_url_link_parameters['unassigned'] = FILTER_PROPERTY_HANDLER_ID . '=[none]' . '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_hide_status_default;
+$t_url_link_parameters['unassigned'] = [
+	FILTER_PROPERTY_HANDLER_ID => '[none]',
+	FILTER_PROPERTY_HIDE_STATUS => $t_hide_status_default,
+];
 
 # TODO: check. handler value looks wrong
 
 $c_filter['monitored'] = filter_create_monitored_by( helper_get_current_project(), $t_current_user_id );
-$t_url_link_parameters['monitored'] = FILTER_PROPERTY_MONITOR_USER_ID . '=' . $t_current_user_id . '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_hide_status_default;
+$t_url_link_parameters['monitored'] = [
+	FILTER_PROPERTY_MONITOR_USER_ID => $t_current_user_id,
+	FILTER_PROPERTY_HIDE_STATUS => $t_hide_status_default,
+];
 
 $c_filter['feedback'] = array(
 	FILTER_PROPERTY_CATEGORY_ID => array(
@@ -164,7 +180,11 @@ $c_filter['feedback'] = array(
 		'0' => META_FILTER_ANY,
 	),
 );
-$t_url_link_parameters['feedback'] = FILTER_PROPERTY_REPORTER_ID . '=' . $t_current_user_id . '&' . FILTER_PROPERTY_STATUS . '=' . config_get( 'bug_feedback_status' ) . '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_hide_status_default;
+$t_url_link_parameters['feedback'] = [
+	FILTER_PROPERTY_REPORTER_ID => $t_current_user_id,
+	FILTER_PROPERTY_STATUS => config_get( 'bug_feedback_status' ),
+	FILTER_PROPERTY_HIDE_STATUS => $t_hide_status_default,
+];
 
 $c_filter['verify'] = array(
 	FILTER_PROPERTY_CATEGORY_ID => array(
@@ -199,7 +219,10 @@ $c_filter['verify'] = array(
 		'0' => META_FILTER_ANY,
 	),
 );
-$t_url_link_parameters['verify'] = FILTER_PROPERTY_REPORTER_ID . '=' . $t_current_user_id . '&' . FILTER_PROPERTY_STATUS . '=' . $t_bug_resolved_status_threshold;
+$t_url_link_parameters['verify'] = [
+	FILTER_PROPERTY_REPORTER_ID => $t_current_user_id,
+	FILTER_PROPERTY_STATUS => $t_bug_resolved_status_threshold,
+];
 
 $c_filter['my_comments'] = array(
 	FILTER_PROPERTY_CATEGORY_ID => array(
@@ -233,12 +256,15 @@ $c_filter['my_comments'] = array(
 	FILTER_PROPERTY_MONITOR_USER_ID => array(
 		'0' => META_FILTER_ANY,
 	),
-	FILTER_PROPERTY_NOTE_USER_ID=> array(
+	FILTER_PROPERTY_NOTE_USER_ID => array(
 		'0' => META_FILTER_MYSELF,
 	),
 );
 
-$t_url_link_parameters['my_comments'] = FILTER_PROPERTY_NOTE_USER_ID. '=' . META_FILTER_MYSELF . '&' . FILTER_PROPERTY_HIDE_STATUS . '=' . $t_hide_status_default;
+$t_url_link_parameters['my_comments'] = [
+	FILTER_PROPERTY_NOTE_USER_ID => META_FILTER_MYSELF,
+	FILTER_PROPERTY_HIDE_STATUS => $t_hide_status_default,
+];
 $t_rows = filter_get_bug_rows( $f_page_number, $t_per_page, $t_page_count, $t_bug_count, $c_filter[$t_box_title] );
 
 # Improve performance by caching category data in one pass
@@ -274,7 +300,8 @@ $t_bug_string = $t_bug_count == 1 ? 'bug' : 'bugs';
 			<?php print_icon( 'fa-list-alt', 'ace-icon' ); ?>
 <?php
 #-- Box title
-$t_box_url = html_entity_decode( config_get( 'bug_count_hyperlink_prefix' ) ).'&' . $t_url_link_parameters[$t_box_title];
+$t_box_url = html_entity_decode( config_get( 'bug_count_hyperlink_prefix' ) ).'&'
+	. string_build_query( $t_url_link_parameters[$t_box_title] );
 print_link( $t_box_url, $t_box_title_label, false, 'white' );
 
 # -- Viewing range info


### PR DESCRIPTION
Fixes [#35180](https://mantisbt.org/bugs/view.php?id=35180).

Fix HTML issues reported by Nu Html Checker:

- Error: Stray end tag `i` in filter_print_view_type_toggle()
- Error: Element `option` without attribute `label` must not be empty in  filter_draw_selection_area()
- Error: Row 7 of a row group established by a `tbody` element has no  cells beginning on it
- Warning: A table row was 0 columns wide, which is less than the column  count established by the first row (8) in filter_form_draw_inputs()
- Warning: The `type` attribute is unnecessary for JavaScript resources  in  html_javascript_link(), html_javascript_cdn_link() and  html_head_javascript()
- Error: Illegal character in query: `[` is not allowed in my_view_inc.php
- Error: End tag for `body` seen, but there were unclosed elements in lost_pwd_page.php
- Error: Unclosed element `div`
- Warning: Consider avoiding `viewport` values that prevent users from resizing documents in layout_head_meta()
- Error: An `img` element must have an `alt` attribute, except under certain conditions in layout_login_page_logo()
- Error: Element `div` not allowed as child of element `ul` in this context in layout_breadcrumbs()

Add a new method TableGridLayout::render_spacer() to print a HTML code for a spacer row of current table.

Add new function string_build_query() to string_api.php, a unified call of http_build_query().

Moved the extra code from layout_page_begin() and layout_page_end() to new paired functions layout_main_content_row_begin() and layout_main_content_row_end().
