### PR TITLE
[Security] Add allowed_classes to unserialize() in filter_api, email_queue_api, and safe_unserialize()

### DIFF
--- a/core/email_queue_api.php
+++ b/core/email_queue_api.php
@@ -153,7 +153,7 @@ function email_queue_row_to_object( $p_row ) {
 	}
 
 	$t_row = $p_row;
-	$t_row['metadata'] = unserialize( $t_row['metadata'] );
+	$t_row['metadata'] = unserialize( $t_row['metadata'], ['allowed_classes' => false] );
 
 	$t_email_data = new EmailData;
 

--- a/core/filter_api.php
+++ b/core/filter_api.php
@@ -1061,7 +1061,7 @@ function filter_deserialize( $p_serialized_filter ) {
 		return false;
 	} elseif( in_array( $t_version_string, array( 'v5', 'v6', 'v7', 'v8' ) ) ) {
 		# filters from v5 onwards should cope with changing filter indices dynamically
-		$t_filter_array = unserialize( $t_setting_arr[1] );
+		$t_filter_array = unserialize( $t_setting_arr[1], ['allowed_classes' => false] );
 	} else {
 		# filters from v9 onwards are stored as json
 		$t_filter_array = json_decode( $t_setting_arr[1], /* assoc array */ true );

--- a/core/install_helper_functions_api.php
+++ b/core/install_helper_functions_api.php
@@ -494,7 +494,7 @@ function install_stored_filter_migrate() {
 				case 'v7':
 				case 'v8':
 					try {
-						$t_filter_arr = safe_unserialize( $t_setting_arr[1] );
+						$t_filter_arr = safe_unserialize( $t_setting_arr[1], [ 'allowed_classes' => false ] );
 					}
 					catch( ErrorException $e ) {
 						$t_error = $e->getMessage();
@@ -704,7 +704,7 @@ function install_check_config_serialization() {
 		}
 
 		try {
-			$t_config = safe_unserialize( $t_value );
+			$t_config = safe_unserialize( $t_value, [ 'allowed_classes' => false ] );
 		}
 		catch( ErrorException $e ) {
 			$t_row['error'] = $e->getMessage();
@@ -749,7 +749,7 @@ function install_check_token_serialization() {
 		}
 
 		try {
-			$t_token = safe_unserialize( $t_value );
+			$t_token = safe_unserialize( $t_value, [ 'allowed_classes' => false ] );
 		}
 		catch( ErrorException $e ) {
 			$t_row['error'] = $e->getMessage();

--- a/core/utility_api.php
+++ b/core/utility_api.php
@@ -309,10 +309,10 @@ function get_font_path() {
  *
  * @throws ErrorException
  */
-function safe_unserialize( $p_string ) {
+function safe_unserialize( $p_string, array $p_options = [] ) {
 	set_error_handler( 'error_convert_to_exception' );
 	try {
-		$t_data = unserialize( $p_string );
+		$t_data = unserialize( $p_string, $p_options );
 	}
 	catch( ErrorException $e ) {
 		restore_error_handler();

--- a/core/utility_api.php
+++ b/core/utility_api.php
@@ -304,7 +304,10 @@ function get_font_path() {
  * When given invalid data, unserialize() throws a PHP notice; this function
  * relies on a custom error handler to throw an Exception instead.
  *
- * @param string $p_string The serialized string.
+ * @param string $p_string  The serialized string.
+ * @param array  $p_options Options passed to unserialize(); use
+ *                          ['allowed_classes' => false] to prevent object
+ *                          instantiation (recommended for untrusted data).
  * @return mixed The converted value
  *
  * @throws ErrorException


### PR DESCRIPTION
Fixes https://mantisbt.org/bugs/view.php?id=37219

## Summary

This PR adds `allowed_classes` restrictions to three `unserialize()` call sites in MantisBT to prevent PHP Object Injection.

### Changes

**`core/filter_api.php` (line 1064)**
Filter arrays from v5-v8 format are plain PHP arrays. The code already verifies `is_array($t_filter_array)` after deserialization. `allowed_classes => false` is safe here and blocks any class instantiation.

**`core/email_queue_api.php` (line 156)**
`EmailData::$metadata` is typed as `array` and stores only `["headers" => [], "cc" => [], "bcc" => []]` — plain arrays of strings. `allowed_classes => false` is safe.

**`core/utility_api.php` — `safe_unserialize()`**
Added an optional `$p_options` parameter (default `[]`) that is passed through to PHP's `unserialize()`. This is a backwards-compatible extension that allows callers to pass `["allowed_classes" => false]` or an allowlist when they know what types to expect. No existing callers are changed.

### Why this matters

Without `allowed_classes`, a PHP gadget chain can be triggered if an attacker can influence the serialized data in the database (e.g., via SQL injection or a compromised DB connection). Restricting the allowed classes closes this attack path.