### PR TITLE
Add link to issue notes in timeline.

### DIFF
--- a/core/classes/IssueNoteCreatedTimelineEvent.class.php
+++ b/core/classes/IssueNoteCreatedTimelineEvent.class.php
@@ -50,7 +50,7 @@ class IssueNoteCreatedTimelineEvent extends TimelineEvent {
 	 */
 	public function html() {
 		$t_html = $this->html_start( 'fa-comment-o' );
-		$t_html .= '<div class="action">' . sprintf( lang_get( 'timeline_issue_note_created' ), prepare_user_name( $this->user_id ), string_get_bug_view_link( $this->issue_id ) ) . '</div>';
+		$t_html .= '<div class="action">' . sprintf( lang_get( 'timeline_issue_note_created' ), prepare_user_name( $this->user_id ), string_get_bugnote_view_link( $this->issue_id, $this->issue_note_id ) ) . '</div>';
 		$t_html .= $this->html_end();
 
 		return $t_html;

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -658,28 +658,31 @@ function string_get_bug_page( $p_action ) {
  * @return string
  */
 function string_get_bug_view_link( $p_bug_id, $p_detail_info = true, $p_fqdn = false ) {
-	if( bug_exists( $p_bug_id ) ) {
+	$t_bug_id = (int)$p_bug_id;
+	$t_bug_link_tag = string_html_specialchars( config_get( 'bug_link_tag' ) );
+
+	if( bug_exists( $t_bug_id ) ) {
 		$t_link = '<a href="';
 		if( $p_fqdn ) {
 			$t_link .= config_get_global( 'path' );
 		} else {
 			$t_link .= config_get_global( 'short_path' );
 		}
-		$t_link .= string_get_bug_view_url( $p_bug_id ) . '"';
+		$t_link .= string_get_bug_view_url( $t_bug_id ) . '"';
 		if( $p_detail_info ) {
-			$t_summary = string_attribute( bug_get_field( $p_bug_id, 'summary' ) );
-			$t_project_id = bug_get_field( $p_bug_id, 'project_id' );
-			$t_status = string_attribute( get_enum_element( 'status', bug_get_field( $p_bug_id, 'status' ), $t_project_id ) );
+			$t_summary = string_attribute( bug_get_field( $t_bug_id, 'summary' ) );
+			$t_project_id = bug_get_field( $t_bug_id, 'project_id' );
+			$t_status = string_attribute( get_enum_element( 'status', bug_get_field( $t_bug_id, 'status' ), $t_project_id ) );
 			$t_link .= ' title="[' . $t_status . '] ' . $t_summary . '"';
 
-			$t_resolved = bug_get_field( $p_bug_id, 'status' ) >= config_get( 'bug_resolved_status_threshold', null, null, $t_project_id );
+			$t_resolved = bug_get_field( $t_bug_id, 'status' ) >= config_get( 'bug_resolved_status_threshold', null, null, $t_project_id );
 			if( $t_resolved ) {
 				$t_link .= ' class="resolved"';
 			}
 		}
-		$t_link .= '>' . bug_format_id( $p_bug_id ) . '</a>';
+		$t_link .= '>' . $t_bug_link_tag . bug_format_id( $t_bug_id ) . '</a>';
 	} else {
-		$t_link = bug_format_id( $p_bug_id );
+		$t_link = '<span class="resolved">' . $t_bug_link_tag . bug_format_id( $t_bug_id ) . '</span>';
 	}
 
 	return $t_link;
@@ -695,8 +698,11 @@ function string_get_bug_view_link( $p_bug_id, $p_detail_info = true, $p_fqdn = f
  */
 function string_get_bugnote_view_link( $p_bug_id, $p_bugnote_id, $p_detail_info = true, $p_fqdn = false ) {
 	$t_bug_id = (int)$p_bug_id;
+	$t_bugnote_id = (int)$p_bugnote_id;
+	$t_bug_link_tag = string_html_specialchars( config_get( 'bug_link_tag' ) );
+	$t_bugnote_link_tag = string_html_specialchars( config_get( 'bugnote_link_tag' ) );
 
-	if( bug_exists( $t_bug_id ) && bugnote_exists( $p_bugnote_id ) ) {
+	if( bug_exists( $t_bug_id ) && bugnote_exists( $t_bugnote_id ) ) {
 		$t_link = '<a href="';
 		if( $p_fqdn ) {
 			$t_link .= config_get_global( 'path' );
@@ -704,10 +710,10 @@ function string_get_bugnote_view_link( $p_bug_id, $p_bugnote_id, $p_detail_info 
 			$t_link .= config_get_global( 'short_path' );
 		}
 
-		$t_link .= string_get_bugnote_view_url( $p_bug_id, $p_bugnote_id ) . '"';
+		$t_link .= string_get_bugnote_view_url( $t_bug_id, $t_bugnote_id ) . '"';
 		if( $p_detail_info ) {
-			$t_reporter = string_attribute( user_get_name( bugnote_get_field( $p_bugnote_id, 'reporter_id' ) ) );
-			$t_update_date = string_attribute( date( config_get( 'normal_date_format' ), ( bugnote_get_field( $p_bugnote_id, 'last_modified' ) ) ) );
+			$t_reporter = string_attribute( user_get_name( bugnote_get_field( $t_bugnote_id, 'reporter_id' ) ) );
+			$t_update_date = string_attribute( date( config_get( 'normal_date_format' ), ( bugnote_get_field( $t_bugnote_id, 'last_modified' ) ) ) );
 			$t_link .= ' title="' . bug_format_id( $t_bug_id ) . ': [' . $t_update_date . '] ' . $t_reporter . '"';
 		}
 
@@ -715,9 +721,11 @@ function string_get_bugnote_view_link( $p_bug_id, $p_bugnote_id, $p_detail_info 
 			$t_link .= ' class="resolved"';
 		}
 
-		$t_link .= '>' . bug_format_id( $t_bug_id ) . ':' . bugnote_format_id( $p_bugnote_id ) . '</a>';
+		$t_link .= '>' . $t_bug_link_tag . bug_format_id( $t_bug_id )
+			. ':' . $t_bugnote_link_tag . bugnote_format_id( $t_bugnote_id ) . '</a>';
 	} else {
-		$t_link = bug_format_id( $t_bug_id ) . ':' . bugnote_format_id( $p_bugnote_id );
+		$t_link = string_get_bug_view_link( $t_bug_id, $t_bugnote_id, $p_detail_info, $p_fqdn )
+			. ':<span class="resolved">' . $t_bugnote_link_tag . bugnote_format_id( $t_bugnote_id ) . '</span>';
 	}
 
 	return $t_link;
@@ -729,7 +737,7 @@ function string_get_bugnote_view_link( $p_bug_id, $p_bugnote_id, $p_detail_info 
  * @return string
  */
 function string_get_bug_view_url( $p_bug_id ) {
-	return 'view.php?id=' . $p_bug_id;
+	return 'view.php?id=' . (int)$p_bug_id;
 }
 
 /**
@@ -739,7 +747,7 @@ function string_get_bug_view_url( $p_bug_id ) {
  * @return string
  */
 function string_get_bugnote_view_url( $p_bug_id, $p_bugnote_id ) {
-	return 'view.php?id=' . $p_bug_id . '#c' . $p_bugnote_id;
+	return string_get_bug_view_url( $p_bug_id ) . '#c' . (int)$p_bugnote_id;
 }
 
 /**
@@ -752,7 +760,7 @@ function string_get_bugnote_view_url( $p_bug_id, $p_bugnote_id ) {
  * @return string
  */
 function string_get_bugnote_view_url_with_fqdn( $p_bug_id, $p_bugnote_id ) {
-	return config_get_global( 'path' ) . string_get_bug_view_url( $p_bug_id ) . '#c' . $p_bugnote_id;
+	return config_get_global( 'path' ) . string_get_bugnote_view_url( $p_bug_id, $p_bugnote_id );
 }
 
 /**

--- a/core/string_api.php
+++ b/core/string_api.php
@@ -659,7 +659,6 @@ function string_get_bug_page( $p_action ) {
  */
 function string_get_bug_view_link( $p_bug_id, $p_detail_info = true, $p_fqdn = false ) {
 	$t_bug_id = (int)$p_bug_id;
-	$t_bug_link_tag = string_html_specialchars( config_get( 'bug_link_tag' ) );
 
 	if( bug_exists( $t_bug_id ) ) {
 		$t_link = '<a href="';
@@ -680,9 +679,9 @@ function string_get_bug_view_link( $p_bug_id, $p_detail_info = true, $p_fqdn = f
 				$t_link .= ' class="resolved"';
 			}
 		}
-		$t_link .= '>' . $t_bug_link_tag . bug_format_id( $t_bug_id ) . '</a>';
+		$t_link .= '>' . bug_format_id( $t_bug_id ) . '</a>';
 	} else {
-		$t_link = '<span class="resolved">' . $t_bug_link_tag . bug_format_id( $t_bug_id ) . '</span>';
+		$t_link = '<span class="resolved">' . bug_format_id( $t_bug_id ) . '</span>';
 	}
 
 	return $t_link;
@@ -699,8 +698,6 @@ function string_get_bug_view_link( $p_bug_id, $p_detail_info = true, $p_fqdn = f
 function string_get_bugnote_view_link( $p_bug_id, $p_bugnote_id, $p_detail_info = true, $p_fqdn = false ) {
 	$t_bug_id = (int)$p_bug_id;
 	$t_bugnote_id = (int)$p_bugnote_id;
-	$t_bug_link_tag = string_html_specialchars( config_get( 'bug_link_tag' ) );
-	$t_bugnote_link_tag = string_html_specialchars( config_get( 'bugnote_link_tag' ) );
 
 	if( bug_exists( $t_bug_id ) && bugnote_exists( $t_bugnote_id ) ) {
 		$t_link = '<a href="';
@@ -721,11 +718,10 @@ function string_get_bugnote_view_link( $p_bug_id, $p_bugnote_id, $p_detail_info 
 			$t_link .= ' class="resolved"';
 		}
 
-		$t_link .= '>' . $t_bug_link_tag . bug_format_id( $t_bug_id )
-			. ':' . $t_bugnote_link_tag . bugnote_format_id( $t_bugnote_id ) . '</a>';
+		$t_link .= '>' . bug_format_id( $t_bug_id ) . ':' . bugnote_format_id( $t_bugnote_id ) . '</a>';
 	} else {
 		$t_link = string_get_bug_view_link( $t_bug_id, $t_bugnote_id, $p_detail_info, $p_fqdn )
-			. ':<span class="resolved">' . $t_bugnote_link_tag . bugnote_format_id( $t_bugnote_id ) . '</span>';
+			. ':<span class="resolved">' . bugnote_format_id( $t_bugnote_id ) . '</span>';
 	}
 
 	return $t_link;


### PR DESCRIPTION
Fixed wrong format of bugnote anchor link (mistakenly left-side padded by zeroes) in `string_get_bugnote_view_url()` function.

Also added bug and bugnote link tag symbols.

Fixes [#23220](https://mantisbt.org/bugs/view.php?id=23220).