### PR TITLE
Extend the use of the query parameter

### DIFF
--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -385,7 +385,7 @@ while( $t_row = $t_config_query->fetch() ) {
 					'config_option' => $v_config_id,
 					'action'        => MANAGE_CONFIG_ACTION_VIEW
 				);
-		$t_url_view = helper_url_combine( 'adm_config_page.php', http_build_query( $t_url_params ) );
+		$t_url_view = helper_url_combine( 'adm_config_page.php', $t_url_params );
 		$t_html_value = '<div class="adm_config_expand" data-config_id="' . $v_config_id . '"'
 				. ' data-project_id="' . $v_project_id . '" data-user_id="' . $v_user_id . '">'
 				. '<span class ="expand_show"><a href="' . $t_url_view . '" class="toggle small">[' . lang_get( 'show_content' ) . ']</a></span>'
@@ -422,7 +422,7 @@ while( $t_row = $t_config_query->fetch() ) {
 
 			# Update button
 			$t_action_params['action'] = MANAGE_CONFIG_ACTION_EDIT;
-			$t_url_edit = helper_url_combine( 'adm_config_page.php', http_build_query( $t_action_params ) );
+			$t_url_edit = helper_url_combine( 'adm_config_page.php', $t_action_params );
 			echo '<div class="pull-left">';
 			print_link_button( $t_url_edit, lang_get( 'edit' ), 'btn-xs' );
 			echo '</div>';
@@ -430,7 +430,7 @@ while( $t_row = $t_config_query->fetch() ) {
 			# Clone button
 			echo '<div class="pull-left">';
 			$t_action_params['action'] = MANAGE_CONFIG_ACTION_CLONE;
-			$t_url_clone = helper_url_combine( 'adm_config_page.php', http_build_query( $t_action_params ) );
+			$t_url_clone = helper_url_combine( 'adm_config_page.php', $t_action_params );
 			print_link_button( $t_url_clone, lang_get( 'create_child_bug_button' ), 'btn-xs' );
 			echo '</div>';
 

--- a/admin/check/check_database_inc.php
+++ b/admin/check/check_database_inc.php
@@ -25,6 +25,7 @@
  * @uses check_api.php
  * @uses config_api.php
  * @uses database_api.php
+ * @uses helper_api.php
  * @uses utility_api.php
  */
 
@@ -36,6 +37,7 @@ if( !defined( 'CHECK_DATABASE_INC_ALLOW' ) ) {
 require_once( 'check_api.php' );
 require_api( 'config_api.php' );
 require_api( 'database_api.php' );
+require_api( 'helper_api.php' );
 require_api( 'utility_api.php' );
 
 check_print_section_header_row( 'Database' );
@@ -258,7 +260,7 @@ if( db_is_mysql() ) {
 			'summary' => "MySQL version $t_db_major_version is not defined in Admin Checks",
 			'description' => "Please add the missing version to " . basename( __FILE__ ) . ".",
 		];
-		$t_report_bug_url = 'https://mantisbt.org/bugs/bug_report_page.php?' . http_build_query( $t_param );
+		$t_report_bug_url = helper_url_combine( 'https://mantisbt.org/bugs/bug_report_page.php', $t_param );
 		check_print_test_warn_row(
 			'MySQL Lifecycle and Release Support data availability',
 			false,

--- a/admin/check/index.php
+++ b/admin/check/index.php
@@ -27,6 +27,7 @@
  *
  * @uses check_api.php
  * @uses gpc_api.php
+ * @uses helper_api.php
  * @uses html_api.php
  */
 
@@ -45,6 +46,7 @@ require_once( dirname( __DIR__, 2 ) . '/core.php' );
 require_once( 'check_api.php' );
 
 require_api( 'gpc_api.php' );
+require_api( 'helper_api.php' );
 require_api( 'html_api.php' );
 require_api( 'http_api.php' );
 
@@ -68,12 +70,10 @@ $g_show_errors = gpc_get_bool( 'show_errors', false );
  * @return string url
  */
 function mode_url( $p_all, $p_errors ) {
-	return basename( __FILE__ ) . '?' . http_build_query(
-		array(
-			'show_all' => (int)$p_all,
-			'show_errors' => (int)$p_errors,
-		)
-	);
+	return helper_url_combine( basename( __FILE__ ), [
+		'show_all' => (int)$p_all,
+		'show_errors' => (int)$p_errors,
+	] );
 }
 
 $t_link = '<a href="%s">%s %s</a>';

--- a/billing_export_to_excel.php
+++ b/billing_export_to_excel.php
@@ -26,12 +26,14 @@
  * @uses billing_api.php
  * @uses bug_api.php
  * @uses excel_api.php
+ * @uses string_api.php
  */
 
 require_once( 'core.php' );
 require_api( 'billing_api.php' );
 require_api( 'bug_api.php' );
 require_api( 'excel_api.php' );
+require_api( 'string_api.php' );
 
 helper_begin_long_process();
 
@@ -52,7 +54,7 @@ $t_billing_rows = billing_get_for_project( $f_project_id, $f_from, $f_to, $f_cos
 
 header( 'Content-Type: application/vnd.ms-excel; charset=UTF-8' );
 header( 'Pragma: public' );
-header( 'Content-Disposition: attachment; filename="' . urlencode( file_clean_name( $t_filename ) ) . '.xml"' ) ;
+header( 'Content-Disposition: attachment; filename="' . string_url( file_clean_name( $t_filename ) ) . '.xml"' ) ;
 
 echo excel_get_header( $t_filename );
 echo excel_get_start_row();

--- a/bug_report.php
+++ b/bug_report.php
@@ -278,7 +278,7 @@ if( $f_report_stay ) {
 	$t_data['product_version'] = $t_issue->version;
 	$t_data['report_stay'] = 1;
 
-	$t_report_more_bugs_url = string_get_bug_report_url() . '?' . http_build_query( $t_data );
+	$t_report_more_bugs_url = helper_url_combine( string_get_bug_report_url(), $t_data );
 
 	print_header_redirect( $t_report_more_bugs_url );
 } else {

--- a/core/access_api.php
+++ b/core/access_api.php
@@ -79,8 +79,8 @@ function access_denied() {
 			if( isset( $_SERVER['QUERY_STRING'] ) ) {
 				$t_return_page .= '?' . $_SERVER['QUERY_STRING'];
 			}
-			$t_return_page = string_url( string_sanitize_url( $t_return_page ) );
-			print_header_redirect( auth_login_page( 'return=' . $t_return_page ) );
+			$t_return_page = string_sanitize_url( $t_return_page );
+			print_header_redirect( auth_login_page( [ 'return' => $t_return_page ] ) );
 		}
 	} else {
 		if( current_user_is_anonymous() ) {
@@ -89,9 +89,9 @@ function access_denied() {
 				if( isset( $_SERVER['QUERY_STRING'] ) ) {
 					$t_return_page .= '?' . $_SERVER['QUERY_STRING'];
 				}
-				$t_return_page = string_url( string_sanitize_url( $t_return_page ) );
+				$t_return_page = string_sanitize_url( $t_return_page );
 				echo '<p class="center">' . error_string( ERROR_ACCESS_DENIED ) . '</p><p class="center">';
-				print_link_button( auth_login_page( 'return=' . $t_return_page ), lang_get( 'login' ) );
+				print_link_button( auth_login_page( [ 'return' => $t_return_page ] ), lang_get( 'login' ) );
 				echo '</p><p class="center">';
 				print_link_button(
 					helper_mantis_url( config_get_global( 'default_home_page' ) ),

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -221,7 +221,8 @@ function auth_session_expiry( $p_user_id, $p_perm_login ) {
 /**
  * Gets the login page to redirect to when login is needed, it will return a
  * relative url.
- * @param string $p_query_string query string parameters.
+ *
+ * @param string|array $p_query_string The query string or array of query parameters.
  * @return string login page (e.g. 'login_page.php' )
  * @throws ClientException
  */
@@ -236,9 +237,9 @@ function auth_login_page( $p_query_string = '' ) {
  * Gets the page that asks the user for credentials based on the user's
  * authentication model.
  *
- * @param string   $p_query_string The query string, can be empty.
- * @param int|null $p_user_id      The user id or null for current logged in user.
- * @param string   $p_username     The username
+ * @param string|array $p_query_string The query string or array of query parameters, can be empty.
+ * @param int|null     $p_user_id      The user id or null for current logged in user.
+ * @param string       $p_username     The username
  * @return string The credentials page with query string.
  * @throws ClientException
  */
@@ -322,8 +323,7 @@ function auth_ensure_user_authenticated( $p_return_page = '' ) {
 			}
 			$p_return_page = $_SERVER['REQUEST_URI'];
 		}
-		$p_return_page = string_url( $p_return_page );
-		print_header_redirect( auth_login_page( 'return=' . $p_return_page ) );
+		print_header_redirect( auth_login_page( [ 'return' => $p_return_page ] ) );
 	}
 }
 
@@ -1057,11 +1057,11 @@ function auth_reauthenticate() {
 			return true;
 		}
 
-		$t_query_params = http_build_query( array(
+		$t_query_params = [
 			'reauthenticate' => 1,
 			'username' => $t_username,
-			'return' => string_url( $_SERVER['REQUEST_URI'] ),
-		) );
+			'return' => $_SERVER['REQUEST_URI'],
+		];
 
 		# redirect to login page
 		return print_header_redirect( auth_credential_page( $t_query_params ) );

--- a/core/classes/AuthFlags.class.php
+++ b/core/classes/AuthFlags.class.php
@@ -215,7 +215,7 @@ class AuthFlags {
 	 * Gets the page to use to ask for user credentials.  This should be a page that is
 	 * provided by MantisBT core or one of the plugins.  Such page can redirect as needed.
 	 *
-	 * @param string $p_query_string The query string or empty.
+	 * @param string|array $p_query_string The query string or array of query parameters, can be empty.
 	 * @return string The relative url for the credential page.
 	 * @see setCredentialsPage()
 	 */

--- a/core/csv_api.php
+++ b/core/csv_api.php
@@ -31,6 +31,7 @@
  * @uses file_api.php
  * @uses helper_api.php
  * @uses project_api.php
+ * @uses string_api.php
  * @uses user_api.php
  *
  * @noinspection PhpDocMissingThrowsInspection
@@ -46,6 +47,7 @@ require_api( 'constant_inc.php' );
 require_api( 'file_api.php' );
 require_api( 'helper_api.php' );
 require_api( 'project_api.php' );
+require_api( 'string_api.php' );
 require_api( 'user_api.php' );
 
 /**
@@ -56,7 +58,7 @@ require_api( 'user_api.php' );
  * @return void
  */
 function csv_start( $p_filename ) {
-	$t_filename = urlencode( file_clean_name( $p_filename ) );
+	$t_filename = string_url( file_clean_name( $p_filename ) );
 
 	header( 'Pragma: public' );
 	header( 'Content-Encoding: UTF-8' );

--- a/core/excel_api.php
+++ b/core/excel_api.php
@@ -33,6 +33,7 @@
  * @uses helper_api.php
  * @uses lang_api.php
  * @uses project_api.php
+ * @uses string_api.php
  * @uses user_api.php
  */
 
@@ -46,6 +47,7 @@ require_api( 'custom_field_api.php' );
 require_api( 'helper_api.php' );
 require_api( 'lang_api.php' );
 require_api( 'project_api.php' );
+require_api( 'string_api.php' );
 require_api( 'user_api.php' );
 
 /**
@@ -61,7 +63,7 @@ function excel_get_header( $p_worksheet_title, array $p_styles = array() ) {
  <Workbook xmlns=\"urn:schemas-microsoft-com:office:spreadsheet\"
  xmlns:x=\"urn:schemas-microsoft-com:office:excel\"
  xmlns:ss=\"urn:schemas-microsoft-com:office:spreadsheet\"
- xmlns:html=\"http://www.w3.org/TR/REC-html40\">\n ". excel_get_styles( $p_styles ). '<Worksheet ss:Name="' . urlencode( $p_worksheet_title ) . "\">\n<Table>\n<Column ss:Index=\"1\" ss:AutoFitWidth=\"0\" ss:Width=\"110\"/>\n";
+ xmlns:html=\"http://www.w3.org/TR/REC-html40\">\n ". excel_get_styles( $p_styles ). '<Worksheet ss:Name="' . string_url( $p_worksheet_title ) . "\">\n<Table>\n<Column ss:Index=\"1\" ss:AutoFitWidth=\"0\" ss:Width=\"110\"/>\n";
 }
 
 /**

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -408,13 +408,13 @@ function filter_encode_field_and_value( $p_field_name, $p_field_value, $p_field_
 		$t_count = count( $p_field_value );
 		if( $t_count > 1 || $p_field_type == FILTER_TYPE_MULTI_STRING || $p_field_type == FILTER_TYPE_MULTI_INT ) {
 			foreach( $p_field_value as $t_value ) {
-				$t_query_array[] = urlencode( $p_field_name . '[]' ) . '=' . urlencode( $t_value );
+				$t_query_array[] = string_url( $p_field_name . '[]' ) . '=' . string_url( $t_value );
 			}
 		} else if( $t_count == 1 ) {
-			$t_query_array[] = urlencode( $p_field_name ) . '=' . urlencode( $p_field_value[0] );
+			$t_query_array[] = string_url( $p_field_name ) . '=' . string_url( $p_field_value[0] );
 		}
 	} else {
-		$t_query_array[] = urlencode( $p_field_name ) . '=' . urlencode( $p_field_value );
+		$t_query_array[] = string_url( $p_field_name ) . '=' . string_url( $p_field_value );
 	}
 
 	return implode( '&', $t_query_array );

--- a/core/filter_form_api.php
+++ b/core/filter_form_api.php
@@ -2607,7 +2607,7 @@ function filter_form_draw_inputs( $p_filter, $p_for_screen = true, $p_static = f
 	$t_get_params['view_type'] = ( FILTER_VIEW_TYPE_ADVANCED == $t_view_type )
 		? FILTER_VIEW_TYPE_ADVANCED
 		: FILTER_VIEW_TYPE_SIMPLE;
-	$t_filters_url .= '?' . http_build_query( $t_get_params );
+	$t_filters_url = helper_url_combine( $t_filters_url, $t_get_params );
 
 	$t_show_product_version =  version_should_show_product_version( $t_filter_projects );
 	$t_show_build = $t_show_product_version && ( config_get( 'enable_product_build' ) == ON );

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -737,18 +737,19 @@ function helper_filter_by_prefix( array $p_set, $p_prefix ) {
 /**
  * Combine a URL with a query string or an array of query parameters.
  *
- * @param string       $p_page         The page (relative or full)
+ * @param string       $p_page         The page (relative or full).
  * @param string|array $p_query_string The query string or array of query parameters.
  * @return string The combined url.
  */
-function helper_url_combine( $p_page, $p_query_string ) {
+function helper_url_combine( string $p_page, $p_query_string ): string {
 	$t_url = $p_page;
 	$t_query_string = is_array( $p_query_string )
 		? string_build_query( $p_query_string )
 		: $p_query_string;
 
 	if( !is_blank( $t_query_string ) ) {
-		if( stripos( $p_page, '?' ) !== false ) {
+		$t_url = rtrim( $t_url, '?' );
+		if( stripos( $t_url, '?' ) !== false ) {
 			$t_url .= '&' . $t_query_string;
 		} else {
 			$t_url .= '?' . $t_query_string;

--- a/core/helper_api.php
+++ b/core/helper_api.php
@@ -34,6 +34,7 @@
  * @uses lang_api.php
  * @uses print_api.php
  * @uses project_api.php
+ * @uses string_api.php
  * @uses user_api.php
  * @uses user_pref_api.php
  * @uses utility_api.php
@@ -50,6 +51,7 @@ require_api( 'html_api.php' );
 require_api( 'lang_api.php' );
 require_api( 'print_api.php' );
 require_api( 'project_api.php' );
+require_api( 'string_api.php' );
 require_api( 'user_api.php' );
 require_api( 'user_pref_api.php' );
 require_api( 'utility_api.php' );
@@ -733,20 +735,23 @@ function helper_filter_by_prefix( array $p_set, $p_prefix ) {
 }
 
 /**
- * Combine a Mantis page with a query string.  This handles the case where the page is a native
- * page or a plugin page.
- * @param string $p_page The page (relative or full)
- * @param string $p_query_string The query string
+ * Combine a URL with a query string or an array of query parameters.
+ *
+ * @param string       $p_page         The page (relative or full)
+ * @param string|array $p_query_string The query string or array of query parameters.
  * @return string The combined url.
  */
 function helper_url_combine( $p_page, $p_query_string ) {
 	$t_url = $p_page;
+	$t_query_string = is_array( $p_query_string )
+		? string_build_query( $p_query_string )
+		: $p_query_string;
 
-	if( !is_blank( $p_query_string ) ) {
+	if( !is_blank( $t_query_string ) ) {
 		if( stripos( $p_page, '?' ) !== false ) {
-			$t_url .= '&' . $p_query_string;
+			$t_url .= '&' . $t_query_string;
 		} else {
-			$t_url .= '?' . $p_query_string;
+			$t_url .= '?' . $t_query_string;
 		}
 	}
 

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -1014,7 +1014,7 @@ function print_admin_menu_bar( $p_page ) {
  */
 function html_button( $p_action, $p_button_text, array $p_fields = array(), $p_method = 'post' ) {
 	$t_form_name = explode( '.php', $p_action, 2 );
-	$p_action = urlencode( $p_action );
+	$p_action = string_url( $p_action );
 	$p_button_text = string_attribute( $p_button_text );
 
 	if( strtolower( $p_method ) == 'get' ) {

--- a/core/html_api.php
+++ b/core/html_api.php
@@ -228,7 +228,7 @@ function html_css() {
 		if( $t_stylesheet_path == 'status_config.php' ) {
 			$t_stylesheet_path = helper_url_combine(
 				helper_mantis_url( 'css/status_config.php' ),
-				'cache_key=' . helper_generate_cache_key( array( 'user' ) )
+				[ 'cache_key' => helper_generate_cache_key( array( 'user' ) ) ]
 			);
 		}
 
@@ -259,7 +259,7 @@ function html_css_link( $p_filename, $p_cache_key = '' ) {
 
 	$t_url = helper_mantis_url( $t_filename );
 	if ( !empty( $p_cache_key ) ) {
-		$t_url = helper_url_combine( $t_url, 'cache_key=' . $p_cache_key );
+		$t_url = helper_url_combine( $t_url, [ 'cache_key' => $p_cache_key ] );
 	}
 
 	echo "\t", '<link rel="stylesheet" type="text/css" href="', string_sanitize_url( $t_url, true ), '" />', "\n";
@@ -347,11 +347,11 @@ function html_head_javascript() {
 	# a reload when the content may differ.
 	$t_javascript_translations = helper_url_combine(
 		helper_mantis_url( 'javascript_translations.php' ),
-		'cache_key=' . helper_generate_cache_key( array( 'lang' ) )
+		[ 'cache_key' => helper_generate_cache_key( array( 'lang' ) ) ]
 	);
 	$t_javascript_config = helper_url_combine(
 		helper_mantis_url( 'javascript_config.php' ),
-		'cache_key=' . helper_generate_cache_key( array( 'user' ) )
+		[ 'cache_key' => helper_generate_cache_key( array( 'user' ) ) ]
 	);
 	echo "\t" . '<script src="' . $t_javascript_config . '"></script>' . "\n";
 	echo "\t" . '<script src="' . $t_javascript_translations . '"></script>' . "\n";

--- a/core/http_api.php
+++ b/core/http_api.php
@@ -25,9 +25,11 @@
  * @link http://www.mantisbt.org
  *
  * @uses config_api.php
+ * @uses string_api.php
  */
 
 require_api( 'config_api.php' );
+require_api( 'string_api.php' );
 
 /**
  * The Content-Security-Policy settings array.  Use http_csp_add() to update it.
@@ -77,7 +79,7 @@ function is_browser_chrome() {
  */
 function http_content_disposition_header( $p_filename, $p_inline = false ) {
 	if( !headers_sent() ) {
-		$t_encoded_filename = rawurlencode( $p_filename );
+		$t_encoded_filename = string_url( $p_filename );
 		$t_disposition = '';
 		if( !$p_inline ) {
 			$t_disposition = 'attachment;';

--- a/core/install_helper_functions_api.php
+++ b/core/install_helper_functions_api.php
@@ -24,11 +24,13 @@
  * @link http://www.mantisbt.org
  *
  * @uses database_api.php
+ * @uses string_api.php
  *
  * @noinspection PhpUnused
  */
 
 require_api( 'database_api.php' );
+require_api( 'string_api.php' );
 
 /**
  * Legacy pre-1.2 date function used for upgrading from datetime to integer
@@ -838,7 +840,7 @@ function install_print_unserialize_errors_csv( $p_table, $p_data ) {
 
 	# CSV download (as data URL)
 ?>
-	<a href="data:text/csv;charset=UTF-8,<?php echo rawurlencode( $t_csv ) ?>"
+	<a href="data:text/csv;charset=UTF-8,<?php echo string_url( $t_csv ) ?>"
 	   download="errors_<?php echo $p_table; ?>.csv"
 	   class="btn btn-primary btn-white btn-round"
 	>

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -259,7 +259,7 @@ function layout_head_css() {
 
 		# theme text fonts
 		$t_font_family =  config_get( 'font_family', null, null, ALL_PROJECTS );
-		html_css_cdn_link( 'https://fonts.googleapis.com/css?family=' . urlencode( $t_font_family ) );
+		html_css_cdn_link( helper_url_combine( 'https://fonts.googleapis.com/css', [ 'family' => $t_font_family ] ) );
 
 		# datetimepicker
 		html_css_cdn_link( 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/' . DATETIME_PICKER_VERSION . '/css/bootstrap-datetimepicker.min.css', DATETIME_PICKER_HASH_CSS );

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -1045,12 +1045,10 @@ function layout_breadcrumbs() {
 			$t_return_page .= '?' . $_SERVER['QUERY_STRING'];
 		}
 
-		$t_return_page = string_url( $t_return_page );
-
 		echo '  ' . lang_get( 'anonymous' ) . "\n";
 
 		echo '  <div class="btn-group btn-corner">' . "\n";
-		echo '	<a href="' . helper_mantis_url( auth_login_page( 'return=' . $t_return_page ) ) .
+		echo '	<a href="' . helper_mantis_url( auth_login_page( [ 'return' => $t_return_page ] ) ) .
 			'" class="btn btn-primary btn-xs">' . lang_get( 'login' ) . '</a>' . "\n";
 		if( auth_signup_enabled() ) {
 			echo '	<a href="' . helper_mantis_url( 'signup_page.php' ) . '" class="btn btn-primary btn-xs">' .

--- a/core/print_api.php
+++ b/core/print_api.php
@@ -1370,14 +1370,18 @@ function print_view_bug_sort_link( $p_label, $p_sort_field, $p_sort, $p_dir, $p_
 				# Otherwise always start with ascending
 				$p_dir = 'ASC';
 			}
-			$t_sort_field = rawurlencode( $p_sort_field );
-			$t_print_parameter = ( $p_columns_target == COLUMNS_TARGET_PRINT_PAGE ) ? '&print=1' : '';
-			$t_filter_parameter = filter_is_temporary( $g_filter ) ? filter_get_temporary_key_param( $g_filter ) . '&' : '';
-			$t_url = 'view_all_set.php?' . $t_filter_parameter
-				. 'sort_add=' . $t_sort_field
-				. '&dir_add=' . $p_dir
-				. '&type=' . FILTER_ACTION_PARSE_ADD
-				. $t_print_parameter;
+			$t_params = [
+				'sort_add' => $p_sort_field,
+				'dir_add' => $p_dir,
+				'type' => FILTER_ACTION_PARSE_ADD
+			];
+			if( $p_columns_target == COLUMNS_TARGET_PRINT_PAGE ) {
+				$t_params['print'] = 1;
+			}
+			$t_url = helper_url_combine( 'view_all_set.php', $t_params );
+			if( filter_is_temporary( $g_filter ) ) {
+				$t_url .= '&' . filter_get_temporary_key_param( $g_filter );
+			}
 			print_link( $t_url, $p_label, false, '', $p_icon );
 			break;
 		default:
@@ -1412,10 +1416,16 @@ function print_manage_user_sort_link( $p_page, $p_string, $p_field, $p_dir, $p_s
 		$t_dir = 'ASC';
 	}
 
-	$t_field = rawurlencode( $p_field );
 	print_link(
-		$p_page . '?sort=' . $t_field . '&dir=' . $t_dir . '&save=1&hideinactive=' . $p_hide_inactive
-		. '&showdisabled=' . $p_show_disabled . '&filter=' . $p_filter . '&search=' . $p_search,
+		helper_url_combine( $p_page, [
+			'sort' => $p_field,
+			'dir' => $t_dir,
+			'save' => '1',
+			'hideinactive' => $p_hide_inactive,
+			'showdisabled' => $p_show_disabled,
+			'filter' => $p_filter,
+			'search' => $p_search
+		] ),
 		$p_string,
 		false,
 		$p_class
@@ -1444,8 +1454,13 @@ function print_manage_project_sort_link( $p_page, $p_string, $p_field, $p_dir, $
 		$t_dir = 'ASC';
 	}
 
-	$t_field = rawurlencode( $p_field );
-	print_link( $p_page . '?sort=' . $t_field . '&dir=' . $t_dir, $p_string );
+	print_link(
+		helper_url_combine( $p_page, [
+			'sort' => $p_field,
+			'dir' => $t_dir
+		] ),
+		$p_string
+	);
 }
 
 /**

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -816,7 +816,10 @@ function string_get_bug_report_url() {
  * @return string
  */
 function string_get_confirm_hash_url( $p_user_id, $p_confirm_hash ) {
-	return config_get_global( 'path' ) . 'verify.php?id=' . string_url( $p_user_id ) . '&confirm_hash=' . string_url( $p_confirm_hash );
+	return helper_url_combine( config_get_global( 'path' ) . 'verify.php', [
+		'id' => $p_user_id,
+		'confirm_hash' => $p_confirm_hash
+	] );
 }
 
 /**

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -295,10 +295,10 @@ function string_sanitize_url( $p_url, $p_return_absolute = false ) {
 		foreach( $t_pairs as $t_key => $t_value ) {
 			if( is_array( $t_value ) ) {
 				foreach( $t_value as $t_value_each ) {
-					$t_clean_pairs[] = rawurlencode( $t_key ) . '[]=' . rawurlencode( $t_value_each );
+					$t_clean_pairs[] = string_url( $t_key ) . '[]=' . string_url( $t_value_each );
 				}
 			} else {
-				$t_clean_pairs[] = rawurlencode( $t_key ) . '=' . rawurlencode( $t_value );
+				$t_clean_pairs[] = string_url( $t_key ) . '=' . string_url( $t_value );
 			}
 		}
 
@@ -310,7 +310,7 @@ function string_sanitize_url( $p_url, $p_return_absolute = false ) {
 	# encode link anchor
 	$t_anchor = '';
 	if( isset( $t_matches['anchor'] ) ) {
-		$t_anchor = '#' . rawurlencode( $t_matches['anchor'] );
+		$t_anchor = '#' . string_url( $t_matches['anchor'] );
 	}
 
 	# Return an appropriate re-combined URL string

--- a/core/summary_api.php
+++ b/core/summary_api.php
@@ -664,7 +664,7 @@ function summary_print_by_category( array $p_filter = [] ) {
 
 		$t_link_prefix = summary_get_link_prefix( $p_filter );
 
-		$t_bug_link = $t_link_prefix . '&amp;' . FILTER_PROPERTY_CATEGORY_ID . '=' . urlencode( $t_label );
+		$t_bug_link = $t_link_prefix . '&amp;' . FILTER_PROPERTY_CATEGORY_ID . '=' . string_url( $t_label );
 		summary_helper_build_buglinks( $t_bug_link, $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total );
 		summary_helper_print_row( string_display_line( $t_label ), $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total, $t_bugs_ratio[0], $t_bugs_ratio[1] );
 	}
@@ -734,7 +734,7 @@ function summary_print_by_project( array $p_projects = [], int $p_level = 0, arr
 		$t_bugs_ratio = summary_helper_get_bugratio( $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total_count);
 
 # FILTER_PROPERTY_PROJECT_ID filter by project does not work ??
-#		$t_bug_link = '<a class="subtle" href="' . config_get( 'bug_count_hyperlink_prefix' ) . '&amp;' . FILTER_PROPERTY_PROJECT_ID . '=' . urlencode( $t_project );
+#		$t_bug_link = '<a class="subtle" href="' . config_get( 'bug_count_hyperlink_prefix' ) . '&amp;' . FILTER_PROPERTY_PROJECT_ID . '=' . string_url( $t_project );
 #		summary_helper_build_buglinks( $t_bug_link, $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total );
 
 		summary_helper_print_row( string_display_line( $t_name ), $t_bugs_open, $t_bugs_resolved, $t_bugs_closed, $t_bugs_total, $t_bugs_ratio[0], $t_bugs_ratio[1]);

--- a/excel_xml_export.php
+++ b/excel_xml_export.php
@@ -33,6 +33,7 @@
  * @uses gpc_api.php
  * @uses helper_api.php
  * @uses print_api.php
+ * @uses string_api.php
  * @uses utility_api.php
  */
 
@@ -50,6 +51,7 @@ require_api( 'filter_api.php' );
 require_api( 'gpc_api.php' );
 require_api( 'helper_api.php' );
 require_api( 'print_api.php' );
+require_api( 'string_api.php' );
 require_api( 'utility_api.php' );
 
 auth_ensure_user_authenticated();
@@ -66,7 +68,7 @@ $t_short_date_format = config_get( 'short_date_format' );
 
 header( 'Content-Type: application/vnd.ms-excel; charset=UTF-8' );
 header( 'Pragma: public' );
-header( 'Content-Disposition: attachment; filename="' . urlencode( file_clean_name( $t_export_title ) ) . '.xml"' ) ;
+header( 'Content-Disposition: attachment; filename="' . string_url( file_clean_name( $t_export_title ) ) . '.xml"' ) ;
 
 echo excel_get_header( $t_export_title );
 echo excel_get_titles_row();

--- a/login.php
+++ b/login.php
@@ -27,6 +27,7 @@
  * @uses config_api.php
  * @uses constant_inc.php
  * @uses gpc_api.php
+ * @uses helper_api.php
  * @uses print_api.php
  * @uses session_api.php
  * @uses string_api.php
@@ -37,13 +38,14 @@ require_api( 'authentication_api.php' );
 require_api( 'config_api.php' );
 require_api( 'constant_inc.php' );
 require_api( 'gpc_api.php' );
+require_api( 'helper_api.php' );
 require_api( 'print_api.php' );
 require_api( 'session_api.php' );
 require_api( 'string_api.php' );
 
 $f_username		= gpc_get_string( 'username', '' );
 $f_password		= gpc_get_string( 'password', '' );
-$t_return		= string_url( string_sanitize_url( gpc_get_string( 'return', config_get_global( 'default_home_page' ) ) ) );
+$t_return		= string_sanitize_url( gpc_get_string( 'return', config_get_global( 'default_home_page' ) ) );
 $f_from			= gpc_get_string( 'from', '' );
 $f_secure_session = gpc_get_bool( 'secure_session', false );
 $f_reauthenticate = gpc_get_bool( 'reauthenticate', false );
@@ -70,7 +72,7 @@ if( auth_attempt_login( $f_username, $f_password, $f_perm_login ) ) {
 		$t_return = 'account_page.php';
 	}
 
-	$t_redirect_url = 'login_cookie_test.php?return=' . $t_return;
+	$t_redirect_url = helper_url_combine( 'login_cookie_test.php', [ 'return' => $t_return ] );
 } else {
 	$t_query_args = array(
 		'error' => 1,
@@ -90,9 +92,7 @@ if( auth_attempt_login( $f_username, $f_password, $f_perm_login ) ) {
 		$t_query_args['perm_login'] = 1;
 	}
 
-	$t_query_text = http_build_query( $t_query_args, '', '&' );
-
-	$t_redirect_url = auth_login_page( $t_query_text );
+	$t_redirect_url = auth_login_page( $t_query_args );
 
 	if( HTTP_AUTH == config_get_global( 'login_method' ) ) {
 		auth_http_prompt();

--- a/login_anon.php
+++ b/login_anon.php
@@ -33,6 +33,7 @@
  * @uses core.php
  * @uses config_api.php
  * @uses gpc_api.php
+ * @uses helper_api.php
  * @uses print_api.php
  * @uses string_api.php
  */
@@ -40,16 +41,19 @@
 require_once( 'core.php' );
 require_api( 'config_api.php' );
 require_api( 'gpc_api.php' );
+require_api( 'helper_api.php' );
 require_api( 'print_api.php' );
 require_api( 'string_api.php' );
 
-$f_return = gpc_get_string( 'return', '' );
+$f_return = string_sanitize_url( gpc_get_string( 'return', '' ) );
 
-$t_anonymous_account = auth_anonymous_account();
+$t_params = [
+	'username' => auth_anonymous_account(),
+	'perm_login' => false
+];
 
-if( $f_return !== '' ) {
-	$t_return = string_url( string_sanitize_url( $f_return ) );
-	print_header_redirect( 'login.php?username=' . $t_anonymous_account . '&perm_login=false&return=' . $t_return );
-} else {
-	print_header_redirect( 'login.php?username=' . $t_anonymous_account . '&perm_login=false' );
+if( !is_blank( $f_return ) ) {
+	$t_params['return'] = $f_return;
 }
+
+print_header_redirect( helper_url_combine( 'login.php', $t_params ) );

--- a/login_page.php
+++ b/login_page.php
@@ -32,6 +32,7 @@
  * @uses current_user_api.php
  * @uses database_api.php
  * @uses gpc_api.php
+ * @uses helper_api.php
  * @uses html_api.php
  * @uses lang_api.php
  * @uses print_api.php
@@ -47,6 +48,7 @@ require_api( 'constant_inc.php' );
 require_api( 'current_user_api.php' );
 require_api( 'database_api.php' );
 require_api( 'gpc_api.php' );
+require_api( 'helper_api.php' );
 require_api( 'html_api.php' );
 require_api( 'lang_api.php' );
 require_api( 'print_api.php' );
@@ -99,7 +101,7 @@ if( auth_automatic_logon_bypass_form() ) {
 	}
 
 	if( !is_blank( $f_return ) ) {
-		$t_uri .= '?return=' . string_url( $f_return );
+		$t_uri = helper_url_combine( $t_uri, [ 'return' => $f_return ] );
 	}
 
 	print_header_redirect( $t_uri );
@@ -263,7 +265,11 @@ if( $t_show_anonymous_login || $t_show_signup ) {
 	echo '<div class="toolbar center">';
 
 	if( $t_show_anonymous_login ) {
-		echo '<a class="back-to-login-link pull-right" href="login_anon.php?return=' . string_url( $f_return ) . '">' . lang_get( 'login_anonymously' ) . '</a>';
+		echo '<a class="back-to-login-link pull-right" href="',
+			helper_url_combine( 'login_anon.php', [
+				'return' => $f_return
+			] ),
+			'">', lang_get( 'login_anonymously' ), '</a>';
 	}
 
 	if( $t_show_signup ) {

--- a/login_password_page.php
+++ b/login_password_page.php
@@ -32,6 +32,7 @@
  * @uses current_user_api.php
  * @uses database_api.php
  * @uses gpc_api.php
+ * @uses helper_api.php
  * @uses html_api.php
  * @uses lang_api.php
  * @uses print_api.php
@@ -47,6 +48,7 @@ require_api( 'constant_inc.php' );
 require_api( 'current_user_api.php' );
 require_api( 'database_api.php' );
 require_api( 'gpc_api.php' );
+require_api( 'helper_api.php' );
 require_api( 'html_api.php' );
 require_api( 'lang_api.php' );
 require_api( 'print_api.php' );
@@ -73,9 +75,7 @@ if( is_blank( $t_username ) ) {
 		'return' => $f_return,
 	);
 
-	$t_query_text = http_build_query( $t_query_args, '', '&' );
-
-	$t_redirect_url = auth_login_page( $t_query_text );
+	$t_redirect_url = auth_login_page( $t_query_args );
 	print_header_redirect( $t_redirect_url );
 }
 
@@ -103,12 +103,10 @@ if( $t_should_redirect ) {
 		$t_query_args['cookie_error'] = $f_cookie_error;
 	}
 
-	$t_query_text = http_build_query( $t_query_args, '', '&' );
-
 	# Determine the credential page URL based on user id (if it exists) or username
 	$t_redirect_url = $t_user_id !== false
-		? auth_credential_page( $t_query_text, $t_user_id )
-		: auth_credential_page( $t_query_text, NO_USER, $t_username );
+		? auth_credential_page( $t_query_args, $t_user_id )
+		: auth_credential_page( $t_query_args, NO_USER, $t_username );
 	print_header_redirect( $t_redirect_url );
 }
 
@@ -261,7 +259,11 @@ if( config_get_global( 'admin_checks' ) == ON && file_exists( __DIR__ .'/admin/.
 			<?php
 			# lost password feature disabled or reset password via email disabled -> stop here!
 			if( $t_show_reset_password ) {
-				echo '<a class="pull-right" href="lost_pwd_page.php?username=', urlencode( $t_username ), '">', lang_get( 'lost_password_link' ), '</a>';
+				echo '<a class="pull-right" href="',
+					helper_url_combine( 'lost_pwd_page.php', [
+						'username' => $t_username
+					] ),
+					'">', lang_get( 'lost_password_link' ), '</a>';
 			}
 			?>
 		</fieldset>

--- a/login_select_proj_page.php
+++ b/login_select_proj_page.php
@@ -27,6 +27,7 @@
  * @uses constant_inc.php
  * @uses current_user_api.php
  * @uses gpc_api.php
+ * @uses helper_api.php
  * @uses html_api.php
  * @uses lang_api.php
  * @uses print_api.php
@@ -38,6 +39,7 @@ require_api( 'authentication_api.php' );
 require_api( 'constant_inc.php' );
 require_api( 'current_user_api.php' );
 require_api( 'gpc_api.php' );
+require_api( 'helper_api.php' );
 require_api( 'html_api.php' );
 require_api( 'lang_api.php' );
 require_api( 'print_api.php' );
@@ -51,8 +53,13 @@ if( count( current_user_get_accessible_projects() ) == 1 ) {
 	$t_project_ids = current_user_get_accessible_projects();
 	$t_project_id = (int)$t_project_ids[0];
 	if( count( current_user_get_accessible_subprojects( $t_project_id ) ) == 0 ) {
-		$t_ref_urlencoded = string_url( $f_ref );
-		print_header_redirect( 'set_project.php?project_id=' . $t_project_id . '&ref=' . $t_ref_urlencoded, true );
+		print_header_redirect(
+			helper_url_combine( 'set_project.php', [
+				'project_id' => $t_project_id,
+				'ref' => $f_ref
+			] ),
+			true
+		);
 		# print_header_redirect terminates script execution
 	}
 }

--- a/manage_proj_page.php
+++ b/manage_proj_page.php
@@ -264,16 +264,20 @@ print_manage_menu( 'manage_proj_page.php' );
 				<td class="center">
 					<div class="btn-group inline">
 						<div class="pull-left"><?php
-						$t_id = urlencode( $t_id );
-						$t_project_id = urlencode( ALL_PROJECTS );
 						print_form_button(
-							"manage_proj_cat_edit_page.php?category_id=$t_id&project_id=$t_project_id",
+							helper_url_combine( 'manage_proj_cat_edit_page.php', [
+								'category_id' => $t_id,
+								'project_id' => ALL_PROJECTS
+							] ),
 							lang_get( 'edit' )
 						); ?>
 						</div>
 						<div class="pull-left"><?php
 						print_form_button(
-							"manage_proj_cat_delete.php?category_id=$t_id&project_id=$t_project_id",
+							helper_url_combine( 'manage_proj_cat_delete.php', [
+								'category_id' => $t_id,
+								'project_id' => ALL_PROJECTS
+							] ),
 							lang_get( 'delete' )
 						); ?>
 						</div>

--- a/my_view_inc.php
+++ b/my_view_inc.php
@@ -300,8 +300,8 @@ $t_bug_string = $t_bug_count == 1 ? 'bug' : 'bugs';
 			<?php print_icon( 'fa-list-alt', 'ace-icon' ); ?>
 <?php
 #-- Box title
-$t_box_url = html_entity_decode( config_get( 'bug_count_hyperlink_prefix' ) ).'&'
-	. string_build_query( $t_url_link_parameters[$t_box_title] );
+$t_box_url = helper_url_combine( html_entity_decode( config_get( 'bug_count_hyperlink_prefix' ) ),
+	$t_url_link_parameters[$t_box_title] );
 print_link( $t_box_url, $t_box_title_label, false, 'white' );
 
 # -- Viewing range info

--- a/print_all_bug_page.php
+++ b/print_all_bug_page.php
@@ -144,15 +144,13 @@ $f_export = implode( ',', $f_bug_arr );
 		$t_new_dir = 'DESC';
 	}
 
-	$t_search = urlencode( $f_search );
-
 	$t_icons = array(
 		array( 'print_all_bug_page_word', 'word', '', 'fa-file-word-o', 'Word 2000' ),
 		array( 'print_all_bug_page_word', 'html', 'target="_blank"', 'fa-internet-explorer', 'Word View' ) );
 
 	foreach ( $t_icons as $t_icon ) {
 		$t_params = array(
-			FILTER_PROPERTY_SEARCH => $t_search,
+			FILTER_PROPERTY_SEARCH => $f_search,
 			FILTER_PROPERTY_SORT_FIELD_NAME => $f_sort,
 			FILTER_PROPERTY_SORT_DIRECTION => $t_new_dir,
 			'type_page' => $t_icon[1],
@@ -163,7 +161,7 @@ $f_export = implode( ',', $f_bug_arr );
 			$t_params['filter'] = filter_get_temporary_key( $t_filter );
 		}
 
-		echo '<a href="' . $t_icon[0] . '.php?' . http_build_query( $t_params ) . '" ' . $t_icon[2] . '>';
+		echo '<a href="' . helper_url_combine( $t_icon[0] . '.php', $t_params ) . '" ' . $t_icon[2] . '>';
 		print_icon( $t_icon[3], '', $t_icon[4] );
 		echo '</a> ';
 	}

--- a/query_store.php
+++ b/query_store.php
@@ -60,15 +60,15 @@ $t_query_redirect_url = 'query_store_page.php';
 
 # We can't have a blank name
 if( is_blank( $f_query_name ) ) {
-	$t_query_redirect_url = $t_query_redirect_url . '?error_msg='
-		. urlencode( lang_get( 'query_blank_name' ) );
+	$t_query_redirect_url = helper_url_combine( $t_query_redirect_url,
+		[ 'error_msg' => lang_get( 'query_blank_name' ) ] );
 	print_header_redirect( $t_query_redirect_url );
 }
 
 # mantis_filters_table.name has a length of 64. Not allowing longer.
 if( !filter_name_valid_length( $f_query_name ) ) {
-	$t_query_redirect_url = $t_query_redirect_url . '?error_msg='
-		. urlencode( lang_get( 'query_name_too_long' ) );
+	$t_query_redirect_url = helper_url_combine( $t_query_redirect_url,
+		[ 'error_msg' => lang_get( 'query_name_too_long' ) ] );
 	print_header_redirect( $t_query_redirect_url );
 }
 
@@ -77,8 +77,8 @@ if( !filter_name_valid_length( $f_query_name ) ) {
 $t_query_arr = filter_db_get_available_queries();
 foreach( $t_query_arr as $t_id => $t_name )	{
 	if( $f_query_name == $t_name ) {
-		$t_query_redirect_url = $t_query_redirect_url . '?error_msg='
-			. urlencode( lang_get( 'query_dupe_name' ) );
+		$t_query_redirect_url = helper_url_combine( $t_query_redirect_url,
+			[ 'error_msg' => lang_get( 'query_dupe_name' ) ] );
 		print_header_redirect( $t_query_redirect_url );
 		exit;
 	}
@@ -113,8 +113,8 @@ $t_new_row_id = filter_db_create_filter( $t_filter_string, auth_get_current_user
 form_security_purge( 'query_store' );
 
 if( $t_new_row_id == -1 ) {
-	$t_query_redirect_url = $t_query_redirect_url . '?error_msg='
-		. urlencode( lang_get( 'query_store_error' ) );
+	$t_query_redirect_url = helper_url_combine( $t_query_redirect_url,
+		[ 'error_msg' => lang_get( 'query_store_error' ) ] );
 	print_header_redirect( $t_query_redirect_url );
 } else {
 	# Build a redirect to view_all_set to load the filter that was saved.
@@ -126,6 +126,6 @@ if( $t_new_row_id == -1 ) {
 	if( filter_is_temporary( $t_filter ) ) {
 		$t_params['filter'] = filter_get_temporary_key( $t_filter );
 	}
-	$t_redirect = 'view_all_set.php?' . http_build_query( $t_params );
+	$t_redirect = helper_url_combine( 'view_all_set.php', $t_params );
 	print_header_redirect( $t_redirect );
 }

--- a/set_project.php
+++ b/set_project.php
@@ -89,7 +89,7 @@ if( !is_blank( $c_ref ) ) {
 		switch( $t_referrer_page ) {
 			case 'view_all_bug_page.php':		
 				$t_source_filter_id = filter_db_get_project_current( $t_bottom );
-				$t_redirect_url = 'view_all_set.php?' . string_build_query(
+				$t_redirect_url = helper_url_combine( 'view_all_set.php',
 					( $t_source_filter_id !== null )
 						? [ 'type' => FILTER_ACTION_LOAD,
 							'source_query_id' => $t_source_filter_id ]
@@ -99,8 +99,8 @@ if( !is_blank( $c_ref ) ) {
 			case 'manage_proj_edit_page.php':
 			case 'manage_proj_page.php':
 				$t_redirect_url = ( ALL_PROJECTS != $t_bottom )
-					? 'manage_proj_edit_page.php?'
-						. string_build_query( [ 'project_id' => $t_bottom ] )
+					? helper_url_combine( 'manage_proj_edit_page.php',
+						[ 'project_id' => $t_bottom ] )
 					: 'manage_proj_page.php';
 				break;
 

--- a/tag_view_page.php
+++ b/tag_view_page.php
@@ -89,7 +89,8 @@ if( $t_manage_tags ) {
 <div class="widget-body">
 <div class="widget-main no-padding">
 	<div class="widget-toolbox padding-8 clearfix">
-		<?php print_link_button( 'search.php?tag_string='.urlencode($t_tag_row['name']),
+		<?php print_link_button( helper_url_combine( 'search.php', [
+			'tag_string' => $t_tag_row['name'] ] ),
 			sprintf( lang_get( 'tag_filter_default' ), tag_stats_attached( $f_tag_id ) ),
 			'btn-sm pull-right'); ?>
 	</div>
@@ -148,7 +149,8 @@ if( $t_manage_tags ) {
 			$t_name = string_display_line( $t_tag['name'] );
 			$t_description = string_display_line( $t_tag['description'] );
 			$t_count = $t_tag['count'];
-			$t_link = string_html_specialchars( 'search.php?tag_string='.urlencode( '+' . $t_tag_row['name'] . config_get( 'tag_separator' ) . '+' . $t_name ) );
+			$t_link = string_html_specialchars( helper_url_combine( 'search.php', [
+				'tag_string' => ( '+' . $t_tag_row['name'] . config_get( 'tag_separator' ) . '+' . $t_name ) ] ) );
 			$t_label = sprintf( lang_get( 'tag_related_issues' ), $t_tag['count'] );
 ?>
 				<div class="col-md-3 col-xs-6 no-padding">

--- a/tests/Mantis/Helper/UrlCombineTest.php
+++ b/tests/Mantis/Helper/UrlCombineTest.php
@@ -1,0 +1,81 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * MantisBT Core Unit Tests
+ *
+ * @package    Tests
+ * @subpackage Helper
+ * @copyright  Copyright 2025 MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link       https://www.mantisbt.org
+ */
+
+declare(strict_types=1);
+
+namespace Mantis\tests\Mantis\Helper;
+
+use Mantis\tests\Mantis\MantisCoreBase;
+
+/**
+ * Tests for combine URL (Helper API).
+ *
+ * @see helper_url_combine()
+ */
+final class UrlCombineTest extends MantisCoreBase {
+
+	/**
+	 * Tests helper_url_combine()
+	 *
+	 * @param string       $p_page         The page.
+	 * @param string|array $p_query_string The query string or array of query parameters.
+	 * @param mixed        $p_expected     Expected result.
+	 * @return void
+	 *
+	 * @dataProvider providerUrlCombine
+	 */
+	public function testUrlCombine( $p_page, $p_query_string, $p_expected ): void {
+		if( is_subclass_of( $p_expected, '\Throwable' ) ) { 
+			$this->expectException( $p_expected );
+			helper_url_combine( $p_page, $p_query_string );
+		} else {
+			$this->assertEquals( $p_expected, helper_url_combine( $p_page, $p_query_string ) );
+		}
+	}
+
+	/**
+	 * Data provider for testUrlCombine
+	 *
+	 * @return array
+	 */
+	public static function providerUrlCombine(): array {
+		return [
+			'Error parameter (null)' => [ null, null, \TypeError::class ],
+			'Error parameter (array)' => [ [], null, \TypeError::class ],
+			'Empty parameter (null)' => [ '', null, '' ],
+			'Empty parameter (string)' => [ '', '', '' ],
+			'Empty parameter (array)' => [ '', [], '' ],
+			'String parameter (page only)' => [ 'page', '', 'page' ],
+			'String parameter (query only)' => [ '', 'query', '?query' ],
+			'String parameter (page? only)' => [ 'page?', '', 'page?' ],
+			'String parameter (page + query)' => [ 'page', 'query', 'page?query' ],
+			'String parameter (page? + query)' => [ 'page?', 'query', 'page?query' ],
+			'String parameter (full)' => [ 'page?query1', 'query2', 'page?query1&query2' ],
+			'Array parameter (empty)' => [ 'page', [], 'page' ],
+			'Array parameter (full)' => [ 'page', [ 'query1' => 'value1', 'query2' => 'value2', ], 'page?query1=value1&query2=value2' ],
+			'Array parameter (urlencode)' => [ 'page', [ '<query~> &?=' => '<value~> &?=' ], 'page?%3Cquery~%3E%20%26%3F%3D=%3Cvalue~%3E%20%26%3F%3D' ],
+		];
+	}
+}

--- a/timeline_inc.php
+++ b/timeline_inc.php
@@ -18,6 +18,7 @@ if( !defined( 'TIMELINE_INC_ALLOW' ) ) {
 	return;
 }
 
+require_api( 'helper_api.php' );
 require_api( 'timeline_api.php' );
 
 define( 'MAX_EVENTS', 50 );
@@ -90,14 +91,14 @@ unset( $t_url_params['all'] );
 
 				echo '<div class="btn-group">';
 				$t_url_params['days'] = $f_days + 7;
-				$t_href = $t_url_page . '?' . http_build_query( $t_url_params );
+				$t_href = helper_url_combine( $t_url_page, $t_url_params );
 				echo ' <a class="btn btn-primary btn-xs btn-white btn-round" href="' . $t_href . '">' . lang_get( 'prev' ) . '</a>';
 
 				$t_next_days = max( $f_days - 7, 0 );
 
 				if( $t_next_days != $f_days ) {
 					$t_url_params['days'] = $t_next_days;
-					$t_href = $t_url_page . '?' . http_build_query( $t_url_params );
+					$t_href = helper_url_combine( $t_url_page, $t_url_params );
 					echo ' <a class="btn btn-primary btn-xs btn-white btn-round" href="' . $t_href . '">' . lang_get( 'next' ) . '</a>';
 				}
 				echo '</div>';
@@ -118,7 +119,7 @@ unset( $t_url_params['all'] );
 		echo '<div class="btn-toolbar">';
 		$t_url_params['days'] = $f_days;
 		$t_url_params['all'] = 1;
-		$t_href = $t_url_page . '?' . http_build_query( $t_url_params );
+		$t_href = helper_url_combine( $t_url_page, $t_url_params );
 		echo '<a class="btn btn-primary btn-sm btn-white btn-round" href="' . $t_href . '">' . lang_get( 'timeline_more' ) . '</a>';
 		echo '</div>';
 		echo '</div>';


### PR DESCRIPTION
Fixes [#35424](https://mantisbt.org/bugs/view.php?id=35424).

Extended the allowed parameter types of helper_url_combine(), auth_login_page(), auth_credential_page(),
AuthFlags::getCredentialsPage() functions that accepted a query string to also accept an array of query parameters.

Added a new test UrlCombineTest for helper_url_combine().

Fixed double encoding error in:
- print_all_bug_page.php - actual error.
- auth_reauthenticate() - worked because in login_password_page.php the receiving page uses string_sanitize_url() which does another (unnecessary) urldecode() conversion, and the first conversion is done by PHP to $_GET[]. Should we remove or leave this extra conversion?
