### PR TITLE
Fix scroll offset for bugnotes when using anchor with fixed navbar.

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -52,6 +52,9 @@ span.dependency_upgrade		{ color: orange; }
 
 tr.bugnote .bugnote-note { background-color: #e8e8e8; color: #000000; width: 75%; vertical-align: top; }
 
+tr.bugnote {
+  scroll-margin-top: 50px;
+}
 .bugnote-private { background-color: #fcf8e3 !important;}
 
 .nowrap


### PR DESCRIPTION
Fixes issue where bugnote anchors are hidden behind fixed navbar by adding scroll-margin-top.

[#21675](https://mantisbt.org/bugs/view.php?id=21675)

![Snímka obrazovky 2025-04-23 o 13 23 41](https://github.com/user-attachments/assets/c8564dbb-3537-44e1-8c81-b3e74e6fc2a7)
