### PR TITLE
Fix a regression in the layout_api.php file

### DIFF
--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -163,13 +163,15 @@ function layout_page_begin( $p_active_sidebar_page = null ) {
 
 	layout_page_content_begin();
 
-	layout_main_content_row_begin();
-
 	if( auth_is_user_authenticated() ) {
 		if( ON == config_get( 'show_project_menu_bar' ) ) {
+			layout_main_content_row_begin();
 			print_project_menu_bar();
+			layout_main_content_row_end();
 		}
 	}
+
+	layout_main_content_row_begin();
 
 	event_signal( 'EVENT_LAYOUT_CONTENT_BEGIN' );
 }


### PR DESCRIPTION
Fixes [#35493](https://mantisbt.org/bugs/view.php?id=35493).

When the `nav-tabs` element is displayed, the active area of the project selection buttons (displayed when `$g_show_project_menu_bar = ON`) is overlapped because `nav-tabs` has relative positioning and is attached to the top of the parent element.

Introduced in https://github.com/mantisbt/mantisbt/pull/2096/commits/4395fad8d05e3808f7820993ae42bea5f7b35eaf.