### PR TITLE
Remove the issue update when watchers change.

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -2305,9 +2305,6 @@ function bug_monitor( $p_bug_id, $p_user_id ) {
 	# log new monitoring action
 	history_log_event_special( $c_bug_id, BUG_MONITOR, $c_user_id );
 
-	# updated the last_updated date
-	bug_update_date( $p_bug_id );
-
 	email_monitor_added( $p_bug_id, $p_user_id );
 
 	return true;
@@ -2396,9 +2393,6 @@ function bug_unmonitor( $p_bug_id, $p_user_id ) {
 
 	# log new un-monitor action
 	history_log_event_special( $p_bug_id, BUG_UNMONITOR, (int)$p_user_id );
-
-	# updated the last_updated date
-	bug_update_date( $p_bug_id );
 
 	return true;
 }


### PR DESCRIPTION
Calls to the `bug_update_date()` function have been removed from the `bug_monitor()` and `bug_unmonitor()` functions.

Fixes [#10857](https://mantisbt.org/bugs/view.php?id=10857).
