### PR TITLE
Refactor and improve log_print_to_page()

### DIFF
--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -25,12 +25,14 @@
  * @copyright Copyright 2002  MantisBT Team - mantisbt-dev@lists.sourceforge.net
  * @link http://www.mantisbt.org
  *
+ * @uses collapse_api.php
  * @uses config_api.php
  * @uses constant_inc.php
  * @uses event_api.php
  * @uses utility_api.php
  */
 
+require_api( 'collapse_api.php' );
 require_api( 'config_api.php' );
 require_api( 'constant_inc.php' );
 require_api( 'event_api.php' );
@@ -175,18 +177,27 @@ function log_print_to_page() {
 
 	$t_icon = icon_get( 'fa-flag-o', 'ace-icon' );
 	$t_section_title = lang_get( 'debug_log' );
+	$t_collapse_block = is_collapsed( 'debuglog' );
+	$t_block_css = $t_collapse_block ? ' collapsed' : '';
+	$t_block_icon = icon_get(
+		$t_collapse_block ? 'fa-chevron-down' : 'fa-chevron-up',
+		'1 ace-icon bigger-125'
+	);
 	echo <<<HTML
 
 		<!-- Mantis Debug Log Output -->
 		<div class="space-10"></div>
 		<div class="row">
 			<div class="col-xs-12">
-				<div class="widget-box widget-color-red">
+				<div class="widget-box widget-color-red$t_block_css">
 					<div class="widget-header widget-header-small">
 						<h4 class="widget-title lighter">
 							$t_icon 
 							$t_section_title
 						</h4>
+						<div class="widget-toolbar">
+							<a data-action="collapse" href="#">$t_block_icon</a>
+						</div>
 					</div>
 					<div class="widget-body">
 

--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -49,9 +49,11 @@ $g_log_levels = array(
 );
 
 /**
- * Log an event
- * @param integer          $p_level Valid debug log level.
- * @param string|array,... $p_msg   Either a string, or an array structured as (string,execution time).
+ * Log an event.
+ *
+ * @param integer      $p_level Valid debug log level.
+ * @param string|array $p_msg   Either a string, or an array structured as (string,execution time).
+ *
  * @return void
  */
 function log_event( $p_level, $p_msg ) {
@@ -151,8 +153,10 @@ function log_event( $p_level, $p_msg ) {
 }
 
 /**
- * Print logging api output to bottom of html page
+ * Print logging api output to bottom of html page.
+ *
  * @return void
+ * @throws \PHPMailer\PHPMailer\Exception
  */
 function log_print_to_page() {
 	if( !helper_log_to_page() ) {
@@ -287,15 +291,17 @@ function log_print_to_page() {
 }
 
 /**
- * Builds a string with information from the call backtrace of current logging action
+ * Builds a string with information from the call backtrace of current logging action.
+ *
  * The output format is, where available:
  *    {plugin} {file}:{line} {class}[::|->]{function}
  *
  * Some of the actual backtrace is removed to get more informative line to the user.
  * The log type is used to selectively remove some internal call traces.
  *
- * @param integer $p_level	Log level type constant
- * @return string	Output string with caller information
+ * @param int $p_level Log level type constant
+ *
+ * @return string Output string with caller information
  */
 function log_get_caller( $p_level = null ) {
 	$t_full_backtrace = debug_backtrace();

--- a/core/logging_api.php
+++ b/core/logging_api.php
@@ -171,6 +171,8 @@ function log_print_to_page() {
 		email_send_all();
 	}
 
+
+	$t_total_event_count = count( $g_log_events ?? [] );
 	$t_total_query_execution_time = 0;
 	$t_unique_queries = array();
 	$t_total_queries_count = 0;
@@ -194,6 +196,7 @@ function log_print_to_page() {
 						<h4 class="widget-title lighter">
 							$t_icon 
 							$t_section_title
+							<span class="badge">$t_total_event_count</span>
 						</h4>
 						<div class="widget-toolbar">
 							<a data-action="collapse" href="#">$t_block_icon</a>

--- a/css/default.css
+++ b/css/default.css
@@ -187,3 +187,7 @@ table.filters td.category {
     display: inline-grid;
     grid-template-columns: 1fr 20px 1fr;
 }
+
+#log-event-list .duplicate-query {
+    color: #E2755F;
+}

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -616,6 +616,7 @@ $s_page_execution_time = 'Page execution time: %1$s seconds';
 $s_memory_usage = 'Memory usage: %1$s KiB';
 
 # log_api.php
+$s_debug_log = 'Debug Log';
 $s_log_page_number = 'Number';
 $s_log_page_time = 'Execution time';
 $s_log_page_caller = 'Caller';


### PR DESCRIPTION
- fixes the invalid HTML structure [#22098](https://mantisbt.org/bugs/view.php?id=22098).
- refactored the function (use HEREDOC, call helper_log_to_page(), process log events with a single loop)
- highlighted duplicate SQL queries in DB log entries (as it was before MantisBT 2.0)
- localized string in the section header
- Improvements by @raspopov (cherry-picked from #2115):
  - make the Debug log section collapsible 
  - display the number of events logged

Fixes [#35551](https://mantisbt.org/bugs/view.php?id=35551)
Supersedes PR #2115
