### PR TITLE
Fix error message page layout

### DIFF
--- a/core/error_api.php
+++ b/core/error_api.php
@@ -327,12 +327,7 @@ function error_handler( $p_type, $p_error, $p_file, $p_line ) {
 					if( $t_html_api ) {
 						layout_page_header();
 						if( $p_error != ERROR_DB_QUERY_FAILED && $t_db_connected ) {
-							if( auth_is_user_authenticated() ) {
-								layout_page_begin();
-							} else {
-								layout_navbar();
-								layout_main_container_begin();
-							}
+							layout_page_begin();
 						}
 					} else {
 						layout_page_header( $t_error_type );
@@ -379,12 +374,7 @@ function error_handler( $p_type, $p_error, $p_file, $p_line ) {
 
 				if( $t_html_api ) {
 					if( $p_error != ERROR_DB_QUERY_FAILED && $t_db_connected ) {
-						if( auth_is_user_authenticated() ) {
-							layout_page_end();
-						} else {
-							layout_main_container_end();
-							layout_footer();
-						}
+						layout_page_end();
 					} else {
 						layout_body_javascript();
 						html_body_end();


### PR DESCRIPTION
For the anonymous user, the layout was broken and the footer overlapped the content of the page.

Fixes [#35562](https://mantisbt.org/bugs/view.php?id=35562).