### PR TITLE
Reject multiline issue summaries when creating via API

### DIFF
--- a/core/bug_api.php
+++ b/core/bug_api.php
@@ -490,6 +490,14 @@ class BugData {
 			trigger_error( ERROR_EMPTY_FIELD, ERROR );
 		}
 
+		if( preg_match( '/[\r\n]/', $this->summary ) ) {
+			throw new ClientException(
+				'Field "summary" cannot contain line breaks.',
+				ERROR_INVALID_FIELD_VALUE,
+				array( lang_get( 'summary' ) )
+			);
+		}
+
 		if( mb_strlen( $this->summary ) > DB_FIELD_SIZE_BUG_SUMMARY ) {
 			throw new ClientException(
 				'Field "summary" exceeds maximum length ' . DB_FIELD_SIZE_BUG_SUMMARY . '.',

--- a/tests/rest/RestIssueTest.php
+++ b/tests/rest/RestIssueTest.php
@@ -172,6 +172,42 @@ class RestIssueTest extends RestBase {
 		);
 	}
 
+	/**
+	 * Summary is a single-line field and must reject line breaks.
+	 *
+	 * @return void
+	 */
+	public function testSummaryCannotContainLineBreaks() {
+		$t_issue_to_add = $this->getIssueToAdd( 'summary-newline' );
+		$t_issue_to_add['summary'] .= "\nsecond line";
+
+		$t_response = $this->builder()->post( '/issues', $t_issue_to_add )->send();
+		$this->assertEquals( HTTP_STATUS_BAD_REQUEST, $t_response->getStatusCode(),
+			'Creating an issue with a multiline summary should fail'
+		);
+	}
+
+	/**
+	 * Summary is a single-line field and must reject line breaks on update.
+	 *
+	 * @return void
+	 */
+	public function testUpdateIssueWithSummaryContainingLineBreaks() {
+		$t_issue_to_add = $this->getIssueToAdd( 'summary-update-newline' );
+		$t_response = $this->builder()->post( '/issues', $t_issue_to_add )->send();
+		$this->assertEquals( HTTP_STATUS_CREATED, $t_response->getStatusCode() );
+		$t_issue_id = json_decode( $t_response->getBody(), true )['issue']['id'];
+		$this->deleteIssueAfterRun( $t_issue_id );
+
+		$t_response = $this->builder()->patch(
+			'/issues/' . $t_issue_id,
+			array( 'summary' => $t_issue_to_add['summary'] . "\rsecond line" )
+		)->send();
+		$this->assertEquals( HTTP_STATUS_BAD_REQUEST, $t_response->getStatusCode(),
+			'Updating an issue with a multiline summary should fail'
+		);
+	}
+
 	public function testCreateIssueWithEnumIds() {
 		$t_issue_to_add = $this->getIssueToAdd();
 		$t_issue_to_add['status']['id'] = 50; # assigned


### PR DESCRIPTION
Fixes [#26984](https://mantisbt.org/bugs/view.php?id=26984)

This fixes new occurrences of the issue. Due to this being an unlikely issue to happen, I didn't add a db migration step.