### PR TITLE
Update Slim to 3.13.0 for PHP 8.1+ support and revert our workarounds

### DIFF
--- a/api/rest/index.php
+++ b/api/rest/index.php
@@ -47,80 +47,11 @@ require_once( $t_restcore_dir . 'VersionMiddleware.php' );
 # For example, this will disable logic like encoding dates with XSD meta-data.
 ApiObjectFactory::$soap = false;
 
+# Show SLIM detailed errors according to Mantis settings
 $t_config = array();
 
-# Show SLIM detailed errors according to Mantis settings
 if( ON == config_get_global( 'show_detailed_errors' ) ) {
 	$t_config['settings'] = array( 'displayErrorDetails' => true );
-}
-
-# For debugging purposes, uncomment this line to avoid truncated error messages
-# $t_config['settings']['addContentLengthHeader'] = false;
-
-
-if( version_compare( Slim\App::VERSION, '4.0', '<' ) ) {
-	/**
-	 * Error Handler to process Slim 3.x deprecated warnings on PHP 8.1+.
-	 *
-	 * Some components required by Slim Framework 3.x throw deprecation warnings
-	 * on PHP 8.1 and later. Depending on PHP error_reporting() settings, these
-	 * cause the REST API to fail, while still returning an HTTP 200 status code
-	 * (the response body contains HTML with details about the errors).
-	 *
-	 * To properly fix this, we need to upgrade to Slim 4.x (no small undertaking,
-	 * covered in #31699), or maintain our own fork of the offending components
-	 * (which is a pain).
-	 *
-	 * So as a workaround, we define a custom error handler selectively squelch the
-	 * known deprecation notices, and throw an exception for any other warning.
-	 *
-	 * It's worth noting that Slim's documented way of handling PHP errors
-	 * {@see https://www.slimframework.com/docs/v3/handlers/php-error.html}
-	 * is not able to catch these warnings, as some of them occur before the error
-	 * handling container becomes active (while it's being initialized, in fact).
-	 *
-	 * @throws StateException
-	 */
-	function deprecated_errors_handler(
-		int    $p_type,
-		string $p_error,
-		string $p_file,
-		int    $p_line
-	): bool {
-		if( is_windows_server() ) {
-			# Convert to Unix-style path
-			$p_file = str_replace( '\\', '/', $p_file );
-		}
-
-		if( preg_match( '~/vendor/(?:\w+/){2}(.*)$~', $p_file, $t_matches ) ) {
-			# Selectively handle deprecation warnings
-			switch( $t_matches[1] ) {
-				case 'src/Pimple/Container.php':
-				case 'Slim/Collection.php':
-					if( strpos( $p_error, '#[\ReturnTypeWillChange]' ) ) {
-						return true;
-					}
-					break;
-
-				# Passing null to parameter of type ... is deprecated
-				case 'Slim/Http/Request.php':
-				case 'Slim/Http/Uri.php':
-					return true;
-			}
-		}
-
-		# For any other, unknown warnings, throw an exception
-		throw new StateException(
-			sprintf( "Unhandled deprecation warning in %s line %d: '%s'",
-				$p_file,
-				$p_line,
-				$p_error
-			),
-			ERROR_GENERIC
-		);
-	}
-
-	set_error_handler( 'deprecated_errors_handler', E_DEPRECATED );
 }
 
 $t_container = new Container( $t_config );
@@ -157,34 +88,24 @@ $t_container['errorHandler'] = function( $p_container ) {
 	};
 };
 
+$g_app = new App( $t_container );
 
-# Wrap the whole API initialization and execution in a try/catch block, to
-# ensure we capture every error that could be occurring.
-try {
-	$g_app = new App( $t_container );
+# Add middleware - executed in reverse order of appearing here.
+$g_app->add( new ApiEnabledMiddleware() );
+$g_app->add( new AuthMiddleware() );
+$g_app->add( new VersionMiddleware() );
+$g_app->add( new OfflineMiddleware() );
+$g_app->add( new CacheMiddleware() );
 
-	# Add middleware - executed in reverse order of appearing here.
-	$g_app->add( new ApiEnabledMiddleware() );
-	$g_app->add( new AuthMiddleware() );
-	$g_app->add( new VersionMiddleware() );
-	$g_app->add( new OfflineMiddleware() );
-	$g_app->add( new CacheMiddleware() );
+require_once( $t_restcore_dir . 'config_rest.php' );
+require_once( $t_restcore_dir . 'filters_rest.php' );
+require_once( $t_restcore_dir . 'internal_rest.php' );
+require_once( $t_restcore_dir . 'issues_rest.php' );
+require_once( $t_restcore_dir . 'lang_rest.php' );
+require_once( $t_restcore_dir . 'projects_rest.php' );
+require_once( $t_restcore_dir . 'users_rest.php' );
+require_once( $t_restcore_dir . 'pages_rest.php' );
 
-	require_once( $t_restcore_dir . 'config_rest.php' );
-	require_once( $t_restcore_dir . 'filters_rest.php' );
-	require_once( $t_restcore_dir . 'internal_rest.php' );
-	require_once( $t_restcore_dir . 'issues_rest.php' );
-	require_once( $t_restcore_dir . 'lang_rest.php' );
-	require_once( $t_restcore_dir . 'projects_rest.php' );
-	require_once( $t_restcore_dir . 'users_rest.php' );
-	require_once( $t_restcore_dir . 'pages_rest.php' );
+event_signal( 'EVENT_REST_API_ROUTES', array( array( 'app' => $g_app ) ) );
 
-	event_signal( 'EVENT_REST_API_ROUTES', array( array( 'app' => $g_app ) ) );
-
-	$g_app->run();
-}
-catch( Throwable $e ) {
-	header( 'Content-type: text/plain');
-	http_response_code( HTTP_STATUS_INTERNAL_SERVER_ERROR );
-	echo $e;
-}
+$g_app->run();

--- a/api/rest/index.php
+++ b/api/rest/index.php
@@ -57,12 +57,6 @@ if( ON == config_get_global( 'show_detailed_errors' ) ) {
 # For debugging purposes, uncomment this line to avoid truncated error messages
 # $t_config['settings']['addContentLengthHeader'] = false;
 
-# Disable E_DEPRECATED warnings for PHP 8.4
-# Necessary to catch errors in method signatures triggered before our custom
-# error handler is in place.
-if( version_compare( PHP_VERSION, '8.4', '>=' ) ) {
-	$t_old_error_reporting = error_reporting( error_reporting() & ~E_DEPRECATED );
-}
 
 if( version_compare( Slim\App::VERSION, '4.0', '<' ) ) {
 	/**
@@ -111,12 +105,6 @@ if( version_compare( Slim\App::VERSION, '4.0', '<' ) ) {
 				# Passing null to parameter of type ... is deprecated
 				case 'Slim/Http/Request.php':
 				case 'Slim/Http/Uri.php':
-
-				# Implicitly marking parameter ... as nullable is deprecated
-				case 'Slim/DeferredCallable.php':
-				case 'Slim/Router.php':
-				case 'Slim/RouteGroup.php':
-				case 'Slim/Http/Response.php':
 					return true;
 			}
 		}
@@ -193,11 +181,6 @@ try {
 
 	event_signal( 'EVENT_REST_API_ROUTES', array( array( 'app' => $g_app ) ) );
 
-	# Restore error reporting to its original state before executing the request
-	if( isset( $t_old_error_reporting ) ) {
-		error_reporting( $t_old_error_reporting );
-	}
-	
 	$g_app->run();
 }
 catch( Throwable $e ) {

--- a/composer.lock
+++ b/composer.lock
@@ -1022,16 +1022,16 @@
         },
         {
             "name": "slim/slim",
-            "version": "3.12.5",
+            "version": "3.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slimphp/Slim.git",
-                "reference": "565632b2d9b64ecedf89546edbbf4f3648089f0c"
+                "reference": "f899a6e0be000b9e56d164a4241aa60ab8f33c7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slimphp/Slim/zipball/565632b2d9b64ecedf89546edbbf4f3648089f0c",
-                "reference": "565632b2d9b64ecedf89546edbbf4f3648089f0c",
+                "url": "https://api.github.com/repos/slimphp/Slim/zipball/f899a6e0be000b9e56d164a4241aa60ab8f33c7f",
+                "reference": "f899a6e0be000b9e56d164a4241aa60ab8f33c7f",
                 "shasum": ""
             },
             "require": {
@@ -1039,7 +1039,7 @@
                 "ext-libxml": "*",
                 "ext-simplexml": "*",
                 "nikic/fast-route": "^1.0",
-                "php": ">=5.5.0",
+                "php": "^8.1",
                 "pimple/pimple": "^3.0",
                 "psr/container": "^1.0",
                 "psr/http-message": "^1.0"
@@ -1048,7 +1048,8 @@
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^10.5",
                 "squizlabs/php_codesniffer": "^3.6.0"
             },
             "type": "library",
@@ -1093,7 +1094,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slimphp/Slim/issues",
-                "source": "https://github.com/slimphp/Slim/tree/3.12.5"
+                "source": "https://github.com/slimphp/Slim/tree/3.13.0"
             },
             "funding": [
                 {
@@ -1105,7 +1106,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-23T04:32:51+00:00"
+            "time": "2026-04-28T08:53:26+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",


### PR DESCRIPTION
Slim [3.13.0 was released](https://github.com/slimphp/Slim/releases#release-3.13.0) in April 2026, with support for PHP 8.1+, despite the [earlier statement](https://github.com/slimphp/Slim/pull/3186#issuecomment-1098254226) by the Slim project team that 3.x was end-of-life and would not be updated.

Consequently, the workarounds that were implemented to support PHP 8.x with Slim 3.12.5 are no longer needed. 

This PR:
- Bumps [slim/slim](https://github.com/slimphp/Slim) from 3.12.5 to 3.13.0 (replaces dependabot PR #2236)
- Reverts the hacks 
   - [#32866](https://mantisbt.org/bugs/view.php?id=32866) (795ff02e5500008f055589038ae0404ed575537a)
   - [#35284](https://mantisbt.org/bugs/view.php?id=32866) (d5a30a0cb15e617749a1feb0ef46dbe782b522b2)

Fixes [#37288](https://mantisbt.org/bugs/view.php?id=37288)
