### PR TITLE
Add display of all plugin dependencies

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -50,6 +50,10 @@ span.dependency_met			{ color: green; }
 span.dependency_unmet		{ color: red; }
 span.dependency_upgrade		{ color: orange; }
 
+.label.multiline {
+	margin-top: .3em;
+}
+	
 tr.bugnote, div.widget-box, a#attachments, .test-langs tr {
 	scroll-margin-top: 50px;
 }

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -1809,3 +1809,4 @@ $s_filter_new = 'New';
 $s_filter_unused_tags = 'Unused';
 $s_filter_unused = 'Unused';
 $s_unknown = 'unknown';
+$s_optional = 'Optional';

--- a/manage_plugin_page.php
+++ b/manage_plugin_page.php
@@ -439,6 +439,7 @@ class AvailablePlugin extends PluginForDisplay {
 			. '<span class="small">' . $t_author . $t_url . '</span>';
 
 		# Dependencies
+        $this->can_install = true;
 		if( is_array( $p_plugin->requires ) && !empty( $p_plugin->requires ) ) {
 			$t_deps_types[] = $p_plugin->requires;
 			$t_deps_names[] = '';
@@ -452,8 +453,6 @@ class AvailablePlugin extends PluginForDisplay {
 			$t_all_plugins = plugin_find_all();
 			foreach( $t_deps_types as $t_deps_index => $t_deps_type ) {
 				foreach( $t_deps_type as $t_required_basename => $t_version ) {
-					$this->can_install = false;
-
 					switch( plugin_dependency( $t_required_basename, $t_version ) ) {
 						case 1:
 							$t_upgrade_needed = plugin_is_registered( $t_required_basename )
@@ -461,20 +460,28 @@ class AvailablePlugin extends PluginForDisplay {
 							if( $t_upgrade_needed ) {
 								$t_class = 'dependency_upgrade';
 								$t_tooltip = lang_get( 'plugin_key_upgrade' );
+								if( !$t_deps_index ) {
+									$this->can_install = false;
+								}
 							} else {
 								$t_class = 'dependency_met';
 								$t_tooltip = lang_get( 'plugin_key_met' );
-								$this->can_install = true;
 							}
 							break;
 						case -1:
 							$t_class = 'dependency_dated';
 							$t_tooltip = lang_get( 'plugin_key_dated' );
+							if( !$t_deps_index ) {
+								$this->can_install = false;
+							}
 							break;
 						case 0:
 						default:
 							$t_class = 'dependency_unmet';
 							$t_tooltip = lang_get( 'plugin_key_unmet' );
+							if( !$t_deps_index ) {
+								$this->can_install = false;
+							}
 							break;
 					}
 
@@ -495,7 +502,6 @@ class AvailablePlugin extends PluginForDisplay {
 			$this->dependencies[] = '<span class="dependency_met">'
 				. lang_get( 'plugin_no_depends' )
 				. '</span>';
-            $this->can_install = true;
 		}
 
 		$this->upgrade_needed = plugin_needs_upgrade( $p_plugin );

--- a/manage_plugin_page.php
+++ b/manage_plugin_page.php
@@ -445,7 +445,7 @@ class AvailablePlugin extends PluginForDisplay {
 		}
 		if( is_array( $p_plugin->uses ) && !empty( $p_plugin->uses ) ) {
 			$t_deps_types[] = $p_plugin->uses;
-			$t_deps_names[] = '<span class="label label-light arrowed">'
+			$t_deps_names[] = '<span class="label label-light arrowed multiline">'
 				. lang_get( 'optional' ) . '</span>';
 		}
 		if( !empty( $t_deps_types ) ) {

--- a/manage_plugin_page.php
+++ b/manage_plugin_page.php
@@ -440,11 +440,13 @@ class AvailablePlugin extends PluginForDisplay {
 
 		# Dependencies
 		if( is_array( $p_plugin->requires ) && !empty( $p_plugin->requires ) ) {
-			$t_deps_types[0] = $p_plugin->requires;
-			$t_deps_names[0] = lang_get( 'required' );
+			$t_deps_types[] = $p_plugin->requires;
+			$t_deps_names[] = '';
 		}
 		if( is_array( $p_plugin->uses ) && !empty( $p_plugin->uses ) ) {
-			$t_deps_types[1] = $p_plugin->uses;
+			$t_deps_types[] = $p_plugin->uses;
+			$t_deps_names[] = '<span class="label label-light arrowed">'
+				. lang_get( 'optional' ) . '</span>';
 		}
 		if( !empty( $t_deps_types ) ) {
 			$t_all_plugins = plugin_find_all();
@@ -480,14 +482,12 @@ class AvailablePlugin extends PluginForDisplay {
 						? $t_all_plugins[$t_required_basename]->name
 						: $t_required_basename;
 					$t_dependency_name .= ' ' . $t_version;
-					if( !empty( $t_deps_names[ $t_deps_index ] ) ) {
-						$t_dependency_name .= ' (' . $t_deps_names[ $t_deps_index ] . ')';
-					}
 
-					$this->dependencies[] = sprintf( '<span class="%s" title="%s">%s</span>',
+					$this->dependencies[] = sprintf( '<span class="%s" title="%s">%s</span> %s',
 						$t_class,
 						$t_tooltip,
-						string_attribute( $t_dependency_name )
+						string_attribute( $t_dependency_name ),
+						$t_deps_names[ $t_deps_index ]
 					);
 				}
 			}
@@ -505,7 +505,7 @@ class AvailablePlugin extends PluginForDisplay {
 		parent::renderColumns();
 
 		# Dependencies
-		echo '<td>', implode( '<br>', $this->dependencies ), '</td>', "\n";
+		echo '<td class="nowrap">', implode( '<br>', $this->dependencies ), '</td>', "\n";
 
 		# Actions
 		# Only displayed if current object is of AvailablePlugin class

--- a/manage_plugin_page.php
+++ b/manage_plugin_page.php
@@ -440,44 +440,56 @@ class AvailablePlugin extends PluginForDisplay {
 
 		# Dependencies
 		if( is_array( $p_plugin->requires ) && !empty( $p_plugin->requires ) ) {
+			$t_deps_types[0] = $p_plugin->requires;
+			$t_deps_names[0] = lang_get( 'required' );
+		}
+		if( is_array( $p_plugin->uses ) && !empty( $p_plugin->uses ) ) {
+			$t_deps_types[1] = $p_plugin->uses;
+		}
+		if( !empty( $t_deps_types ) ) {
 			$t_all_plugins = plugin_find_all();
-			foreach( $p_plugin->requires as $t_required_basename => $t_version ) {
-				$this->can_install = false;
+			foreach( $t_deps_types as $t_deps_index => $t_deps_type ) {
+				foreach( $t_deps_type as $t_required_basename => $t_version ) {
+					$this->can_install = false;
 
-				switch( plugin_dependency( $t_required_basename, $t_version ) ) {
-					case 1:
-						$t_upgrade_needed = plugin_is_registered( $t_required_basename )
-							&& plugin_needs_upgrade( plugin_get( $t_required_basename ) );
-						if( $t_upgrade_needed ) {
-							$t_class = 'dependency_upgrade';
-							$t_tooltip = lang_get( 'plugin_key_upgrade' );
-						} else {
-							$t_class = 'dependency_met';
-							$t_tooltip = lang_get( 'plugin_key_met' );
-							$this->can_install = true;
-						}
-						break;
-					case -1:
-						$t_class = 'dependency_dated';
-						$t_tooltip = lang_get( 'plugin_key_dated' );
-						break;
-					case 0:
-					default:
-						$t_class = 'dependency_unmet';
-						$t_tooltip = lang_get( 'plugin_key_unmet' );
-						break;
+					switch( plugin_dependency( $t_required_basename, $t_version ) ) {
+						case 1:
+							$t_upgrade_needed = plugin_is_registered( $t_required_basename )
+								&& plugin_needs_upgrade( plugin_get( $t_required_basename ) );
+							if( $t_upgrade_needed ) {
+								$t_class = 'dependency_upgrade';
+								$t_tooltip = lang_get( 'plugin_key_upgrade' );
+							} else {
+								$t_class = 'dependency_met';
+								$t_tooltip = lang_get( 'plugin_key_met' );
+								$this->can_install = true;
+							}
+							break;
+						case -1:
+							$t_class = 'dependency_dated';
+							$t_tooltip = lang_get( 'plugin_key_dated' );
+							break;
+						case 0:
+						default:
+							$t_class = 'dependency_unmet';
+							$t_tooltip = lang_get( 'plugin_key_unmet' );
+							break;
+					}
+
+					$t_dependency_name = array_key_exists( $t_required_basename, $t_all_plugins )
+						? $t_all_plugins[$t_required_basename]->name
+						: $t_required_basename;
+					$t_dependency_name .= ' ' . $t_version;
+					if( !empty( $t_deps_names[ $t_deps_index ] ) ) {
+						$t_dependency_name .= ' (' . $t_deps_names[ $t_deps_index ] . ')';
+					}
+
+					$this->dependencies[] = sprintf( '<span class="%s" title="%s">%s</span>',
+						$t_class,
+						$t_tooltip,
+						string_attribute( $t_dependency_name )
+					);
 				}
-
-				$t_dependency_name = array_key_exists( $t_required_basename, $t_all_plugins )
-					? $t_all_plugins[$t_required_basename]->name
-					: $t_required_basename;
-				$t_dependency_name .= ' ' . $t_version;
-
-				$this->dependencies[] = sprintf( '<span class="%s" title="%s">%s</span>',
-					$t_class,
-					$t_tooltip,
-					string_attribute( $t_dependency_name )
-				);
 			}
 		} else {
 			$this->dependencies[] = '<span class="dependency_met">'


### PR DESCRIPTION
Fixes [#37144](https://mantisbt.org/bugs/view.php?id=37144).

Before:
<img width="1404" height="469" alt="before" src="https://github.com/user-attachments/assets/63c91838-810a-4a85-912b-55c085502d94" />

After:
<img width="1404" height="469" alt="after" src="https://github.com/user-attachments/assets/c834cf58-7839-4708-be24-494a26be0a01" />
