### PR TITLE
Clear PHPMailer Message-ID between messages

### DIFF
--- a/core/classes/EmailSenderPhpMailer.class.php
+++ b/core/classes/EmailSenderPhpMailer.class.php
@@ -193,6 +193,13 @@ class EmailSenderPhpMailer extends EmailSender {
 		$p_mail->clearAttachments();
 		$p_mail->clearReplyTos();
 		$p_mail->clearCustomHeaders();
+
+		# Only notifications for newly submitted issues set a Message-ID (see
+		# email_bug_info_to_one_user()). As the PHPMailer object is reused, the
+		# value would otherwise be inherited by every subsequent message, so
+		# unrelated issues end up sharing a Message-ID. An empty value makes
+		# PHPMailer generate a unique one per message.
+		$p_mail->MessageID = '';
 	}
 }
 


### PR DESCRIPTION
A single PHPMailer instance is reused for all messages sent within a process, but reset() did not clear the MessageID property. Since only notifications for newly submitted issues set a Message-ID, every subsequent message inherited the value, so notifications for unrelated issues were sent under an identical Message-ID.

An empty MessageID is the PHPMailer default and makes it generate a unique one per message. Threading is unaffected, In-Reply-To is added as a custom header and already cleared.

Fixes #37355


## Reference
Fixes [#37355](https://mantisbt.org/bugs/view.php?id=37355)
