### PR TITLE
Fix HTML errors and warnings 2

### DIFF
--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -131,6 +131,9 @@ layout_page_begin();
 	<form id="bug-change-status-form" name="bug_change_status_form" method="post" action="bug_update.php">
 
 	<fieldset>
+		<input type="hidden" name="bug_id" value="<?php echo $f_bug_id ?>" />
+		<input type="hidden" name="status" value="<?php echo $f_new_status ?>" />
+		<input type="hidden" name="last_updated" value="<?php echo $t_bug->last_updated ?>" />
 
 	<?php echo form_security_field( 'bug_update' ) ?>
 	<div class="widget-box widget-color-blue2">
@@ -146,9 +149,6 @@ layout_page_begin();
 	<div class="table-responsive">
 	<table class="table table-bordered table-condensed table-striped">
 		<thead>
-			<input type="hidden" name="bug_id" value="<?php echo $f_bug_id ?>" />
-			<input type="hidden" name="status" value="<?php echo $f_new_status ?>" />
-			<input type="hidden" name="last_updated" value="<?php echo $t_bug->last_updated ?>" />
 			<?php
 				if( $f_new_status >= $t_resolved ) {
 					if( relationship_can_resolve_bug( $f_bug_id ) == false ) {
@@ -222,7 +222,7 @@ layout_page_begin();
 				</th>
 				<td>
 					<select name="handler_id" class="input-sm">
-						<option value="0"></option>
+						<option value="0">&nbsp;</option>
 						<?php print_assign_to_option_list( $t_suggested_handler_id, $t_bug->project_id ) ?>
 					</select>
 				</td>
@@ -416,9 +416,10 @@ layout_page_begin();
 </div>
 </div>
 </div>
-</div>
+</fieldset>
 </form>
 <div class="space-10"></div>
+</div>
 </div>
 <?php
 define( 'BUG_VIEW_INC_ALLOW', true );

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -229,6 +229,8 @@ $t_show_due_date = in_array( 'due_date', $t_fields ) && access_has_project_level
 $t_show_attachments = in_array( 'attachments', $t_fields ) && file_allow_bug_upload();
 $t_show_view_state = in_array( 'view_state', $t_fields ) && access_has_project_level( config_get( 'set_view_status_threshold' ) );
 
+$t_has_profiles = count( profile_get_all_for_user( auth_get_current_user_id() ) ) > 0;
+
 # don't index bug report page
 html_robots_noindex();
 
@@ -375,10 +377,15 @@ if( $t_show_attachments ) {
 <?php if( $t_show_platform || $t_show_os || $t_show_os_build ) { ?>
 	<tr>
 		<th class="category">
-			<label for="profile_id"><?php echo lang_get( 'select_profile' ) ?></label>
+			<?php
+			if( $t_has_profiles ) echo '<label for="profile_id">';
+			echo lang_get( 'select_profile' );
+			if( $t_has_profiles ) echo '</label>';
+			?>
+
 		</th>
 		<td>
-			<?php if( count( profile_get_all_for_user( auth_get_current_user_id() ) ) > 0 ) { ?>
+			<?php if( $t_has_profiles ) { ?>
 				<select <?php echo helper_get_tab_index() ?> id="profile_id" name="profile_id" class="input-sm">
 					<?php print_profile_option_list( auth_get_current_user_id(), $f_profile_id ) ?>
 				</select>
@@ -485,7 +492,7 @@ if( $t_show_attachments ) {
 		</th>
 		<td>
 			<select <?php echo helper_get_tab_index() ?> id="handler_id" name="handler_id" class="input-sm">
-				<option value="0" selected="selected"></option>
+				<option value="0" selected="selected">&nbsp;</option>
 				<?php print_assign_to_option_list( $f_handler_id ) ?>
 			</select>
 		</td>
@@ -611,7 +618,7 @@ if( $t_show_attachments ) {
 <?php if( $t_show_tags ) { ?>
 	<tr>
 		<th class="category">
-			<label for="attach_tag"><?php echo lang_get( 'tag_attach_long' ) ?></label>
+			<label for="tag_string"><?php echo lang_get( 'tag_attach_long' ) ?></label>
 		</th>
 		<td>
 			<?php

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -204,18 +204,18 @@ if( $t_show_id || $t_show_project || $t_show_category || $t_show_view_state || $
 	#
 
 	echo '<tr>';
-	echo '<td width="15%" class="category">', $t_show_id ? lang_get( 'id' ) : '', '</td>';
-	echo '<td width="20%" class="category">', $t_show_project ? lang_get( 'email_project' ) : '', '</td>';
-	echo '<td width="15%" class="category">';
+	echo '<td class="category">', $t_show_id ? lang_get( 'id' ) : '', '</td>';
+	echo '<td class="category">', $t_show_project ? lang_get( 'email_project' ) : '', '</td>';
+	echo '<td class="category">';
 	if( $t_show_category ) {
 		$t_allow_no_category = config_get( 'allow_no_category' );
 		echo $t_allow_no_category ? '' : '<span class="required">*</span> ';
 		echo '<label for="category_id">' . lang_get( 'category' ) . '</label>';
 	}
 	echo '</td>';
-	echo '<td width="20%" class="category">', $t_show_view_state ? '<label for="view_state">' . lang_get( 'view_status' ) . '</label>' : '', '</td>';
-	echo '<td width="15%" class="category">', $t_show_date_submitted ? lang_get( 'date_submitted' ) : '', '</td>';
-	echo '<td width="15%" class="category">', $t_show_last_updated ? lang_get( 'last_update' ) : '', '</td>';
+	echo '<td class="category">', $t_show_view_state ? '<label for="view_state">' . lang_get( 'view_status' ) . '</label>' : '', '</td>';
+	echo '<td class="category">', $t_show_date_submitted ? lang_get( 'date_submitted' ) : '', '</td>';
+	echo '<td class="category">', $t_show_last_updated ? lang_get( 'last_update' ) : '', '</td>';
 	echo '</tr>';
 
 	#
@@ -314,7 +314,7 @@ if( $t_show_reporter || $t_show_handler || $t_show_due_date ) {
 
 		if( access_has_project_level( config_get( 'update_bug_assign_threshold', config_get( 'update_bug_threshold' ) ) ) ) {
 			echo '<select ' . helper_get_tab_index() . ' id="handler_id" name="handler_id" class="input-sm">';
-			echo '<option value="0"></option>';
+			echo '<option value="0">&nbsp;</option>';
 			print_assign_to_option_list( $t_bug->handler_id, $t_bug->project_id );
 			echo '</select>';
 		} else {

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -271,9 +271,7 @@ if( $t_show_id || $t_show_project || $t_show_category || $t_show_view_state || $
 
 	echo '</tr>';
 
-	# spacer
-	echo '<tr class="spacer"><td colspan="6"></td></tr>';
-	echo '<tr class="hidden"></tr>';
+	print_table_spacer( 6 );
 }
 
 #
@@ -638,9 +636,7 @@ if( $t_show_target_version || $t_show_fixed_in_version ) {
 
 event_signal( 'EVENT_UPDATE_BUG_FORM', array( $t_bug_id ) );
 
-# spacer
-echo '<tr class="spacer"><td colspan="6"></td></tr>';
-echo '<tr class="hidden"></tr>';
+print_table_spacer( 6 );
 
 # Summary
 if( $t_show_summary ) {
@@ -692,8 +688,7 @@ if( $t_show_additional_information ) {
 	echo '</td></tr>';
 }
 
-echo '<tr class="spacer"><td colspan="6"></td></tr>';
-echo '<tr class="hidden"></tr>';
+print_table_spacer( 6 );
 
 # Custom Fields
 $t_custom_fields_found = false;
@@ -724,9 +719,7 @@ foreach ( $t_related_custom_field_ids as $t_id ) {
 } # foreach( $t_related_custom_field_ids as $t_id )
 
 if( $t_custom_fields_found ) {
-	# spacer
-	echo '<tr class="spacer"><td colspan="6"></td></tr>';
-	echo '<tr class="hidden"></tr>';
+	print_table_spacer( 6 );
 }
 
 # Bugnote Text Box

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -299,7 +299,7 @@ if( $t_show_reporter || $t_show_handler || $t_show_due_date ) {
 				echo '</select>';
 			} else {
 				echo string_attribute( user_get_name( $t_bug->reporter_id ) );
-				echo ' [<a href="#reporter_edit" class="click-url" url="' . string_get_bug_update_url( $f_bug_id ) . '&amp;reporter_edit=true">' . lang_get( 'edit' ) . '</a>]';
+				echo ' [<a href="#reporter_edit" class="click-url" data-url="' . string_get_bug_update_url( $f_bug_id ) . '&amp;reporter_edit=true">' . lang_get( 'edit' ) . '</a>]';
 			}
 		}
 		echo '</td>';

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -180,8 +180,6 @@ layout_page_begin();
 		<div class="widget-body">
 		<div class="widget-main no-padding">
 		<div class="table-responsive">
-		<table class="table table-bordered table-condensed table-striped">
-
 <?php
 # Submit Button
 if( $t_top_buttons_enabled ) {
@@ -194,6 +192,7 @@ if( $t_top_buttons_enabled ) {
 <?php
 }
 ?>
+		<table class="table table-bordered table-condensed table-striped">
 			<tbody>
 <?php
 event_signal( 'EVENT_UPDATE_BUG_FORM_TOP', array( $t_bug_id ) );
@@ -285,15 +284,18 @@ if( $t_show_reporter || $t_show_handler || $t_show_due_date ) {
 
 	if( $t_show_reporter ) {
 		# Reporter
-		echo '<th class="category"><label for="reporter_id">' . lang_get( 'reporter' ) . '</label></th>';
-		echo '<td>';
+		echo '<th class="category">';
+		if( $f_reporter_edit ) echo '<label for="reporter_id">';
+		echo lang_get( 'reporter' );
+		if( $f_reporter_edit ) echo '</label>';
+		echo '</th><td>';
 
 		# Do not allow the bug's reporter to edit the Reporter field
 		# when limit_reporters is ON
 		if( access_has_limited_view( $t_bug->project_id ) ) {
 			echo string_attribute( user_get_name( $t_bug->reporter_id ) );
 		} else {
-			if ( $f_reporter_edit ) {
+			if( $f_reporter_edit ) {
 				echo '<select ' . helper_get_tab_index() . ' id="reporter_id" name="reporter_id">';
 				print_reporter_option_list( $t_bug->reporter_id, $t_bug->project_id );
 				echo '</select>';
@@ -760,12 +762,13 @@ if( config_get( 'time_tracking_enabled' ) ) {
 }
 
 event_signal( 'EVENT_BUGNOTE_ADD_FORM', array( $t_bug_id ) );
-
-echo '</table>';
-echo '</div>';
-echo '</div>';
-echo '</div>';
-
+?>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<?php
 # Submit Button
 if( $t_bottom_buttons_enabled ) {
 ?>

--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -212,13 +212,11 @@ echo '<div class="table-responsive">';
 echo '<table class="table table-bordered table-condensed">';
 
 if( $t_top_buttons_enabled ) {
-	echo '<thead><tr class="bug-nav">';
-	echo '<tr class="top-buttons noprint">';
-	echo '<td colspan="6">';
+	echo '<thead>';
+	echo '<tr class="top-buttons noprint"><td colspan="6">';
 	/** @noinspection PhpUnhandledExceptionInspection */
 	bug_view_action_buttons( $f_issue_id, $t_flags );
-	echo '</td>';
-	echo '</tr>';
+	echo '</td></tr>';
 	echo '</thead>';
 }
 
@@ -1228,7 +1226,7 @@ function bug_view_button_bug_assign_to( BugData $p_bug ) {
 
 	# allow un-assigning if already assigned.
 	if( $p_bug->handler_id != 0 ) {
-		echo '<option value="0"></option>';
+		echo '<option value="0">&nbsp;</option>';
 	}
 
 	# 0 means currently selected

--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -280,9 +280,7 @@ if( $t_flags['id_show'] || $t_flags['project_show'] || $t_flags['category_show']
 
 	echo '</tr>';
 
-	# spacer
-	echo '<tr class="spacer"><td colspan="6"></td></tr>';
-	echo '<tr class="hidden"></tr>';
+	print_table_spacer( 6 );
 }
 
 #
@@ -558,9 +556,7 @@ if( ( $t_flags['versions_target_version_show'] && isset( $t_issue['target_versio
 
 event_signal( 'EVENT_VIEW_BUG_DETAILS', array( $f_issue_id ) );
 
-# spacer
-echo '<tr class="spacer"><td colspan="6"></td></tr>';
-echo '<tr class="hidden"></tr>';
+print_table_spacer( 6 );
 
 #
 # Bug Details (screen wide fields)
@@ -639,9 +635,7 @@ if( !empty( $t_result['issue']['attachments'] ) ) {
 	echo '</td></tr>';
 }
 
-# spacer
-echo '<tr class="spacer"><td colspan="6"></td></tr>';
-echo '<tr class="hidden"></tr>';
+print_table_spacer( 6 );
 
 # Custom Fields
 if( isset( $t_issue['custom_fields'] ) ) {
@@ -656,9 +650,7 @@ if( isset( $t_issue['custom_fields'] ) ) {
 		echo '</td></tr>';
 	}
 
-	# spacer
-	echo '<tr class="spacer"><td colspan="6"></td></tr>';
-	echo '<tr class="hidden"></tr>';
+	print_table_spacer( 6 );
 }
 
 echo '</tbody></table>';

--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -222,15 +222,6 @@ if( $t_top_buttons_enabled ) {
 	echo '</thead>';
 }
 
-if( $t_bottom_buttons_enabled ) {
-	echo '<tfoot>';
-	echo '<tr class="noprint"><td colspan="6">';
-	/** @noinspection PhpUnhandledExceptionInspection */
-	bug_view_action_buttons( $f_issue_id, $t_flags );
-	echo '</td></tr>';
-	echo '</tfoot>';
-}
-
 echo '<tbody>';
 
 if( $t_flags['id_show'] || $t_flags['project_show'] || $t_flags['category_show'] ||
@@ -653,7 +644,19 @@ if( isset( $t_issue['custom_fields'] ) ) {
 	print_table_spacer( 6 );
 }
 
-echo '</tbody></table>';
+echo '</tbody>';
+
+if( $t_bottom_buttons_enabled ) {
+	echo '<tfoot>';
+	echo '<tr class="noprint"><td colspan="6">';
+	/** @noinspection PhpUnhandledExceptionInspection */
+	bug_view_action_buttons( $f_issue_id, $t_flags );
+	echo '</td></tr>';
+	echo '</tfoot>';
+}
+
+echo '</table>';
+
 echo '</div></div></div></div></div>';
 
 # User list sponsoring the bug
@@ -791,7 +794,7 @@ if( $t_flags['history_show'] && $f_history ) {
 	$t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 	$t_history = history_get_events_array( $f_issue_id );
 ?>
-		<div id="history" class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
+		<div class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
 			<div class="widget-header widget-header-small">
 				<h4 class="widget-title lighter">
 					<?php print_icon( 'fa-history', 'ace-icon' ); ?>

--- a/bugnote_view_inc.php
+++ b/bugnote_view_inc.php
@@ -109,7 +109,7 @@ $t_block_css = $t_collapse_block ? 'collapsed' : '';
 $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 
 ?>
-<div id="bugnotes" class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
+<div class="widget-box widget-color-blue2 <?php echo $t_block_css ?>">
 <div class="widget-header widget-header-small">
 	<h4 class="widget-title lighter">
 		<?php print_icon( 'fa-comments', 'ace-icon' ); ?>
@@ -130,7 +130,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 	if( 0 == $t_activities_count ) {
 ?>
 <tr class="bugnotes-empty">
-	<td class="center" colspan="2">
+	<td class="center">
 		<?php echo lang_get( 'no_bugnotes_msg' ) ?>
 	</td>
 </tr>
@@ -154,7 +154,7 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 		}
 ?>
 <tr class="bugnote visible-on-hover-toggle" id="c<?php echo $t_activity['id'] ?>">
-		<td class="category">
+	<td class="category">
 		<div class="pull-left padding-2"><?php print_avatar( $t_activity['user_id'], 'bugnote', 80 ); ?>
 		</div>
 		<div class="pull-left padding-2">

--- a/bugnote_view_inc.php
+++ b/bugnote_view_inc.php
@@ -343,14 +343,11 @@ $t_block_icon = $t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up';
 	</td>
 </tr>
 <?php
-if( $t_activity['type'] == ENTRY_TYPE_NOTE ) {
-	event_signal( 'EVENT_VIEW_BUGNOTE', array( $f_bug_id, $t_activity['id'], $t_activity['private'] ) );
-}
-?>
-<tr class="spacer">
-	<td colspan="2"></td>
-</tr>
-<?php
+		if( $t_activity['type'] == ENTRY_TYPE_NOTE ) {
+			event_signal( 'EVENT_VIEW_BUGNOTE', array( $f_bug_id, $t_activity['id'], $t_activity['private'] ) );
+		}
+
+		print_table_spacer( 2 );
 	} # end for loop
 
 	event_signal( 'EVENT_VIEW_BUGNOTES_END', $f_bug_id );

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1256,10 +1256,9 @@ class TableGridLayout {
 
 	/**
 	 * Prints HTML code for a spacer row
-	 * @param string $p_class Class of the row ('spacer' by default)
 	 */
-	public function render_spacer( $p_class = 'spacer' ) {
-		echo '<tr class="', $p_class, '"><td colspan="', $this->cols, '"></td></tr>';
+	public function render_spacer() {
+		print_table_spacer( $this->cols );
 	}
 
 	/**

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -2315,3 +2315,14 @@ function print_relationship_list_box( $p_default_rel_type = BUG_REL_ANY, $p_sele
 <?php
 }
 
+/**
+ * Print table spacer.
+ *
+ * @param integer $p_cols Number of columns in the table
+ * @return void
+ */
+function print_table_spacer( int $p_cols ) {
+	if( $p_cols > 0 ) {
+		echo '<tr class="spacer"><td colspan="', $p_cols, '"></td></tr>';
+	}
+}

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -2230,7 +2230,7 @@ function print_dropzone_template(){
 	<div id="dropzone-preview-template" class="hidden">
 		<div class="dz-preview dz-file-preview">
 			<div class="dz-filename"><span data-dz-name></span></div>
-			<img data-dz-thumbnail />
+			<img src="#" alt="" data-dz-thumbnail>
 			<div class="dz-error-message">
 				<div class="dz-error-mark"><span><?php print_icon('fa-times-circle'); ?></span></div>
 				<span data-dz-errormessage></span>

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -788,17 +788,15 @@ function print_category_option_list( $p_category_id = 0, $p_project_id = null, $
 		echo category_full_name( 0, false );
 		echo '</option>', PHP_EOL;
 	} else {
-		if( 0 == $p_category_id ) {
-			if( count( $t_cat_arr ) == 1 ) {
-				$p_category_id = (int) $t_cat_arr[0]['id'];
-			} else {
-				echo '<option value="" disabled hidden';
-				check_selected( $p_category_id, 0 );
-				echo '>';
-				echo string_attribute( lang_get( 'select_option' ) );
-				echo '</option>', PHP_EOL;
-			}
+		if( 0 == $p_category_id && count( $t_cat_arr ) == 1 ) {
+			# Single option are selected by default
+			$p_category_id = (int) $t_cat_arr[0]['id'];
 		}
+		echo '<option value="" disabled hidden';
+		check_selected( $p_category_id, 0 );
+		echo '>';
+		echo string_attribute( lang_get( 'select_option' ) );
+		echo '</option>', PHP_EOL;
 	}
 
 	foreach( $t_cat_arr as $t_category_row ) {
@@ -925,7 +923,7 @@ function print_version_option_list( $p_version = '', $p_project_ids = null, $p_r
 	}
 
 	if( $p_leading_blank ) {
-		echo '<option value=""></option>';
+		echo '<option value="">&nbsp;</option>';
 	}
 
 	$t_listed = array();

--- a/js/common.js
+++ b/js/common.js
@@ -535,7 +535,7 @@ $(document).ready( function() {
 	});
 
 	$('a.click-url').bind("click", function() {
-		$(this).attr("href", $(this).attr("url"));
+		$(this).attr("href", $(this).data("url"));
 	});
 
 	$('input[name=private].ace').bind("click", function() {

--- a/manage_overview_page.php
+++ b/manage_overview_page.php
@@ -75,11 +75,8 @@ print_manage_menu( 'manage_overview_page.php' );
 			<th class="category"><?php echo lang_get( 'schema_version' ) ?></th>
 			<td><?php echo config_get( 'database_version', 0, ALL_USERS, ALL_PROJECTS ) ?></td>
 		</tr>
-		<tr class="spacer">
-			<td colspan="2"></td>
-		</tr>
-		<tr class="hidden"></tr>
 	<?php
+	print_table_spacer( 2 );
 	$t_is_admin = current_user_is_administrator();
 	if( $t_is_admin ) {
 	?>
@@ -103,9 +100,7 @@ print_manage_menu( 'manage_overview_page.php' );
 				?>
 			</td>
 		</tr>
-		<tr class="spacer">
-			<td colspan="2"></td>
-		</tr>
+		<?php print_table_spacer( 2 ) ?>
 		<tr>
 			<th class="category"><?php echo lang_get( 'site_path' ) ?></th>
 			<td><?php echo config_get_global( 'absolute_path' ) ?></td>
@@ -118,10 +113,8 @@ print_manage_menu( 'manage_overview_page.php' );
 			<th class="category"><?php echo lang_get( 'plugin_path' ) ?></th>
 			<td><?php echo config_get_global( 'plugin_path' ) ?></td>
 		</tr>
-		<tr class="spacer">
-			<td colspan="2"></td>
-		</tr>
 	<?php
+		print_table_spacer( 2 );
 	}
 
 	event_signal( 'EVENT_MANAGE_OVERVIEW_INFO', array( $t_is_admin ) )

--- a/manage_user_create_page.php
+++ b/manage_user_create_page.php
@@ -61,7 +61,7 @@ print_manage_menu( 'manage_user_create_page.php' );
 <div class="space-10"></div>
 <div id="manage-user-create-div" class="form-container">
 	<form id="manage-user-create-form" method="post" action="manage_user_create.php">
-	<div class="widget-box widget-color-blue2">
+		<div class="widget-box widget-color-blue2">
 		<div class="widget-header widget-header-small">
 			<h4 class="widget-title lighter">
 				<?php print_icon( 'fa-user', 'ace-icon' ); ?>
@@ -71,10 +71,9 @@ print_manage_menu( 'manage_user_create_page.php' );
 		<div class="widget-body">
 		<div class="widget-main no-padding">
 		<div class="table-responsive">
-		<table class="table table-bordered table-condensed table-striped">
 		<fieldset>
-			<?php echo form_security_field( 'manage_user_create' ) ?>
-
+		<?php echo form_security_field( 'manage_user_create' ) ?>
+		<table class="table table-bordered table-condensed table-striped">
 			<tr>
 				<td class="category">
 					<?php echo lang_get( 'username' ) ?>
@@ -152,21 +151,20 @@ print_manage_menu( 'manage_user_create_page.php' );
 					</label>
 				</td>
 			</tr>
-			</fieldset>
-			</table>
-			</div>
-			</div>
-			</div>
+		</table>
+		</fieldset>
+		</div>
+		</div>
+		</div>
 
-			<?php event_signal( 'EVENT_MANAGE_USER_CREATE_FORM' ) ?>
+		<?php event_signal( 'EVENT_MANAGE_USER_CREATE_FORM' ) ?>
 
-			<div class="widget-toolbox padding-8 clearfix">
-				<input type="submit" class="btn btn-primary btn-white btn-round" value="<?php echo lang_get( 'create_user_button' ) ?>" />
-			</div>
+		<div class="widget-toolbox padding-8 clearfix">
+			<input type="submit" class="btn btn-primary btn-white btn-round" value="<?php echo lang_get( 'create_user_button' ) ?>" />
 		</div>
 		</div>
 	</form>
 </div>
-
+</div>
 <?php
 layout_page_end();

--- a/print_all_bug_page.php
+++ b/print_all_bug_page.php
@@ -210,11 +210,8 @@ if( filter_is_temporary( $t_filter ) ) {
 		}
 	?>
 </tr>
-<tr class="spacer">
-	<td colspan="<?php echo $t_num_of_columns ?>"></td>
-</tr>
+<?php print_table_spacer( $t_num_of_columns ) ?>
 </thead>
-
 <tbody>
 <?php
 	for( $i=0; $i < $t_row_count; $i++ ) {
@@ -232,11 +229,10 @@ if( filter_is_temporary( $t_filter ) ) {
 <?php
 		} # isset_loop
 	} # for_loop
+
+	print_table_spacer( $t_num_of_columns );
 ?>
-<tr class="spacer">
-    <td colspan="<?php echo $t_num_of_columns ?>"></td>
-</tr>
-<tr>
+<tr class="noprint">
     <td colspan="<?php echo $t_num_of_columns ?>">
         <input type="hidden" name="show_flag" value="1" />
         <input type="submit" class="btn btn-sm btn-primary btn-white btn-round" value="<?php echo lang_get( 'hide_button' ) ?>" />

--- a/print_all_bug_page.php
+++ b/print_all_bug_page.php
@@ -115,7 +115,7 @@ layout_page_header();
 	<input type="hidden" name="<?php echo FILTER_PROPERTY_SORT_FIELD_NAME; ?>" value="<?php echo $f_sort ?>" />
 	<input type="hidden" name="<?php echo FILTER_PROPERTY_SORT_DIRECTION; ?>" value="<?php echo $f_dir ?>" />
 
-<table class="table table-striped table-bordered table-condensed no-margin">
+<table class="table table-striped table-bordered table-condensed no-margin noprint">
 <?php
 #<SQLI> Excel & Print export
 #$f_bug_array stores the number of the selected rows
@@ -134,9 +134,8 @@ for( $i=0; $i < $t_row_count; $i++ ) {
 $f_export = implode( ',', $f_bug_arr );
 
 ?>
-
 <tr>
-	<td colspan="<?php echo $t_num_of_columns ?>">
+	<td>
 <?php
 	if( 'DESC' == $f_dir ) {
 		$t_new_dir = 'ASC';
@@ -168,7 +167,6 @@ $f_export = implode( ',', $f_bug_arr );
 		echo '</a> ';
 	}
 ?>
-
 	</td>
 </tr>
 </table>
@@ -184,8 +182,9 @@ if( filter_is_temporary( $t_filter ) ) {
 <?php # CSRF protection not required here - form does not result in modifications ?>
 
 <table id="buglist" class="table table-striped table-bordered table-condensed no-margin">
+<thead>
 <tr>
-    <td class="bold bigger-110" colspan="<?php echo $t_num_of_columns / 2 + $t_num_of_columns % 2; ?>">
+    <td class="bold bigger-110" colspan="<?php echo $t_num_of_columns ?>">
 		<?php
 			echo lang_get( 'viewing_bugs_title' );
 
@@ -198,8 +197,6 @@ if( filter_is_temporary( $t_filter ) ) {
 			}
 			echo '( ' . $v_start . ' - ' . $v_end . ' )';
 		?>
-	</td>
-<tr>
 	</td>
 </tr>
 <tr class="row-category">

--- a/print_all_bug_page_word.php
+++ b/print_all_bug_page_word.php
@@ -193,22 +193,22 @@ for( $j=0; $j < $t_row_count; $j++ ) {
 </tr>
 <?php print_table_spacer( 6 ) ?>
 <tr class="bold">
-	<td width="16%">
+	<td>
 		<?php echo sprintf( lang_get( 'label' ), $t_lang_id ) ?>
 	</td>
-	<td width="16%">
+	<td>
 		<?php echo sprintf( lang_get( 'label' ), $t_lang_category ) ?>
 	</td>
-	<td width="16%">
+	<td>
 		<?php echo sprintf( lang_get( 'label' ), $t_lang_severity ) ?>
 	</td>
-	<td width="16%">
+	<td>
 		<?php echo sprintf( lang_get( 'label' ), $t_lang_reproducibility ) ?>
 	</td>
-	<td width="16%">
+	<td>
 		<?php echo sprintf( lang_get( 'label' ), $t_lang_date_submitted ) ?>
 	</td>
-	<td width="16%">
+	<td>
 		<?php echo sprintf( lang_get( 'label' ), $t_lang_last_update ) ?>
 	</td>
 </tr>
@@ -506,7 +506,7 @@ $t_bugnotes = bugnote_get_all_visible_bugnotes( $t_id, $t_user_bugnote_order, $t
 	if( 0 == count( $t_bugnotes ) ) {
 	?>
 <tr>
-	<td class="bold" colspan="2">
+	<td class="bold">
 		<?php echo $t_lang_no_bugnotes_msg ?>
 	</td>
 </tr>
@@ -527,7 +527,7 @@ $t_bugnotes = bugnote_get_all_visible_bugnotes( $t_id, $t_user_bugnote_order, $t
 			$t_note = string_display_links( $t_bugnote->note );
 	?>
 <tr>
-	<td width="12%">
+	<td>
 				(<?php echo bugnote_format_id( $t_bugnote->id ) ?>)
 			<br />
 				<?php print_user( $t_bugnote->reporter_id, false ) ?>&#160;&#160;&#160;

--- a/print_all_bug_page_word.php
+++ b/print_all_bug_page_word.php
@@ -174,7 +174,11 @@ for( $j=0; $j < $t_row_count; $j++ ) {
 	# display the available and selected bugs
 	if( in_array( $t_id, $f_bug_arr ) || !$f_show_flag ) {
 		if( $t_count_exported > 0 ) {
-			echo '<br style="mso-special-character: line-break; page-break-before: always" />';
+			if( $f_type_page == 'html' ) {
+				echo '<div class="clearfix" style="page-break-before: always">&nbsp;</div>';
+			} else {
+				echo '<br clear=all style="mso-special-character: line-break; page-break-before: always">&nbsp;';
+			}
 		}
 
 		$t_count_exported++;
@@ -560,14 +564,7 @@ $t_bugnotes = bugnote_get_all_visible_bugnotes( $t_id, $t_user_bugnote_order, $t
 	} # end else
 ?>
 </table>
-
-<?php # Bugnotes END ?>
-
-
 <?php
-		if( $f_type_page != 'html' ) {
-			echo '<hr>';
-		}
 	} # end in_array
 }  # end main loop
 

--- a/print_all_bug_page_word.php
+++ b/print_all_bug_page_word.php
@@ -191,9 +191,7 @@ for( $j=0; $j < $t_row_count; $j++ ) {
 		<?php echo $t_lang_bug_view_title ?>
 	</td>
 </tr>
-<tr class="spacer" >
-	<td colspan="6"></td>
-</tr>
+<?php print_table_spacer( 6 ) ?>
 <tr class="bold">
 	<td width="16%">
 		<?php echo sprintf( lang_get( 'label' ), $t_lang_id ) ?>
@@ -234,9 +232,7 @@ for( $j=0; $j < $t_row_count; $j++ ) {
 		<?php echo date( $t_date_format, $t_bug->last_updated ) ?>
 	</td>
 </tr>
-<tr class="spacer" >
-	<td colspan="6"></td>
-</tr>
+<?php print_table_spacer( 6 ) ?>
 <tr>
 	<td class="bold">
 		<?php echo sprintf( lang_get( 'label' ), $t_lang_reporter ) ?>
@@ -402,9 +398,7 @@ foreach( $t_related_custom_field_ids as $t_custom_field_id ) {
 <?php
 }       # foreach
 ?>
-<tr class="spacer" >
-	<td colspan="6"></td>
-</tr>
+<?php print_table_spacer( 6 ) ?>
 <tr>
 	<td class="bold">
 		<?php echo sprintf( lang_get( 'label' ), $t_lang_summary ) ?>
@@ -497,8 +491,7 @@ foreach( $t_related_custom_field_ids as $t_custom_field_id ) {
 		?>
 	</td>
 </tr>
-
-<tr class="spacer"><td colspan="6"></td></tr>
+<?php print_table_spacer( 6 ) ?>
 </table>
 
 <?php
@@ -561,8 +554,8 @@ $t_bugnotes = bugnote_get_all_visible_bugnotes( $t_id, $t_user_bugnote_order, $t
 				?>
 			</td>
 		</tr>
-		<tr class="spacer"><td colspan="2"></td></tr>
 <?php
+			print_table_spacer( 2 );
 		} # end for
 	} # end else
 ?>


### PR DESCRIPTION
Fixes [#35503](https://mantisbt.org/bugs/view.php?id=35503).

Add a new function print_table_spacer() to print table spacer with specified columns.

Restored pagination when printing in both HTML and DOC formats.

Fix Nu Html Checker issues in dropzone (print_api.php):

- Error: Element `img` is missing required attribute `src`.
- Error: An `img` element must have an `alt` attribute, except under certain conditions.

In bug_view_inc.php:

- Error: Element `tbody` not allowed as child of element `table` in this context.
- Error: Duplicate ID history.
- Error: Row 1 of a row group established by a `thead` element has no cells beginning on it.
- Error: Element `option` without attribute `label` must not be empty.
- Warning: A table row was 6 columns wide and exceeded the column count established by the first row (0).

In bug_update_page.php, bugnote_view_inc.php, common.js:

- Error: Attribute `url` not allowed on element `a` at this point.
- Error: The width attribute on the `td` element is obsolete.
- Warning: A table row was 0 columns wide, which is less than the column count established by the first row (6).
- Error: Element `option` without attribute `label` must not be empty.
- Error: Duplicate ID bugnotes.
- Error: The first child `option` element of a `select` element with a `required` attribute, and without a `multiple` attribute, and without  a `size` attribute whose value is greater than 1, must have either an  empty `value` attribute, or must have no text content.

In print_all_bug_page.php:

- Error: Stray end tag `td`.
- Error: Row 2 of a row group established by a `tbody` element has no cells beginning on it.
- Warning: A table row was 10 columns wide and exceeded the column count established by the first row (5).

In print_all_bug_page_word.php:

- Error: The `width` attribute on the `td` element is obsolete.
- Error: Row 2 of a row group established by a `tbody` element has no cells beginning on it.

In bug_change_status_page.php:

- Error: Start tag `input` seen in `table`.
- Error: Element `option` without attribute `label` must not be empty.
- Error: End tag `div` seen, but there were open elements.
- Error: Unclosed element `fieldset`.

In bug_report_page.php:

- Error: Element `option` without attribute `label` must not be empty.
- Error: The value of the `for` attribute of the `label` element must be  the ID of a non-hidden form control.

In manage_user_create_page.php:

- Error: Start tag `fieldset` seen in `table`.
- Error: Unclosed element `div`.
