### PR TITLE
Remove $g_cookie_secure_flag_enabled global var

### DIFF
--- a/core/gpc_api.php
+++ b/core/gpc_api.php
@@ -37,12 +37,6 @@ require_api( 'constant_inc.php' );
 require_api( 'error_api.php' );
 require_api( 'http_api.php' );
 
-# Determines (once-off) whether the client is accessing this script via a
-# secure connection. If they are, we want to use the Secure cookie flag to
-# prevent the cookie from being transmitted to other domains.
-# @global boolean $g_cookie_secure_flag_enabled
-$g_cookie_secure_flag_enabled = http_is_protocol_https();
-
 /**
  * Retrieve a GPC variable.
  * If the variable is not set, the default is returned.
@@ -379,8 +373,6 @@ function gpc_get_cookie( $p_var_name, $p_default = null ) {
  * @return boolean - true on success, false on failure
  */
 function gpc_set_cookie( $p_name, $p_value, $p_expire = false, $p_path = null, $p_domain = null, $p_httponly = true, $p_samesite = null ) {
-	global $g_cookie_secure_flag_enabled;
-
 	if( false === $p_expire ) {
 		$p_expire = 0;
 	} else if( true === $p_expire ) {
@@ -405,7 +397,7 @@ function gpc_set_cookie( $p_name, $p_value, $p_expire = false, $p_path = null, $
 		'path' => $p_path,
 		'domain' => $p_domain,
 		'samesite' => $p_samesite,
-		'secure' => $g_cookie_secure_flag_enabled,
+		'secure' => http_is_protocol_https(),
 		'httponly' => $p_httponly,
 	);
 	return setcookie( $p_name, $p_value, $t_options );

--- a/core/session_api.php
+++ b/core/session_api.php
@@ -113,8 +113,6 @@ class MantisPHPSession extends MantisSession {
 	 * @param integer $p_session_id The session id.
 	 */
 	function __construct( $p_session_id = null ) {
-		global $g_cookie_secure_flag_enabled;
-
 		$this->key = hash( 'whirlpool',
 			$this::SESSION_KEY_PREFIX . config_get_global( 'crypto_master_salt' )
 		);
@@ -135,7 +133,7 @@ class MantisPHPSession extends MantisSession {
 			'path' => $t_path,
 			'domain' => $t_domain,
 			'samesite' => $t_samesite,
-			'secure' => $g_cookie_secure_flag_enabled,
+			'secure' => http_is_protocol_https(),
 			'httponly' => true,
 		);
 		session_set_cookie_params( $t_options );


### PR DESCRIPTION
With the introduction of http_is_https_protocol() function, this global variable is not really needed anymore, as we can simply call the function whenever we need to set a cookie's secure flag.

Fixes [#37007](https://mantisbt.org/bugs/view.php?id=37007)
