### PR TITLE
Fix inconsistent display in navbar user menu

### DIFF
--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -455,14 +455,9 @@ function layout_navbar_user_menu( $p_show_avatar = true ) {
 	echo '<a data-toggle="dropdown" href="#" class="dropdown-toggle">';
 	if( $p_show_avatar ) {
 		layout_navbar_user_avatar();
-		echo '<span class="user-info">';
-		echo $t_username;
-		echo '</span>';
-		print_icon( 'fa-angle-down', 'ace-icon' );
-	} else {
-		echo '&#160;' . $t_username . '&#160;' . "\n";
-		print_icon( 'fa-angle-down', 'ace-icon bigger-110' );
 	}
+	echo '<span class="user-info">', $t_username, '</span>';
+	print_icon( 'fa-angle-down', 'ace-icon bigger-110' );
 	echo '</a>';
 	echo '<ul class="user-menu dropdown-menu dropdown-menu-right dropdown-yellow dropdown-caret dropdown-close">';
 


### PR DESCRIPTION
When using avatar ($g_show_avatar = ON), the username is displayed in a span with user-info class, but when OFF the span and class were not present.

With this commit, the span and class are always used.

Fixes [#35425](https://mantisbt.org/bugs/view.php?id=35425)