### PR TITLE
Fix URLs in the summary field

### DIFF
--- a/core/columns_api.php
+++ b/core/columns_api.php
@@ -1518,7 +1518,7 @@ function print_column_summary( BugData $p_bug, $p_columns_target = COLUMNS_TARGE
 	if( $p_columns_target == COLUMNS_TARGET_CSV_PAGE ) {
 		$t_summary = string_attribute( $p_bug->summary );
 	} else {
-		$t_summary = string_display_line_links( $p_bug->summary );
+		$t_summary = string_display_line_without_links( $p_bug->summary );
 	}
 	
 	$t_bug_url = string_get_bug_view_url( $p_bug->id );

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -177,6 +177,16 @@ function string_display_line_links( $p_string ) {
 }
 
 /**
+ * Prepare a single-line string for display in HTML, like the string_display_line_links()
+ * function does, but exclude any anchor tags to ensure that it can safely be used as a link.
+ * @param string $p_string String to be processed.
+ * @return string
+ */
+function string_display_line_without_links( $p_string ) {
+	return preg_replace( '/<a\s[^>]*>|<\/a>/is', '', string_display_line_links( $p_string ) );
+}
+
+/**
  * Prepare a string for display in rss
  * @param string $p_string String to be processed.
  * @return string

--- a/my_view_inc.php
+++ b/my_view_inc.php
@@ -341,7 +341,7 @@ if( $t_count == 0 ) {
 for( $i = 0;$i < $t_count; $i++ ) {
 	$t_bug = $t_rows[$i];
 
-	$t_summary = string_display_line_links( $t_bug->summary );
+	$t_summary = string_display_line_without_links( $t_bug->summary );
 	$t_last_updated = date( config_get( 'normal_date_format' ), $t_bug->last_updated );
 
 	# Check for attachments


### PR DESCRIPTION
~~Added a new function string_wrap() and test for it.~~

The new string_display_line_without_links() function was added to simply remove any anchors.

Fixes [#35539](https://mantisbt.org/bugs/view.php?id=35539).