### PR TITLE
Prevent internal application error in url_get()

### DIFF
--- a/core/url_api.php
+++ b/core/url_api.php
@@ -74,6 +74,10 @@ function url_get( $p_url ) {
 	}
 
 	# Last resort system call
-	$t_url = escapeshellarg( $p_url );
-	return shell_exec( 'curl ' . $t_url );
+	if( function_exists( 'shell_exec' ) ) {
+		$t_url = escapeshellarg( $p_url );
+		return shell_exec( 'curl ' . $t_url );
+	}
+
+	return null;
 }


### PR DESCRIPTION
When allow_url_fopen = OFF, curl extension is not installed, url_get() falls back to a shell_exec() call to run curl, but if shell_exec() function is disabled in php.ini, then an internal application error is thrown.

This checks that shell_exec() function exists before calling it, and returns null if not.

Fixes [#35540](https://mantisbt.org/bugs/view.php?id=35540)