### PR TITLE
Add .editorconfig file to help indenting with 4 character tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# Prevents other .editorconfig files higher in the folder hierarchy to interfere
+root = true
+
+[*.{php,js,css}]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
This PR adds an [EditorConfig](https://editorconfig.org/) file at the root of the project.

This file, supported by [a lot of text editors and IDEs](https://editorconfig.org/#pre-installed) can help enforce some project-specific code style rules. Here I use it only for indenting, because it's very easy to mess up (all modern editors have auto-indenting features) and a pain to fix...

I picked the rule from [Mantis coding guidelines](https://mantisbt.org/wiki/doku.php/mantisbt:coding_guidelines#general_formatting)

Please note there was a already #812 which tried to introduce this and was refused. I try it again because : 

- It was 9 years ago
- Its author included more rules in the file (that may be pertinent for the project but for which I didn't find any information in the guidelines)
- The reason for which it was refused looked more like a misunderstanding between author and reviewer than actual arguments against using EditorConfig