### PR TITLE
Fix error when updating category on PostgreSQL

### DIFF
--- a/manage_proj_cat_update.php
+++ b/manage_proj_cat_update.php
@@ -56,7 +56,8 @@ auth_reauthenticate();
 $f_category_id     = gpc_get_int( 'category_id' );
 $f_name            = trim( gpc_get_string( 'name' ) );
 $f_assigned_to     = gpc_get_int( 'assigned_to', 0 );
-$f_status          = gpc_get_bool( 'status', CATEGORY_STATUS_DISABLED );
+# Underlying DB column is integer, but we use it as bool since we only have 2 states
+$f_status          = (int)gpc_get_bool( 'status', CATEGORY_STATUS_DISABLED );
 
 if( is_blank( $f_name ) ) {
 	error_parameters( 'name' );


### PR DESCRIPTION
Updating a category results in APPLICATION ERROR 401 Database query failed. Error received from database was #-1: ERROR: invalid input syntax for type integer: "FALSE"

This is due to internally handling the category's status as a boolean, while the underlying database column is an integer.

Typecasting the Checkbox post variable to int prevents the problem.

Fixes [#35544](https://mantisbt.org/bugs/view.php?id=35544)