### PR TITLE
Use $g_absolute_path as base for SOAP API includes

### DIFF
--- a/core/classes/FilterConverter.class.php
+++ b/core/classes/FilterConverter.class.php
@@ -21,11 +21,12 @@
  * @package MantisBT
  */
 
-$t_api_path = dirname( __DIR__, 2 ) . '/api/soap/';
-require_once( $t_api_path . 'mc_api.php' );
-require_once( $t_api_path . 'mc_account_api.php' );
-require_once( $t_api_path . 'mc_enum_api.php' );
-require_once( $t_api_path . 'mc_project_api.php' );
+global $g_absolute_path;
+$t_soap_dir = $g_absolute_path . 'api/soap/';
+require_once( $t_soap_dir . 'mc_api.php' );
+require_once( $t_soap_dir . 'mc_account_api.php' );
+require_once( $t_soap_dir . 'mc_enum_api.php' );
+require_once( $t_soap_dir . 'mc_project_api.php' );
 
 require_api( 'custom_field_api.php' );
 

--- a/core/commands/ConfigsSetCommand.php
+++ b/core/commands/ConfigsSetCommand.php
@@ -16,7 +16,8 @@
 
 use Mantis\Exceptions\ClientException;
 
-$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+global $g_absolute_path;
+$t_soap_dir = $g_absolute_path . 'api/soap/';
 require_once( $t_soap_dir . 'mc_api.php' );
 
 /**

--- a/core/commands/IssueAddCommand.php
+++ b/core/commands/IssueAddCommand.php
@@ -33,7 +33,8 @@ require_api( 'relationship_api.php' );
 require_api( 'string_api.php' );
 require_api( 'user_api.php' );
 
-$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+global $g_absolute_path;
+$t_soap_dir = $g_absolute_path . 'api/soap/';
 require_once( $t_soap_dir . 'mc_api.php' );
 require_once( $t_soap_dir . 'mc_enum_api.php' );
 require_once( $t_soap_dir . 'mc_issue_api.php' );

--- a/core/commands/IssueViewPageCommand.php
+++ b/core/commands/IssueViewPageCommand.php
@@ -33,7 +33,8 @@ require_api( 'relationship_api.php' );
 require_api( 'string_api.php' );
 require_api( 'user_api.php' );
 
-$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+global $g_absolute_path;
+$t_soap_dir = $g_absolute_path . 'api/soap/';
 require_once( $t_soap_dir . 'mc_api.php' );
 require_once( $t_soap_dir . 'mc_issue_api.php' );
 

--- a/core/commands/ProjectAddCommand.php
+++ b/core/commands/ProjectAddCommand.php
@@ -16,7 +16,8 @@
 
 require_api( 'project_api.php' );
 
-$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+global $g_absolute_path;
+$t_soap_dir = $g_absolute_path . 'api/soap/';
 require_once( $t_soap_dir . 'mc_api.php' );
 require_once( $t_soap_dir . 'mc_enum_api.php' );
 

--- a/core/commands/ProjectHierarchyAddCommand.php
+++ b/core/commands/ProjectHierarchyAddCommand.php
@@ -20,7 +20,8 @@ require_api( 'helper_api.php' );
 require_api( 'project_api.php' );
 require_api( 'project_hierarchy_api.php' );
 
-$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+global $g_absolute_path;
+$t_soap_dir = $g_absolute_path . 'api/soap/';
 require_once( $t_soap_dir . 'mc_api.php' );
 
 use Mantis\Exceptions\ClientException;

--- a/core/commands/ProjectUpdateCommand.php
+++ b/core/commands/ProjectUpdateCommand.php
@@ -16,7 +16,8 @@
 
 require_api( 'project_api.php' );
 
-$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+global $g_absolute_path;
+$t_soap_dir = $g_absolute_path . 'api/soap/';
 require_once( $t_soap_dir . 'mc_api.php' );
 require_once( $t_soap_dir . 'mc_enum_api.php' );
 

--- a/core/commands/ProjectUsersAddCommand.php
+++ b/core/commands/ProjectUsersAddCommand.php
@@ -19,7 +19,8 @@ use Mantis\Exceptions\ClientException;
 require_api( 'authentication_api.php' );
 require_api( 'user_pref_api.php' );
 
-$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+global $g_absolute_path;
+$t_soap_dir = $g_absolute_path . 'api/soap/';
 require_once( $t_soap_dir . 'mc_api.php' );
 
 /**

--- a/core/commands/ProjectUsersGetCommand.php
+++ b/core/commands/ProjectUsersGetCommand.php
@@ -19,7 +19,8 @@ use Mantis\Exceptions\ClientException;
 require_api( 'authentication_api.php' );
 require_api( 'user_pref_api.php' );
 
-$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+global $g_absolute_path;
+$t_soap_dir = $g_absolute_path . 'api/soap/';
 require_once( $t_soap_dir . 'mc_account_api.php' );
 require_once( $t_soap_dir . 'mc_enum_api.php' );
 

--- a/core/commands/UserTokenCreateCommand.php
+++ b/core/commands/UserTokenCreateCommand.php
@@ -19,7 +19,8 @@ require_api( 'api_token_api.php' );
 
 use Mantis\Exceptions\ClientException;
 
-$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+global $g_absolute_path;
+$t_soap_dir = $g_absolute_path . 'api/soap/';
 require_once( $t_soap_dir . 'mc_api.php' );
 require_once( $t_soap_dir . 'mc_account_api.php' );
 

--- a/core/commands/UserUpdateCommand.php
+++ b/core/commands/UserUpdateCommand.php
@@ -22,7 +22,8 @@ require_api( 'user_api.php' );
 
 use Mantis\Exceptions\ClientException;
 
-$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+global $g_absolute_path;
+$t_soap_dir = $g_absolute_path . 'api/soap/';
 require_once( $t_soap_dir . 'mc_api.php' );
 require_once( $t_soap_dir . 'mc_account_api.php' );
 

--- a/core/commands/VersionGetCommand.php
+++ b/core/commands/VersionGetCommand.php
@@ -20,7 +20,8 @@ require_api( 'helper_api.php' );
 
 use Mantis\Exceptions\ClientException;
 
-$t_soap_dir = dirname( __DIR__, 2 ) . '/api/soap/';
+global $g_absolute_path;
+$t_soap_dir = $g_absolute_path . 'api/soap/';
 require_once( $t_soap_dir . 'mc_api.php' );
 
 /**


### PR DESCRIPTION
Several Commands require SOAP API scripts to function. Until now, the path to include these was built using `dirname( __DIR__, 2 )`, but this does not work when $g_core_path has been moved outside of MantisBT root.

This is because Commands are in $g_core_path/commands, while SOAP API scripts are in $g_absolute_path/api/soap, which can be in different trees.

Fixes [#24389](https://mantisbt.org/bugs/view.php?id=24389)