### PR TITLE
Disable javascript inclusion to printed pages

### DIFF
--- a/print_all_bug_page_word.php
+++ b/print_all_bug_page_word.php
@@ -578,6 +578,8 @@ $t_bugnotes = bugnote_get_all_visible_bugnotes( $t_id, $t_user_bugnote_order, $t
 	} # end in_array
 }  # end main loop
 
-layout_body_javascript();
+if( $f_type_page == 'html' ) {
+	layout_body_javascript();
+}
 html_body_end();
 html_end();


### PR DESCRIPTION
JavaScripts must not be part of the print page, especially not in doc format.

Fixes [#35314](https://mantisbt.org/bugs/view.php?id=35314).