### PR TITLE
Fix PHP 8.5 deprecation warning in XML import

### DIFF
--- a/plugins/XmlImportExport/ImportXml/Issue.php
+++ b/plugins/XmlImportExport/ImportXml/Issue.php
@@ -149,7 +149,7 @@ class ImportXml_Issue implements ImportXml_Interface {
 						$this->old_id_ = $t_reader->value;
 						break;
 
-					case 'project';
+					case 'project':
 						# ignore original value, use current project
 						$this->newbug_->project_id = $t_project_id;
 						break;


### PR DESCRIPTION
The alternate syntax using a semicolon after case has been deprecated

Fixes [#37366](https://mantisbt.org/bugs/view.php?id=37366)