### PR TITLE
Added openssl requirement to installation documentation

### DIFF
--- a/docbook/Admin_Guide/en-US/Installation.xml
+++ b/docbook/Admin_Guide/en-US/Installation.xml
@@ -227,6 +227,12 @@
 									(see <xref linkend="admin.auth.ldap" />).
 								</para></listitem>
 
+								<listitem><para><emphasis>openssl</emphasis> -
+									required for SMTP servers using SSL/TLS alongside
+									with PHPMailer's SMTP method.
+									(see <xref linkend="admin.config.email" />).
+								</para></listitem>								
+
 								<listitem><para><emphasis>SOAP</emphasis> -
 									required to use the SOAP API
 									(see <xref linkend="admin.config.api" />).


### PR DESCRIPTION
Up to this point, `openssl` PHP extension was not mentioned as PHP extension required to be able to send e-mails via PHPMailer's SMTP method.  
  
After some debugging, I found out that openssl extension was simply missing from my setup.  
  
This PR adds mention about requirement of `openssl`, if Mantis is going to use SSL/TLS SMTP servers.