### PR TITLE
Increase navbar user name width

### DIFF
--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -242,6 +242,7 @@ a:link:after, a:visited:after {
 
 .user-info {
     line-height: 33px !important;
+    max-width: 270px !important;
 }
 
 .page-content {


### PR DESCRIPTION
The max-width increased from 100px to 270px, this is the maximum size at which the navbar menu does not collapse on narrow screens.

Fixes [#23593](https://mantisbt.org/bugs/view.php?id=23593).
