### PR TITLE
Fix the string_sanitize_url() lost slash.

### DIFF
--- a/core/string_api.php
+++ b/core/string_api.php
@@ -268,7 +268,7 @@ function string_sanitize_url( $p_url, $p_return_absolute = false ) {
 	$t_path = rtrim( config_get_global( 'path' ), '/' );
 	$t_short_path = rtrim( config_get_global( 'short_path' ), '/' );
 
-	$t_pattern = '(?:/*(?P<script>[^\?#]*))(?:\?(?P<query>[^#]*))?(?:#(?P<anchor>[^#]*))?';
+	$t_pattern = '(?:(?P<script>[^\?#]*))(?:\?(?P<query>[^#]*))?(?:#(?P<anchor>[^#]*))?';
 
 	# Break the given URL into pieces for path, script, query, and anchor
 	$t_type = 0;

--- a/tests/Mantis/StringTest.php
+++ b/tests/Mantis/StringTest.php
@@ -79,6 +79,8 @@ class StringTest extends MantisCoreBase {
 			array( 'login_page.php?return=http://google.com/', 'index.php'),
 			array( 'javascript:alert(1);', 'index.php'),
 			array( '\/csrf-22702', '%5C/csrf-22702' ),
+			array( '/abc.php', '/abc.php' ),
+			array( '/a/b/c/abc.php', '/a/b/c/abc.php' ),
 		);
 
 		# @FIXME


### PR DESCRIPTION
Fixed an issue where the “/” was missing when rebuilding URLs during sanitization.

Fixes [#37133](https://mantisbt.org/bugs/view.php?id=37133).