### PR TITLE
IssuefileDeleteCommand: accept empty issue id

### DIFF
--- a/api/soap/mc_issue_attachment_api.php
+++ b/api/soap/mc_issue_attachment_api.php
@@ -99,13 +99,11 @@ function mc_issue_attachment_delete( $p_username, $p_password, $p_issue_attachme
 		return mci_fault_login_failed();
 	}
 
-	$t_file = file_get_field( $p_issue_attachment_id, 'bug_id' );
-	$t_command = new IssueFileDeleteCommand( array(
-		'query' => array(
-			'issue_id' => $t_file,
+	$t_command = new IssueFileDeleteCommand( [
+		'query' => [
 			'file_id' => $p_issue_attachment_id,
-		)
-	) );
+		]
+	] );
 	$t_command->execute();
 
 	return true;

--- a/bug_file_delete.php
+++ b/bug_file_delete.php
@@ -45,16 +45,13 @@ form_security_validate( 'bug_file_delete' );
 
 $f_file_id = gpc_get_int( 'file_id' );
 
-$t_bug_id = file_get_field( $f_file_id, 'bug_id' );
-
 helper_ensure_confirmed( lang_get( 'delete_attachment_sure_msg' ), lang_get( 'delete' ) );
 
-$t_command = new IssueFileDeleteCommand( array(
-	'query' => array(
-		'issue_id' => $t_bug_id,
+$t_command = new IssueFileDeleteCommand( [
+	'query' => [
 		'file_id' => $f_file_id,
-	)
-) );
+	]
+] );
 $t_result = $t_command->execute();
 
 form_security_purge( 'bug_file_delete' );

--- a/core/commands/IssueFileDeleteCommand.php
+++ b/core/commands/IssueFileDeleteCommand.php
@@ -25,6 +25,12 @@ use Mantis\Exceptions\ClientException;
 
 /**
  * A command that deletes an issue attachment.
+ *
+ * Payload:
+ * - query:
+ *   - issue_id: issue identifier (optional); if not given, will be retrieved
+ *               from the file record.
+ *   - file_id: attachment identifier (must belong to issue_id if provided)
  */
 class IssueFileDeleteCommand extends Command {
 	/** @var int */
@@ -39,15 +45,24 @@ class IssueFileDeleteCommand extends Command {
 	 * @throws ClientException
 	 */
 	function validate() {
-		$this->issue_id = helper_parse_issue_id( $this->query( 'issue_id' ) );
+		$this->file_id = helper_parse_id( $this->query( 'file_id' ), 'file_id' );
+		$t_file_issue_id = file_get_field( $this->file_id, 'bug_id' );
+
+		$t_issue_id = (string)$this->query( 'issue_id' );
+		if( is_blank( $t_issue_id ) ) {
+			# Issue id was not specified, retrieve it from the file
+			if( $t_file_issue_id === false ) {
+				throw new ClientException( "Attachment '$this->file_id' not found",
+					ERROR_FILE_NOT_FOUND,
+					[ $this->file_id ]
+				);
+			}
+			$this->issue_id = (int)$t_file_issue_id;
+		} else {
+			$this->issue_id = helper_parse_issue_id( $t_issue_id );
+		}
 		bug_ensure_exists( $this->issue_id );
 
-		$this->file_id = (int)$this->query( 'file_id' );
-		if( $this->file_id < 1 ) {
-			throw new ClientException( "'file_id' must be >= 1", ERROR_INVALID_FIELD_VALUE, array( 'file_id' ) );
-		}
-
-		$t_file_issue_id = file_get_field( $this->file_id, 'bug_id' );
 		# A missing attachment and an attachment belonging to another issue are
 		# handled identically to avoid exposing whether a file id exists.
 		if( (int)$t_file_issue_id !== $this->issue_id ) {


### PR DESCRIPTION
Requiring it makes no sense from SOAP API (mc_issue_attachment_delete() function) or the Web UI (bug_file_delete.php) contexts, because the issue id is unknown to the caller, forcing them to retrieve it using file_get_field().

Problem, file_get_field() returns false when the given id does not exist, so error handling would be required but that is currently not implemented, and the command's validate() returns a misleading error message: "'issue_id' missing".

Refactor validate() method to retrieve issue_id from the file record when it is not provided or blank, and return a meaningful error message if not found. If issue_id is given (i.e. from REST API), behavior is u nchanged.

Adapt mc_issue_attachment_delete() and bug_file_delete.php: remove unnecessary file_get_field() call and do not pass issue_id to Command.

Fixes [#37370](https://mantisbt.org/bugs/view.php?id=37370)
