### PR TITLE
Fix the synchronization of mail and real name with LDAP.

### DIFF
--- a/core/user_api.php
+++ b/core/user_api.php
@@ -653,6 +653,20 @@ function user_create( $p_username, $p_password, $p_email = '',
 		$p_access_level = config_get( 'default_new_account_access_level' );
 	}
 
+	if( ON == config_get_global( 'use_ldap_realname' ) ) {
+		$t_realname = ldap_realname_from_username( $p_username );
+		if( !empty( $t_realname ) ) {
+			$p_realname = $t_realname;
+		}
+	}
+
+	if( ON == config_get_global( 'use_ldap_email' ) ) {
+		$t_email = ldap_email_from_username( $p_username );
+		if( !empty( $t_email ) ) {
+			$p_email = $t_email;
+		}
+	}
+
 	$t_password = auth_process_plain_password( $p_password );
 
 	$c_enabled = (bool)$p_enabled;


### PR DESCRIPTION
- The update of the email address and real name to the database from LDAP was added when a user is created.
- Corrected the issue of erroneously clearing the email and real name from the database when updating a non-existent user in LDAP.

Fixes [#36873](https://mantisbt.org/bugs/view.php?id=36873).

Likely needs PR  #1308, as there is a shared file. 🤔
