### PR TITLE
Deprecate rest api auth without bearer scheme

### DIFF
--- a/api/rest/mantisbt_openapi.yaml
+++ b/api/rest/mantisbt_openapi.yaml
@@ -12,8 +12,9 @@ info:
 
     The token is passed using the standard RFC 6750 bearer scheme
     (`Authorization: Bearer <token>`); the scheme name is matched case-insensitively.
-    For backwards compatibility, the bare form (`Authorization: <token>`) is also
-    still accepted.
+    For backwards compatibility, the legacy, bare form (`Authorization: <token>`) is 
+    still accepted, but this usage is deprecated and will be removed in a future
+    release.
 
     There has been significant improvements and feature additions for REST API in each of the
     recent releases.  Hence, it is highly recommended to use latest release when leveraging the
@@ -30,10 +31,10 @@ info:
     different format.
 
     Create an API token in MantisBT, then send the token value directly in the `Authorization`
-    header. Do not prefix the token with `Bearer`:
+    header:
 
     ```http
-    Authorization: <api-token>
+    Authorization: Bearer <api-token>
     Content-Type: application/json
     ```
 
@@ -1820,7 +1821,9 @@ components:
       scheme: bearer
       description: |-
         The user's API token, sent with the RFC 6750 bearer scheme (`Bearer <token>`).
-        The bare form (`<token>`) is also accepted for backwards compatibility.
+        
+        The legacy bare form (`<token>`) is still accepted for backwards compatibility,
+        but this usage is deprecated and will be removed in a future release.
   headers:
     ETag:
       description: Entity tag for the response representation, when conditional requests are supported.

--- a/api/rest/restcore/AuthMiddleware.php
+++ b/api/rest/restcore/AuthMiddleware.php
@@ -52,6 +52,14 @@ class AuthMiddleware {
 					$t_username = user_get_username( $t_user_id );
 					$t_password = $t_api_token;
 					$t_login_method = LOGIN_METHOD_API_TOKEN;
+
+					# Send Deprecated header if token was passed without bearer scheme
+					if( $t_api_token === $t_credentials ) {
+						$t_doc_link = 'https://mantisbt.org/docs/master/en-US/Developers_Guide/html-desktop/#restapi.auth';
+						$response = $response
+							->withHeader( HEADER_DEPRECATION, '@1788480117')
+							->withAddedHeader( HEADER_LINK, '<' . $t_doc_link. '>; rel="deprecation"');
+					}
 					break;
 				}
 			}

--- a/core/constant_inc.php
+++ b/core/constant_inc.php
@@ -734,6 +734,8 @@ define( 'HEADER_IF_MATCH', 'If-Match' );
 define( 'HEADER_IF_NONE_MATCH', 'If-None-Match' );
 define( 'HEADER_ETAG', 'ETag' );
 define( 'HEADER_WWW_AUTHENTICATE', 'WWW-Authenticate' );
+define( 'HEADER_DEPRECATION', 'Deprecation' );
+define( 'HEADER_LINK', 'Link' );
 
 # LOGIN METHODS
 define( 'LOGIN_METHOD_COOKIE', 'cookie' );

--- a/docbook/Developers_Guide/en-US/Api_Rest.xml
+++ b/docbook/Developers_Guide/en-US/Api_Rest.xml
@@ -25,14 +25,24 @@
 			<varlistentry>
 				<term>API Token</term>
 				<listitem>
-					<para>
-						The primary authentication method. Create an API token for your user
-						account and pass it in the <literal>Authorization</literal> HTTP request
-						header using the RFC 6750 bearer scheme
-						(<literal>Authorization: Bearer &lt;token&gt;</literal>).  The bare token
-						form (<literal>Authorization: &lt;token&gt;</literal>) is also accepted for
-						backwards compatibility.  API token authentication is required when using
-						impersonation.
+					<para>This is the primary authentication method.
+					</para>
+					<para>Create an API token for your user account and pass it in the
+						<literal>Authorization</literal> HTTP request header
+						using the RFC 6750 bearer scheme
+						(<literal>Authorization: Bearer &lt;token&gt;</literal>).
+					</para>
+					<warning>
+						<para>The legacy, bare token form
+							(<literal>Authorization: &lt;token&gt;</literal>)
+							has been deprecated in 2.29.0.
+							It is still accepted for backwards compatibility,
+							but will be removed in a future release.
+							The API will issue an HTTP <emphasis>Deprecation</emphasis>
+							header in responses to requests using it.
+						</para>
+					</warning>
+					<para>API token authentication is required when using impersonation.
 					</para>
 					<para>
 						When a request requires authentication but none is provided (and

--- a/tests/rest/RestAuthHeaderTest.php
+++ b/tests/rest/RestAuthHeaderTest.php
@@ -54,6 +54,11 @@ class RestAuthHeaderTest extends RestBase {
 			->send();
 
 		$this->assertEquals( HTTP_STATUS_SUCCESS, $t_response->getStatusCode() );
+
+		# Deprecation header must be present
+		$this->assertTrue( $t_response->hasHeader( HEADER_DEPRECATION ),
+			"API Token Auth without Bearer scheme is deprecated"
+		);
 	}
 
 	/**


### PR DESCRIPTION
Following-up on #2252, implementing the deprecation per the original discussion in https://github.com/mantisbt/mantisbt/pull/2071#issuecomment-2616503343

Fixes [#35286](https://mantisbt.org/bugs/view.php?id=35286)
