### PR TITLE
Seed CSRF login_token on anonymous

### DIFF
--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -52,6 +52,7 @@ require_api( 'crypto_api.php' );
 require_api( 'current_user_api.php' );
 require_api( 'database_api.php' );
 require_api( 'error_api.php' );
+require_api( 'form_api.php' );
 require_api( 'gpc_api.php' );
 require_api( 'helper_api.php' );
 require_api( 'html_api.php' );
@@ -1142,6 +1143,14 @@ function auth_reauthenticate() {
 			'username' => $t_username,
 			'return' => $_SERVER['REQUEST_URI'],
 		];
+
+		# This redirect reaches the credentials page via GET, never passing
+		# through login_page.php where the CSRF token is normally generated.
+		# Without it the subsequent form_security_validate( 'login' ) fails
+		# with ERROR #2800, blocking re-authentication from every manage_*
+		# page. Generate the token here (which also seeds it into the session)
+		# and carry it in the URL so the validation succeeds.
+		$t_query_params['login_token'] = form_security_token( 'login' );
 
 		# redirect to login page
 		return print_header_redirect( auth_credential_page( $t_query_params ) );

--- a/core/authentication_api.php
+++ b/core/authentication_api.php
@@ -52,7 +52,6 @@ require_api( 'crypto_api.php' );
 require_api( 'current_user_api.php' );
 require_api( 'database_api.php' );
 require_api( 'error_api.php' );
-require_api( 'form_api.php' );
 require_api( 'gpc_api.php' );
 require_api( 'helper_api.php' );
 require_api( 'html_api.php' );
@@ -1143,14 +1142,6 @@ function auth_reauthenticate() {
 			'username' => $t_username,
 			'return' => $_SERVER['REQUEST_URI'],
 		];
-
-		# This redirect reaches the credentials page via GET, never passing
-		# through login_page.php where the CSRF token is normally generated.
-		# Without it the subsequent form_security_validate( 'login' ) fails
-		# with ERROR #2800, blocking re-authentication from every manage_*
-		# page. Generate the token here (which also seeds it into the session)
-		# and carry it in the URL so the validation succeeds.
-		$t_query_params['login_token'] = form_security_token( 'login' );
 
 		# redirect to login page
 		return print_header_redirect( auth_credential_page( $t_query_params ) );

--- a/login_anon.php
+++ b/login_anon.php
@@ -52,6 +52,13 @@ $t_params = [
 	'perm_login' => false
 ];
 
+# Anonymous login redirects straight to login.php, bypassing login_page.php
+# where the CSRF token is normally generated. Generate the token here (which
+# also seeds it into the session) and pass it in the URL so login.php's
+# form_security_validate( 'login' ) succeeds. The browser preserves PHPSESSID
+# across the redirect, so $_SESSION (where the nonce is stored) is shared.
+$t_params['login_token'] = form_security_token( 'login' );
+
 if( !is_blank( $f_return ) ) {
 	$t_params['return'] = $f_return;
 }


### PR DESCRIPTION
Fixes [#37135](https://mantisbt.org/bugs/view.php?id=37135)

## Summary
Fixes CSRF validation failures (`ERROR #2800`) on two GET-redirect login
paths that bypass `login_page.php` — where the `login` form security token
is normally minted.

`form_security_token('login')` both returns a nonce **and** seeds it into
`$_SESSION['form_security_tokens']['login']`; `form_security_validate('login')`
reads `login_token` from GET or POST. Generating the token at the redirect
and passing it in the URL therefore makes downstream validation pass, since
`PHPSESSID` (and thus the session store) survives the redirect.

## Changes

- **`login_anon.php`** — anonymous login redirects directly to `login.php`,
  which calls `form_security_validate('login')`. Seed `login_token` into the
  redirect query string so validation succeeds.
