### PR TITLE
Fix dropzone displaying HTML code when errors occur during upload

### DIFF
--- a/bug_report.php
+++ b/bug_report.php
@@ -52,6 +52,12 @@ require_api( 'print_api.php' );
 require_api( 'string_api.php' );
 require_api( 'utility_api.php' );
 
+# If we're processing an AJAX call from Dropzone, prevent output of HTML
+# in the content if errors occur, we just want a plain-text error message.
+if( 'XMLHttpRequest' == ( $_SERVER['HTTP_X_REQUESTED_WITH'] ?? '' ) ) {
+	define( 'DISABLE_INLINE_ERROR_REPORTING', 'text' );
+}
+
 form_security_validate( 'bug_report' );
 
 $f_master_bug_id = gpc_get_int( 'm_id', 0 );

--- a/bugnote_add.php
+++ b/bugnote_add.php
@@ -35,6 +35,12 @@ require_api( 'form_api.php' );
 require_api( 'gpc_api.php' );
 require_api( 'print_api.php' );
 
+# If we're processing an AJAX call from Dropzone, prevent output of HTML
+# in the content if errors occur, we just want a plain-text error message.
+if( 'XMLHttpRequest' == ( $_SERVER['HTTP_X_REQUESTED_WITH'] ?? '' ) ) {
+	define( 'DISABLE_INLINE_ERROR_REPORTING', 'text' );
+}
+
 form_security_validate( 'bugnote_add' );
 
 $f_bug_id = gpc_get_int( 'bug_id' );

--- a/core/error_api.php
+++ b/core/error_api.php
@@ -318,6 +318,11 @@ function error_handler( $p_type, $p_error, $p_file, $p_line ) {
 
 				# If HTML error output was disabled, set the HTTP response code and stop
 				if( defined( 'DISABLE_INLINE_ERROR_REPORTING' ) ) {
+					if( DISABLE_INLINE_ERROR_REPORTING == 'text' ) {
+						# Send error message as response body
+						header( 'Content-Type: text/plain' );
+						echo $t_error_description;
+					}
 					http_response_code( error_map_mantis_error_to_http_code( $p_error ) );
 					exit(1);
 				}

--- a/js/common.js
+++ b/js/common.js
@@ -804,6 +804,11 @@ function enableDropzone( classPrefix, autoUpload ) {
 				document.write( response );
 				document.close();
 			});
+			this.on( "complete", function( file ) {
+				// Set progress bar as inactive
+				let progressbar = file.previewElement.querySelector('.progress');
+				progressbar.classList.remove('active');
+			});
 			/**
 			 * 'addedfiles' is undocumented but works similar to 'addedfile'
 			 * It's triggered once after a multiple file addition, and receives


### PR DESCRIPTION
Fixes [#36303](https://mantisbt.org/bugs/view.php?id=36303)

PR also includes a tweak to the javascript that removes the active class on the progress bar after upload completes (fixes [#36353](https://mantisbt.org/bugs/view.php?id=36353)).


* Before <img width="1886" height="1316" alt="image" src="https://github.com/user-attachments/assets/e0814b76-45fd-498e-a5d8-15c21f77ae42" />
* After <img width="1886" height="1316" alt="image" src="https://github.com/user-attachments/assets/710f9225-f536-41a7-9c8b-a5297a50813a" />
