### PR TITLE
Fix inline error message showing behind navbar

### DIFF
--- a/core/error_api.php
+++ b/core/error_api.php
@@ -42,7 +42,25 @@ require_api( 'html_api.php' );
 require_api( 'lang_api.php' );
 
 $g_error_parameters = array();
+
+/**
+ * Determine if inline warnings should be printed immediately (true)
+ * or at page bottom (false).
+ *
+ * True initially, layout API sets it to false when the page header has been
+ * printed. Call {@see error_delay_reporting()} to change this value.
+ *
+ * @see error_log_delayed(), error_print_delayed()
+ * @global bool $g_error_delay_reporting
+ */
+$g_error_delay_reporting = true;
+
+/**
+ * List of delayed error messages to be printed at page bottom.
+ * @global array $g_errors_delayed
+ */
 $g_errors_delayed = array();
+
 $g_error_handled = false;
 $g_error_proceed_url = null;
 $g_error_send_page_header = true;
@@ -399,7 +417,8 @@ function error_handler( $p_type, $p_error, $p_file, $p_line ) {
 
 			case DISPLAY_ERROR_INLINE:
 				if( !defined( 'DISABLE_INLINE_ERROR_REPORTING' ) ) {
-					if( defined( 'DELAY_INLINE_ERROR_REPORTING')) {
+					global $g_error_delay_reporting;
+					if( $g_error_delay_reporting ) {
 						error_log_delayed( $t_error_type . ': ' . $t_error_description );
 					} else {
 						echo '<div class="alert alert-warning">', $t_error_type, ': ', $t_error_description, '</div>';
@@ -446,12 +465,15 @@ function error_convert_to_exception( $p_type, $p_error, $p_file, $p_line ) {
  * This should be called prior to trigger_error() when required, e.g. when
  * a warning could be triggered before the page layout has been sent.
  *
+ * @param bool $p_delay If true (default), inline warnings will be logged and
+ *                      display at the end of the page instead of being printed
+ *                      immediately.
+ *
  * @return void
  */
-function error_delay_reporting() {
-	if( !defined( 'DELAY_INLINE_ERROR_REPORTING' ) ) {
-		define( 'DELAY_INLINE_ERROR_REPORTING', true );
-	}
+function error_delay_reporting( bool $p_delay = true) {
+	global $g_error_delay_reporting;
+	$g_error_delay_reporting = $p_delay;
 }
 
 /**

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -512,6 +512,9 @@ function error_print_delayed() {
 
 		$g_errors_delayed = array();
 	}
+
+	# Make sure any subsequent inline errors are displayed
+	error_delay_reporting( false );
 }
 
 /**

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -176,6 +176,9 @@ function layout_page_begin( $p_active_sidebar_page = null ) {
 	layout_main_content_row_begin();
 
 	event_signal( 'EVENT_LAYOUT_CONTENT_BEGIN' );
+
+	# Layout is in place, inline warnings can now be displayed without messing it up.
+	error_delay_reporting( false );
 }
 
 /**

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -387,6 +387,7 @@ function layout_login_page_begin( $p_page_title = '' ) {
 function layout_login_page_end() {
 	layout_main_content_row_end();
 	layout_main_content_end();
+	error_print_delayed();
 	html_bottom_banner();
 	layout_scroll_up_button();
 	layout_main_container_end();


### PR DESCRIPTION
<del>At this point, this PR is just a cherry-pick of @raspopov's proposed fix from PR #2115, with the shortcomings discussed there and in the bugtracker.</del>

Improves the delayed printing mechanism implemented in [#35207](https://mantisbt.org/bugs/view.php?id= 35207), replacing the DELAY_INLINE_ERROR_REPORTING constant by a global variable ($g_errors_delay_reporting), allowing to switch delayed reporting on and off as needed.

Reporting is delayed by default, and Layout API (layout_page_begin()) switches it off when the page header has been displayed.

Fixes [#35552](https://mantisbt.org/bugs/view.php?id=35552)

Also fixes delayed warnings not displayed on login page [#35583](https://mantisbt.org/bugs/view.php?id=35583).