### PR TITLE
REST API: Add delete issue attachment API

### DIFF
--- a/api/rest/mantisbt_openapi.yaml
+++ b/api/rest/mantisbt_openapi.yaml
@@ -315,6 +315,34 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
+    delete:
+      summary: Delete an attachment from an issue
+      operationId: IssueFileDelete
+      description: Deletes an attachment when the authenticated user has permission to do so.
+      tags:
+        - 'Issue Attachments'
+      parameters:
+        - $ref: '#/components/parameters/issue_id'
+        - name: file_id
+          in: path
+          schema:
+            type: integer
+          description: ID of the attachment to delete.
+          required: true
+          example: 567
+      responses:
+        '200':
+          $ref: '#/components/responses/Success'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
   '/api/rest/issues/{id}/notes':
     parameters:
       - $ref: '#/components/parameters/X-Mantis-Username'

--- a/api/rest/mantisbt_openapi.yaml
+++ b/api/rest/mantisbt_openapi.yaml
@@ -315,34 +315,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '503':
           $ref: '#/components/responses/ServiceUnavailable'
-    delete:
-      summary: Delete an attachment from an issue
-      operationId: IssueFileDelete
-      description: Deletes an attachment when the authenticated user has permission to do so.
-      tags:
-        - 'Issue Attachments'
-      parameters:
-        - $ref: '#/components/parameters/issue_id'
-        - name: file_id
-          in: path
-          schema:
-            type: integer
-          description: ID of the attachment to delete.
-          required: true
-          example: 567
-      responses:
-        '200':
-          $ref: '#/components/responses/Success'
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '503':
-          $ref: '#/components/responses/ServiceUnavailable'
   '/api/rest/issues/{id}/notes':
     parameters:
       - $ref: '#/components/parameters/X-Mantis-Username'
@@ -748,6 +720,34 @@ paths:
               $ref: '#/components/headers/X-Mantis-LoginMethod'
             X-Mantis-Version:
               $ref: '#/components/headers/X-Mantis-Version'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+    delete:
+      summary: Delete an attachment from an issue
+      operationId: IssueFileDelete
+      description: Deletes an attachment when the authenticated user has permission to do so.
+      tags:
+        - 'Issue Attachments'
+      parameters:
+        - $ref: '#/components/parameters/issue_id'
+        - name: file_id
+          in: path
+          schema:
+            type: integer
+          description: ID of the attachment to delete.
+          required: true
+          example: 567
+      responses:
+        '200':
+          $ref: '#/components/responses/Success'
         '400':
           $ref: '#/components/responses/BadRequest'
         '404':

--- a/api/rest/restcore/issues_rest.php
+++ b/api/rest/restcore/issues_rest.php
@@ -77,6 +77,8 @@ $g_app->group('/issues', function() use ( $g_app ) {
 	$g_app->get( '/{id}/files', 'rest_issue_files_get' );
 	$g_app->get( '/{id}/files/{file_id}/', 'rest_issue_files_get' );
 	$g_app->get( '/{id}/files/{file_id}', 'rest_issue_files_get' );
+	$g_app->delete( '/{id}/files/{file_id}/', 'rest_issue_file_delete' );
+	$g_app->delete( '/{id}/files/{file_id}', 'rest_issue_file_delete' );
 });
 
 /**
@@ -578,6 +580,33 @@ function rest_issue_files_get( Request $p_request, Response $p_response, array $
 
 	return $p_response->withStatus( HTTP_STATUS_SUCCESS )->
 		withJson( array( 'files' => $t_files ) );
+}
+
+/**
+ * Delete a file associated with an issue.
+ *
+ * @param Request  $p_request The request.
+ * @param Response $p_response The response.
+ * @param array    $p_args Route arguments.
+ *
+ * @return Response The augmented response.
+ * @throws ClientException
+ */
+function rest_issue_file_delete( Request $p_request, Response $p_response, array $p_args ) {
+	$t_issue_id = $p_args['id'];
+	$t_file_id = $p_args['file_id'];
+
+	$t_command = new IssueFileDeleteCommand( array(
+		'query' => array(
+			'issue_id' => $t_issue_id,
+			'file_id' => $t_file_id,
+		)
+	) );
+	$t_command->execute();
+
+	$t_issue = mc_issue_get( /* username */ '', /* password */ '', $t_issue_id );
+	return $p_response->withStatus( HTTP_STATUS_SUCCESS )
+		->withJson( array( 'issue' => $t_issue ) );
 }
 
 /**

--- a/api/soap/mc_issue_attachment_api.php
+++ b/api/soap/mc_issue_attachment_api.php
@@ -97,18 +97,14 @@ function mc_issue_attachment_delete( $p_username, $p_password, $p_issue_attachme
 		return mci_fault_login_failed();
 	}
 
-	$t_bug_id = file_get_field( $p_issue_attachment_id, 'bug_id' );
+	$t_file = file_get_field( $p_issue_attachment_id, 'bug_id' );
+	$t_command = new IssueFileDeleteCommand( array(
+		'query' => array(
+			'issue_id' => $t_file,
+			'file_id' => $p_issue_attachment_id,
+		)
+	) );
+	$t_command->execute();
 
-	# Perform access control checks
-	$t_attachment_owner = file_get_field( $p_issue_attachment_id, 'user_id' );
-	$t_current_user_is_attachment_owner = $t_attachment_owner == $t_user_id;
-	# Factor in allow_delete_own_attachments=ON|OFF
-	if( !$t_current_user_is_attachment_owner || !config_get( 'allow_delete_own_attachments' ) ) {
-		# Check access against delete_attachments_threshold
-		if( !access_has_bug_level( config_get( 'delete_attachments_threshold' ), $t_bug_id, $t_user_id ) ) {
-			return mci_fault_access_denied( $t_user_id );
-		}
-	}
-
-	return file_delete( $p_issue_attachment_id, 'bug' );
+	return true;
 }

--- a/bug_file_delete.php
+++ b/bug_file_delete.php
@@ -35,10 +35,6 @@
  */
 
 require_once( 'core.php' );
-require_api( 'access_api.php' );
-require_api( 'bug_api.php' );
-require_api( 'config_api.php' );
-require_api( 'file_api.php' );
 require_api( 'form_api.php' );
 require_api( 'gpc_api.php' );
 require_api( 'helper_api.php' );
@@ -51,23 +47,16 @@ $f_file_id = gpc_get_int( 'file_id' );
 
 $t_bug_id = file_get_field( $f_file_id, 'bug_id' );
 
-$t_bug = bug_get( $t_bug_id, true );
-if( $t_bug->project_id != helper_get_current_project() ) {
-	# in case the current project is not the same project of the bug we are viewing...
-	# ... override the current project. This to avoid problems with categories and handlers lists etc.
-	$g_project_override = $t_bug->project_id;
-}
-
-$t_attachment_owner = file_get_field( $f_file_id, 'user_id' );
-$t_current_user_is_attachment_owner = $t_attachment_owner == auth_get_current_user_id();
-if( !$t_current_user_is_attachment_owner || ( $t_current_user_is_attachment_owner && !config_get( 'allow_delete_own_attachments' ) ) ) {
-	access_ensure_bug_level( config_get( 'delete_attachments_threshold' ), $t_bug_id );
-}
-
 helper_ensure_confirmed( lang_get( 'delete_attachment_sure_msg' ), lang_get( 'delete' ) );
 
-file_delete( $f_file_id, 'bug' );
+$t_command = new IssueFileDeleteCommand( array(
+	'query' => array(
+		'issue_id' => $t_bug_id,
+		'file_id' => $f_file_id,
+	)
+) );
+$t_result = $t_command->execute();
 
 form_security_purge( 'bug_file_delete' );
 
-print_header_redirect_view( $t_bug_id );
+print_header_redirect_view( $t_result['issue_id'] );

--- a/core/commands/IssueFileDeleteCommand.php
+++ b/core/commands/IssueFileDeleteCommand.php
@@ -1,0 +1,90 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+require_api( 'authentication_api.php' );
+require_api( 'bug_api.php' );
+require_api( 'config_api.php' );
+require_api( 'constant_inc.php' );
+require_api( 'file_api.php' );
+require_api( 'helper_api.php' );
+
+use Mantis\Exceptions\ClientException;
+
+/**
+ * A command that deletes an issue attachment.
+ */
+class IssueFileDeleteCommand extends Command {
+	/** @var int */
+	private $issue_id;
+
+	/** @var int */
+	private $file_id;
+
+	/**
+	 * Validate the deletion request and its permissions.
+	 *
+	 * @throws ClientException
+	 */
+	function validate() {
+		$this->issue_id = helper_parse_issue_id( $this->query( 'issue_id' ) );
+		bug_ensure_exists( $this->issue_id );
+
+		$this->file_id = (int)$this->query( 'file_id' );
+		if( $this->file_id < 1 ) {
+			throw new ClientException( "'file_id' must be >= 1", ERROR_INVALID_FIELD_VALUE, array( 'file_id' ) );
+		}
+
+		$t_file_issue_id = file_get_field( $this->file_id, 'bug_id' );
+		# A missing attachment and an attachment belonging to another issue are
+		# handled identically to avoid exposing whether a file id exists.
+		if( (int)$t_file_issue_id !== $this->issue_id ) {
+			throw new ClientException( 'Attachment does not belong to issue', ERROR_INVALID_FIELD_VALUE, array( 'file_id' ) );
+		}
+
+		$t_project_id = (int)bug_get_field( $this->issue_id, 'project_id' );
+		if( $t_project_id != helper_get_current_project() ) {
+			global $g_project_override;
+			$g_project_override = $t_project_id;
+		}
+
+		if( bug_is_readonly( $this->issue_id ) ) {
+			throw new ClientException(
+				sprintf( "Issue '%d' is read-only.", $this->issue_id ),
+				ERROR_BUG_READ_ONLY_ACTION_DENIED,
+				array( $this->issue_id )
+			);
+		}
+
+		$t_file_owner_id = file_get_field( $this->file_id, 'user_id' );
+		$t_user_id = auth_get_current_user_id();
+		$t_is_owner = $t_file_owner_id == $t_user_id;
+		if( !$t_is_owner || !config_get( 'allow_delete_own_attachments' ) ) {
+			if( !access_has_bug_level( config_get( 'delete_attachments_threshold' ), $this->issue_id, $t_user_id ) ) {
+				throw new ClientException( 'Access denied', ERROR_ACCESS_DENIED );
+			}
+		}
+	}
+
+	/**
+	 * Delete the attachment and return its issue id.
+	 *
+	 * @return array
+	 */
+	protected function process() {
+		file_delete( $this->file_id, 'bug' );
+		return array( 'issue_id' => $this->issue_id );
+	}
+}

--- a/tests/rest/RestIssueFilesTest.php
+++ b/tests/rest/RestIssueFilesTest.php
@@ -1,0 +1,208 @@
+<?php
+# MantisBT - A PHP based bugtracking system
+
+# MantisBT is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MantisBT is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MantisBT.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Mantis Webservice Tests
+ *
+ * @package Tests
+ * @subpackage UnitTests
+ * @copyright Copyright MantisBT Team - mantisbt-dev@lists.sourceforge.net
+ * @link http://www.mantisbt.org
+ */
+
+namespace Mantis\tests\rest;
+
+use Mantis\tests\core\Faker;
+
+require_once 'RestBase.php';
+
+/**
+ * Test fixture for issue file webservice methods.
+ *
+ * @requires extension curl
+ * @group REST
+ */
+class RestIssueFilesTest extends RestBase {
+	/**
+	 * An uploader may delete their own attachment only when configured to do so.
+	 */
+	public function testOwnAttachmentDeletionRequiresConfiguration() {
+		$t_user = $this->createReporter();
+		$t_issue_id = $this->createIssue();
+		$t_file_id = $this->addFileAs( $t_issue_id, $t_user['name'] );
+		$t_old_config = $this->setConfig( 'allow_delete_own_attachments', OFF );
+
+		try {
+			$t_response = $this->deleteFileAs( $t_issue_id, $t_file_id, $t_user['name'] );
+			$this->assertEquals( HTTP_STATUS_FORBIDDEN, $t_response->getStatusCode() );
+
+			$this->setConfig( 'allow_delete_own_attachments', ON );
+			$t_response = $this->deleteFileAs( $t_issue_id, $t_file_id, $t_user['name'] );
+			$this->assertEquals( HTTP_STATUS_SUCCESS, $t_response->getStatusCode() );
+		} finally {
+			$this->restoreConfig( 'allow_delete_own_attachments', $t_old_config );
+		}
+	}
+
+	/**
+	 * Deleting another user's attachment requires the configured access level.
+	 */
+	public function testOtherUserAttachmentDeletionRequiresAccessLevel() {
+		$t_user = $this->createReporter();
+		$t_issue_id = $this->createIssue();
+		$t_file_id = $this->addFile( $t_issue_id );
+
+		$t_response = $this->deleteFileAs( $t_issue_id, $t_file_id, $t_user['name'] );
+		$this->assertEquals( HTTP_STATUS_FORBIDDEN, $t_response->getStatusCode() );
+
+		$t_response = $this->deleteFileAs( $t_issue_id, $t_file_id );
+		$this->assertEquals( HTTP_STATUS_SUCCESS, $t_response->getStatusCode() );
+	}
+
+	/**
+	 * Test adding an attachment to an issue.
+	 */
+	public function testAddIssueFile() {
+		$t_issue_id = $this->createIssue();
+		$t_file_id = $this->addFile( $t_issue_id );
+
+		$t_response = $this->builder()->get(
+			'/issues/' . $t_issue_id . '/files/' . $t_file_id
+		)->send();
+		$this->assertEquals( HTTP_STATUS_SUCCESS, $t_response->getStatusCode() );
+		$t_file = json_decode( $t_response->getBody(), true )['files'][0];
+		$this->assertEquals( 'delete-test.txt', $t_file['filename'] );
+		$this->assertEquals( base64_encode( 'attachment to delete' ), $t_file['content'] );
+	}
+
+	/**
+	 * Test deleting an attachment from its issue.
+	 */
+	public function testDeleteIssueFile() {
+		$t_issue_id = $this->createIssue();
+		$t_file_id = $this->addFile( $t_issue_id );
+
+		$t_response = $this->builder()->delete(
+			'/issues/' . $t_issue_id . '/files/' . $t_file_id
+		)->send();
+		$this->assertEquals( HTTP_STATUS_SUCCESS, $t_response->getStatusCode() );
+		$this->assertEquals( $t_issue_id, json_decode( $t_response->getBody() )->issue->id );
+
+		$t_response = $this->builder()->get( '/issues/' . $t_issue_id . '/files' )->send();
+		$this->assertEquals( HTTP_STATUS_SUCCESS, $t_response->getStatusCode() );
+		$this->assertCount( 0, json_decode( $t_response->getBody() )->files );
+	}
+
+	/**
+	 * An attachment must belong to the issue in the URL.
+	 */
+	public function testCannotDeleteIssueFileFromAnotherIssue() {
+		$t_issue_id = $this->createIssue();
+		$t_other_issue_id = $this->createIssue();
+		$t_file_id = $this->addFile( $t_issue_id );
+
+		$t_response = $this->builder()->delete(
+			'/issues/' . $t_other_issue_id . '/files/' . $t_file_id
+		)->send();
+		$this->assertEquals( HTTP_STATUS_BAD_REQUEST, $t_response->getStatusCode() );
+
+		$t_response = $this->builder()->get( '/issues/' . $t_issue_id . '/files/' . $t_file_id )->send();
+		$this->assertEquals( HTTP_STATUS_SUCCESS, $t_response->getStatusCode() );
+	}
+
+	/**
+	 * Create an issue and register it for cleanup.
+	 *
+	 * @return int
+	 */
+	private function createIssue() {
+		$t_response = $this->builder()->post( '/issues', $this->getIssueToAdd() )->send();
+		$this->assertEquals( HTTP_STATUS_CREATED, $t_response->getStatusCode() );
+		$t_issue_id = json_decode( $t_response->getBody(), true )['issue']['id'];
+		$this->deleteIssueAfterRun( $t_issue_id );
+		return $t_issue_id;
+	}
+
+	/**
+	 * Add a small attachment to an issue.
+	 *
+	 * @param int $p_issue_id Issue identifier.
+	 * @return int Attachment identifier.
+	 */
+	private function addFile( $p_issue_id ) {
+		return $this->addFileAs( $p_issue_id );
+	}
+
+	/**
+	 * Add a small attachment to an issue as an optionally impersonated user.
+	 *
+	 * @param int    $p_issue_id Issue identifier.
+	 * @param string $p_username Username to impersonate.
+	 * @return int Attachment identifier.
+	 */
+	private function addFileAs( $p_issue_id, $p_username = null ) {
+		$t_builder = $this->builder()->post(
+			'/issues/' . $p_issue_id . '/files',
+			array( 'files' => array( array(
+				'name' => 'delete-test.txt',
+				'content' => base64_encode( 'attachment to delete' ),
+			) ) )
+		);
+		if( $p_username !== null ) {
+			$t_builder->impersonate( $p_username );
+		}
+		$t_response = $t_builder->send();
+		$this->assertEquals( HTTP_STATUS_CREATED, $t_response->getStatusCode() );
+
+		$t_response = $this->builder()->get( '/issues/' . $p_issue_id . '/files' )->send();
+		$this->assertEquals( HTTP_STATUS_SUCCESS, $t_response->getStatusCode() );
+		$t_files = json_decode( $t_response->getBody(), true )['files'];
+		$this->assertCount( 1, $t_files );
+		return $t_files[0]['id'];
+	}
+
+	/**
+	 * Delete an attachment as an optionally impersonated user.
+	 *
+	 * @param int    $p_issue_id Issue identifier.
+	 * @param int    $p_file_id Attachment identifier.
+	 * @param string $p_username Username to impersonate.
+	 * @return \Psr\Http\Message\ResponseInterface
+	 */
+	private function deleteFileAs( $p_issue_id, $p_file_id, $p_username = null ) {
+		$t_builder = $this->builder()->delete( '/issues/' . $p_issue_id . '/files/' . $p_file_id );
+		if( $p_username !== null ) {
+			$t_builder->impersonate( $p_username );
+		}
+		return $t_builder->send();
+	}
+
+	/**
+	 * Create an enabled reporter user and register it for cleanup.
+	 *
+	 * @return array User data.
+	 */
+	private function createReporter() {
+		$t_response = $this->builder()->post( '/users', array(
+			'name' => Faker::username(),
+			'access_level' => array( 'name' => 'reporter' ),
+			'enabled' => true,
+		) )->send();
+		$this->deleteAfterRunUserIfCreated( $t_response );
+		$this->assertEquals( HTTP_STATUS_CREATED, $t_response->getStatusCode() );
+		return json_decode( $t_response->getBody(), true )['user'];
+	}
+}

--- a/tests/soap/AttachmentTest.php
+++ b/tests/soap/AttachmentTest.php
@@ -99,6 +99,31 @@ class AttachmentTest extends SoapBase {
 	}
 
 	/**
+	 * Test deleting an issue attachment through SOAP.
+	 *
+	 * @return void
+	 */
+	public function testIssueAttachmentDelete() {
+		$t_issue_id = $this->client->mc_issue_add( $this->userName, $this->password, $this->getIssueToAdd() );
+		$this->deleteAfterRun( $t_issue_id );
+
+		$t_attachment_id = $this->client->mc_issue_attachment_add(
+			$this->userName,
+			$this->password,
+			$t_issue_id,
+			'delete.txt',
+			'txt',
+			base64_encode( 'Attachment contents.' )
+		);
+
+		$this->assertTrue(
+			$this->client->mc_issue_attachment_delete( $this->userName, $this->password, $t_attachment_id )
+		);
+		$t_issue = $this->client->mc_issue_get( $this->userName, $this->password, $t_issue_id );
+		$this->assertCount( 0, $t_issue->attachments );
+	}
+
+	/**
 	 * A test case that tests the following:
 	 * 1. Create an issue.
 	 * 2. Adds at attachemnt


### PR DESCRIPTION
Fixes [#34425](https://mantisbt.org/bugs/view.php?id=34425)

- Add command to delete attachment
- Add to REST API
- Use from SOAP API
- Use from Web UI
