### PR TITLE
gpc_get_int() don't remove spaces in middle of string

### DIFF
--- a/core/gpc_api.php
+++ b/core/gpc_api.php
@@ -131,8 +131,8 @@ function gpc_get_int( $p_var_name, $p_default = null ) {
 		error_parameters( $p_var_name );
 		trigger_error( ERROR_GPC_ARRAY_UNEXPECTED, ERROR );
 	}
-	$t_val = str_replace( ' ', '', trim( (string)$t_result ) );
-	if( !preg_match( '/^-?([0-9])*$/', $t_val ) ) {
+	$t_val = trim( (string)$t_result );
+	if( !preg_match( '/^-?[0-9]*$/', $t_val ) ) {
 		error_parameters( $p_var_name );
 		trigger_error( ERROR_GPC_NOT_NUMBER, ERROR );
 	}


### PR DESCRIPTION
Keep using preg_match() instead of calling filter_var() as the latter's interpretation of what an integer is is too strict for our purposes (e.g. `01` is not considered as an integer).

Code cleanup: remove unnecessary capturing group in the number validation regex.

Fixes [#35525](https://mantisbt.org/bugs/view.php?id=35525)