### PR TITLE
Fix CSRF validation failure in reauthenticate flow (fixes #37130)

### DIFF
--- a/login_password_page.php
+++ b/login_password_page.php
@@ -57,13 +57,19 @@ require_api( 'user_api.php' );
 require_api( 'utility_api.php' );
 require_css( 'login.css' );
 
-form_security_validate( 'login' );
+# auth_reauthenticate() redirects here via GET (no POST body, no CSRF token),
+# bypassing login_page.php which normally generates the token. Skip validation
+# for that path; the token rendered in the form still protects the subsequent
+# password submission via login.php.
+$f_reauthenticate        = gpc_get_bool( 'reauthenticate', false );
+if( !$f_reauthenticate ) {
+	form_security_validate( 'login' );
+}
 
 $f_error                 = gpc_get_bool( 'error' );
 $f_cookie_error          = gpc_get_bool( 'cookie_error' );
 $f_return                = string_sanitize_url( gpc_get_string( 'return', '' ) );
 $f_username              = trim( gpc_get_string( 'username', '' ) );
-$f_reauthenticate        = gpc_get_bool( 'reauthenticate', false );
 $f_perm_login            = gpc_get_bool( 'perm_login', false );
 $f_secure_session        = gpc_get_bool( 'secure_session', false );
 $f_secure_session_cookie = gpc_get_cookie( config_get_global( 'cookie_prefix' ) . '_secure_session', null );


### PR DESCRIPTION
## Summary

`auth_reauthenticate()` redirects to `login_password_page.php` via HTTP GET, bypassing `login_page.php` which normally generates the CSRF token. The `form_security_validate('login')` call added in commit 75b10b39 (2.28.2) therefore always fails with ERROR #2800, making re-authentication impossible.

Regression introduced in 2.28.2 via 75b10b39 ("Add CSRF protection to login process"). Versions 2.28.0 and 2.28.1 are not affected.

See: https://mantisbt.org/bugs/view.php?id=37130

## Changes

- Move `$f_reauthenticate` above the CSRF check in `login_password_page.php`
- Skip `form_security_validate()` when the page is reached via the reauthenticate path
- The CSRF token rendered in the form still protects the subsequent password submission via `login.php`

## Test plan

- [ ] Normal login (username → password page → submit): CSRF validation still active, no regression
- [ ] Re-authentication flow (`$g_reauthentication = ON`, navigate to `account_page.php` after token expiry): password form is shown correctly, no ERROR #2800
- [ ] Password submission after re-authentication completes successfully