### PR TITLE
Replace deprecated strftime() with date() in MantisGraph Period

### DIFF
--- a/plugins/MantisGraph/core/Period.php
+++ b/plugins/MantisGraph/core/Period.php
@@ -65,8 +65,8 @@ class Period {
 	function a_week( $p_when, $p_weeks = 1 ) {
 		list( $t_year, $t_month, $t_day ) = explode( '-', $p_when );
 		$t_now = getdate( mktime( 0, 0, 0, $t_month, $t_day, $t_year ) );
-		$this->end = strftime( '%Y-%m-%d 23:59:59', mktime( 0, 0, 0, $t_month, $t_day - $t_now['wday'] + ( $p_weeks * 7 ) - 1, $t_year ) );
-		$this->start = strftime( '%Y-%m-%d 00:00:00', mktime( 0, 0, 0, $t_month, $t_day - $t_now['wday'], $t_year ) );
+		$this->end = date( 'Y-m-d 23:59:59', mktime( 0, 0, 0, $t_month, $t_day - $t_now['wday'] + ( $p_weeks * 7 ) - 1, $t_year ) );
+		$this->start = date( 'Y-m-d 00:00:00', mktime( 0, 0, 0, $t_month, $t_day - $t_now['wday'], $t_year ) );
 	}
 
 	/**
@@ -105,8 +105,8 @@ class Period {
 	 */
 	function a_month( $p_when ) {
 		list( $t_year, $t_month, $t_day ) = explode( '-', $p_when );
-		$this->end = strftime( '%Y-%m-%d 23:59:59', mktime( 0, 0, 0, $t_month + 1, 0, $t_year ) );
-		$this->start = strftime( '%Y-%m-%d 00:00:00', mktime( 0, 0, 0, $t_month, 1, $t_year ) );
+		$this->end = date( 'Y-m-d 23:59:59', mktime( 0, 0, 0, $t_month + 1, 0, $t_year ) );
+		$this->start = date( 'Y-m-d 00:00:00', mktime( 0, 0, 0, $t_month, 1, $t_year ) );
 	}
 
 	/**
@@ -135,7 +135,7 @@ class Period {
 	function month_to_date() {
 		$this->end = date( 'Y-m-d' ) . ' 23:59:59';
 		list( $t_year, $t_month, $t_day ) = explode( '-', $this->end );
-		$this->start = strftime( '%Y-%m-%d 00:00:00', mktime( 0, 0, 0, $t_month, 1, $t_year ) );
+		$this->start = date( 'Y-m-d 00:00:00', mktime( 0, 0, 0, $t_month, 1, $t_year ) );
 	}
 
 	/**
@@ -147,8 +147,8 @@ class Period {
 	function a_quarter( $p_when ) {
 		list( $t_year, $t_month, $t_day ) = explode( '-', $p_when );
 		$t_month = ( (int)(( $t_month - 1 ) / 3 ) * 3 ) + 1;
-		$this->end = strftime( '%Y-%m-%d 23:59:59', mktime( 0, 0, 0, $t_month + 3, 0, $t_year ) );
-		$this->start = strftime( '%Y-%m-%d 00:00:00', mktime( 0, 0, 0, $t_month, 1, $t_year ) );
+		$this->end = date( 'Y-m-d 23:59:59', mktime( 0, 0, 0, $t_month + 3, 0, $t_year ) );
+		$this->start = date( 'Y-m-d 00:00:00', mktime( 0, 0, 0, $t_month, 1, $t_year ) );
 	}
 
 	/**
@@ -178,7 +178,7 @@ class Period {
 		$this->end = date( 'Y-m-d' ) . ' 23:59:59';
 		list( $t_year, $t_month, $t_day ) = explode( '-', $this->end );
 		$t_month = ( (int)(( $t_month - 1 ) / 3 ) * 3 ) + 1;
-		$this->start = strftime( '%Y-%m-%d 00:00:00', mktime( 0, 0, 0, $t_month, 1, $t_year ) );
+		$this->start = date( 'Y-m-d 00:00:00', mktime( 0, 0, 0, $t_month, 1, $t_year ) );
 	}
 
 	/**
@@ -189,8 +189,8 @@ class Period {
 	 */
 	function a_year( $p_when ) {
 		list( $t_year, $t_month, $t_day ) = explode( '-', $p_when );
-		$this->end = strftime( '%Y-%m-%d 23:59:59', mktime( 0, 0, 0, 12, 31, $t_year ) );
-		$this->start = strftime( '%Y-%m-%d 00:00:00', mktime( 0, 0, 0, 1, 1, $t_year ) );
+		$this->end = date( 'Y-m-d 23:59:59', mktime( 0, 0, 0, 12, 31, $t_year ) );
+		$this->start = date( 'Y-m-d 00:00:00', mktime( 0, 0, 0, 1, 1, $t_year ) );
 	}
 
 	/**
@@ -210,7 +210,7 @@ class Period {
 	function year_to_date() {
 		$this->end = date( 'Y-m-d' ) . ' 23:59:59';
 		list( $t_year, $t_month, $t_day ) = explode( '-', $this->end );
-		$this->start = strftime( '%Y-%m-%d 00:00:00', mktime( 0, 0, 0, 1, 1, $t_year ) );
+		$this->start = date( 'Y-m-d 00:00:00', mktime( 0, 0, 0, 1, 1, $t_year ) );
 	}
 
 	/**
@@ -246,7 +246,7 @@ class Period {
 	 * @return string
 	 */
 	function get_start_formatted() {
-		return( $this->start == '' ? '' : strftime( '%Y-%m-%d', $this->get_start_timestamp() ) );
+		return( $this->start == '' ? '' : date( 'Y-m-d', $this->get_start_timestamp() ) );
 	}
 
 	/**
@@ -255,7 +255,7 @@ class Period {
 	 * @return string
 	 */
 	function get_end_formatted() {
-		return( $this->end == '' ? '' : strftime( '%Y-%m-%d', $this->get_end_timestamp() ) );
+		return( $this->end == '' ? '' : date( 'Y-m-d', $this->get_end_timestamp() ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes [#37136](https://mantisbt.org/bugs/view.php?id=37136)

`strftime()` was deprecated in PHP 8.1 and removed entirely in PHP 9.0.
The `Period` class in the MantisGraph plugin still relied on it for
formatting period start/end boundaries, which triggers deprecation
notices on PHP 8.1+ and will fatal on PHP 9.0.

This replaces every `strftime()` call with an equivalent `date()` call.
The format conversion is 1:1 and output-preserving:

- `'%Y-%m-%d 23:59:59'` -> `'Y-m-d 23:59:59'`
- `'%Y-%m-%d 00:00:00'` -> `'Y-m-d 00:00:00'`
- `'%Y-%m-%d'`           -> `'Y-m-d'`

## Changes

- `plugins/MantisGraph/core/Period.php`
  - `a_week()`, `a_month()`, `month_to_date()`, `a_quarter()`,
    `quarter_to_date()`, `a_year()`, `year_to_date()`
  - `get_start_formatted()`, `get_end_formatted()`
