### PR TITLE
[MantisGraph] Combine all JS scripts into a single function

### DIFF
--- a/core/html_api.php
+++ b/core/html_api.php
@@ -130,7 +130,14 @@ function html_rss_link() {
  * @return void
  */
 function html_javascript_link( $p_filename ) {
-	echo "\t", '<script src="', helper_mantis_url( 'js/' . $p_filename ), '"></script>', "\n";
+	$t_filename = $p_filename;
+
+	# If no path is specified, look for JavaScript files in default directory
+	if( $t_filename == basename( $t_filename ) ) {
+		$t_filename = 'js/' . $p_filename;
+	}
+
+	echo "\t", '<script src="', helper_mantis_url( $t_filename ), '"></script>', "\n";
 }
 
 /**
@@ -199,34 +206,30 @@ function html_title( $p_page_title = '' ) {
  * @param string|array $p_stylesheet_path Path to local CSS style sheet or
  *                                        an ['URL','integrity'] array,
  *                                        'integrity' is optional.
+ * @param bool         $p_prepend         Move the path to the top.
  * @return void
  */
-function require_css( $p_stylesheet_path ) {
+function require_css( $p_stylesheet_path, bool $p_prepend = false ) {
 	global $g_stylesheets_included;
-	if( is_array( $p_stylesheet_path ) ) {
-		$g_stylesheets_included[$p_stylesheet_path[0]] = $p_stylesheet_path;
-	} else {
-		$g_stylesheets_included[$p_stylesheet_path] = $p_stylesheet_path;
+	$t_stylesheet_index = is_array( $p_stylesheet_path ) ? $p_stylesheet_path[0] : $p_stylesheet_path;
+	if( !isset( $g_stylesheets_included[$t_stylesheet_index] ) ) {
+		if( $p_prepend ) {
+			$g_stylesheets_included = array_merge( [ $t_stylesheet_index => $p_stylesheet_path ], $g_stylesheets_included );
+		} else {
+			$g_stylesheets_included[$t_stylesheet_index] = $p_stylesheet_path;
+		}
 	}
 }
 
 /**
- * Print the link to include the CSS file
+ * Publish the links to CSS files requested by the require_css() function.
+ * @see require_css()
  * @return void
  */
 function html_css() {
 	global $g_stylesheets_included;
 
-	$t_cache_key = helper_generate_cache_key();
-
-	html_css_link( config_get_global( 'css_include_file' ), $t_cache_key );
-
-	# Add right-to-left css if needed
-	if( lang_get( 'directionality' ) == 'rtl' ) {
-		html_css_link( config_get_global( 'css_rtl_include_file' ), $t_cache_key );
-	}
-
-	foreach( $g_stylesheets_included as $t_stylesheet_path ) {
+	foreach( $g_stylesheets_included as $t_stylesheet_index => $t_stylesheet_path ) {
 		# status_config.php is a special css file, dynamically generated.
 		# Add a hash to the query string to differentiate content based on its
 		# relevant properties. This allows a browser to cache them separately and force
@@ -238,10 +241,13 @@ function html_css() {
 			);
 		}
 
-		if( is_array( $t_stylesheet_path ) ) {
-			html_css_cdn_link( $t_stylesheet_path[0], $t_stylesheet_path[1] ?? '' );
-		} else {
-			html_css_link( $t_stylesheet_path );
+		if( $t_stylesheet_path ) {
+			if( is_array( $t_stylesheet_path ) ) {
+				html_css_cdn_link( $t_stylesheet_path[0], $t_stylesheet_path[1] ?? '' );
+			} else {
+				html_css_link( $t_stylesheet_path );
+			}
+			$g_stylesheets_included[$t_stylesheet_index] = false;
 		}
 	}
 }
@@ -334,19 +340,24 @@ function html_meta_canonical( $p_url ) {
  * @param string|array $p_script_path Path to local javascript file or
  *                                    an ['URL','integrity'] array,
  *                                    'integrity' is optional.
+ * @param bool         $p_prepend     Move the path to the top.
  * @return void
  */
-function require_js( $p_script_path ) {
+function require_js( $p_script_path, bool $p_prepend = false ) {
 	global $g_scripts_included;
-	if( is_array( $p_script_path ) ) {
-		$g_scripts_included[$p_script_path[0]] = $p_script_path;
-	} else {
-		$g_scripts_included[$p_script_path] = $p_script_path;
+	$t_script_index = is_array( $p_script_path ) ? $p_script_path[0] : $p_script_path;
+	if( !isset( $g_scripts_included[$t_script_index] ) ) {
+		if( $p_prepend ) {
+			$g_scripts_included = array_merge( [ $t_script_index => $p_script_path ], $g_scripts_included );
+		} else {
+			$g_scripts_included[$t_script_index] = $p_script_path;
+		}
 	}
 }
 
 /**
- * Javascript...
+ * Publish the links to JavaScript scripts requested by the require_js() function.
+ * @see require_js()
  * @return void
  */
 function html_head_javascript() {
@@ -362,24 +373,27 @@ function html_head_javascript() {
 		helper_mantis_url( 'javascript_config.php' ),
 		[ 'cache_key' => helper_generate_cache_key( array( 'user' ) ) ]
 	);
-	echo "\t" . '<script src="' . $t_javascript_config . '"></script>' . "\n";
-	echo "\t" . '<script src="' . $t_javascript_translations . '"></script>' . "\n";
+	require_js( $t_javascript_config, true );
+	require_js( $t_javascript_translations, true );
 
 	if ( config_get_global( 'cdn_enabled' ) == ON ) {
 		# JQuery
-		html_javascript_cdn_link( 'https://ajax.googleapis.com/ajax/libs/jquery/' . JQUERY_VERSION . '/jquery.min.js', JQUERY_HASH );
+		require_js( [ 'https://ajax.googleapis.com/ajax/libs/jquery/' . JQUERY_VERSION . '/jquery.min.js', JQUERY_HASH ], true );
 	} else {
 		# JQuery
-		html_javascript_link( 'jquery-' . JQUERY_VERSION . '.min.js' );
+		require_js( 'jquery-' . JQUERY_VERSION . '.min.js', true );
 	}
 
 	require_js( 'common.js' );
 
-	foreach ( $g_scripts_included as $t_script_path ) {
-		if( is_array( $t_script_path ) ) {
-			html_javascript_cdn_link( $t_script_path[0], $t_script_path[1] ?? '' );
-		} else {
-			html_javascript_link( $t_script_path );
+	foreach ( $g_scripts_included as $t_script_index => $t_script_path ) {
+		if( $t_script_path ) {
+			if( is_array( $t_script_path ) ) {
+				html_javascript_cdn_link( $t_script_path[0], $t_script_path[1] ?? '' );
+			} else {
+				html_javascript_link( $t_script_path );
+			}
+			$g_scripts_included[$t_script_index] = false;
 		}
 	}
 }

--- a/core/layout_api.php
+++ b/core/layout_api.php
@@ -84,7 +84,6 @@ function layout_page_header_begin( $p_page_title = '' ) {
 
 	html_title( $p_page_title );
 	layout_head_meta();
-	html_css();
 	layout_head_css();
 	html_rss_link();
 
@@ -123,6 +122,11 @@ function layout_page_header_end( $p_page_id = null) {
 	global $g_error_send_page_header;
 
 	event_signal( 'EVENT_LAYOUT_RESOURCES' );
+
+	# A second chance to output the requested styles and scripts
+	html_css();
+	html_head_javascript();
+
 	html_head_end();
 
 	if ( $p_page_id === null ) {
@@ -275,6 +279,14 @@ function layout_head_meta() {
 function layout_head_css() {
 	$t_cache_key = helper_generate_cache_key();
 
+	# default.css by default
+	html_css_link( config_get_global( 'css_include_file' ), $t_cache_key );
+
+	# Add right-to-left css if needed, rtl.css by default
+	if( lang_get( 'directionality' ) == 'rtl' ) {
+		html_css_link( config_get_global( 'css_rtl_include_file' ), $t_cache_key );
+	}
+
 	# bootstrap & fontawesome
 	if ( config_get_global( 'cdn_enabled' ) == ON ) {
 		html_css_cdn_link( 'https://stackpath.bootstrapcdn.com/bootstrap/' . BOOTSTRAP_VERSION . '/css/bootstrap.min.css',BOOTSTRAP_HASH_CSS );
@@ -300,6 +312,9 @@ function layout_head_css() {
 		html_css_link( 'ace-rtl.min.css', $t_cache_key );
 	}
 	html_css_link( 'ace-mantis.css', $t_cache_key );
+
+	# The initial output of the requested styles
+	html_css();
 
 	# Set font preference
 	layout_user_font_preference();

--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -119,7 +119,6 @@ class MantisGraphPlugin extends MantisPlugin  {
 	function hooks() {
 		$t_hooks = array(
 			'EVENT_REST_API_ROUTES' => 'routes',
-			'EVENT_LAYOUT_RESOURCES' => 'resources',
 			'EVENT_CORE_HEADERS' => 'csp_headers',
 			'EVENT_MENU_SUMMARY' => 'summary_menu',
 			'EVENT_MENU_FILTER' => 'graph_filter_menu'
@@ -162,6 +161,9 @@ class MantisGraphPlugin extends MantisPlugin  {
 		if( config_get_global( 'cdn_enabled' ) == ON ) {
 			http_csp_add( 'script-src', self::CHARTJS_CDN );
 		}
+		if( current( explode( '/', gpc_get_string( 'page', '' ) ) ) === $this->basename ) {
+			$this->include_chartjs();
+		}
 	}
 
 	/**
@@ -191,35 +193,19 @@ class MantisGraphPlugin extends MantisPlugin  {
 
 			# Chart.js library
 			$t_link = sprintf( $t_cdn_url, 'chart.js', self::CHARTJS_VERSION );
-			html_javascript_cdn_link( $t_link . 'chart.min.js', self::CHARTJS_HASH );
+			require_js( [ $t_link . 'chart.min.js', self::CHARTJS_HASH ] );
 
 			# Chart.js color schemes plugin
 			$t_link = sprintf( $t_cdn_url, 'hw-chartjs-plugin-colorschemes', self::CHARTJS_COLORSCHEMES_VERSION );
-			html_javascript_cdn_link( $t_link . 'chartjs-plugin-colorschemes.min.js', self::CHARTJS_COLORSCHEMES_HASH );
+			require_js( [ $t_link . 'chartjs-plugin-colorschemes.min.js', self::CHARTJS_COLORSCHEMES_HASH ] );
 		} else {
-			$t_scripts = array(
-				'chart-' . self::CHARTJS_VERSION . '.min.js',
-				'chartjs-plugin-colorschemes-' . self::CHARTJS_COLORSCHEMES_VERSION . '.min.js',
-			);
-			foreach( $t_scripts as $t_script ) {
-				printf( "\t<script type=\"text/javascript\" src=\"%s\"></script>\n",
-					plugin_file( $t_script, false, $this->basename )
-				);
-			}
+			# Chart.js library
+			require_js( [ plugin_file( 'chart-' . self::CHARTJS_VERSION . '.min.js', false, $this->basename ) ] );
+			
+			# Chart.js color schemes plugin
+			require_js( [ plugin_file( 'chartjs-plugin-colorschemes-' . self::CHARTJS_COLORSCHEMES_VERSION . '.min.js', false, $this->basename ) ] );
 		}
-	}
-
-	/**
-	 * Include javascript files for chart.js
-	 * @return void
-	 */
-	function resources() {
-		if( current( explode( '/', gpc_get_string( 'page', '' ) ) ) === $this->basename ) {
-			$this->include_chartjs();
-			printf( "\t<script src=\"%s\"></script>\n",
-				plugin_file( 'MantisGraph.js' )
-			);
-		}
+		require_js( [ plugin_file( 'MantisGraph.js', false, $this->basename ) ] );
 	}
 
 	/**

--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -65,7 +65,7 @@ class MantisGraphPlugin extends MantisPlugin  {
 
 		$this->version = MANTIS_VERSION;
 		$this->requires = array(
-			'MantisCore' => '2.25.0',
+			'MantisCore' => '2.29',
 		);
 
 		$this->author = 'MantisBT Team';
@@ -119,7 +119,7 @@ class MantisGraphPlugin extends MantisPlugin  {
 	function hooks() {
 		$t_hooks = array(
 			'EVENT_REST_API_ROUTES' => 'routes',
-			'EVENT_CORE_HEADERS' => 'csp_headers',
+			'EVENT_CORE_HEADERS' => 'core_headers',
 			'EVENT_MENU_SUMMARY' => 'summary_menu',
 			'EVENT_MENU_FILTER' => 'graph_filter_menu'
 		);
@@ -154,13 +154,11 @@ class MantisGraphPlugin extends MantisPlugin  {
 	}
 
 	/**
-	 * Add Content-Security-Policy directives that are needed to load scripts for CDN.
+	 * Make sure that Chart.js and its plugins are included on the plugins' own pages.
+	 *
 	 * @return void
 	 */
-	function csp_headers() {
-		if( config_get_global( 'cdn_enabled' ) == ON ) {
-			http_csp_add( 'script-src', self::CHARTJS_CDN );
-		}
+	function core_headers() {
 		if( current( explode( '/', gpc_get_string( 'page', '' ) ) ) === $this->basename ) {
 			$this->include_chartjs();
 		}
@@ -180,16 +178,20 @@ class MantisGraphPlugin extends MantisPlugin  {
 	}
 
 	/**
-	 * Include Chart.js and plugins.
+	 * Include Chart.js and its plugins, configure CSP.
 	 *
 	 * This function can be called by other plugins that may need to use
-	 * Chart.js.
+	 * Chart.js. It must be called early; the suggested call location is
+	 * the EVENT_CORE_HEADERS handler.
 	 *
 	 * @return void
 	 */
 	function include_chartjs() {
 		if( config_get_global( 'cdn_enabled' ) == ON ) {
 			$t_cdn_url = self::CHARTJS_CDN . '/npm/%s@%s/dist/';
+
+			# Add Content-Security-Policy directives that are needed to load scripts for CDN
+			http_csp_add( 'script-src', self::CHARTJS_CDN );
 
 			# Chart.js library
 			$t_link = sprintf( $t_cdn_url, 'chart.js', self::CHARTJS_VERSION );

--- a/plugins/MantisGraph/MantisGraph.php
+++ b/plugins/MantisGraph/MantisGraph.php
@@ -159,6 +159,13 @@ class MantisGraphPlugin extends MantisPlugin  {
 	 * @return void
 	 */
 	function core_headers() {
+		# TODO: Move the http_csp_add() call to the include_chartjs() below
+		# once other plugins that use this plugin have moved their include_chartjs()
+		# calls to the EVENT_CORE_HEADERS handler or earlier.
+		if( config_get_global( 'cdn_enabled' ) == ON ) {
+			# Add Content-Security-Policy directives that are needed to load scripts for CDN
+			http_csp_add( 'script-src', self::CHARTJS_CDN );
+		}
 		if( current( explode( '/', gpc_get_string( 'page', '' ) ) ) === $this->basename ) {
 			$this->include_chartjs();
 		}
@@ -190,9 +197,6 @@ class MantisGraphPlugin extends MantisPlugin  {
 		if( config_get_global( 'cdn_enabled' ) == ON ) {
 			$t_cdn_url = self::CHARTJS_CDN . '/npm/%s@%s/dist/';
 
-			# Add Content-Security-Policy directives that are needed to load scripts for CDN
-			http_csp_add( 'script-src', self::CHARTJS_CDN );
-
 			# Chart.js library
 			$t_link = sprintf( $t_cdn_url, 'chart.js', self::CHARTJS_VERSION );
 			require_js( [ $t_link . 'chart.min.js', self::CHARTJS_HASH ] );
@@ -202,12 +206,12 @@ class MantisGraphPlugin extends MantisPlugin  {
 			require_js( [ $t_link . 'chartjs-plugin-colorschemes.min.js', self::CHARTJS_COLORSCHEMES_HASH ] );
 		} else {
 			# Chart.js library
-			require_js( [ plugin_file( 'chart-' . self::CHARTJS_VERSION . '.min.js', false, $this->basename ) ] );
+			require_js( plugin_file( 'chart-' . self::CHARTJS_VERSION . '.min.js', false, $this->basename ) );
 			
 			# Chart.js color schemes plugin
-			require_js( [ plugin_file( 'chartjs-plugin-colorschemes-' . self::CHARTJS_COLORSCHEMES_VERSION . '.min.js', false, $this->basename ) ] );
+			require_js( plugin_file( 'chartjs-plugin-colorschemes-' . self::CHARTJS_COLORSCHEMES_VERSION . '.min.js', false, $this->basename ) );
 		}
-		require_js( [ plugin_file( 'MantisGraph.js', false, $this->basename ) ] );
+		require_js( plugin_file( 'MantisGraph.js', false, $this->basename ) );
 	}
 
 	/**


### PR DESCRIPTION
The loading of the `MantisGraph.js` file has been moved from the `resources()` function to the `include_chartjs()` function.
The request to load scripts by the Mantis Graph plugin itself is now placed earlier — in the `csp_headers()` function.
The redundant `resources()` function — the `EVENT_LAYOUT_RESOURCES` event handler — has been removed.
Now all scripts are loaded in order and in the same way.

Fixes [#37146](https://mantisbt.org/bugs/view.php?id=37146).