### PR TITLE
Restrict DateTimePicker loading to pages using it

### DIFF
--- a/bug_actiongroup_page.php
+++ b/bug_actiongroup_page.php
@@ -50,7 +50,6 @@ require_api( 'bug_group_action_api.php' );
 require_api( 'config_api.php' );
 require_api( 'constant_inc.php' );
 require_api( 'custom_field_api.php' );
-require_api( 'datetimepicker_api.php' );
 require_api( 'event_api.php' );
 require_api( 'form_api.php' );
 require_api( 'gpc_api.php' );
@@ -247,6 +246,7 @@ switch( $f_action ) {
 		$t_question_title		= lang_get( 'due_date_bugs_conf_msg' );
 		$t_button_title			= lang_get( 'due_date_group_bugs_button' );
 		$t_form					= 'due_date';
+		require_api( 'datetimepicker_api.php' );
 		break;
 	case 'CUSTOM' :
 		$t_custom_field_def = custom_field_get_definition( $t_custom_field_id );

--- a/bug_actiongroup_page.php
+++ b/bug_actiongroup_page.php
@@ -30,6 +30,7 @@
  * @uses config_api.php
  * @uses constant_inc.php
  * @uses custom_field_api.php
+ * @uses datetimepicker_api.php
  * @uses event_api.php
  * @uses form_api.php
  * @uses gpc_api.php
@@ -49,6 +50,7 @@ require_api( 'bug_group_action_api.php' );
 require_api( 'config_api.php' );
 require_api( 'constant_inc.php' );
 require_api( 'custom_field_api.php' );
+require_api( 'datetimepicker_api.php' );
 require_api( 'event_api.php' );
 require_api( 'form_api.php' );
 require_api( 'gpc_api.php' );
@@ -321,12 +323,7 @@ if( $t_multiple_projects ) {
 					$t_date_to_display = date( config_get( 'normal_date_format' ), $t_bug->due_date );
 				}
 			}
-
-			echo '<input type="text" id="due_date" name="due_date" class="datetimepicker input-sm" size="16" maxlength="16" ' .
-				'data-picker-locale="' . lang_get_current_datetime_locale() .
-				'" data-picker-format="' . config_get( 'datetime_picker_format' ) . '"' .
-				'" value="' . $t_date_to_display . '" />';
-			print_icon( 'fa-calendar', 'fa-xlg datetimepicker' );
+			datetimepicker_print( $t_date_to_display, 'due_date' );
 		} else {
 			echo '<select name="' . $t_form . '" class="input-sm" required>';
 

--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -29,6 +29,7 @@
  * @uses constant_inc.php
  * @uses custom_field_api.php
  * @uses date_api.php
+ * @uses datetimepicker_api.php
  * @uses event_api.php
  * @uses form_api.php
  * @uses gpc_api.php
@@ -49,6 +50,7 @@ require_api( 'config_api.php' );
 require_api( 'constant_inc.php' );
 require_api( 'custom_field_api.php' );
 require_api( 'date_api.php' );
+require_api( 'datetimepicker_api.php' );
 require_api( 'event_api.php' );
 require_api( 'form_api.php' );
 require_api( 'gpc_api.php' );
@@ -240,14 +242,10 @@ layout_page_begin();
 	<!-- Due date -->
 	<tr>
 		<th class="category">
-			<?php echo lang_get( 'due_date' ) ?>
+			<label for="due_date"><?php echo lang_get( 'due_date' ) ?></label>
 		</th>
 		<td>
-			<input type="text" id="due_date" name="due_date" class="datetimepicker input-sm" size="16" maxlength="16"
-				data-picker-locale="<?php lang_get_current_datetime_locale() ?>"
-				data-picker-format="<?php echo config_get( 'datetime_picker_format' ) ?>"
-				<?php helper_get_tab_index() ?> value="<?php echo $t_date_to_display ?>" />
-			<?php print_icon( 'fa-calendar', 'fa-xlg datetimepicker' ); ?>
+			<?php datetimepicker_print( $t_date_to_display, 'due_date' ) ?>
 		</td>
 	</tr>
 

--- a/bug_change_status_page.php
+++ b/bug_change_status_page.php
@@ -50,7 +50,6 @@ require_api( 'config_api.php' );
 require_api( 'constant_inc.php' );
 require_api( 'custom_field_api.php' );
 require_api( 'date_api.php' );
-require_api( 'datetimepicker_api.php' );
 require_api( 'event_api.php' );
 require_api( 'form_api.php' );
 require_api( 'gpc_api.php' );
@@ -98,6 +97,9 @@ if( $f_new_status == $t_reopen && $f_change_type == BUG_UPDATE_TYPE_REOPEN ) {
 }
 
 $t_can_update_due_date = access_has_bug_level( config_get( 'due_date_update_threshold' ), $f_bug_id );
+if( $t_can_update_due_date ) {
+	require_api( 'datetimepicker_api.php' );
+}
 
 # get new issue handler if set, otherwise default to original handler
 $f_handler_id = gpc_get_int( 'handler_id', $t_bug->handler_id );

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -60,7 +60,6 @@ require_api( 'config_api.php' );
 require_api( 'constant_inc.php' );
 require_api( 'custom_field_api.php' );
 require_api( 'date_api.php' );
-require_api( 'datetimepicker_api.php' );
 require_api( 'error_api.php' );
 require_api( 'event_api.php' );
 require_api( 'file_api.php' );
@@ -226,6 +225,9 @@ $t_show_product_build = $t_show_versions && in_array( 'product_build', $t_fields
 $t_show_target_version = $t_show_versions && in_array( 'target_version', $t_fields ) && access_has_project_level( config_get( 'roadmap_update_threshold' ) );
 $t_show_additional_info = in_array( 'additional_info', $t_fields );
 $t_show_due_date = in_array( 'due_date', $t_fields ) && access_has_project_level( config_get( 'due_date_update_threshold' ), helper_get_current_project(), auth_get_current_user_id() );
+if( $t_show_due_date ) {
+	require_api( 'datetimepicker_api.php' );
+}
 $t_show_attachments = in_array( 'attachments', $t_fields ) && file_allow_bug_upload() && !event_signal( 'EVENT_REPORT_BUG_MODERATE_CHECK', array() );
 $t_show_view_state = in_array( 'view_state', $t_fields ) && access_has_project_level( config_get( 'set_view_status_threshold' ) );
 $t_max_length = config_get_global( 'max_textarea_length' );

--- a/bug_report_page.php
+++ b/bug_report_page.php
@@ -32,6 +32,7 @@
  * @uses constant_inc.php
  * @uses custom_field_api.php
  * @uses date_api.php
+ * @uses datetimepicker_api.ph
  * @uses error_api.php
  * @uses event_api.php
  * @uses file_api.php
@@ -59,6 +60,7 @@ require_api( 'config_api.php' );
 require_api( 'constant_inc.php' );
 require_api( 'custom_field_api.php' );
 require_api( 'date_api.php' );
+require_api( 'datetimepicker_api.php' );
 require_api( 'error_api.php' );
 require_api( 'event_api.php' );
 require_api( 'file_api.php' );
@@ -365,11 +367,7 @@ if( $t_show_attachments ) {
 			<label for="due_date"><?php print_documentation_link( 'due_date' ) ?></label>
 		</th>
 		<td>
-			<?php echo '<input ' . helper_get_tab_index() . ' type="text" id="due_date" name="due_date" class="datetimepicker input-sm" ' .
-				'data-picker-locale="' . lang_get_current_datetime_locale() .
-				'" data-picker-format="' . config_get( 'datetime_picker_format' ) . '" ' .
-				'size="20" maxlength="16" value="' . $t_date_to_display . '" />' ?>
-			<?php print_icon( 'fa-calendar', 'fa-xlg datetimepicker' ); ?>
+			<?php datetimepicker_print( $t_date_to_display, 'due_date' ) ?>
 		</td>
 	</tr>
 <?php } ?>

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -55,7 +55,6 @@ require_api( 'columns_api.php' );
 require_api( 'config_api.php' );
 require_api( 'constant_inc.php' );
 require_api( 'custom_field_api.php' );
-require_api( 'datetimepicker_api.php' );
 require_api( 'error_api.php' );
 require_api( 'event_api.php' );
 require_api( 'form_api.php' );
@@ -129,6 +128,10 @@ $t_product_build_attribute = $t_show_product_build ? string_attribute( $t_bug->b
 $t_show_target_version = $t_show_versions && in_array( 'target_version', $t_fields ) && access_has_bug_level( config_get( 'roadmap_update_threshold' ), $t_bug_id );
 $t_show_fixed_in_version = $t_show_versions && in_array( 'fixed_in_version', $t_fields );
 $t_show_due_date = in_array( 'due_date', $t_fields ) && access_has_bug_level( config_get( 'due_date_view_threshold' ), $t_bug_id );
+$t_can_update_due_date = $t_show_due_date && access_has_bug_level( config_get( 'due_date_update_threshold' ), $t_bug_id );
+if( $t_can_update_due_date ) {
+	require_api( 'datetimepicker_api.php' );
+}
 $t_show_summary = in_array( 'summary', $t_fields );
 $t_summary_attribute = $t_show_summary ? string_attribute( $t_bug->summary ) : '';
 $t_show_description = in_array( 'description', $t_fields );
@@ -342,7 +345,7 @@ if( $t_show_reporter || $t_show_handler || $t_show_due_date ) {
 			echo '<td class="due-', $t_level, '">';
 		}
 
-		if( access_has_bug_level( config_get( 'due_date_update_threshold' ), $t_bug_id ) ) {
+		if( $t_can_update_due_date ) {
 			$t_date_to_display = '';
 
 			if( !date_is_null( $t_bug->due_date ) ) {

--- a/bug_update_page.php
+++ b/bug_update_page.php
@@ -30,6 +30,7 @@
  * @uses config_api.php
  * @uses constant_inc.php
  * @uses custom_field_api.php
+ * @uses datetimepicker_api.php
  * @uses error_api.php
  * @uses event_api.php
  * @uses form_api.php
@@ -54,6 +55,7 @@ require_api( 'columns_api.php' );
 require_api( 'config_api.php' );
 require_api( 'constant_inc.php' );
 require_api( 'custom_field_api.php' );
+require_api( 'datetimepicker_api.php' );
 require_api( 'error_api.php' );
 require_api( 'event_api.php' );
 require_api( 'form_api.php' );
@@ -346,10 +348,7 @@ if( $t_show_reporter || $t_show_handler || $t_show_due_date ) {
 			if( !date_is_null( $t_bug->due_date ) ) {
 				$t_date_to_display = date( config_get( 'normal_date_format' ), $t_bug->due_date );
 			}
-			echo '<input ' . helper_get_tab_index() . ' type="text" id="due_date" name="due_date" class="datetimepicker input-sm" size="16" ' .
-				'data-picker-locale="' . lang_get_current_datetime_locale() .  '" data-picker-format="' . config_get( 'datetime_picker_format' ) . '" ' .
-				'maxlength="16" value="' . $t_date_to_display . '" />';
-			print_icon( 'fa-calendar', 'fa-xlg datetimepicker' );
+			datetimepicker_print( $t_date_to_display, 'due_date' );
 		} else {
 			if( !date_is_null( $t_bug->due_date ) ) {
 				echo date( config_get( 'short_date_format' ), $t_bug->due_date );

--- a/bug_view_inc.php
+++ b/bug_view_inc.php
@@ -34,6 +34,7 @@
  * @uses current_user_api.php
  * @uses custom_field_api.php
  * @uses date_api.php
+ * @uses datetimepicker_api.php
  * @uses event_api.php
  * @uses gpc_api.php
  * @uses helper_api.php
@@ -102,6 +103,13 @@ $f_history = gpc_get_bool( 'history', config_get( 'history_default_visible' ) );
 # compat variables for included pages
 $f_bug_id = $f_issue_id;
 $t_bug = bug_get( $f_bug_id, true );
+
+# Used in bugnote_add_inc.php
+if( !$t_force_readonly ) {
+	if( config_get( 'time_tracking_enabled' ) && config_get( 'time_tracking_stopwatch' ) ) {
+		require_api( 'datetimepicker_api.php' );
+	}
+}
 
 $t_data = array(
 	'query' => array( 'id' => $f_issue_id ),

--- a/core/datetimepicker_api.php
+++ b/core/datetimepicker_api.php
@@ -1,0 +1,81 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * DateTimePicker API
+ *
+ * @package CoreAPI
+ * @subpackage DateTimePickerAPI
+ * @copyright Copyright 2000 - 2002  Kenzaburo Ito - kenito@300baud.org
+ * @copyright Copyright 2026  MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ *
+ * @uses config_api.php
+ * @uses constant_inc.php
+ * @uses helper_api.php
+ * @uses html_api.php
+ * @uses icon_api.php
+ * @uses lang_api.php
+ * @uses string_api.php
+ */
+
+require_api( 'config_api.php' );
+require_api( 'constant_inc.php' );
+require_api( 'helper_api.php' );
+require_api( 'html_api.php' );
+require_api( 'icon_api.php' );
+require_api( 'lang_api.php' );
+require_api( 'string_api.php' );
+
+# Include Moment.js and Bootstrap DateTimePicker.js
+if( config_get_global( 'cdn_enabled' ) == ON ) {
+	require_css( [ 'https://cdnjs.cloudflare.com/ajax/libs/eonasdan-bootstrap-datetimepicker/' . DATETIME_PICKER_VERSION . '/css/bootstrap-datetimepicker.min.css', DATETIME_PICKER_HASH_CSS ] );
+	require_js( [ 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/' . MOMENT_VERSION . '/moment-with-locales.min.js', MOMENT_HASH ] );
+	require_js( [ 'https://cdnjs.cloudflare.com/ajax/libs/eonasdan-bootstrap-datetimepicker/' . DATETIME_PICKER_VERSION . '/js/bootstrap-datetimepicker.min.js', DATETIME_PICKER_HASH_JS ] );
+} else {
+	require_css( 'bootstrap-datetimepicker-' . DATETIME_PICKER_VERSION . '.min.css' );
+	require_js( 'moment-with-locales-' . MOMENT_VERSION . '.min.js' );
+	require_js( 'bootstrap-datetimepicker-' . DATETIME_PICKER_VERSION . '.min.js' );
+}
+require_js( 'datetimepicker-proxy.js' );
+
+/**
+ * Get a form element with DateTimePicker.
+ * @param string $p_date   Date to display.
+ * @param string $p_id     Id of element.
+ * @param string $p_format Time format, by default, the value from the $g_datetime_picker_format is used.
+ * @return string Element to output.
+ */
+function datetimepicker_get_field(string $p_date, string $p_id, string $p_format = '') {
+	return '<input type="text" id="' . $p_id . '" name="' . $p_id . '"'
+		. ' class="datetimepicker input-sm" size="20" maxlength="20"'
+		. ' data-picker-locale="' . string_html_specialchars( lang_get_current_datetime_locale() ) . '"'
+		. ' data-picker-format="' . string_html_specialchars( $p_format ?: config_get( 'datetime_picker_format' ) ) . '"'
+		. ' ' . helper_get_tab_index()
+		. ' value="' . string_html_specialchars( $p_date ) . '">'
+		. icon_get( 'fa-calendar', 'fa-xlg datetimepicker' );
+}
+
+/**
+ * Populate form element with DateTimePicker.
+ * @param string $p_date   Date to display.
+ * @param string $p_id     Id of element.
+ * @param string $p_format Time format, by default, the value from the $g_datetime_picker_format is used.
+ * @return void
+ */
+function datetimepicker_print(string $p_date, string $p_id, string $p_format = '') {
+	echo datetimepicker_get_field( $p_date, $p_id, $p_format );
+}

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -283,18 +283,12 @@ function layout_head_css() {
 		# theme text fonts
 		$t_font_family =  config_get( 'font_family', null, null, ALL_PROJECTS );
 		html_css_cdn_link( helper_url_combine( 'https://fonts.googleapis.com/css', [ 'family' => $t_font_family ] ) );
-
-		# datetimepicker
-		html_css_cdn_link( 'https://cdnjs.cloudflare.com/ajax/libs/eonasdan-bootstrap-datetimepicker/' . DATETIME_PICKER_VERSION . '/css/bootstrap-datetimepicker.min.css', DATETIME_PICKER_HASH_CSS );
 	} else {
 		html_css_link( 'bootstrap-' . BOOTSTRAP_VERSION . '.min.css' );
 		html_css_link( 'font-awesome-' . FONT_AWESOME_VERSION . '.min.css' );
 
 		# theme text fonts
 		html_css_link( 'fonts.css', $t_cache_key );
-
-		# datetimepicker
-		html_css_link( 'bootstrap-datetimepicker-' . DATETIME_PICKER_VERSION . '.min.css' );
 	}
 
 	# page specific plugin styles
@@ -332,10 +326,6 @@ function layout_body_javascript() {
 		# bootstrap
 		html_javascript_cdn_link( 'https://stackpath.bootstrapcdn.com/bootstrap/' . BOOTSTRAP_VERSION . '/js/bootstrap.min.js', BOOTSTRAP_HASH_JS );
 
-		# moment & datetimepicker
-		html_javascript_cdn_link( 'https://cdnjs.cloudflare.com/ajax/libs/moment.js/' . MOMENT_VERSION . '/moment-with-locales.min.js', MOMENT_HASH );
-		html_javascript_cdn_link( 'https://cdnjs.cloudflare.com/ajax/libs/eonasdan-bootstrap-datetimepicker/' . DATETIME_PICKER_VERSION . '/js/bootstrap-datetimepicker.min.js', DATETIME_PICKER_HASH_JS );
-
 		# typeahead.js
 		html_javascript_cdn_link( 'https://cdnjs.cloudflare.com/ajax/libs/corejs-typeahead/' . TYPEAHEAD_VERSION . '/typeahead.jquery.min.js', TYPEAHEAD_HASH );
 
@@ -344,10 +334,6 @@ function layout_body_javascript() {
 	} else {
 		# bootstrap
 		html_javascript_link( 'bootstrap-' . BOOTSTRAP_VERSION . '.min.js' );
-
-		# moment & datetimepicker
-		html_javascript_link( 'moment-with-locales-' . MOMENT_VERSION . '.min.js' );
-		html_javascript_link( 'bootstrap-datetimepicker-' . DATETIME_PICKER_VERSION . '.min.js' );
 
 		# typeahead.js
 		html_javascript_link( 'typeahead.jquery-' . TYPEAHEAD_VERSION . '.min.js' );

--- a/js/common.js
+++ b/js/common.js
@@ -333,101 +333,6 @@ $(document).ready( function() {
 		jcontainer.data('checkbox-range-last-clicked', this);
 	});
 
-	var stopwatch = {
-		timerID: 0,
-		startTime: null,
-		zeroTime: moment('0', 's'),
-		tick: function() {
-			var elapsedDiff = moment().diff(this.startTime),
-				elapsedTime = this.zeroTime.clone().add(elapsedDiff);
-
-			$('input[type=text].stopwatch_time').val(elapsedTime.format('HH:mm:ss'));
-		},
-		reset: function() {
-			this.stop();
-			$('input[type=text].stopwatch_time').val('');
-		},
-		start: function() {
-			var self = this,
-				timeFormat = '',
-				stoppedTime = $('input[type=text].stopwatch_time').val();
-
-			this.stop();
-
-			if (stoppedTime) {
-				switch (stoppedTime.split(':').length) {
-					case 1:
-						timeFormat = 'ss';
-						break;
-
-					case 2:
-						timeFormat = 'mm:ss';
-						break;
-
-					default:
-						timeFormat = 'HH:mm:ss';
-				}
-
-				this.startTime = moment().add(this.zeroTime.clone().diff(moment(stoppedTime, timeFormat)));
-			} else {
-				this.startTime = moment();
-			}
-
-			this.timerID = window.setInterval(function() {
-				self.tick();
-			}, 1000);
-
-			$('input[type=button].stopwatch_toggle').val(translations['time_tracking_stopwatch_stop']);
-		},
-		stop: function() {
-			if (this.timerID) {
-				window.clearInterval(this.timerID);
-				this.timerID = 0;
-			}
-
-			$('input[type=button].stopwatch_toggle').val(translations['time_tracking_stopwatch_start']);
-		}
-	};
-
-	$('input[type=button].stopwatch_toggle').click(function() {
-		if (!stopwatch.timerID) {
-			stopwatch.start();
-		} else {
-			stopwatch.stop();
-		}
-	});
-
-	$('input[type=button].stopwatch_reset').click(function() {
-		stopwatch.reset();
-	});
-
-	$('input[type=text].datetimepicker').each(function(index, element) {
-		// Ensure the parent has relative positioning for the datetimepicker widget
-		var $parent = $(this).parent();
-		if ($parent.css('position') === 'static') {
-			$parent.css('position', 'relative');
-		}
-
-		$(this).datetimepicker({
-			locale: $(this).data('picker-locale'),
-			format: $(this).data('picker-format'),
-			useCurrent: false,
-			icons: {
-				time: 'fa fa-clock-o',
-				date: 'fa fa-calendar',
-				up: 'fa fa-chevron-up',
-				down: 'fa fa-chevron-down',
-				previous: 'fa fa-chevron-left',
-				next: 'fa fa-chevron-right',
-				today: 'fa fa-arrows ',
-				clear: 'fa fa-trash',
-				close: 'fa fa-times'
-			}
-		}).next().on(ace.click_event, function() {
-			$(this).prev().focus();
-		});
-	});
-
 	$( 'form .dropzone' ).each(function(){
 		var classPrefix = 'dropzone';
 		var autoUpload = $(this).hasClass('auto-dropzone');
@@ -515,18 +420,6 @@ $(document).ready( function() {
 				$(table).find("select[name*=_end_month]").prop('disabled', true);
 				$(table).find("select[name*=_end_day]").prop('disabled', true);
 				break;
-		}
-	});
-
-	/* For Period.php bundled with the core MantisGraph plugin */
-	$('#dates > input[type=image].datetime').hide();
-	$('#period_menu > select#interval').change(function() {
-		if ($(this).val() == 10) {
-			$('#dates > input[type=text].datetime').prop('disabled', false);
-			$('#dates > input[type=image].datetime').show();
-		} else {
-			$('#dates > input[type=text].datetime').prop('disabled', true);
-			$('#dates > input[type=image].datetime').hide();
 		}
 	});
 

--- a/js/datetimepicker-proxy.js
+++ b/js/datetimepicker-proxy.js
@@ -1,0 +1,121 @@
+/*
+# Mantis - a php based bugtracking system
+
+# Copyright 2000 - 2002  Kenzaburo Ito - kenito@300baud.org
+# Copyright 2026 MantisBT Team   - mantisbt-dev@lists.sourceforge.net
+
+# Mantis is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Mantis is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Mantis.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* jshint esversion: 8 */
+/* globals ace, moment, translations, $ */
+$(function() {
+	'use strict';
+
+	var stopwatch = {
+		timerID: 0,
+		startTime: null,
+		zeroTime: moment('0', 's'),
+		tick: function() {
+			var elapsedDiff = moment().diff(this.startTime),
+				elapsedTime = this.zeroTime.clone().add(elapsedDiff);
+
+			$('input[type=text].stopwatch_time').val(elapsedTime.format('HH:mm:ss'));
+		},
+		reset: function() {
+			this.stop();
+			$('input[type=text].stopwatch_time').val('');
+		},
+		start: function() {
+			var self = this,
+				timeFormat = '',
+				stoppedTime = $('input[type=text].stopwatch_time').val();
+
+			this.stop();
+
+			if (stoppedTime) {
+				switch (stoppedTime.split(':').length) {
+					case 1:
+						timeFormat = 'ss';
+						break;
+
+					case 2:
+						timeFormat = 'mm:ss';
+						break;
+
+					default:
+						timeFormat = 'HH:mm:ss';
+				}
+
+				this.startTime = moment().add(this.zeroTime.clone().diff(moment(stoppedTime, timeFormat)));
+			} else {
+				this.startTime = moment();
+			}
+
+			this.timerID = window.setInterval( function() {
+				self.tick();
+			}, 1000);
+
+			$('input[type=button].stopwatch_toggle').val(translations['time_tracking_stopwatch_stop']);
+		},
+		stop: function() {
+			if (this.timerID) {
+				window.clearInterval(this.timerID);
+				this.timerID = 0;
+			}
+
+			$('input[type=button].stopwatch_toggle').val(translations['time_tracking_stopwatch_start']);
+		}
+	};
+
+	$('input[type=button].stopwatch_toggle').click( function() {
+		if (!stopwatch.timerID) {
+			stopwatch.start();
+		} else {
+			stopwatch.stop();
+		}
+	});
+
+	$('input[type=button].stopwatch_reset').click( function() {
+		stopwatch.reset();
+	});
+
+	$('input[type=text].datetimepicker').each( function(index, element) {
+		// Ensure the parent has relative positioning for the datetimepicker widget
+		var $parent = $(this).parent();
+		if ($parent.css('position') === 'static') {
+			$parent.css('position', 'relative');
+		}
+
+		$(this).datetimepicker({
+			locale: $(this).data('picker-locale'),
+			format: $(this).data('picker-format'),
+			useCurrent: false,
+			showTodayButton: true,
+			icons: {
+				time: 'fa fa-clock-o',
+				date: 'fa fa-calendar',
+				up: 'fa fa-chevron-up',
+				down: 'fa fa-chevron-down',
+				previous: 'fa fa-chevron-left',
+				next: 'fa fa-chevron-right',
+				today: 'fa fa-calendar-times-o',
+				clear: 'fa fa-trash',
+				close: 'fa fa-times'
+			}
+		}).next().on( ace.click_event, function() {
+			$(this).prev().focus();
+		});
+	});
+});

--- a/manage_proj_ver_edit_page.php
+++ b/manage_proj_ver_edit_page.php
@@ -27,6 +27,7 @@
  * @uses authentication_api.php
  * @uses config_api.php
  * @uses constant_inc.php
+ * @uses datetimepicker_api.php
  * @uses event_api.php
  * @uses form_api.php
  * @uses gpc_api.php
@@ -42,6 +43,7 @@ require_api( 'access_api.php' );
 require_api( 'authentication_api.php' );
 require_api( 'config_api.php' );
 require_api( 'constant_inc.php' );
+require_api( 'datetimepicker_api.php' );
 require_api( 'event_api.php' );
 require_api( 'form_api.php' );
 require_api( 'gpc_api.php' );
@@ -93,14 +95,12 @@ print_manage_menu( 'manage_proj_ver_edit_page.php' );
 			</tr>
 			<tr>
 				<td class="category">
-					<?php echo lang_get( 'date_order' ) ?>
+					<label for="date_order"><?php echo lang_get( 'date_order' ) ?></label>
 				</td>
 				<td>
-					<input type="text" id="proj-version-date-order" name="date_order" class="datetimepicker input-sm"
-						data-picker-locale="<?php echo lang_get_current_datetime_locale() ?>"
-						data-picker-format="<?php echo config_get( 'datetime_picker_format' ) ?>"
-						size="16" value="<?php echo (date_is_null( $t_version->date_order ) ? '' : string_attribute( date( config_get( 'normal_date_format' ), $t_version->date_order ) ) ) ?>" />
-					<?php print_icon( 'fa-calendar', 'fa-xlg datetimepicker' ); ?>
+					<?php datetimepicker_print( date_is_null( $t_version->date_order )
+							? ''
+							: date( config_get( 'normal_date_format' ), $t_version->date_order ), 'date_order' ) ?>
 				</td>
 			</tr>
 			<tr>

--- a/plugins/MantisGraph/core/Period.php
+++ b/plugins/MantisGraph/core/Period.php
@@ -293,8 +293,10 @@ class Period {
 		$t_ret .= get_dropdown( $t_periods, $p_control_name, $t_default, false, false );
 		$t_ret .= "</div> <br />\n";
 		$t_ret .= "<div id=\"dates\">\n";
-		$t_ret .= lang_get( 'from_date' ) . ' <input type="text" id="start_date" name="start_date" size="12" value="' . $t_formatted_start . '" class="datetimepicker input-xs" disabled="disabled" />' . "\n";
-		$t_ret .= lang_get( 'to_date' ) . ' <input type="text" id="end_date" name="end_date" size="12" value="' . $t_formatted_end . '" class="datetimepicker input-xs" disabled="disabled" />' . "\n";
+		$t_ret .= '<span class="inline"><label for="start_date" class="padding-4">' . lang_get( 'from_date' ) . '</label> '
+			. datetimepicker_get_field( $t_formatted_start, 'start_date', 'Y-MM-DD' ) . "</span>\n";
+		$t_ret .= '<span class="inline"><label for="end_date" class="padding-4">' . lang_get( 'to_date' ) . '</label> '
+			. datetimepicker_get_field( $t_formatted_end, 'end_date', 'Y-MM-DD' ) . "</span>\n";
 		$t_ret .= "</div>\n";
 		return $t_ret;
 	}

--- a/plugins/MantisGraph/files/MantisGraph.js
+++ b/plugins/MantisGraph/files/MantisGraph.js
@@ -1,10 +1,19 @@
 /* jshint esversion: 6, -W097, -W031 */
 /* globals Chart */
-"use strict";
-
 $(function() {
+	"use strict";
+
     // Default color scheme
     Chart.defaults.plugins.colorschemes.scheme = 'tableau.Classic20';
+
+	// Period selector, created by Period::period_selector() in Period.php
+	const period_selector = $('#period_menu > select#interval');
+	const dates_picker = $('#dates input[type=text].datetimepicker');
+	const period_selector_update = function() {
+		dates_picker.prop('disabled', period_selector.val() != 10);
+	};
+	period_selector.change( period_selector_update );
+	period_selector_update();
 
     // Bar charts
     $("canvas[id*='barchart']").each( function() {

--- a/plugins/MantisGraph/pages/issues_trend_page.php
+++ b/plugins/MantisGraph/pages/issues_trend_page.php
@@ -24,10 +24,13 @@
  * @uses Period.php
  * @uses access_api.php
  * @uses config_api.php
+ * @uses datetimepicker_api.php
  * @uses gpc_api.php
  * @uses html_api.php
  * @uses plugin_api.php
  */
+
+require_api( 'datetimepicker_api.php' );
 
 access_ensure_project_level( config_get( 'view_summary_threshold' ) );
 

--- a/view.php
+++ b/view.php
@@ -23,11 +23,9 @@
  * @link http://www.mantisbt.org
  *
  * @uses core.php
- * @uses datetimepicker_api.php
  */
 
 require_once( 'core.php' );
-require_api( 'datetimepicker_api.php' );
 
 $t_file = __FILE__;
 $t_mantis_dir = __DIR__ . DIRECTORY_SEPARATOR;

--- a/view.php
+++ b/view.php
@@ -23,9 +23,11 @@
  * @link http://www.mantisbt.org
  *
  * @uses core.php
+ * @uses datetimepicker_api.php
  */
 
 require_once( 'core.php' );
+require_api( 'datetimepicker_api.php' );
 
 $t_file = __FILE__;
 $t_mantis_dir = __DIR__ . DIRECTORY_SEPARATOR;


### PR DESCRIPTION
Added DateTimePickerAPI: `datetimepicker_print()` and `datetimepicker_get_field()` functions.

Moved and fixed DateTimePicker and MantisGraph code from `common.js` to `datetimepicker-proxy.js` and `MantisGraph.js`.

Added some missed `<label>` tags.

Added "Today" button to DateTimePicker widget.

Fixes [#36968](https://mantisbt.org/bugs/view.php?id=36968).