### PR TITLE
Add a check for the presence of the admin folder.

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -657,6 +657,27 @@ $(document).ready( function() {
 		bottom_placeholder.css('height', parseInt(bottom.height()) + 'px');
 		footer.css('padding-top', parseInt(footer_content.height()) + 'px');
 		}).triggerHandler('resize.footer');
+
+	/**
+	 * Admin directory on-line check (login_page.php)
+	 */
+	$('#warning_admin_directory_present').each(function() {
+		var spinner = $('<i class="fa fa-spin fa-spinner margin-left-8"></i>');
+		$(this).append(spinner);
+		fetch(config['short_path'] + 'admin/', { credentials: 'omit' })
+			.then(response => {
+				spinner.remove();
+				return response.text();
+			})
+			.then(data => {
+				if( !data.includes('MantisBT Administration') ) {
+					$(this).remove();
+				}
+			})
+			.catch(error => {
+				spinner.remove();
+			});
+	});
 });
 
 function setBugLabel() {

--- a/js/common.js
+++ b/js/common.js
@@ -662,16 +662,31 @@ $(document).ready( function() {
 	 * Admin directory on-line check (login_page.php)
 	 */
 	$('#warning_admin_directory_present').each(function() {
+		function isDenied(response) {
+			return ( response.status >= 400 && response.status < 500 ) ||
+				   ( response.status == 200 && response.redirected === true && response.url.includes('/login_page.php?') );
+		}
 		var spinner = $('<i class="fa fa-spin fa-spinner margin-left-8"></i>');
 		$(this).append(spinner);
-		fetch(config['short_path'] + 'admin/', { credentials: 'omit' })
+		fetch(config['short_path'] + 'admin/install.php', { credentials: 'omit' })
 			.then(response => {
-				spinner.remove();
-				return response.text();
-			})
-			.then(data => {
-				if( !data.includes('MantisBT Administration') ) {
-					$(this).remove();
+				if( isDenied(response) ) {
+					fetch(config['short_path'] + 'admin/check/', { credentials: 'omit' })
+						.then(response => {
+							spinner.remove();
+							if( isDenied(response) ) {
+								if( $(this).parent().children().length === 1 ) {
+									$(this).parent().remove();
+								} else {
+									$(this).remove();
+								}
+							}
+						})
+						.catch(error => {
+							spinner.remove();
+						});
+				} else {
+					spinner.remove();
 				}
 			})
 			.catch(error => {

--- a/login_page.php
+++ b/login_page.php
@@ -140,7 +140,7 @@ if( config_get_global( 'admin_checks' ) == ON ) {
 	$t_admin_dir = __DIR__ . '/admin';
 	$t_admin_dir_is_accessible = @is_readable( $t_admin_dir );
 	if( $t_admin_dir_is_accessible ) {
-		$t_warnings[] = lang_get( 'warning_admin_directory_present' );
+		$t_warnings[] = [ lang_get( 'warning_admin_directory_present' ), 'warning_admin_directory_present' ];
 	}
 
 	# Generate a warning if default user administrator/root is valid.
@@ -253,7 +253,11 @@ if( count( $t_warnings ) > 0 ) {
 	echo '<div class="space-10"></div>';
 	echo '<div class="alert alert-warning">';
 	foreach( $t_warnings AS $t_warning ) {
-		echo '<p>' . $t_warning . '</p>';
+		if( is_array( $t_warning ) ) {
+			echo '<p id="' . $t_warning[1] . '">' . $t_warning[0] . '</p>';
+		} else {
+			echo '<p>' . $t_warning . '</p>';
+		}
 	}
 	echo '</div>';
 }


### PR DESCRIPTION
The check is performed from the browser by attempting to load the "/admin/install.php" and "/admin/check/" pages and checking for a 4xx error code is returned or if a redirect to the login page occurs.

Fixes [#23211](https://mantisbt.org/bugs/view.php?id=23211).