### PR TITLE
Fix extra require_once() calls from require_api()

### DIFF
--- a/core.php
+++ b/core.php
@@ -279,13 +279,13 @@ function require_api( $p_api_name ) {
 	static $s_api_included;
 	global $g_core_path;
 	if( !isset( $s_api_included[$p_api_name] ) ) {
+		/** @noinspection PhpUnusedLocalVariableInspection */
+		$s_api_included[$p_api_name] = 1;
 		require_once( $g_core_path . $p_api_name );
-		$t_new_globals = array_diff_key( get_defined_vars(), $GLOBALS, array( 't_new_globals' => 0 ) );
+		$t_new_globals = array_diff_key( get_defined_vars(), $GLOBALS, array( 't_new_globals' => 0, 'p_api_name' => 0, 's_api_included' => 0 ) );
 		foreach ( $t_new_globals as $t_global_name => $t_global_value ) {
 			$GLOBALS[$t_global_name] = $t_global_value;
 		}
-		/** @noinspection PhpUnusedLocalVariableInspection */
-		$s_api_included[$p_api_name] = 1;
 	}
 }
 

--- a/core.php
+++ b/core.php
@@ -282,7 +282,11 @@ function require_api( $p_api_name ) {
 		/** @noinspection PhpUnusedLocalVariableInspection */
 		$s_api_included[$p_api_name] = 1;
 		require_once( $g_core_path . $p_api_name );
-		$t_new_globals = array_diff_key( get_defined_vars(), $GLOBALS, array( 't_new_globals' => 0, 'p_api_name' => 0, 's_api_included' => 0 ) );
+		$t_new_globals = array_diff_key( get_defined_vars(), $GLOBALS, [
+				't_new_globals' => 0,
+				'p_api_name' => 0,
+				's_api_included' => 0
+			] );
 		foreach ( $t_new_globals as $t_global_name => $t_global_value ) {
 			$GLOBALS[$t_global_name] = $t_global_value;
 		}
@@ -297,24 +301,25 @@ function require_api( $p_api_name ) {
  */
 function require_lib( $p_library_name ) {
 	static $s_libraries_included;
-
+	global $g_library_path;
 	if( !isset( $s_libraries_included[$p_library_name] ) ) {
-		global $g_library_path;
+		/** @noinspection PhpUnusedLocalVariableInspection */
+		$s_libraries_included[$p_library_name] = 1;
 		$t_library_file_path = $g_library_path . $p_library_name;
-
 		if( file_exists( $t_library_file_path ) ) {
 			require_once( $t_library_file_path );
 		} else {
 			fatal_error( 'External library \'' . $t_library_file_path . '\' not found.' );
 		}
-
-		$t_new_globals = array_diff_key( get_defined_vars(), $GLOBALS, array( 't_new_globals' => 0 ) );
+		$t_new_globals = array_diff_key( get_defined_vars(), $GLOBALS, [
+				't_new_globals' => 0,
+				't_library_file_path' => 0,
+				'p_library_name' => 0,
+				's_libraries_included' => 0
+			] );
 		foreach ( $t_new_globals as $t_global_name => $t_global_value ) {
 			$GLOBALS[$t_global_name] = $t_global_value;
 		}
-
-		/** @noinspection PhpUnusedLocalVariableInspection */
-		$s_libraries_included[$p_library_name] = 1;
 	}
 }
 


### PR DESCRIPTION
To prevent recursive calls to the `require_api()` function, move the loading flag after `require_once()` to before it.

Fixes [#37018](https://mantisbt.org/bugs/view.php?id=37018).